### PR TITLE
[V26-769..V26-774] Add remote terminal app update command

### DIFF
--- a/docs/plans/2026-06-18-001-feat-remote-terminal-app-update-command-plan.html
+++ b/docs/plans/2026-06-18-001-feat-remote-terminal-app-update-command-plan.html
@@ -1,0 +1,265 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>feat: Add Remote Terminal App Update Command</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f8fafc;
+      --paper: #ffffff;
+      --ink: #111827;
+      --muted: #5b6472;
+      --line: #d9dee7;
+      --accent: #2563eb;
+      --accent-soft: #e7efff;
+      --warn: #9a5b00;
+      --warn-soft: #fff4d6;
+      --code: #f3f5f8;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 32px 20px 56px;
+    }
+    header, section {
+      background: var(--paper);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 24px;
+      margin: 16px 0;
+    }
+    h1 { margin: 0 0 8px; font-size: 2rem; line-height: 1.15; }
+    h2 { margin: 0 0 14px; font-size: 1.25rem; }
+    h3 { margin: 22px 0 8px; font-size: 1rem; }
+    p { margin: 0 0 12px; }
+    ul, ol { margin: 8px 0 0; padding-left: 22px; }
+    li { margin: 6px 0; }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code {
+      background: var(--code);
+      border-radius: 4px;
+      padding: 1px 5px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.92em;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 10px;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: #f3f6fb; }
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 14px;
+    }
+    .pill {
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 4px 10px;
+      color: var(--muted);
+      background: #fbfcfe;
+      font-size: 0.875rem;
+    }
+    .callout {
+      border-left: 4px solid var(--accent);
+      background: var(--accent-soft);
+      padding: 12px 14px;
+      border-radius: 6px;
+    }
+    .warning {
+      border-left-color: var(--warn);
+      background: var(--warn-soft);
+    }
+    .toc {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 8px;
+      padding-left: 0;
+      list-style: none;
+    }
+    .unit {
+      border-top: 1px solid var(--line);
+      padding-top: 16px;
+      margin-top: 16px;
+    }
+    .unit:first-of-type {
+      border-top: 0;
+      padding-top: 0;
+    }
+    .small { color: var(--muted); font-size: 0.92rem; }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>feat: Add Remote Terminal App Update Command</h1>
+    <p>Plan for adding an anytime Terminal Health command that asks a POS terminal to update through the existing app-update coordinator, while deriving outdated/current state from fresh runtime evidence.</p>
+    <div class="meta">
+      <span class="pill">Type: feat</span>
+      <span class="pill">Status: active</span>
+      <span class="pill">Date: 2026-06-18</span>
+      <span class="pill">Markdown: <a href="./2026-06-18-001-feat-remote-terminal-app-update-command-plan.md">source</a></span>
+    </div>
+  </header>
+
+  <section aria-labelledby="toc">
+    <h2 id="toc">Contents</h2>
+    <ul class="toc">
+      <li><a href="#scope">Scope</a></li>
+      <li><a href="#decisions">Key Decisions</a></li>
+      <li><a href="#state-model">State Model</a></li>
+      <li><a href="#units">Implementation Units</a></li>
+      <li><a href="#verification">Verification</a></li>
+      <li><a href="#risks">Risks</a></li>
+      <li><a href="#references">References</a></li>
+    </ul>
+  </section>
+
+  <section id="scope" aria-labelledby="scope-heading">
+    <h2 id="scope-heading">Scope</h2>
+    <p>The active scope is the bridge between two existing foundations: typed terminal recovery commands and the update-ready coordinator. Support can queue the request any time; the terminal evaluates local coordinator state and blockers before any reload.</p>
+    <div class="callout warning">
+      <p><strong>Boundary:</strong> this is not remote control and not a forced refresh. Command acknowledgement is action lifecycle only; fresh command-correlated runtime evidence is the update truth.</p>
+    </div>
+    <h3>Requirements Digest</h3>
+    <ul>
+      <li>Full-admin support can send an allow-listed <code>update_app</code> command to active terminals.</li>
+      <li>The terminal handles current, update-ready, blocked, applying, detector-failed, ready-unstaged, stale, and unknown states locally.</li>
+      <li>The command queue enforces single-consumer execution with a claim token or execution id.</li>
+      <li>Runtime status publishes sanitized, code-based app-update evidence for Terminal Health.</li>
+      <li>Coordinator blockers and cross-tab blockers remain authoritative.</li>
+      <li>No secret, staff proof, payment, customer, or raw local payload data leaks through command or runtime evidence.</li>
+    </ul>
+  </section>
+
+  <section id="decisions" aria-labelledby="decisions-heading">
+    <h2 id="decisions-heading">Key Decisions</h2>
+    <ul>
+      <li>Add <code>update_app</code> to the existing terminal command queue instead of adding a new support channel.</li>
+      <li>Make the command an anytime intent; the terminal applies the latest pending build at execution time.</li>
+      <li>Publish structured app-update evidence instead of relying only on ad hoc build-string comparison.</li>
+      <li>Acknowledge before reload because <code>applyUpdate()</code> can reload synchronously.</li>
+      <li>Use server-side claim semantics as the authoritative exactly-once guard; browser locks are only defense in depth.</li>
+      <li>Require command-correlated runtime evidence so replayed pre-command status cannot verify a new command.</li>
+      <li>Model blocked and no-op outcomes as completed local evaluations, not support-recovery failures.</li>
+      <li>Keep Terminal Health state derived from fresh runtime evidence, with command status shown as lifecycle context.</li>
+    </ul>
+  </section>
+
+  <section id="state-model" aria-labelledby="state-model-heading">
+    <h2 id="state-model-heading">Canonical App-Update Status Model</h2>
+    <p>Terminal Health and command acknowledgement should use the same normalized vocabulary even if the coordinator keeps its own internal state names.</p>
+    <table>
+      <thead>
+        <tr><th>Status</th><th>Meaning</th><th>Command behavior</th><th>Terminal Health behavior</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>current</code></td><td>No pending update, or already on the latest known build.</td><td>Acknowledge completed no-op.</td><td>Show current evidence; keep the action available for future retry.</td></tr>
+        <tr><td><code>update_ready</code></td><td>Pending update exists and coordinator says apply is safe.</td><td>Acknowledge applying, then invoke the reload latch.</td><td>Show update ready until post-reload check-in verifies current.</td></tr>
+        <tr><td><code>update_ready_unstaged</code></td><td>Update exists, but assets are not ready or <code>canApply</code> is false for staging reasons.</td><td>Acknowledge completed evaluation unless <code>canApply</code> is true at execution time.</td><td>Show update available but not ready to refresh.</td></tr>
+        <tr><td><code>blocked</code></td><td>Local work, sync review, payment/sale risk, or cross-tab blocker prevents refresh.</td><td>Acknowledge blocked evaluation; do not reload.</td><td>Show operational blocker guidance without marking terminal failed.</td></tr>
+        <tr><td><code>applying</code></td><td>The terminal accepted apply and acknowledged before reload.</td><td>Wait for fresh command-correlated runtime evidence.</td><td>Show waiting for check-in, not verified.</td></tr>
+        <tr><td><code>detector_failed</code></td><td>The update detector errored or cannot produce a trustworthy snapshot.</td><td>Acknowledge unable-to-determine evaluation.</td><td>Show unable to determine, with retry available.</td></tr>
+        <tr><td><code>stale</code></td><td>Runtime evidence is older than the freshness window.</td><td>Do not use stale evidence to verify a command.</td><td>Show stale/unknown, not current or outdated certainty.</td></tr>
+        <tr><td><code>unknown</code></td><td>Older client, missing adapter, or missing app-update evidence.</td><td>Acknowledge unsupported/unable-to-determine when claimed by such a client.</td><td>Show not reported/unknown and keep active-terminal action scoped by role and command lifecycle.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="units" aria-labelledby="units-heading">
+    <h2 id="units-heading">Implementation Units</h2>
+    <article class="unit">
+      <h3>U1. Extend the terminal command contract with Update app</h3>
+      <p>Add <code>update_app</code> through backend/frontend command type unions, validators, expected evidence, command issue tests, dedupe, redaction, and server-side single-consumer claim semantics.</p>
+      <p class="small">Primary files: terminal recovery types/schema/service, public terminal functions, terminal health types, command service/public tests.</p>
+    </article>
+    <article class="unit">
+      <h3>U2. Publish structured app-update runtime evidence</h3>
+      <p>Thread current build, pending build, canonical coordinator status code, apply availability, staging state, selected blocker code, observed timestamp, and optional command execution id/nonce through runtime status.</p>
+      <p class="small">Primary files: runtime status schema, public terminal input stripping, terminal commands, local runtime builder, runtime tests.</p>
+    </article>
+    <article class="unit">
+      <h3>U3. Execute Update app through the coordinator</h3>
+      <p>Add an optional runtime adapter and two-phase executor: evaluate, persist acknowledgement, then run the post-ack effect such as <code>applyUpdate()</code>. Server claim tokens remain the authoritative duplicate-tab guard.</p>
+      <p class="small">Primary files: local recovery command executor, POS local sync runtime, update coordinator/provider tests.</p>
+    </article>
+    <article class="unit">
+      <h3>U4. Derive Terminal Health update state from runtime evidence</h3>
+      <p>Normalize fresh, command-correlated app-update evidence into the canonical states without treating update readiness as a health blocker or letting stale command state overrule runtime truth.</p>
+      <p class="small">Primary files: terminal queries, terminal health types/presentation, terminal detail/roster UI tests.</p>
+    </article>
+    <article class="unit">
+      <h3>U5. Wire Terminal Health Update app action</h3>
+      <p>Expose the anytime Update app support action for active terminals with explicit disabled states, duplicate protection, accessible status announcements, and calm operational copy.</p>
+      <p class="small">Primary files: terminal detail, terminal health roster, presentation helpers, component tests.</p>
+    </article>
+    <article class="unit">
+      <h3>U6. Update validation routing and durable docs</h3>
+      <p>Update solution notes and, only if current routing is missing coverage, harness routing so future changes to this boundary run both app-update and terminal-health validation slices.</p>
+      <p class="small">Primary files: solution notes, validation guide/map, harness registry and tests.</p>
+    </article>
+  </section>
+
+  <section id="verification" aria-labelledby="verification-heading">
+    <h2 id="verification-heading">Verification Strategy</h2>
+    <p>Implementation should combine the existing app-update readiness/apply-safety suite with the POS terminal health diagnostics suite.</p>
+    <ul>
+      <li>Command service/public tests for <code>update_app</code>, dedupe, auth, and redaction.</li>
+      <li>Concurrent claim and stale-token tests for server-side single-consumer execution.</li>
+      <li>Runtime status tests for app-update evidence and publish-loop stability.</li>
+      <li>Local runtime tests for ack-before-reload, blocked/no-op/applying outcomes, replayed evidence rejection, and duplicate-tab safety.</li>
+      <li>Terminal Health query/presentation/component tests for fresh, stale, blocked, current, unknown, accessibility, and command/runtime lane separation.</li>
+      <li>At least one manual or Playwright multi-tab gate before production rollout.</li>
+      <li>Typecheck, build, Convex audit/lint, graphify rebuild after code changes, and harness review when validation routing changes.</li>
+    </ul>
+  </section>
+
+  <section id="risks" aria-labelledby="risks-heading">
+    <h2 id="risks-heading">Risks</h2>
+    <table>
+      <thead>
+        <tr><th>Risk</th><th>Mitigation</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Reload before acknowledgement persists</td><td>Use a two-phase executor and test with synchronous reload mocks.</td></tr>
+        <tr><td>Support bypasses local blockers</td><td>Execute only through coordinator snapshot/apply APIs.</td></tr>
+        <tr><td>Command ack mistaken for update truth</td><td>Derive state from fresh runtime evidence and keep command status as lifecycle context.</td></tr>
+        <tr><td>Duplicate tabs run the same command</td><td>Enforce server-side claim/ack tokens, with browser-local locking as defense in depth.</td></tr>
+        <tr><td>Replayed runtime evidence verifies a new command</td><td>Require a safe execution id, nonce, or issued-at observation after command issue.</td></tr>
+        <tr><td>Runtime evidence leaks sensitive details</td><td>Use code-based evidence, sanitized blocker summaries, secret-like rejection, and redacted acknowledgement copy.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="references" aria-labelledby="references-heading">
+    <h2 id="references-heading">References</h2>
+    <ul>
+      <li><a href="../plans/2026-06-13-001-feat-remote-terminal-commands-plan.md">Remote terminal commands plan</a></li>
+      <li><a href="../plans/2026-06-17-002-feat-update-ready-coordinator-plan.md">Update ready coordinator plan</a></li>
+      <li><a href="../solutions/architecture/athena-app-update-apply-safety-2026-06-17.md">App update apply safety solution</a></li>
+      <li><a href="../solutions/architecture/athena-pos-terminal-recovery-readiness-boundary-2026-06-14.md">Terminal recovery readiness boundary</a></li>
+      <li><a href="../solutions/architecture/athena-pos-remote-terminal-health-recovery-2026-06-11.md">Remote terminal health recovery</a></li>
+      <li><a href="../../packages/athena-webapp/docs/agent/validation-guide.md">Athena validation guide</a></li>
+    </ul>
+  </section>
+</main>
+</body>
+</html>

--- a/docs/plans/2026-06-18-001-feat-remote-terminal-app-update-command-plan.md
+++ b/docs/plans/2026-06-18-001-feat-remote-terminal-app-update-command-plan.md
@@ -1,0 +1,512 @@
+---
+title: "feat: Add Remote Terminal App Update Command"
+type: feat
+status: active
+date: 2026-06-18
+---
+
+# feat: Add Remote Terminal App Update Command
+
+## Summary
+
+Extend Athena's existing terminal recovery command lane so support can send an Update app command to an active POS terminal at any time. The terminal decides locally through the existing update coordinator whether to apply the update, report a safe no-op, or report that active work is blocking refresh, while Terminal Health derives current/outdated state from fresh runtime evidence instead of command history.
+
+---
+
+## Problem Frame
+
+Remote terminal commands and app update readiness now exist as separate foundations. Terminal Health can already queue allow-listed terminal-local commands, and the app update coordinator can already detect a pending build, stage assets, block unsafe refreshes, and apply through a single reload latch. The gap is operational: support needs a safe way to ask a terminal to update, and Terminal Health needs a current view of whether the terminal is actually running an outdated app build.
+
+The implementation must not collapse that into remote control or a forced reload. A support command records intent; the matching terminal uses its own coordinator state and local blockers to decide what can happen.
+
+---
+
+## Assumptions
+
+*This plan was authored from the user's confirmed product direction plus repo/subagent research. These are the plan-time bets that should be reviewed before implementation proceeds.*
+
+- `Update app` should be sendable any time for active terminals, even when Terminal Health does not currently know whether an update is pending.
+- The command should apply the latest pending build known by the terminal at execution time, not a build id frozen by the support user's browser.
+- No-op and blocked update checks should acknowledge as completed local evaluations, not scary repair failures. Terminal Health truth still comes from fresh runtime evidence.
+- Cross-tab safety should use both the update coordinator's blocker merge and an `update_app` single-flight guard so two tabs do not race the same reload.
+- The command queue must enforce single-consumer execution for `update_app` with a claim token or execution id. Browser-local locking is a defense-in-depth guard, not the authoritative exactly-once mechanism.
+
+---
+
+## Requirements
+
+- R1. A full-admin support user can send an allow-listed Update app command to any eligible active store terminal from Terminal Health.
+- R2. The command remains terminal-scoped, audited, deduped while active, single-consumer while claimed, and impossible to turn into arbitrary remote execution.
+- R3. The matching terminal evaluates the command locally through the app update coordinator and maps every result to the canonical status model in this plan.
+- R4. The terminal never bypasses update coordinator blockers or calls a blind reload path. Active POS work, in-flight commands, resumability risk, and cross-tab blockers can prevent apply.
+- R5. Command acknowledgement happens before any reload attempt, and verification waits for a fresh post-command runtime check-in that reports command-correlated app-update evidence.
+- R6. Terminal runtime status publishes structured app-update evidence so Terminal Health can compute canonical current, update-ready, blocked, applying, detector-failed, stale, or unknown states from fresh evidence.
+- R7. Terminal Health shows Update app as an anytime support action for active terminals, while using runtime evidence to explain whether the terminal is current, outdated, blocked, or unknown.
+- R8. No command context, acknowledgement, runtime status, or UI copy leaks sync secrets, staff proof/PIN material, raw local payloads, customer/payment data, or raw backend errors.
+- R9. Tests cover command contract changes, runtime evidence publishing, command-correlated verification, coordinator execution, ack-before-reload, duplicate/cross-tab safety, Terminal Health presentation, accessibility, and validation routing.
+
+---
+
+## Scope Boundaries
+
+- This plan does not add remote shell, remote code execution, free-form command text, or support-authored scripts.
+- This plan does not let support force-refresh a terminal that has active local work or cross-tab blockers.
+- This plan does not expand service-worker caching beyond existing static app-shell assets.
+- This plan does not change POS sale, payment, inventory, closeout, staff proof, customer data, or sync review authority.
+- This plan does not require a fleet-wide update scheduler or mass terminal rollout UI.
+- This plan does not make command acknowledgement the source of truth for whether a terminal is updated.
+
+### Deferred to Follow-Up Work
+
+- Fleet-wide "update all terminals" orchestration and progress tracking.
+- Emergency/security update override policy, if the product later needs one.
+- Remote Assist live-session controls that issue Update app from an attended support console.
+- Fully automated browser-level multi-tab coverage beyond one required pre-production manual or Playwright gate, if the current harness cannot support it without brittle setup.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/convex/pos/application/terminalRecovery/types.ts` defines allow-listed command types and expected evidence.
+- `packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts` handles issue, duplicate suppression, claim, acknowledgement, redaction, expiry, and runtime verification.
+- `packages/athena-webapp/convex/pos/public/terminals.ts` exposes support issue and terminal list/claim/ack/runtime-status functions.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts` polls, claims, executes, acknowledges, and then forces a fresh runtime status publish.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts` keeps browser-local command execution allow-listed.
+- `packages/athena-webapp/src/lib/app-update/updateCoordinator.ts` owns update states, blockers, cross-tab blocker leases, and `applyUpdate()`.
+- `packages/athena-webapp/src/lib/app-update/UpdateCoordinatorProvider.tsx` is the current reload boundary.
+- `packages/athena-webapp/src/lib/app-update/useUpdateApplyBlocker.ts` is the generic surface-owned blocker API.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts`, `packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts`, and `packages/athena-webapp/convex/pos/application/commands/terminals.ts` shape runtime evidence.
+- `packages/athena-webapp/convex/pos/application/queries/terminals.ts`, `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`, `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx`, and `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx` shape Terminal Health evidence and actions.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-app-update-apply-safety-2026-06-17.md` separates update detection from applying the update; detection must not reload the page.
+- `docs/solutions/architecture/athena-pos-terminal-recovery-readiness-boundary-2026-06-14.md` keeps support recovery, sales readiness, diagnostic evidence, and command history separate.
+- `docs/solutions/architecture/athena-pos-remote-terminal-health-recovery-2026-06-11.md` establishes that terminal recovery is support orchestration with runtime verification, not server-side force-clear behavior.
+- `docs/plans/2026-06-13-001-feat-remote-terminal-commands-plan.md` defines the remote command lane as typed, allow-listed, audited, terminal-scoped, and locally executed.
+- `docs/plans/2026-06-17-002-feat-update-ready-coordinator-plan.md` defines the update coordinator, manual apply boundary, cross-tab blockers, and static-asset cache boundary.
+- `docs/product-copy-tone.md` requires calm, clear, operational copy that names the state and the next action without raw backend wording.
+
+### External References
+
+- External research skipped. The relevant implementation contract is repo-local: Convex terminal commands, POS runtime status, and the existing app-update coordinator.
+
+---
+
+## Key Technical Decisions
+
+- Add `update_app` to the existing terminal recovery command allow-list instead of introducing a new support channel. The existing queue already provides audit, terminal scoping, duplicate suppression, claim/ack, and runtime verification.
+- Treat Update app as an anytime intent command. Terminal Health may send it without proving update readiness first; the terminal's coordinator state decides what happens.
+- Publish structured app-update runtime evidence instead of relying only on build string comparison in Terminal Health. Build metadata comparison remains useful, but runtime coordinator state is needed for blocked, applying, detector-failed, and unknown cases.
+- Keep the app-update coordinator generic. POS terminal command execution should call into a narrow adapter/callback, not import terminal recovery concepts into `src/lib/app-update`.
+- Acknowledge before reload. `applyUpdate()` can reload synchronously, so command execution must persist its local decision before invoking the reload latch.
+- Verify by fresh runtime evidence. A command that acknowledged "applying" is not verified until a new runtime check-in reports the expected app-update/build state within the existing freshness window.
+- Model blocked/no-op as completed local evaluations with runtime evidence, not as support-recovery failures. That keeps an idle current terminal from looking broken after support clicks Update app.
+- Server-side claim semantics are authoritative for `update_app` exactly-once execution. Browser-local locks reduce duplicate work but cannot be the only race guard.
+- Runtime verification is command-correlated: the terminal reports a safe execution id, nonce, or issued-at observation so replayed pre-command runtime evidence cannot verify a command.
+- Persisted runtime evidence should use code/enums and sanitized summaries, not raw blocker labels, local payloads, or copied browser strings.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should support be able to send Update app any time? Yes. The terminal gates behavior locally.
+- Should Update app target the build support saw or the latest pending build at the terminal? The latest pending build at execution time. This keeps the command useful when support evidence is stale.
+- Should blocked/no-op command outcomes be failures? No. They are completed local evaluations. Terminal Health should still show the blocking/current state from runtime evidence.
+- Should Terminal Health compute outdated state from command history? No. It should derive it from fresh runtime app-update evidence, using command state only as action lifecycle context.
+
+### Deferred to Implementation
+
+- Exact app-update runtime evidence field names and enum labels.
+
+## Canonical App-Update Status Model
+
+Terminal Health and command acknowledgement should use the same normalized status vocabulary even if the underlying coordinator names differ.
+
+| Status | Meaning | Command behavior | Terminal Health behavior |
+|--------|---------|------------------|--------------------------|
+| `current` | The terminal reports no pending app update or already runs the latest known build. | Acknowledge as completed no-op. | Show current evidence and keep Update app available for a future retry. |
+| `update_ready` | The terminal reports a pending update and coordinator says apply is safe. | Acknowledge applying, then invoke the coordinator reload latch. | Show outdated/update-ready evidence until post-reload check-in verifies current. |
+| `update_ready_unstaged` | The terminal knows an update exists but assets are not fully staged or `canApply` is false for staging reasons. | Acknowledge completed evaluation unless coordinator `canApply` is true at execution time. | Show update available but not ready to refresh yet. |
+| `blocked` | Local work, sync review, payment/sale risk, or a cross-tab blocker prevents refresh. | Acknowledge completed blocked evaluation and do not reload. | Show operational blocker guidance without marking the terminal failed. |
+| `applying` | The terminal accepted apply and acknowledged before reload. | Wait for fresh post-command runtime evidence. | Show waiting for check-in/update in progress, not verified. |
+| `detector_failed` | The update detector errored or cannot produce a trustworthy snapshot. | Acknowledge completed unable-to-determine evaluation. | Show unable to determine, with retry available. |
+| `stale` | Runtime evidence is older than the freshness window. | Do not use stale evidence to verify a command. | Show stale/unknown state, not current or outdated certainty. |
+| `unknown` | Older client, missing coordinator adapter, or missing app-update evidence. | Acknowledge unsupported/unable-to-determine when the command is claimed by such a client. | Show not reported/unknown and keep active-terminal action availability scoped by role and command lifecycle. |
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+  participant Support as Support user
+  participant Health as Terminal Health
+  participant Queue as Recovery command queue
+  participant Runtime as Terminal runtime
+  participant Coordinator as Update coordinator
+  participant Checkin as Runtime status
+
+  Support->>Health: Send Update app
+  Health->>Queue: Issue allow-listed update_app
+  Runtime->>Queue: Claim command
+  Runtime->>Coordinator: Read snapshot and blockers
+  alt can apply
+    Runtime->>Queue: Acknowledge applying
+    Runtime->>Coordinator: applyUpdate()
+    Runtime->>Checkin: Post-reload runtime evidence
+  else current, blocked, or unknown
+    Runtime->>Queue: Acknowledge completed local evaluation
+    Runtime->>Checkin: Publish app-update evidence
+  end
+  Checkin->>Health: Derive current/update-ready/blocked/unknown
+```
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 Command contract"]
+  U2["U2 Runtime evidence"]
+  U3["U3 Coordinator execution"]
+  U4["U4 Terminal Health derivation"]
+  U5["U5 Terminal Health action UI"]
+  U6["U6 Validation and docs"]
+
+  U1 --> U3
+  U1 --> U4
+  U2 --> U3
+  U2 --> U4
+  U3 --> U4
+  U4 --> U5
+  U5 --> U6
+```
+
+- U1. **Extend the terminal command contract with Update app**
+
+**Goal:** Add `update_app` as a first-class, allow-listed terminal recovery command with safe context, duplicate handling, labels, and expected evidence support.
+
+**Requirements:** R1, R2, R5, R8, R9.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/terminalRecovery/types.ts`
+- Modify: `packages/athena-webapp/convex/schemas/pos/posTerminalRecovery.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts`
+- Test: `packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts`
+- Test: `packages/athena-webapp/convex/pos/public/terminals.test.ts`
+
+**Approach:**
+- Add `update_app` to the backend and frontend command type unions and validators.
+- Keep support issuance full-admin only and terminal execution terminal-sync-secret scoped.
+- Extend expected evidence to cover app-update verification without storing secrets or raw browser payloads.
+- Adjust duplicate suppression so an active update command for a terminal prevents duplicate pending work, while completed/verified/no-op commands do not block future update attempts for later builds.
+- Tighten `update_app` claim semantics so only one runtime can execute a claimed command. Persist a claim token or execution id, require that token on acknowledgement and verification evidence, and reject acknowledgements from stale or competing claims.
+- Use an "apply latest" dedupe context. Expected evidence should identify the command execution and observation window, not freeze the build id support saw in Terminal Health.
+
+**Execution note:** Implement new command contract behavior test-first before touching browser execution.
+
+**Patterns to follow:**
+- Existing `repair_terminal_seed` and `retry_sync` lifecycle tests in `packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts`.
+- Secret-like field rejection and acknowledgement message redaction in `packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts`.
+
+**Test scenarios:**
+- Happy path: full-admin support can issue `update_app` to an active terminal.
+- Happy path: equivalent active `update_app` commands dedupe instead of creating duplicate pending work.
+- Happy path: one terminal runtime receives a valid claim token or execution id and can acknowledge the command.
+- Edge case: completed or verified no-op update command does not prevent a later update command.
+- Edge case: expired active update command can be replaced.
+- Edge case: concurrent claim attempts for the same `update_app` do not both become executable.
+- Error path: `pos_only` users and terminal runtime calls cannot issue `update_app`.
+- Error path: inactive/revoked/wrong-store terminal cannot receive `update_app`.
+- Error path: acknowledgement with a missing, stale, or mismatched claim token is rejected.
+- Error path: secret-like fields in command context or expected evidence are rejected before persistence.
+
+**Verification:**
+- The command queue accepts `update_app` as a typed terminal command and preserves existing auth, scoping, dedupe, and redaction guarantees.
+
+---
+
+- U2. **Publish structured app-update runtime evidence**
+
+**Goal:** Thread app-update state through terminal runtime status so Terminal Health can derive current/outdated/blocked/unknown from fresh terminal evidence.
+
+**Requirements:** R3, R4, R6, R8, R9.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/terminals.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
+- Test: `packages/athena-webapp/convex/pos/public/terminals.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/terminals.test.ts`
+
+**Approach:**
+- Add a structured runtime evidence object for app-update state: current build, pending build when known, canonical coordinator status code, can-apply flag, staging status, selected blocker code, detector failure/unknown state, observed timestamp, and optional command execution id/nonce for command-triggered checks.
+- Keep evidence sanitized. Publish blocker codes and product-copy-safe summaries only, not raw payloads, copied blocker labels, local diagnostic payloads, or internal errors.
+- Preserve runtime publish-loop stability by excluding volatile fields from the publish signature or normalizing them the same way existing runtime status avoids `reportedAt` churn.
+- Keep older clients compatible: missing app-update evidence means unknown, not unhealthy.
+
+**Execution note:** Add characterization coverage for current `appVersion`/`buildSha` status before extending the runtime payload.
+
+**Patterns to follow:**
+- Existing `appShell` and `appSessionRecovery` runtime evidence in `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts`.
+- Existing `stripRuntimeStatusInput` sanitization in `packages/athena-webapp/convex/pos/public/terminals.ts`.
+
+**Test scenarios:**
+- Happy path: ready coordinator snapshot publishes pending build and update-ready evidence.
+- Happy path: current/no pending update publishes current app-update evidence.
+- Happy path: blocked coordinator snapshot publishes a sanitized selected blocker and no sensitive payload.
+- Happy path: command-triggered runtime evidence includes a safe execution id/nonce that can be matched to the command being verified.
+- Edge case: detector-failed or missing coordinator state publishes unknown/detector-failed evidence without blocking sales.
+- Edge case: old clients with only `appVersion`/`buildSha` still render as unknown or comparable by existing metadata.
+- Error path: volatile app-update timestamps do not create repeated runtime-status publish loops.
+- Error path: raw blocker strings, backend errors, and local payload fields are not persisted in runtime evidence.
+
+**Verification:**
+- Runtime status contains enough sanitized evidence for Terminal Health to compute update state without reading command history.
+
+---
+
+- U3. **Execute Update app through the coordinator**
+
+**Goal:** Teach the terminal runtime to execute `update_app` by consulting the app-update coordinator and calling `applyUpdate()` only after safe acknowledgement.
+
+**Requirements:** R3, R4, R5, R8, R9.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Modify: `packages/athena-webapp/src/lib/app-update/updateCoordinator.ts`
+- Modify: `packages/athena-webapp/src/lib/app-update/UpdateCoordinatorProvider.tsx`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
+- Test: `packages/athena-webapp/src/lib/app-update/updateCoordinator.test.ts`
+
+**Approach:**
+- Add an optional `appUpdateCoordinator` adapter input to the POS local runtime host. The adapter exposes snapshot/evaluate/apply behavior to command execution without importing terminal recovery concepts into `src/lib/app-update`.
+- Define local decision outcomes by mapping coordinator data to the canonical status model: already current/no update, update ready and applying, blocked by active work, detector failed/unknown, ready-unstaged, stale, and unsupported coordinator.
+- Make command execution two-phase: first evaluate and prepare the acknowledgement payload, then persist acknowledgement, then run the post-ack effect such as `applyUpdate()`. This is required because `applyUpdate()` can reload synchronously.
+- If `applyUpdate()` returns false because blockers appeared after acknowledgement, publish fresh runtime evidence that records the blocked/current state for the same command execution id.
+- Use the server claim token/execution id as the authoritative single-flight guard; add browser-local locking only as defense in depth for duplicate tabs.
+- Force a runtime status observation for all non-reload outcomes and rely on post-reload startup check-in for successful apply.
+
+**Execution note:** Start with an immediate reload mock to prove acknowledgement is persisted before `applyUpdate()`.
+
+**Patterns to follow:**
+- Existing command callback pattern for `refresh_staff_authority`, `refresh_snapshots`, and `report_diagnostics`.
+- Existing update coordinator `snapshot.canApply` and reload latch tests.
+
+**Test scenarios:**
+- Happy path: update ready with no blockers acknowledges applying before invoking `applyUpdate()` exactly once.
+- Happy path: no update ready acknowledges completed no-op and publishes current evidence without reload.
+- Happy path: blocked update acknowledges completed blocked evaluation and publishes blocker evidence without reload.
+- Edge case: ready-unstaged follows coordinator `canApply` semantics and reports staging state.
+- Edge case: detector failed/unknown reports unable-to-determine evidence without failing support recovery.
+- Edge case: duplicate tabs cannot both acknowledge or apply the same `update_app` command.
+- Error path: `applyUpdate()` returning false after the snapshot was ready does not reload and reports blocked/current evidence.
+- Error path: coordinator unavailable fails safely without mutating unrelated local POS state.
+- Error path: command evaluation cannot call reload before acknowledgement succeeds.
+
+**Verification:**
+- The terminal can evaluate and apply an update command without bypassing coordinator blockers or losing the command acknowledgement to reload timing.
+
+---
+
+- U4. **Derive Terminal Health update state from runtime evidence**
+
+**Goal:** Normalize runtime app-update evidence into Terminal Health preview and presentation state, keeping update readiness separate from support recovery blockers and command history.
+
+**Requirements:** R6, R7, R8, R9.
+
+**Dependencies:** U1, U2, U3.
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/queries/terminals.ts`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx`
+- Test: `packages/athena-webapp/convex/pos/application/queries/terminals.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx`
+
+**Approach:**
+- Add a normalized app-update status to terminal preview/detail: current, update ready/outdated, apply blocked, applying, detector failed, stale evidence, or unknown.
+- Treat stale runtime evidence as stale/unknown, not as live update readiness.
+- Continue showing current build and latest build metadata, but prefer structured runtime app-update evidence when present.
+- Do not add support recovery blockers merely because an update is available. Update app is an available support action, not evidence that the terminal cannot transact.
+- Keep command status as action lifecycle context: queued/running/waiting for check-in/verified. Do not let an old blocked/no-op/precondition state overrule fresh runtime evidence.
+- Keep command lifecycle and runtime truth visually distinct. For example, "Update command queued" belongs to the action lane, while "Update blocked by active sale" belongs to runtime app-update state.
+- Verify command success only when runtime evidence is fresh and command-correlated. A stale or pre-command runtime payload cannot mark the command verified.
+
+**Patterns to follow:**
+- `buildTerminalRecoveryPreview` and `buildTerminalRecoveryPresentation` readiness boundaries.
+- Existing version comparison helper in `POSTerminalDetailView.tsx`, which can be retained or moved behind shared presentation logic.
+
+**Test scenarios:**
+- Happy path: fresh runtime evidence with pending build renders update ready/outdated state.
+- Happy path: fresh current evidence renders current state and still allows the anytime Update app action.
+- Happy path: blocked evidence renders blocker guidance without making terminal health look failed.
+- Happy path: applying command lifecycle renders as waiting for check-in until fresh command-correlated runtime evidence arrives.
+- Edge case: missing app-update evidence on an otherwise healthy terminal renders unknown/not reported, not unhealthy.
+- Edge case: stale runtime evidence renders stale/unknown and does not offer live certainty.
+- Edge case: replayed pre-command runtime evidence does not verify a newly issued command.
+- Edge case: latest command says blocked/no-op but newer runtime evidence says current; current evidence wins.
+- Error path: raw blocker labels or backend messages are normalized before display.
+
+**Verification:**
+- Terminal Health can answer "is this terminal outdated?" from runtime evidence and can distinguish support action availability from health blockers.
+
+---
+
+- U5. **Wire Terminal Health Update app action**
+
+**Goal:** Expose an anytime Update app action on active terminal detail/roster surfaces with safe disabled states, duplicate protection, and calm operational copy.
+
+**Requirements:** R1, R2, R7, R8, R9.
+
+**Dependencies:** U4.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`
+- Test: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts`
+
+**Approach:**
+- Add Update app to the terminal command actions for active terminals, regardless of current app-update evidence.
+- Disable duplicate sends while an equivalent `update_app` command is pending, claimed, or waiting for runtime verification.
+- Keep inactive/revoked terminals, missing terminal identity, and unauthorized support roles unable to issue the command.
+- Use copy shaped around state and action, for example "Update app" and "The checkout station will refresh only when local work is safe."
+- Show local outcomes plainly: current/no update, blocked by active work, applying, waiting for check-in, verified current, or unable to determine.
+- Make disabled states explicit: disabled for inactive/revoked terminals, missing terminal identity, unauthorized roles, and an active equivalent command; enabled for active current, update-ready, blocked, stale, or unknown terminals when no equivalent command is active.
+- Preserve accessible names and status announcements for the action button, command progress, and runtime update state.
+
+**Execution note:** Add UI tests for active/current/blocked/unknown states before wiring the mutation.
+
+**Patterns to follow:**
+- Existing terminal command action rendering in `POSTerminalDetailView.tsx`.
+- Product copy rules in `docs/product-copy-tone.md`.
+
+**Test scenarios:**
+- Happy path: active terminal renders enabled Update app action even when update readiness is unknown.
+- Happy path: clicking Update app issues `update_app` with store id, terminal id, safe context, and expected evidence.
+- Happy path: active update command disables duplicate send and shows queued/running copy.
+- Happy path: action and status text have accessible names and announcements that distinguish queued command state from runtime update state.
+- Edge case: current terminal still offers Update app and later shows no update needed after runtime evidence.
+- Edge case: blocked terminal shows blocker guidance and keeps the action available for a later retry after the current command resolves.
+- Edge case: stale/unknown evidence still allows the action for active terminals while avoiding false current/outdated certainty.
+- Error path: inactive/revoked terminal does not render an enabled action.
+- Error path: mutation failure shows normalized support copy and does not imply the terminal updated.
+
+**Verification:**
+- Support can send Update app from Terminal Health safely without needing to know whether the terminal is already outdated.
+
+---
+
+- U6. **Update validation routing and durable docs**
+
+**Goal:** Make the combined app-update and terminal-command boundary discoverable for future implementers and harness review.
+
+**Requirements:** R8, R9.
+
+**Dependencies:** U5.
+
+**Files:**
+- Modify: `docs/solutions/architecture/athena-app-update-apply-safety-2026-06-17.md`
+- Modify: `docs/solutions/architecture/athena-pos-terminal-recovery-readiness-boundary-2026-06-14.md`
+- Conditional modify: `packages/athena-webapp/docs/agent/validation-guide.md`
+- Conditional modify: `packages/athena-webapp/docs/agent/validation-map.json`
+- Conditional modify: `scripts/harness-app-registry.ts`
+- Conditional test: `scripts/harness-app-registry.test.ts`
+
+**Approach:**
+- Document that remote Update app is an allow-listed command adapter into the update coordinator, not a forced reload.
+- Add the app-update runtime evidence fields and `update_app` command surfaces to validation routing only if generated harness docs do not already cover both affected slices.
+- Keep solution notes explicit about command acknowledgement versus runtime verification.
+- Update product-copy guidance only if implementation introduces reusable update-command wording that belongs outside Terminal Health.
+
+**Test scenarios:**
+- Conditional happy path: harness registry maps app-update runtime evidence and terminal command changes to both app-update and terminal-health validation slices if routing is missing.
+- Conditional edge case: generated validation-map output includes new files without manual-only edits if routing changes.
+- Test expectation: docs-only solution note updates need no behavior tests beyond presentation copy tests when user-facing copy changes.
+
+**Verification:**
+- Future changes to this boundary trigger the right focused tests, and the durable docs explain why support cannot bypass local blockers.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Terminal Health issues a typed Convex command; the terminal runtime claims it; the app-update coordinator decides whether apply is safe; runtime status publishes app-update evidence; Terminal Health derives current/outdated/blocked from that evidence.
+- **Error propagation:** Support issue failures return safe command-result copy. Terminal-local no-op/blocked states are completed local evaluations. Unexpected local failures are redacted before acknowledgement and presentation.
+- **State lifecycle risks:** Ack-before-reload, duplicate tab execution, stale or replayed runtime evidence, pending-build churn, ready-unstaged updates, service-worker cache behavior, and volatile publish signatures all need explicit tests.
+- **API surface parity:** Backend command types, Convex validators, frontend command types, runtime status schema, Terminal Health preview, and UI presentation must all carry the same `update_app` and app-update evidence semantics.
+- **Integration coverage:** Unit tests prove state transforms; component tests prove Terminal Health behavior; focused runtime tests prove command execution; app-update tests prove `applyUpdate()` remains blocker-gated.
+- **Unchanged invariants:** POS continuity remains local-sale-first. Support cannot override active sale work, local sync review, staff proof, drawer authority, payment, inventory, customer, or closeout state.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Reload occurs before command acknowledgement persists | Use a two-phase executor that prepares the result, persists acknowledgement, then runs `applyUpdate()`, and test with a synchronous reload mock. |
+| Support command bypasses local blockers | Execute only through coordinator snapshot/apply APIs and assert blocked snapshots do not reload. |
+| Terminal Health treats command ack as updated truth | Derive app-update status from fresh runtime evidence and keep command state as lifecycle context. |
+| Duplicate tabs run the same update command | Enforce server-side single-consumer claim/ack tokens for `update_app`, with browser-local locking as defense in depth. |
+| Replayed runtime evidence verifies a new command | Require command-correlated runtime evidence with a safe execution id, nonce, or issued-at observation after command issue. |
+| Applying latest conflicts with build evidence support saw | Use command-correlated evidence and fresh runtime status as truth; support-side build metadata is context, not a frozen target. |
+| Runtime app-update evidence causes publish loops | Normalize or exclude volatile fields from runtime publish signatures. |
+| Sensitive details leak through runtime evidence or ack copy | Reuse secret-like field rejection, acknowledgement redaction, code-based evidence, safe blocker summaries, and copy normalization. |
+| Old clients lack app-update evidence | Treat missing evidence as unknown/not reported, not as a blocker or current proof. |
+
+---
+
+## Documentation / Operational Notes
+
+- Implementation should run both validation slices from `packages/athena-webapp/docs/agent/validation-guide.md`: App update readiness/apply-safety and POS terminal health visibility/diagnostics.
+- If code files change, run `bun run graphify:rebuild` before handoff.
+- If Convex public types or validators change, refresh generated Convex artifacts using the repo-documented `bunx convex dev --once` workflow when deployment credentials are available.
+- Verification should be deterministic in local/staging first: one current/no-op path, one blocked path, one ready/applying path with ack-before-reload, one stale/replayed evidence rejection, and one duplicate-tab or concurrent-claim gate.
+- Before production rollout, run at least one manual or Playwright multi-tab gate to prove only one tab can execute a claimed `update_app` command.
+- Production smoke is best effort because real terminal update states are operationally timing-dependent. When available, verify one active terminal reporting update-ready evidence, one blocked terminal that refuses refresh, and one successful post-reload check-in that verifies the updated build.
+
+---
+
+## Sources & References
+
+- Related plan: `docs/plans/2026-06-13-001-feat-remote-terminal-commands-plan.md`
+- Related plan: `docs/plans/2026-06-17-002-feat-update-ready-coordinator-plan.md`
+- Related solution: `docs/solutions/architecture/athena-app-update-apply-safety-2026-06-17.md`
+- Related solution: `docs/solutions/architecture/athena-pos-terminal-recovery-readiness-boundary-2026-06-14.md`
+- Related solution: `docs/solutions/architecture/athena-pos-remote-terminal-health-recovery-2026-06-11.md`
+- Related code: `packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts`
+- Related code: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Related code: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Related code: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts`
+- Related code: `packages/athena-webapp/src/lib/app-update/updateCoordinator.ts`
+- Related UI: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx`
+- Product copy: `docs/product-copy-tone.md`

--- a/docs/solutions/architecture/athena-app-update-apply-safety-2026-06-17.md
+++ b/docs/solutions/architecture/athena-app-update-apply-safety-2026-06-17.md
@@ -59,6 +59,22 @@ banner. POS register surfaces opt in to persistent toast communication so the
 update notice does not shift the register shell or compete with the checkout
 workspace. Both modes use the same coordinator state and the same Refresh action.
 
+## Remote Terminal Update Commands
+
+Remote Terminal Health can ask an active POS terminal to update through the
+same coordinator, but the support command is only intent. The browser that
+claims `update_app` reads its local coordinator snapshot, acknowledges the local
+decision, and calls the coordinator reload latch only after acknowledgement
+persists. It does not call a blind reload path and it cannot bypass blockers
+owned by POS, inventory import, or another surface.
+
+The terminal applies the latest pending build it sees at execution time. The
+support user's build metadata is context for the action, not a frozen target.
+Terminal Health verifies the command through a fresh, command-correlated runtime
+check-in after the command was issued. A command acknowledgement saying
+`applying`, `current`, or `blocked` is lifecycle evidence, not proof that the
+terminal is running a newer bundle.
+
 ## Apply Blockers
 
 Surfaces opt in through `useUpdateApplyBlocker` with:
@@ -122,12 +138,16 @@ app-update module boundary.
 ## Prevention
 
 - Do not call `window.location.reload()` from detection code.
+- Do not call `window.location.reload()` from terminal command code; route
+  remote update requests through the coordinator apply API after acknowledgement.
 - Do not make POS route presence itself an update blocker.
 - Do not hard-code route names in the update coordinator for banner versus toast
   presentation; make the owning surface opt in through the preference provider.
 - Do not add a surface blocker unless the surface has active work, in-flight
   commands, or resumability risk.
 - Do not widen service-worker staging beyond static browser assets.
+- Do not treat remote command acknowledgement as update proof; require fresh
+  command-correlated runtime evidence.
 - Keep operator-facing copy calm and action-oriented; normalize implementation
   details before they reach the banner.
 

--- a/docs/solutions/architecture/athena-pos-terminal-recovery-readiness-boundary-2026-06-14.md
+++ b/docs/solutions/architecture/athena-pos-terminal-recovery-readiness-boundary-2026-06-14.md
@@ -154,6 +154,34 @@ runtime evidence has no current blocker. If current support work exists, show th
 failure reason and the next safe action. If no current support work exists, show
 that no support action is needed.
 
+### Update App Command Outcomes
+
+`update_app` uses the same audited command lane, but its result must stay
+separate from terminal repair readiness. Sending Update app says support asked
+the checkout station to evaluate its app-update coordinator. It does not mean
+the terminal was outdated, and it does not mean the terminal refreshed.
+
+Terminal Health derives app-update state from fresh runtime `appUpdate`
+evidence, not from command history. The canonical states are:
+
+- `current`: no pending update, or the terminal is already on the latest known
+  build.
+- `update_ready`: a pending update exists and the coordinator says refresh is
+  safe.
+- `update_ready_unstaged`: an update exists, but static assets are not ready or
+  the coordinator cannot apply for staging reasons.
+- `blocked`: active local work or cross-tab blocker prevents refresh.
+- `applying`: the command acknowledged before reload and is waiting for a fresh
+  post-reload check-in.
+- `detector_failed`, `stale`, or `unknown`: Terminal Health should avoid live
+  certainty and keep copy operational.
+
+`update_app` is available as an active-terminal support action even when update
+readiness is unknown, but duplicate active update commands should disable the
+same action. Command verification requires a fresh runtime check-in correlated
+to the command execution id or nonce; stale pre-command evidence cannot verify a
+new command.
+
 ## Register Session Review Compatibility
 
 Older review records were created before review items carried structured
@@ -204,6 +232,11 @@ or zero review items, which is not true during the initial query gap.
 
 - Do not add support recovery copy by reading raw command status alone. First
   decide whether current blockers or safe actions still exist.
+- Do not classify an available app update as support recovery work by itself.
+  Show app-update state in its own lane and keep sales/support readiness derived
+  from their existing evidence.
+- Do not verify `update_app` from command acknowledgement or stale runtime
+  evidence. Require fresh command-correlated app-update evidence.
 - Do not let staff authority expiry create a support repair action unless there
   is separate evidence that a terminal-side refresh command is actually needed.
 - Do not treat `cloud_closed` drawer authority as blocked when the matching

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7041 nodes · 7945 edges · 1903 communities detected
+- 7080 nodes · 8031 edges · 1903 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1922,8 +1922,8 @@
 5. `getStoreConfigV2()` - 17 edges
 6. `createConflict()` - 16 edges
 7. `DataTableViewOptions()` - 16 edges
-8. `importInventoryRowsWithCtx()` - 14 edges
-9. `submitTerminalRuntimeStatus()` - 14 edges
+8. `submitTerminalRuntimeStatus()` - 15 edges
+9. `importInventoryRowsWithCtx()` - 14 edges
 10. `validatePendingCheckoutItemDefinedPayload()` - 14 edges
 
 ## Surprising Connections (you probably didn't know these)
@@ -1957,24 +1957,24 @@ Cohesion: 0.11
 Nodes (51): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), collectExistingSaleMappings(), collectSaleSkuQuantities(), conflictResult(), createConflict() (+43 more)
 
 ### Community 4 - "Community 4"
+Cohesion: 0.08
+Nodes (42): buildRecoveryBlockers(), buildRecoveryBlockersFromPreview(), buildRecoveryReadiness(), buildTerminalAppUpdatePresentation(), buildTerminalRecoveryPresentation(), buildUpdateAppAction(), classifyTerminalHealth(), defaultBlockerSummary() (+34 more)
+
+### Community 5 - "Community 5"
 Cohesion: 0.06
 Nodes (26): asRecord(), createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), getExpenseLocalSessionId(), getUploadSequenceScopeId(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeLocalEventPayload() (+18 more)
 
-### Community 5 - "Community 5"
+### Community 6 - "Community 6"
 Cohesion: 0.08
 Nodes (44): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildWeekMetricForDate(), buildWeekMetrics(), compareDailyOperationsTimelineEvents() (+36 more)
 
-### Community 6 - "Community 6"
+### Community 7 - "Community 7"
 Cohesion: 0.1
 Nodes (46): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput() (+38 more)
 
-### Community 7 - "Community 7"
-Cohesion: 0.09
-Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
-
 ### Community 8 - "Community 8"
 Cohesion: 0.09
-Nodes (34): buildRecoveryBlockers(), buildRecoveryBlockersFromPreview(), buildRecoveryReadiness(), buildTerminalRecoveryPresentation(), classifyTerminalHealth(), defaultBlockerSummary(), deriveRecoveryBlockerFromReason(), deriveRecoveryBlockers() (+26 more)
+Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.07
@@ -1985,68 +1985,68 @@ Cohesion: 0.07
 Nodes (22): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+14 more)
 
 ### Community 11 - "Community 11"
+Cohesion: 0.07
+Nodes (18): assertPosLocalStoreOk(), buildRuntimeAppUpdateInput(), clearAcceptedTerminalIntegrityState(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus() (+10 more)
+
+### Community 12 - "Community 12"
+Cohesion: 0.1
+Nodes (30): buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalRecoveryActions(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryManualReview(), buildTerminalRecoveryPreview(), dedupeTerminalActions() (+22 more)
+
+### Community 13 - "Community 13"
 Cohesion: 0.08
 Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
 
-### Community 12 - "Community 12"
+### Community 14 - "Community 14"
 Cohesion: 0.13
 Nodes (35): buildFinalTrustedQuantitiesByRowNumber(), buildProvisionalSkuPatch(), buildSkuInsert(), buildSkuPatch(), finalizeProvisionalImportRowsForAppliedImport(), findExistingSku(), findOrCreateCategory(), findOrCreateProduct() (+27 more)
 
-### Community 13 - "Community 13"
+### Community 15 - "Community 15"
 Cohesion: 0.12
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
-### Community 14 - "Community 14"
+### Community 16 - "Community 16"
 Cohesion: 0.12
 Nodes (32): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+24 more)
 
-### Community 15 - "Community 15"
+### Community 17 - "Community 17"
 Cohesion: 0.07
 Nodes (16): formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary(), formatReviewReportedSummary(), formatReviewTypeSummary(), formatTimestamp() (+8 more)
 
-### Community 16 - "Community 16"
+### Community 18 - "Community 18"
 Cohesion: 0.16
 Nodes (33): asRecord(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale() (+25 more)
 
-### Community 17 - "Community 17"
-Cohesion: 0.15
-Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
-
-### Community 18 - "Community 18"
-Cohesion: 0.08
-Nodes (15): assertPosLocalStoreOk(), clearAcceptedTerminalIntegrityState(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus(), hasPendingLocalCloseout() (+7 more)
-
 ### Community 19 - "Community 19"
-Cohesion: 0.12
-Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
+Cohesion: 0.16
+Nodes (31): completed(), executeCallbackCommand(), executeClearStaleDrawerAuthority(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand(), executeUpdateApp(), failed() (+23 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.15
-Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
+Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
 ### Community 21 - "Community 21"
+Cohesion: 0.12
+Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
+
+### Community 22 - "Community 22"
+Cohesion: 0.15
+Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
+
+### Community 23 - "Community 23"
 Cohesion: 0.08
 Nodes (9): buildMissingDraftResult(), formatQueueWorkItemValue(), getApprovalRequestCopy(), handleDecideApprovalRequest(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft() (+1 more)
 
-### Community 22 - "Community 22"
-Cohesion: 0.18
-Nodes (27): completed(), executeCallbackCommand(), executeClearStaleDrawerAuthority(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand(), failed(), firstDrawerAuthorityPreconditions() (+19 more)
-
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.11
 Nodes (19): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), buildLocalAvailabilityEventIndex(), cartItemsFromLocalRegisterModel(), cartLineSourceKey(), formatLocalPendingCheckoutSku(), localAvailabilityConsumptionFromReadModel(), localPosSessionIdFromEvent() (+11 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.14
 Nodes (24): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+16 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.13
 Nodes (24): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), expenseSessionItemHasTrustedAvailabilityHold(), expenseSessionItemSourceKey(), failure() (+16 more)
-
-### Community 26 - "Community 26"
-Cohesion: 0.12
-Nodes (22): buildTerminalHealthSummary(), buildTerminalRecoveryActions(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryManualReview(), buildTerminalRecoveryPreview(), dedupeTerminalActions(), deriveTerminalHealth() (+14 more)
 
 ### Community 27 - "Community 27"
 Cohesion: 0.2
@@ -2121,120 +2121,120 @@ Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
 ### Community 45 - "Community 45"
+Cohesion: 0.24
+Nodes (19): assertRegisterNumberIsAvailable(), cleanActiveRegisterSession(), cleanAppSessionRecovery(), cleanAppShell(), cleanAppUpdate(), cleanBrowserInfo(), cleanDiagnosticMessage(), cleanDrawerAuthority() (+11 more)
+
+### Community 46 - "Community 46"
 Cohesion: 0.21
 Nodes (21): detectFormat(), extractJsonRows(), flattenJsonRows(), inferProductName(), isRecord(), looksLikeLabel(), normalizeKey(), normalizeLegacyRow() (+13 more)
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
 Cohesion: 0.25
 Nodes (21): asRecord(), errorFor(), getLocalExpenseSessionId(), getOrCreateSession(), isExpenseEvent(), itemSource(), itemSourceKey(), numberField() (+13 more)
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
+Cohesion: 0.18
+Nodes (18): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady(), mapSyncStatus() (+10 more)
+
+### Community 49 - "Community 49"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 48 - "Community 48"
+### Community 50 - "Community 50"
 Cohesion: 0.16
 Nodes (19): automationErrorMessage(), automationIdempotencyKey(), eodDecision(), getLatestDailyOperationsAutomationStatusWithCtx(), getOpeningAutoStartPolicyForApi(), listConfiguredAutomationPolicies(), localDateForPolicy(), openingDecision() (+11 more)
 
-### Community 49 - "Community 49"
+### Community 51 - "Community 51"
 Cohesion: 0.17
 Nodes (17): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+9 more)
 
-### Community 50 - "Community 50"
+### Community 52 - "Community 52"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
-### Community 51 - "Community 51"
-Cohesion: 0.24
-Nodes (18): assertRegisterNumberIsAvailable(), cleanActiveRegisterSession(), cleanAppSessionRecovery(), cleanAppShell(), cleanBrowserInfo(), cleanDiagnosticMessage(), cleanDrawerAuthority(), cleanOptionalString() (+10 more)
-
-### Community 52 - "Community 52"
+### Community 53 - "Community 53"
 Cohesion: 0.21
 Nodes (18): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), formatRecoveryCode(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode() (+10 more)
 
-### Community 53 - "Community 53"
+### Community 54 - "Community 54"
 Cohesion: 0.1
 Nodes (4): handleChange(), isSkuReserved(), parseVariantInputValue(), shouldDisable()
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
+Cohesion: 0.1
+Nodes (4): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onStartRemoteAssist()
+
+### Community 56 - "Community 56"
 Cohesion: 0.13
 Nodes (11): getLatestRuntimeStatusForTerminal(), getTerminalByFingerprint(), getTerminalSyncEvidence(), isActionableRejectedSyncEvent(), isActionableTerminalReviewSyncEvent(), mapTerminalRecord(), omitUndefined(), resolveRegisterSessionActionTarget() (+3 more)
 
-### Community 55 - "Community 55"
+### Community 57 - "Community 57"
 Cohesion: 0.15
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
 
-### Community 56 - "Community 56"
-Cohesion: 0.11
-Nodes (4): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onStartRemoteAssist()
-
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
+Cohesion: 0.2
+Nodes (17): acknowledgeTerminalRecoveryCommand(), buildExecutionId(), claimTerminalRecoveryCommand(), containsSecretLikeField(), getRuntimeAppUpdateEvidence(), isActiveCommand(), isEquivalentCommand(), issueTerminalRecoveryCommand() (+9 more)
+
+### Community 61 - "Community 61"
 Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
 
-### Community 60 - "Community 60"
+### Community 62 - "Community 62"
 Cohesion: 0.18
 Nodes (11): getTransactionById(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile(), loadPendingItemAdjustmentApprovals(), normalizeAdjustmentLineItem(), normalizeAdjustmentMetadata() (+3 more)
 
-### Community 61 - "Community 61"
+### Community 63 - "Community 63"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 62 - "Community 62"
+### Community 64 - "Community 64"
 Cohesion: 0.16
 Nodes (8): asCloudOperableSession(), countPendingSyncableLocalEventsForStaff(), hasSyncedSaleLocalEventsForStaff(), hasUploadedLocalEventsForStaff(), isCloudOperableSession(), isEmptyLocalSaleShell(), trimOptional(), useRegisterViewModel()
 
-### Community 63 - "Community 63"
+### Community 65 - "Community 65"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 64 - "Community 64"
+### Community 66 - "Community 66"
 Cohesion: 0.23
 Nodes (17): assertPrAthenaProofReady(), collectFilesUnder(), collectProofSnapshot(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof(), formatPathList() (+9 more)
 
-### Community 65 - "Community 65"
+### Community 67 - "Community 67"
 Cohesion: 0.24
 Nodes (15): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+7 more)
 
-### Community 66 - "Community 66"
+### Community 68 - "Community 68"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 67 - "Community 67"
+### Community 69 - "Community 69"
 Cohesion: 0.13
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
-### Community 68 - "Community 68"
-Cohesion: 0.23
-Nodes (13): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady(), mapSyncStatus() (+5 more)
-
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.14
 Nodes (5): getBlockedPosTerminalShellCopy(), getPosHubRouteParams(), getRouteParamsForPattern(), getStoreWorkspaceRouteParams(), PosTerminalBlockedShell()
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.15
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
-
-### Community 73 - "Community 73"
-Cohesion: 0.23
-Nodes (14): acknowledgeTerminalRecoveryCommand(), claimTerminalRecoveryCommand(), containsSecretLikeField(), isActiveCommand(), isEquivalentCommand(), issueTerminalRecoveryCommand(), loadScopedCommand(), normalizeOptionalHealthyStatus() (+6 more)
 
 ### Community 74 - "Community 74"
 Cohesion: 0.13
@@ -2677,24 +2677,24 @@ Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
 ### Community 184 - "Community 184"
-Cohesion: 0.32
-Nodes (4): createVersionChecker(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 185 - "Community 185"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 186 - "Community 186"
+### Community 185 - "Community 185"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 187 - "Community 187"
+### Community 186 - "Community 186"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 188 - "Community 188"
+### Community 187 - "Community 187"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
+
+### Community 188 - "Community 188"
+Cohesion: 0.32
+Nodes (4): createVersionChecker(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 189 - "Community 189"
 Cohesion: 0.39
@@ -2833,128 +2833,128 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 223 - "Community 223"
-Cohesion: 0.33
-Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
+Cohesion: 0.38
+Nodes (3): getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusSignature()
 
 ### Community 224 - "Community 224"
-Cohesion: 0.29
-Nodes (0):
+Cohesion: 0.33
+Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
 ### Community 225 - "Community 225"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 226 - "Community 226"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 227 - "Community 227"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
+### Community 227 - "Community 227"
+Cohesion: 0.29
+Nodes (0):
+
 ### Community 228 - "Community 228"
+Cohesion: 0.52
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 229 - "Community 229"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
-
-### Community 236 - "Community 236"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 237 - "Community 237"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 238 - "Community 238"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 239 - "Community 239"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 246 - "Community 246"
+### Community 247 - "Community 247"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 0.4
 Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.4
 Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 253 - "Community 253"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 254 - "Community 254"
 Cohesion: 0.33
@@ -2962,27 +2962,27 @@ Nodes (0):
 
 ### Community 255 - "Community 255"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 256 - "Community 256"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 257 - "Community 257"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 258 - "Community 258"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 260 - "Community 260"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 261 - "Community 261"
 Cohesion: 0.33
@@ -3001,20 +3001,20 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 265 - "Community 265"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 266 - "Community 266"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 266 - "Community 266"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 267 - "Community 267"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 268 - "Community 268"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 269 - "Community 269"
 Cohesion: 0.33
@@ -3261,48 +3261,48 @@ Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
 ### Community 330 - "Community 330"
+Cohesion: 0.5
+Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
+
+### Community 331 - "Community 331"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 331 - "Community 331"
+### Community 332 - "Community 332"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 332 - "Community 332"
+### Community 333 - "Community 333"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 333 - "Community 333"
+### Community 334 - "Community 334"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 334 - "Community 334"
+### Community 335 - "Community 335"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 335 - "Community 335"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 336 - "Community 336"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 337 - "Community 337"
 Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 338 - "Community 338"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
 ### Community 339 - "Community 339"
-Cohesion: 0.7
-Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
-
-### Community 340 - "Community 340"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 340 - "Community 340"
+Cohesion: 0.7
+Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 341 - "Community 341"
 Cohesion: 0.4
@@ -3317,88 +3317,88 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 344 - "Community 344"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 345 - "Community 345"
 Cohesion: 0.5
-Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 346 - "Community 346"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
 ### Community 347 - "Community 347"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 348 - "Community 348"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 349 - "Community 349"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 350 - "Community 350"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 351 - "Community 351"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 352 - "Community 352"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
-
-### Community 353 - "Community 353"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 353 - "Community 353"
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 354 - "Community 354"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 355 - "Community 355"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 356 - "Community 356"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 356 - "Community 356"
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+
 ### Community 357 - "Community 357"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 358 - "Community 358"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 358 - "Community 358"
+### Community 359 - "Community 359"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 359 - "Community 359"
+### Community 360 - "Community 360"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 360 - "Community 360"
+### Community 361 - "Community 361"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 361 - "Community 361"
+### Community 362 - "Community 362"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 362 - "Community 362"
+### Community 363 - "Community 363"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 363 - "Community 363"
+### Community 364 - "Community 364"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 364 - "Community 364"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 365 - "Community 365"
 Cohesion: 0.5
@@ -3421,72 +3421,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 370 - "Community 370"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 371 - "Community 371"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 371 - "Community 371"
+### Community 372 - "Community 372"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 372 - "Community 372"
+### Community 373 - "Community 373"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 373 - "Community 373"
+### Community 374 - "Community 374"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 375 - "Community 375"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 376 - "Community 376"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 377 - "Community 377"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 378 - "Community 378"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 379 - "Community 379"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 379 - "Community 379"
+### Community 380 - "Community 380"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 380 - "Community 380"
+### Community 381 - "Community 381"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 381 - "Community 381"
+### Community 382 - "Community 382"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 382 - "Community 382"
+### Community 383 - "Community 383"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 383 - "Community 383"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 384 - "Community 384"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 385 - "Community 385"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 386 - "Community 386"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 387 - "Community 387"
 Cohesion: 0.5
@@ -3497,20 +3497,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 389 - "Community 389"
-Cohesion: 0.67
-Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 390 - "Community 390"
 Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
+Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
 ### Community 391 - "Community 391"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 392 - "Community 392"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 393 - "Community 393"
 Cohesion: 0.5
@@ -3521,28 +3521,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 395 - "Community 395"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 396 - "Community 396"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 396 - "Community 396"
+### Community 397 - "Community 397"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 397 - "Community 397"
+### Community 398 - "Community 398"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 398 - "Community 398"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 399 - "Community 399"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 400 - "Community 400"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 401 - "Community 401"
 Cohesion: 0.5
@@ -3557,20 +3557,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 404 - "Community 404"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 405 - "Community 405"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 406 - "Community 406"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 407 - "Community 407"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 408 - "Community 408"
 Cohesion: 0.5
@@ -3593,16 +3593,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 413 - "Community 413"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 414 - "Community 414"
 Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 415 - "Community 415"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 416 - "Community 416"
 Cohesion: 0.5
@@ -3613,12 +3613,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 418 - "Community 418"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 419 - "Community 419"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 419 - "Community 419"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 420 - "Community 420"
 Cohesion: 0.5
@@ -3629,32 +3629,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 422 - "Community 422"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 423 - "Community 423"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 423 - "Community 423"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 424 - "Community 424"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 425 - "Community 425"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 426 - "Community 426"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 427 - "Community 427"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 428 - "Community 428"
 Cohesion: 0.67
-Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
 ### Community 429 - "Community 429"
 Cohesion: 0.5
@@ -12070,6 +12070,6 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 3` be split into smaller, more focused modules?**
   _Cohesion score 0.11 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**
-  _Cohesion score 0.06 - nodes in this community are weakly interconnected._
-- **Should `Community 5` be split into smaller, more focused modules?**
   _Cohesion score 0.08 - nodes in this community are weakly interconnected._
+- **Should `Community 5` be split into smaller, more focused modules?**
+  _Cohesion score 0.06 - nodes in this community are weakly interconnected._

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1975
-- Graph nodes: 7041
-- Graph edges: 7945
+- Graph nodes: 7080
+- Graph edges: 8031
 - Communities: 1903
 
 ## Graph Hotspots
@@ -17,10 +17,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 2) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 - `projectLocalEvents.ts` (53 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `posLocalStore.ts` (48 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
-- `dailyOperations.ts` (47 edges, Community 5) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `harness-inferential-review.ts` (47 edges, Community 6) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `storefrontJourneyEvents.ts` (45 edges, Community 7) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `terminalHealthPresentation.ts` (49 edges, Community 4) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
+- `posLocalStore.ts` (48 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
+- `dailyOperations.ts` (47 edges, Community 6) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `harness-inferential-review.ts` (47 edges, Community 7) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 
 ## Registered Packages
 - [Athena Webapp](packages/athena-webapp.md)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -21,7 +21,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 2) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 - `projectLocalEvents.ts` (53 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `posLocalStore.ts` (48 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
+- `terminalHealthPresentation.ts` (49 edges, Community 4) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -17,11 +17,11 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - [validation-map.json](../../../packages/storefront-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `storefrontJourneyEvents.ts` (45 edges, Community 7) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `createJourneyEvent()` (40 edges, Community 7) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 47) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storefrontJourneyEvents.ts` (45 edges, Community 8) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 8) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `getStoreConfigV2()` (17 edges, Community 49) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `checkoutSession.ts` (14 edges, Community 78) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
-- `storeConfig.ts` (14 edges, Community 47) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storeConfig.ts` (14 edges, Community 49) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/pos/application/commands/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/terminals.ts
@@ -247,6 +247,21 @@ export type TerminalRuntimeStatusInput = {
     observedAt: number;
     ready: boolean;
   };
+  appUpdate?: {
+    blockerSummary?: AppUpdateBlockerCode;
+    canApply: boolean;
+    commandExecutionId?: string;
+    commandId?: string;
+    commandIssuedAt?: number;
+    commandNonce?: string;
+    currentBuildId?: string;
+    detectorStatus: AppUpdateDetectorStatus;
+    observedAt: number;
+    pendingBuildId?: string;
+    selectedBlockerCode?: AppUpdateBlockerCode;
+    stagingStatus?: AppUpdateStagingStatus;
+    status: AppUpdateStatus;
+  };
   localStore: {
     available: boolean;
     schemaVersion?: number;
@@ -347,6 +362,26 @@ type AppSessionRecoveryStatus =
   | "retry_exhausted"
   | "stale_assertion";
 
+type AppUpdateStatus =
+  | "current"
+  | "checking"
+  | "update_ready"
+  | "update_ready_unstaged"
+  | "blocked"
+  | "applying"
+  | "detector_failed"
+  | "unknown";
+
+type AppUpdateStagingStatus = "staged" | "unstaged" | "unknown";
+
+type AppUpdateDetectorStatus = "ok" | "failed" | "unknown";
+
+type AppUpdateBlockerCode =
+  | "active_sale"
+  | "active_command"
+  | "resume_required"
+  | "unknown";
+
 const TERMINAL_NOT_ACTIVE_FOR_STORE_MESSAGE =
   "This terminal is not active for this store.";
 const REDACTED_DIAGNOSTIC_VALUE = "[redacted]";
@@ -398,6 +433,7 @@ export async function submitTerminalRuntimeStatus(
     source: args.status.source,
     appSessionRecovery,
     appShell: cleanAppShell(args.status.appShell),
+    appUpdate: cleanAppUpdate(args.status.appUpdate),
     ...omitUndefined({
       appVersion: cleanOptionalString(args.status.appVersion, 80),
       buildSha: cleanOptionalString(args.status.buildSha, 80),
@@ -530,6 +566,38 @@ function cleanAppShell(appShell: TerminalRuntimeStatusInput["appShell"]) {
     observedAt: positiveTimestamp(appShell.observedAt) ?? Date.now(),
     ready: appShell.ready === true,
   };
+}
+
+function cleanAppUpdate(appUpdate: TerminalRuntimeStatusInput["appUpdate"]) {
+  if (!appUpdate) return undefined;
+
+  return omitUndefined({
+    blockerSummary: appUpdateBlockerCodes.has(appUpdate.blockerSummary)
+      ? appUpdate.blockerSummary
+      : undefined,
+    canApply: appUpdate.canApply === true,
+    commandExecutionId: cleanOptionalString(appUpdate.commandExecutionId, 120),
+    commandId: cleanOptionalString(appUpdate.commandId, 120),
+    commandIssuedAt: positiveTimestamp(appUpdate.commandIssuedAt),
+    commandNonce: cleanOptionalString(appUpdate.commandNonce, 120),
+    currentBuildId: cleanOptionalString(appUpdate.currentBuildId, 120),
+    detectorStatus: appUpdateDetectorStatuses.has(appUpdate.detectorStatus)
+      ? appUpdate.detectorStatus
+      : "unknown",
+    observedAt: positiveTimestamp(appUpdate.observedAt) ?? Date.now(),
+    pendingBuildId: cleanOptionalString(appUpdate.pendingBuildId, 120),
+    selectedBlockerCode: appUpdateBlockerCodes.has(
+      appUpdate.selectedBlockerCode,
+    )
+      ? appUpdate.selectedBlockerCode
+      : undefined,
+    stagingStatus: appUpdateStagingStatuses.has(appUpdate.stagingStatus)
+      ? appUpdate.stagingStatus
+      : undefined,
+    status: appUpdateStatuses.has(appUpdate.status)
+      ? appUpdate.status
+      : "unknown",
+  });
 }
 
 function cleanOptionalString(value: string | undefined, maxLength: number) {
@@ -677,6 +745,38 @@ const appSessionRecoveryStatuses = new Set<AppSessionRecoveryStatus>([
   "blocked_store_mismatch",
   "retry_exhausted",
   "stale_assertion",
+]);
+
+const appUpdateStatuses = new Set<AppUpdateStatus>([
+  "current",
+  "checking",
+  "update_ready",
+  "update_ready_unstaged",
+  "blocked",
+  "applying",
+  "detector_failed",
+  "unknown",
+]);
+
+const appUpdateStagingStatuses = new Set<AppUpdateStagingStatus | undefined>([
+  "staged",
+  "unstaged",
+  "unknown",
+  undefined,
+]);
+
+const appUpdateDetectorStatuses = new Set<AppUpdateDetectorStatus>([
+  "ok",
+  "failed",
+  "unknown",
+]);
+
+const appUpdateBlockerCodes = new Set<AppUpdateBlockerCode | undefined>([
+  "active_sale",
+  "active_command",
+  "resume_required",
+  "unknown",
+  undefined,
 ]);
 
 function positiveTimestamp(value: number | undefined) {

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
@@ -232,6 +232,215 @@ describe("terminal health queries", () => {
     expect(summary?.recoveryPreview?.terminalActions).toEqual([]);
   });
 
+  it("derives app update status from fresh runtime evidence", async () => {
+    for (const [runtimeStatus, expectedStatus] of [
+      ["current", "current"],
+      ["update_ready", "update_ready"],
+      ["blocked", "blocked"],
+      ["detector_failed", "detector_failed"],
+    ] as const) {
+      const ctx = buildQueryCtx({
+        posTerminal: [buildTerminal()],
+        posTerminalRuntimeStatus: [
+          buildRuntimeStatus({
+            appUpdate: {
+              canApply: runtimeStatus === "update_ready",
+              currentBuildId: "build-current",
+              detectorStatus: "ok",
+              observedAt: now - 1_000,
+              pendingBuildId: "build-next",
+              selectedBlockerCode:
+                runtimeStatus === "blocked" ? "active_sale" : undefined,
+              stagingStatus:
+                runtimeStatus === "update_ready" ? "staged" : "unknown",
+              status: runtimeStatus,
+            },
+          }),
+        ],
+      });
+
+      const summary = await getTerminalHealthSummary(ctx, {
+        now,
+        storeId,
+        terminalId,
+      });
+
+      expect(summary?.recoveryPreview?.appUpdate).toEqual(
+        expect.objectContaining({
+          currentBuildId: "build-current",
+          evidenceFresh: true,
+          pendingBuildId: "build-next",
+          status: expectedStatus,
+        }),
+      );
+      expect(summary?.recoveryPreview?.terminalActions).toEqual([]);
+    }
+  });
+
+  it("treats missing and stale app update evidence as unknown or stale", async () => {
+    const missingCtx = buildQueryCtx({
+      posTerminal: [buildTerminal()],
+      posTerminalRuntimeStatus: [buildRuntimeStatus()],
+    });
+    const missingSummary = await getTerminalHealthSummary(missingCtx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(missingSummary?.recoveryPreview?.appUpdate).toEqual({
+      evidenceFresh: false,
+      status: "unknown",
+    });
+
+    const staleCtx = buildQueryCtx({
+      posTerminal: [buildTerminal()],
+      posTerminalRuntimeStatus: [
+        buildRuntimeStatus({
+          appUpdate: {
+            canApply: true,
+            currentBuildId: "build-current",
+            detectorStatus: "ok",
+            observedAt: now - 10 * 60_000,
+            pendingBuildId: "build-next",
+            stagingStatus: "staged",
+            status: "update_ready",
+          },
+          receivedAt: now - 10 * 60_000,
+        }),
+      ],
+    });
+    const staleSummary = await getTerminalHealthSummary(staleCtx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(staleSummary?.recoveryPreview?.appUpdate).toEqual(
+      expect.objectContaining({
+        evidenceFresh: false,
+        status: "stale",
+      }),
+    );
+  });
+
+  it("does not treat replayed stale app update evidence as command-correlated", async () => {
+    const ctx = buildQueryCtx({
+      posTerminal: [buildTerminal()],
+      posTerminalRecoveryCommand: [
+        {
+          _id: "command-update" as Id<"posTerminalRecoveryCommand">,
+          _creationTime: now - 5_000,
+          commandContext: {
+            expectedBlockerType: "app_update",
+            reason: "Support requested an app update check.",
+          },
+          commandType: "update_app",
+          expectedEvidence: {
+            appUpdateStatus: "current",
+          },
+          expiresAt: now + 10_000,
+          issuedAt: now - 5_000,
+          issuedByUserId: "user-1" as Id<"athenaUser">,
+          status: "completed",
+          storeId,
+          terminalId,
+          verificationStatus: "runtime_verification_ready",
+        } as unknown as Doc<"posTerminalRecoveryCommand">,
+      ],
+      posTerminalRuntimeStatus: [
+        buildRuntimeStatus({
+          appUpdate: {
+            canApply: false,
+            commandExecutionId: "older-command",
+            commandIssuedAt: now - 20_000,
+            currentBuildId: "build-current",
+            detectorStatus: "ok",
+            observedAt: now - 10 * 60_000,
+            stagingStatus: "unknown",
+            status: "current",
+          },
+          receivedAt: now - 10 * 60_000,
+        }),
+      ],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.recoveryPreview?.commandStatus).toEqual(
+      expect.objectContaining({
+        commandType: "update_app",
+        verificationStatus: "runtime_verification_ready",
+      }),
+    );
+    expect(summary?.recoveryPreview?.appUpdate).toEqual(
+      expect.objectContaining({
+        commandCorrelated: false,
+        evidenceFresh: false,
+        status: "stale",
+      }),
+    );
+  });
+
+  it("marks fresh flat app update commandExecutionId evidence as command-correlated", async () => {
+    const ctx = buildQueryCtx({
+      posTerminal: [buildTerminal()],
+      posTerminalRecoveryCommand: [
+        {
+          _id: "command-update" as Id<"posTerminalRecoveryCommand">,
+          _creationTime: now - 5_000,
+          commandContext: {
+            expectedBlockerType: "app_update",
+            reason: "Support requested an app update check.",
+          },
+          commandType: "update_app",
+          expectedEvidence: {
+            appUpdateCommandExecutionId: "execution-1",
+          },
+          expiresAt: now + 10_000,
+          issuedAt: now - 5_000,
+          issuedByUserId: "user-1" as Id<"athenaUser">,
+          status: "completed",
+          storeId,
+          terminalId,
+          verificationStatus: "runtime_verification_ready",
+        } as unknown as Doc<"posTerminalRecoveryCommand">,
+      ],
+      posTerminalRuntimeStatus: [
+        buildRuntimeStatus({
+          appUpdate: {
+            canApply: false,
+            commandExecutionId: "execution-1",
+            commandIssuedAt: now - 5_000,
+            currentBuildId: "build-current",
+            detectorStatus: "ok",
+            observedAt: now - 1_000,
+            stagingStatus: "unknown",
+            status: "current",
+          },
+        }),
+      ],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.recoveryPreview?.appUpdate).toEqual(
+      expect.objectContaining({
+        commandCorrelated: true,
+        evidenceFresh: true,
+        status: "current",
+      }),
+    );
+  });
+
   it("includes recovery preview on terminal health roster summaries", async () => {
     const ctx = buildQueryCtx({
       posTerminal: [buildTerminal()],

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.ts
@@ -114,6 +114,7 @@ type ActiveRegisterSessionLinkStatus = Extract<
 >;
 
 export type TerminalRecoveryPreview = {
+  appUpdate: TerminalAppUpdatePreview;
   readiness: TerminalRecoveryReadiness;
   runtimeFresh: boolean;
   evidence: {
@@ -126,6 +127,7 @@ export type TerminalRecoveryPreview = {
     skippedConflictIds: Array<Id<"posLocalSyncConflict">>;
   };
   commandStatus: {
+    appUpdateCommandExecutionId?: string;
     commandId?: Id<"posTerminalRecoveryCommand">;
     commandType: TerminalRecoveryCommandType;
     label: string;
@@ -146,6 +148,26 @@ export type TerminalRecoveryPreview = {
       | "cloud_repair";
     type: TerminalHealthAttentionReason["type"] | "unsafe_cloud_conflict";
   }>;
+};
+
+export type TerminalAppUpdateStatus =
+  | "applying"
+  | "blocked"
+  | "current"
+  | "detector_failed"
+  | "stale"
+  | "unknown"
+  | "update_ready"
+  | "update_ready_unstaged";
+
+export type TerminalAppUpdatePreview = {
+  commandCorrelated?: boolean;
+  currentBuildId?: string;
+  evidenceFresh: boolean;
+  observedAt?: number;
+  pendingBuildId?: string;
+  status: TerminalAppUpdateStatus;
+  summary?: string;
 };
 
 export async function listTerminals(
@@ -469,6 +491,12 @@ async function buildTerminalRecoveryPreview(
     activeRegisterSession && healthyIdle && runtimeHasSaleAuthority(args.runtimeStatus);
 
   return {
+    appUpdate: buildTerminalAppUpdatePreview({
+      commandStatus,
+      runtimeAgeMs: args.runtimeAgeMs,
+      runtimeFresh,
+      runtimeStatus: args.runtimeStatus,
+    }),
     readiness: ableToTransactNow
       ? "able_to_transact_now"
       : manualReview.length > 0
@@ -490,6 +518,159 @@ async function buildTerminalRecoveryPreview(
     terminalActions,
     manualReview,
   };
+}
+
+function buildTerminalAppUpdatePreview(args: {
+  commandStatus: TerminalRecoveryPreview["commandStatus"];
+  runtimeAgeMs: number | null;
+  runtimeFresh: boolean;
+  runtimeStatus: Doc<"posTerminalRuntimeStatus"> | null;
+}): TerminalAppUpdatePreview {
+  const evidence = readRuntimeAppUpdateEvidence(args.runtimeStatus);
+  if (!evidence) {
+    return {
+      evidenceFresh: false,
+      status: "unknown",
+    };
+  }
+
+  if (!args.runtimeFresh || args.runtimeAgeMs === null) {
+    return {
+      commandCorrelated: isAppUpdateEvidenceCommandCorrelated(
+        evidence,
+        args.commandStatus,
+      ),
+      currentBuildId: readString(evidence.currentBuildId ?? evidence.currentBuildSha),
+      evidenceFresh: false,
+      observedAt: readNumber(evidence.observedAt),
+      pendingBuildId: readString(evidence.pendingBuildId ?? evidence.latestBuildId),
+      status: "stale",
+      summary:
+        "The latest app update evidence is stale. Send Update app to ask the checkout station to check again.",
+    };
+  }
+
+  const status = normalizeRuntimeAppUpdateStatus(readString(evidence.status));
+  return {
+    commandCorrelated: isAppUpdateEvidenceCommandCorrelated(
+      evidence,
+      args.commandStatus,
+    ),
+    currentBuildId: readString(evidence.currentBuildId ?? evidence.currentBuildSha),
+    evidenceFresh: true,
+    observedAt: readNumber(evidence.observedAt),
+    pendingBuildId: readString(evidence.pendingBuildId ?? evidence.latestBuildId),
+    status,
+    summary: getRuntimeAppUpdateSummary(status, evidence),
+  };
+}
+
+function readRuntimeAppUpdateEvidence(
+  runtimeStatus: Doc<"posTerminalRuntimeStatus"> | null,
+) {
+  if (!runtimeStatus) {
+    return null;
+  }
+
+  const evidence = (runtimeStatus as unknown as { appUpdate?: unknown }).appUpdate;
+  return evidence && typeof evidence === "object"
+    ? (evidence as Record<string, unknown>)
+    : null;
+}
+
+function normalizeRuntimeAppUpdateStatus(
+  status?: string,
+): TerminalAppUpdateStatus {
+  switch (status) {
+    case "applying":
+      return "applying";
+    case "blocked":
+      return "blocked";
+    case "current":
+      return "current";
+    case "detector-failed":
+    case "detector_failed":
+      return "detector_failed";
+    case "ready":
+    case "staged":
+    case "update_ready":
+      return "update_ready";
+    case "ready_unstaged":
+    case "update_ready_unstaged":
+      return "update_ready_unstaged";
+    case "stale":
+      return "stale";
+    case "unknown":
+    default:
+      return "unknown";
+  }
+}
+
+function getRuntimeAppUpdateSummary(
+  status: TerminalAppUpdateStatus,
+  evidence: Record<string, unknown>,
+) {
+  if (status === "blocked") {
+    return normalizeRuntimeAppUpdateBlockerSummary(
+      readString(evidence.blockerSummary),
+    );
+  }
+  if (status === "current") {
+    return "This checkout station reports the current app build.";
+  }
+  if (status === "update_ready") {
+    return "An app update is ready. The checkout station will refresh only when local work is safe.";
+  }
+  if (status === "update_ready_unstaged") {
+    return "An app update is available but not ready to refresh yet.";
+  }
+  if (status === "applying") {
+    return "The checkout station accepted the update. Waiting for a fresh check-in.";
+  }
+  if (status === "detector_failed") {
+    return "Athena could not confirm this checkout station's app update state.";
+  }
+  return "This checkout station has not reported app update readiness.";
+}
+
+function normalizeRuntimeAppUpdateBlockerSummary(value?: string) {
+  if (!value) {
+    return "Refresh is blocked by active checkout work.";
+  }
+  if (/sale|payment|checkout|drawer|sync|review|work/i.test(value)) {
+    return "Refresh is blocked by active checkout work.";
+  }
+  return "Refresh is blocked by local app work.";
+}
+
+function isAppUpdateEvidenceCommandCorrelated(
+  evidence: Record<string, unknown>,
+  commandStatus: TerminalRecoveryPreview["commandStatus"],
+) {
+  if (!commandStatus || String(commandStatus.commandType) !== "update_app") {
+    return false;
+  }
+
+  const command =
+    evidence.command && typeof evidence.command === "object"
+      ? (evidence.command as Record<string, unknown>)
+      : null;
+  const executionId =
+    readString(evidence.commandExecutionId) ?? readString(command?.executionId);
+  const expectedExecutionId = commandStatus.appUpdateCommandExecutionId;
+  if (executionId && expectedExecutionId) {
+    return executionId === expectedExecutionId;
+  }
+
+  return false;
+}
+
+function readString(value: unknown) {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 async function buildTerminalRecoveryCommandStatus(
@@ -518,6 +699,8 @@ async function buildTerminalRecoveryCommandStatus(
   }
 
   return {
+    appUpdateCommandExecutionId:
+      latestCommand.expectedEvidence.appUpdateCommandExecutionId,
     commandId: latestCommand._id,
     commandType: latestCommand.commandType,
     label: getTerminalRecoveryCommandLabel(latestCommand.commandType),
@@ -541,8 +724,12 @@ function getTerminalRecoveryCommandStatusForPreview(
   return command.status;
 }
 
-function getTerminalRecoveryCommandLabel(commandType: TerminalRecoveryCommandType) {
+function getTerminalRecoveryCommandLabel(
+  commandType: TerminalRecoveryCommandType | string,
+) {
   switch (commandType) {
+    case "update_app":
+      return "Update app";
     case "repair_terminal_seed":
       return "Terminal setup repair";
     case "clear_stale_drawer_authority":
@@ -555,6 +742,8 @@ function getTerminalRecoveryCommandLabel(commandType: TerminalRecoveryCommandTyp
       return "Sync retry";
     case "report_diagnostics":
       return "Diagnostics request";
+    default:
+      return "Terminal command";
   }
 }
 

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts
@@ -99,6 +99,241 @@ describe("terminal command service", () => {
     expect(repository.insertCommand).not.toHaveBeenCalled();
   });
 
+  it("issues update_app with command-correlated expected evidence", async () => {
+    const repository = buildRepository();
+
+    const result = await issueTerminalRecoveryCommand(repository, {
+      commandType: "update_app",
+      expectedEvidence: {
+        appUpdateCommandExecutionId: "execution-1",
+        appUpdateStatus: "current",
+      },
+      issuedAt: now,
+      issuedByUserId: "user-1" as Id<"athenaUser">,
+      commandContext: {
+        reason: "Support requested app update.",
+      },
+      storeId,
+      terminalId,
+    });
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        commandType: "update_app",
+        expectedEvidence: {
+          appUpdateCommandExecutionId: "execution-1",
+          appUpdateStatus: "current",
+        },
+        status: "pending",
+      },
+    });
+  });
+
+  it("dedupes active update_app work without freezing support-side build metadata", async () => {
+    const existingCommand = buildCommand({
+      commandType: "update_app",
+      commandContext: {
+        reason: "Support requested app update.",
+      },
+      expectedEvidence: {
+        appUpdateStatus: "current",
+      },
+      status: "claimed",
+    });
+    const repository = buildRepository({
+      commands: [existingCommand],
+    });
+
+    const result = await issueTerminalRecoveryCommand(repository, {
+      commandType: "update_app",
+      expectedEvidence: {
+        appUpdateStatus: "update_ready",
+      },
+      issuedAt: now,
+      issuedByUserId: "user-2" as Id<"athenaUser">,
+      commandContext: {
+        reason: "Support requested app update after a newer check-in.",
+      },
+      storeId,
+      terminalId,
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: existingCommand,
+    });
+    expect(repository.insertCommand).not.toHaveBeenCalled();
+  });
+
+  it("allows update_app retry after completed no-op evaluation", async () => {
+    const repository = buildRepository({
+      commands: [
+        buildCommand({
+          commandType: "update_app",
+          commandContext: {
+            reason: "Support requested app update.",
+          },
+          expectedEvidence: {
+            appUpdateStatus: "current",
+          },
+          status: "completed",
+          verificationStatus: "verified",
+        }),
+      ],
+    });
+
+    const result = await issueTerminalRecoveryCommand(repository, {
+      commandType: "update_app",
+      expectedEvidence: {
+        appUpdateStatus: "current",
+      },
+      issuedAt: now + 1_000,
+      issuedByUserId: "user-2" as Id<"athenaUser">,
+      commandContext: {
+        reason: "Support requested app update again.",
+      },
+      storeId,
+      terminalId,
+    });
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        _id: "command-2",
+        commandType: "update_app",
+        status: "pending",
+      },
+    });
+    expect(repository.insertCommand).toHaveBeenCalled();
+  });
+
+  it("requires the update_app claim execution id for acknowledgement", async () => {
+    const repository = buildRepository({
+      commands: [
+        buildCommand({
+          commandType: "update_app",
+          status: "pending",
+        }),
+      ],
+    });
+
+    const claimed = await claimTerminalRecoveryCommand(repository, {
+      claimedAt: now + 100,
+      commandId: "command-1" as Id<"posTerminalRecoveryCommand">,
+      storeId,
+      terminalId,
+    });
+
+    expect(claimed).toMatchObject({
+      kind: "ok",
+      data: {
+        executionId: "command-1:2000100",
+        status: "claimed",
+      },
+    });
+
+    await expect(
+      acknowledgeTerminalRecoveryCommand(repository, {
+        acknowledgedAt: now + 200,
+        commandId: "command-1" as Id<"posTerminalRecoveryCommand">,
+        executionId: "stale-execution",
+        result: "completed",
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toMatchObject({
+      error: {
+        code: "precondition_failed",
+        message: "This terminal recovery command claim is stale.",
+      },
+      kind: "user_error",
+    });
+
+    await expect(
+      acknowledgeTerminalRecoveryCommand(repository, {
+        acknowledgedAt: now + 300,
+        commandId: "command-1" as Id<"posTerminalRecoveryCommand">,
+        executionId: "command-1:2000100",
+        result: "completed",
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toMatchObject({
+      kind: "ok",
+      data: {
+        status: "completed",
+      },
+    });
+  });
+
+  it("rejects concurrent update_app claims after the first consumer claims it", async () => {
+    const repository = buildRepository({
+      commands: [
+        buildCommand({
+          commandType: "update_app",
+          status: "pending",
+        }),
+      ],
+    });
+
+    await expect(
+      claimTerminalRecoveryCommand(repository, {
+        claimedAt: now + 100,
+        commandId: "command-1" as Id<"posTerminalRecoveryCommand">,
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toMatchObject({
+      kind: "ok",
+      data: {
+        executionId: "command-1:2000100",
+      },
+    });
+
+    await expect(
+      claimTerminalRecoveryCommand(repository, {
+        claimedAt: now + 200,
+        commandId: "command-1" as Id<"posTerminalRecoveryCommand">,
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toMatchObject({
+      error: {
+        code: "precondition_failed",
+        message: "This terminal recovery command is already claimed.",
+      },
+      kind: "user_error",
+    });
+  });
+
+  it("rejects secret-like update_app expected evidence before audit persistence", async () => {
+    const repository = buildRepository();
+
+    const result = await issueTerminalRecoveryCommand(repository, {
+      commandType: "update_app",
+      expectedEvidence: {
+        appUpdateStatus: "current",
+        syncSecret: "do-not-store",
+      } as never,
+      issuedAt: now,
+      issuedByUserId: "user-1" as Id<"athenaUser">,
+      commandContext: {
+        reason: "Support requested app update.",
+      },
+      storeId,
+      terminalId,
+    });
+
+    expect(result).toMatchObject({
+      error: {
+        code: "validation_failed",
+      },
+      kind: "user_error",
+    });
+    expect(repository.insertCommand).not.toHaveBeenCalled();
+  });
+
   it("returns an equivalent active command instead of inserting duplicate work", async () => {
     const existingCommand = buildCommand({
       commandType: "repair_terminal_seed",

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts
@@ -70,6 +70,12 @@ export async function issueTerminalRecoveryCommand(
       message: "Terminal recovery commands can only store non-secret audit data.",
     });
   }
+  if (containsSecretLikeField(args.expectedEvidence)) {
+    return userError({
+      code: "validation_failed",
+      message: "Terminal recovery commands can only store non-secret audit data.",
+    });
+  }
 
   const commandContext = pruneUndefined(args.commandContext);
   const expectedEvidence = pruneUndefined(args.expectedEvidence);
@@ -78,6 +84,17 @@ export async function issueTerminalRecoveryCommand(
     terminalId: args.terminalId,
   });
   for (const command of existingCommands) {
+    if (
+      args.commandType === "update_app" &&
+      command.commandType === "update_app" &&
+      isUpdateAppActiveCommand(command)
+    ) {
+      if (command.expiresAt <= args.issuedAt) {
+        await repository.patchCommand(command._id, { status: "expired" });
+        continue;
+      }
+      return ok(command);
+    }
     if (!isEquivalentCommand(command, {
       commandContext,
       commandType: args.commandType,
@@ -125,14 +142,18 @@ export async function listClaimableTerminalRecoveryCommands(
   });
   const claimable: Doc<"posTerminalRecoveryCommand">[] = [];
   for (const command of commands) {
-    if (command.expiresAt <= args.now && command.status === "pending") {
+    if (
+      command.expiresAt <= args.now &&
+      (command.status === "pending" || command.status === "claimed")
+    ) {
       await repository.patchCommand(command._id, { status: "expired" });
       continue;
     }
     if (
       command.storeId === args.storeId &&
       command.terminalId === args.terminalId &&
-      (command.status === "pending" || command.status === "claimed") &&
+      (command.status === "pending" ||
+        (command.status === "claimed" && command.commandType !== "update_app")) &&
       command.expiresAt > args.now
     ) {
       claimable.push(command);
@@ -167,17 +188,51 @@ export async function claimTerminalRecoveryCommand(
       message: "This terminal recovery command is no longer claimable.",
     });
   }
-
-  if (command.status === "pending") {
-    await repository.patchCommand(command._id, {
-      claimedAt: args.claimedAt,
-      status: "claimed",
+  if (command.commandType === "update_app" && command.status === "claimed") {
+    return userError({
+      code: "precondition_failed",
+      message: "This terminal recovery command is already claimed.",
     });
   }
 
+  if (command.status === "pending") {
+    const executionId =
+      command.commandType === "update_app"
+        ? buildExecutionId(command._id, args.claimedAt)
+        : undefined;
+    await repository.patchCommand(command._id, pruneUndefined({
+      claimedAt: args.claimedAt,
+      executionId,
+      expectedEvidence:
+        command.commandType === "update_app" &&
+        command.expectedEvidence.appUpdateCommandExecutionId === undefined
+          ? {
+              ...command.expectedEvidence,
+              appUpdateCommandExecutionId: executionId,
+            }
+          : undefined,
+      status: "claimed",
+    }));
+  }
+
+  const executionId =
+    command.executionId ??
+    (command.commandType === "update_app"
+      ? buildExecutionId(command._id, args.claimedAt)
+      : undefined);
+  const expectedEvidence =
+    command.commandType === "update_app" &&
+    command.expectedEvidence.appUpdateCommandExecutionId === undefined
+      ? {
+          ...command.expectedEvidence,
+          appUpdateCommandExecutionId: executionId,
+        }
+      : command.expectedEvidence;
   return ok({
     ...command,
     claimedAt: command.claimedAt ?? args.claimedAt,
+    executionId,
+    expectedEvidence,
     status: "claimed",
   });
 }
@@ -187,6 +242,7 @@ export async function acknowledgeTerminalRecoveryCommand(
   args: {
     acknowledgedAt: number;
     commandId: Id<"posTerminalRecoveryCommand">;
+    executionId?: string;
     message?: string;
     result: TerminalRecoveryCommandAckResult;
     storeId: Id<"store">;
@@ -202,6 +258,20 @@ export async function acknowledgeTerminalRecoveryCommand(
       code: "precondition_failed",
       message: "This terminal recovery command cannot be acknowledged.",
     });
+  }
+  if (command.commandType === "update_app") {
+    if (command.status !== "claimed") {
+      return userError({
+        code: "precondition_failed",
+        message: "This terminal recovery command must be claimed before acknowledgement.",
+      });
+    }
+    if (!command.executionId || args.executionId !== command.executionId) {
+      return userError({
+        code: "precondition_failed",
+        message: "This terminal recovery command claim is stale.",
+      });
+    }
   }
 
   const status = args.result;
@@ -289,6 +359,20 @@ function runtimeMatchesExpectedEvidence(
   expectedEvidence: TerminalRecoveryExpectedEvidence,
 ) {
   if (
+    expectedEvidence.appUpdateStatus !== undefined &&
+    getRuntimeAppUpdateEvidence(runtimeStatus).status !==
+      expectedEvidence.appUpdateStatus
+  ) {
+    return false;
+  }
+  if (
+    expectedEvidence.appUpdateCommandExecutionId !== undefined &&
+    getRuntimeAppUpdateEvidence(runtimeStatus).commandExecutionId !==
+      expectedEvidence.appUpdateCommandExecutionId
+  ) {
+    return false;
+  }
+  if (
     expectedEvidence.localStoreAvailable !== undefined &&
     runtimeStatus.localStore.available !== expectedEvidence.localStoreAvailable
   ) {
@@ -347,6 +431,24 @@ function normalizeOptionalHealthyStatus(status: string | undefined) {
   return status ?? "healthy";
 }
 
+function getRuntimeAppUpdateEvidence(
+  runtimeStatus: Doc<"posTerminalRuntimeStatus">,
+): {
+  commandExecutionId?: string;
+  status?: TerminalRecoveryExpectedEvidence["appUpdateStatus"];
+} {
+  const evidence = (
+    runtimeStatus as Doc<"posTerminalRuntimeStatus"> & {
+      appUpdate?: {
+        commandExecutionId?: string;
+        status?: TerminalRecoveryExpectedEvidence["appUpdateStatus"];
+      };
+    }
+  ).appUpdate;
+
+  return evidence ?? {};
+}
+
 function loadScopedCommand(
   repository: TerminalRecoveryCommandRepository,
   args: {
@@ -397,6 +499,17 @@ function isActiveCommand(command: Doc<"posTerminalRecoveryCommand">) {
     command.status === "claimed" ||
     command.verificationStatus === "runtime_verification_ready"
   );
+}
+
+function isUpdateAppActiveCommand(command: Doc<"posTerminalRecoveryCommand">) {
+  return command.status === "pending" || command.status === "claimed";
+}
+
+function buildExecutionId(
+  commandId: Id<"posTerminalRecoveryCommand">,
+  claimedAt: number,
+) {
+  return `${commandId}:${claimedAt}`;
 }
 
 function containsSecretLikeField(value: unknown): boolean {

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/types.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/types.ts
@@ -7,6 +7,7 @@ export const TERMINAL_RECOVERY_COMMAND_TYPES = [
   "refresh_staff_authority",
   "refresh_snapshots",
   "report_diagnostics",
+  "update_app",
 ] as const;
 
 export type TerminalRecoveryCommandType =
@@ -45,6 +46,15 @@ export type TerminalRecoveryCommandPayload = {
 };
 
 export type TerminalRecoveryExpectedEvidence = {
+  appUpdateCommandExecutionId?: string;
+  appUpdateStatus?:
+    | "current"
+    | "update_ready"
+    | "update_ready_unstaged"
+    | "blocked"
+    | "applying"
+    | "detector_failed"
+    | "unknown";
   drawerAuthorityStatus?: "healthy" | "blocked";
   localRegisterSessionId?: string;
   localStoreAvailable?: boolean;

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -460,6 +460,81 @@ describe("submitTerminalRuntimeStatus", () => {
     );
   });
 
+  it("persists sanitized app-update runtime evidence", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
+      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    );
+
+    await submitTerminalRuntimeStatus(
+      { db: null as never } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        status: {
+          ...buildRuntimeStatus(),
+          appUpdate: {
+            blockerSummary: "active_sale",
+            canApply: false,
+            commandExecutionId: "exec-123",
+            commandIssuedAt: 90,
+            commandNonce: "nonce-abc",
+            currentBuildId: " build-current ",
+            detectorStatus: "ok",
+            observedAt: 100,
+            pendingBuildId: "build-next",
+            selectedBlockerCode: "active_sale",
+            stagingStatus: "staged",
+            status: "blocked",
+          },
+        },
+      },
+    );
+
+    expect(vi.mocked(upsertLatestRuntimeStatus)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        appUpdate: {
+          blockerSummary: "active_sale",
+          canApply: false,
+          commandExecutionId: "exec-123",
+          commandIssuedAt: 90,
+          commandNonce: "nonce-abc",
+          currentBuildId: "build-current",
+          detectorStatus: "ok",
+          observedAt: 100,
+          pendingBuildId: "build-next",
+          selectedBlockerCode: "active_sale",
+          stagingStatus: "staged",
+          status: "blocked",
+        },
+      }),
+    );
+  });
+
+  it("clears stale app-update evidence when older clients omit it", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
+      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    );
+
+    await submitTerminalRuntimeStatus(
+      { db: null as never } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        status: buildRuntimeStatus(),
+      },
+    );
+
+    expect(vi.mocked(upsertLatestRuntimeStatus)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        appUpdate: undefined,
+      }),
+    );
+  });
+
   it("clears stale app-session recovery status when runtime check-ins omit it", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
     vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   deleteTerminalCommand: vi.fn(),
   getTerminalHealthSummaryQuery: vi.fn(),
   getTerminalByFingerprintQuery: vi.fn(),
+  getLatestRuntimeStatusForTerminal: vi.fn(),
   issueTerminalRecoveryCommandService: vi.fn(),
   listClaimableTerminalRecoveryCommands: vi.fn(),
   listTerminalHealthSummariesQuery: vi.fn(),
@@ -68,6 +69,10 @@ vi.mock("../application/terminalRecovery/terminalCommandService", () => ({
 vi.mock("../infrastructure/repositories/terminalRecoveryRepository", () => ({
   createTerminalRecoveryCommandRepository:
     mocks.createTerminalRecoveryCommandRepository,
+}));
+
+vi.mock("../infrastructure/repositories/terminalRepository", () => ({
+  getLatestRuntimeStatusForTerminal: mocks.getLatestRuntimeStatusForTerminal,
 }));
 
 vi.mock("../../remoteAssist/infrastructure/remoteAssistRepository", () => ({
@@ -183,6 +188,7 @@ describe("POS terminal public mutations", () => {
     mocks.getTerminalByFingerprintQuery.mockResolvedValue(null);
     mocks.listTerminalHealthSummariesQuery.mockResolvedValue([]);
     mocks.getTerminalHealthSummaryQuery.mockResolvedValue(null);
+    mocks.getLatestRuntimeStatusForTerminal.mockResolvedValue(null);
     mocks.createTerminalRecoveryCommandRepository.mockReturnValue({
       repository: true,
     });
@@ -891,6 +897,77 @@ describe("POS terminal public mutations", () => {
     );
   });
 
+  it("accepts only structured app-update evidence in runtime check-ins", async () => {
+    const ctx = buildCtx({
+      terminal: {
+        _id: "terminal-1",
+        storeId: "store-1",
+        status: "active",
+        registeredByUserId: "athena-user-2",
+        syncSecretHash: SYNC_SECRET_HASH,
+      },
+    });
+
+    await getHandler(submitTerminalRuntimeStatus)(ctx as never, {
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      syncSecretHash: "sync-secret-1",
+      status: buildRuntimeStatus({
+        appUpdate: {
+          canApply: false,
+          command: { localPayload: { staffProofToken: "raw-proof" } },
+          commandExecutionId: "exec-123",
+          commandIssuedAt: 90,
+          commandNonce: "nonce-abc",
+          currentBuildId: "build-current",
+          detectorStatus: "ok",
+          observedAt: 100,
+          pendingBuildId: "build-next",
+          selectedBlockerCode: "active_sale",
+          stagingStatus: "staged",
+          status: "blocked",
+          blockerLabel: "Active sale raw customer details",
+          localPayload: { customerEmail: "customer@example.com" },
+        },
+      }),
+    });
+
+    expect(mocks.submitTerminalRuntimeStatusCommand).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        status: expect.objectContaining({
+          appUpdate: {
+            blockerSummary: "active_sale",
+            canApply: false,
+            commandExecutionId: "exec-123",
+            commandIssuedAt: 90,
+            commandNonce: "nonce-abc",
+            currentBuildId: "build-current",
+            detectorStatus: "ok",
+            observedAt: 100,
+            pendingBuildId: "build-next",
+            selectedBlockerCode: "active_sale",
+            stagingStatus: "staged",
+            status: "blocked",
+          },
+        }),
+      }),
+    );
+
+    const appUpdate =
+      mocks.submitTerminalRuntimeStatusCommand.mock.calls[0]?.[1].status
+        .appUpdate;
+    expect(appUpdate).not.toEqual(
+      expect.objectContaining({
+        blockerLabel: expect.anything(),
+        localPayload: expect.anything(),
+      }),
+    );
+    expect(appUpdate).not.toEqual(
+      expect.objectContaining({ command: expect.anything() }),
+    );
+  });
+
   it.each([
     {
       name: "missing terminal",
@@ -1180,6 +1257,124 @@ describe("POS terminal public mutations", () => {
       expect(result.kind).toBe("ok");
     },
   );
+
+  it("hides update_app commands from terminals that have not reported app-update runtime evidence", async () => {
+    mocks.listClaimableTerminalRecoveryCommands.mockResolvedValue([
+      buildRecoveryCommand({
+        _id: "command-repair",
+        commandType: "repair_terminal_seed",
+      }),
+      buildRecoveryCommand({
+        _id: "command-update",
+        commandType: "update_app",
+        commandContext: {
+          expectedBlockerType: "app_update",
+          reason: "Support requested an app update check.",
+        },
+        expectedEvidence: {},
+      }),
+    ]);
+    mocks.getLatestRuntimeStatusForTerminal.mockResolvedValue({
+      appUpdate: undefined,
+    });
+    const ctx = buildCtx({
+      terminal: {
+        _id: "terminal-1",
+        storeId: "store-1",
+        status: "active",
+        registeredByUserId: "athena-user-2",
+        syncSecretHash: SYNC_SECRET_HASH,
+      },
+    });
+
+    const result = await getHandler(listTerminalRecoveryCommands)(ctx as never, {
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      syncSecretHash: "sync-secret-1",
+    });
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: [expect.objectContaining({ _id: "command-repair" })],
+    });
+  });
+
+  it("lists update_app commands after the terminal reports app-update runtime evidence", async () => {
+    mocks.listClaimableTerminalRecoveryCommands.mockResolvedValue([
+      buildRecoveryCommand({
+        _id: "command-update",
+        commandType: "update_app",
+        commandContext: {
+          expectedBlockerType: "app_update",
+          reason: "Support requested an app update check.",
+        },
+        expectedEvidence: {},
+      }),
+    ]);
+    mocks.getLatestRuntimeStatusForTerminal.mockResolvedValue({
+      appUpdate: { status: "current" },
+    });
+    const ctx = buildCtx({
+      terminal: {
+        _id: "terminal-1",
+        storeId: "store-1",
+        status: "active",
+        registeredByUserId: "athena-user-2",
+        syncSecretHash: SYNC_SECRET_HASH,
+      },
+    });
+
+    const result = await getHandler(listTerminalRecoveryCommands)(ctx as never, {
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      syncSecretHash: "sync-secret-1",
+    });
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: [expect.objectContaining({ _id: "command-update" })],
+    });
+  });
+
+  it("forwards update_app acknowledgement execution ids from terminal runtime proof", async () => {
+    mocks.requireAuthenticatedAthenaUserWithCtx.mockRejectedValue(
+      new Error("not signed in"),
+    );
+    const ctx = buildCtx({
+      terminal: {
+        _id: "terminal-1",
+        storeId: "store-1",
+        status: "active",
+        registeredByUserId: "athena-user-2",
+        syncSecretHash: SYNC_SECRET_HASH,
+      },
+    });
+
+    const result = await getHandler(acknowledgeTerminalRecoveryCommand)(
+      ctx as never,
+      {
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        syncSecretHash: "sync-secret-1",
+        commandId: "command-1",
+        result: "completed",
+        message: "Update app evaluated.",
+        executionId: "command-1:2000100",
+      },
+    );
+
+    expect(mocks.acknowledgeTerminalRecoveryCommandService).toHaveBeenCalledWith(
+      { repository: true },
+      expect.objectContaining({
+        commandId: "command-1",
+        executionId: "command-1:2000100",
+        result: "completed",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    );
+    expect(result.kind).toBe("ok");
+  });
 
   it("does not let terminal runtime proof issue terminal recovery commands", async () => {
     mocks.requireAuthenticatedAthenaUserWithCtx.mockRejectedValue(

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -32,6 +32,7 @@ import {
 } from "../application/terminalRecovery/terminalCommandService";
 import { runAcceptedRuntimeStatusSideEffects } from "../application/terminalRuntime/postRuntimeStatusSideEffects";
 import { createTerminalRecoveryCommandRepository } from "../infrastructure/repositories/terminalRecoveryRepository";
+import { getLatestRuntimeStatusForTerminal } from "../infrastructure/repositories/terminalRepository";
 import {
   disconnectRemoteAssistRuntimeSession,
 } from "../../remoteAssist/application/sessionService";
@@ -47,6 +48,7 @@ import {
   posTerminalRuntimeActiveRegisterSessionValidator,
   posTerminalRuntimeAppSessionRecoveryValidator,
   posTerminalRuntimeAppShellValidator,
+  posTerminalRuntimeAppUpdateValidator,
   posTerminalRuntimeBrowserInfoValidator,
   posTerminalRuntimeDrawerAuthorityValidator,
   posTerminalRuntimeLocalStoreValidator,
@@ -125,6 +127,7 @@ const runtimeStatusInputValidator = v.object({
     posTerminalRuntimeAppSessionRecoveryValidator,
   ),
   appShell: v.optional(posTerminalRuntimeAppShellValidator),
+  appUpdate: v.optional(posTerminalRuntimeAppUpdateValidator),
   localStore: posTerminalRuntimeLocalStoreValidator,
   sync: posTerminalRuntimeSyncValidator,
   staffAuthority: posTerminalRuntimeStaffAuthorityValidator,
@@ -390,6 +393,7 @@ const terminalRecoveryCommandReturnValidator = v.object({
   issuedAt: v.number(),
   expiresAt: v.number(),
   claimedAt: v.optional(v.number()),
+  executionId: v.optional(v.string()),
   acknowledgement: v.optional(
     v.object({
       acknowledgedAt: v.number(),
@@ -444,6 +448,25 @@ function stripRuntimeStatusInput(
       ? {
           observedAt: status.appShell.observedAt,
           ready: status.appShell.ready,
+        }
+      : undefined,
+    appUpdate: status.appUpdate
+      ? {
+          blockerSummary:
+            status.appUpdate.blockerSummary ??
+            status.appUpdate.selectedBlockerCode,
+          canApply: status.appUpdate.canApply,
+          commandExecutionId: status.appUpdate.commandExecutionId,
+          commandId: status.appUpdate.commandId,
+          commandIssuedAt: status.appUpdate.commandIssuedAt,
+          commandNonce: status.appUpdate.commandNonce,
+          currentBuildId: status.appUpdate.currentBuildId,
+          detectorStatus: status.appUpdate.detectorStatus,
+          observedAt: status.appUpdate.observedAt,
+          pendingBuildId: status.appUpdate.pendingBuildId,
+          selectedBlockerCode: status.appUpdate.selectedBlockerCode,
+          stagingStatus: status.appUpdate.stagingStatus,
+          status: status.appUpdate.status,
         }
       : undefined,
     localStore: {
@@ -982,9 +1005,8 @@ export const listTerminalRecoveryCommands = query({
         metadata: { terminalAuthorizationFailure: true },
       });
     }
-    return {
-      kind: "ok" as const,
-      data: await listClaimableTerminalRecoveryCommands(
+    const [commands, runtimeStatus] = await Promise.all([
+      listClaimableTerminalRecoveryCommands(
         createTerminalRecoveryCommandRepository(ctx),
         {
           now: Date.now(),
@@ -992,6 +1014,17 @@ export const listTerminalRecoveryCommands = query({
           terminalId: args.terminalId,
         },
       ),
+      getLatestRuntimeStatusForTerminal(ctx, {
+        storeId: args.storeId,
+        terminalId: args.terminalId,
+      }),
+    ]);
+    const supportsAppUpdateCommands = Boolean(runtimeStatus?.appUpdate);
+    return {
+      kind: "ok" as const,
+      data: supportsAppUpdateCommands
+        ? commands
+        : commands.filter((command) => command.commandType !== "update_app"),
     };
   },
 });
@@ -1038,6 +1071,7 @@ export const acknowledgeTerminalRecoveryCommand = mutation({
       v.literal("precondition_failed"),
     ),
     message: v.optional(v.string()),
+    executionId: v.optional(v.string()),
   },
   returns: commandResultValidator(terminalRecoveryCommandReturnValidator),
   handler: async (ctx, args) => {
@@ -1055,6 +1089,7 @@ export const acknowledgeTerminalRecoveryCommand = mutation({
       {
         acknowledgedAt: Date.now(),
         commandId: args.commandId,
+        executionId: args.executionId,
         message: args.message,
         result: args.result,
         storeId: args.storeId,

--- a/packages/athena-webapp/convex/schemas/pos/posTerminalRecovery.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posTerminalRecovery.ts
@@ -7,6 +7,7 @@ export const posTerminalRecoveryCommandTypeValidator = v.union(
   v.literal("refresh_staff_authority"),
   v.literal("refresh_snapshots"),
   v.literal("report_diagnostics"),
+  v.literal("update_app"),
 );
 
 export const posTerminalRecoveryCommandStatusValidator = v.union(
@@ -36,6 +37,18 @@ export const posTerminalRecoveryCommandPayloadValidator = v.object({
 });
 
 export const posTerminalRecoveryExpectedEvidenceValidator = v.object({
+  appUpdateCommandExecutionId: v.optional(v.string()),
+  appUpdateStatus: v.optional(
+    v.union(
+      v.literal("current"),
+      v.literal("update_ready"),
+      v.literal("update_ready_unstaged"),
+      v.literal("blocked"),
+      v.literal("applying"),
+      v.literal("detector_failed"),
+      v.literal("unknown"),
+    ),
+  ),
   drawerAuthorityStatus: v.optional(v.union(v.literal("healthy"), v.literal("blocked"))),
   localRegisterSessionId: v.optional(v.string()),
   localStoreAvailable: v.optional(v.boolean()),
@@ -99,6 +112,7 @@ export const posTerminalRecoveryCommandSchema = v.object({
   issuedAt: v.number(),
   expiresAt: v.number(),
   claimedAt: v.optional(v.number()),
+  executionId: v.optional(v.string()),
   acknowledgement: v.optional(posTerminalRecoveryCommandAckValidator),
   verifiedAt: v.optional(v.number()),
 });

--- a/packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts
@@ -45,6 +45,54 @@ export const posTerminalRuntimeAppShellValidator = v.object({
   ready: v.boolean(),
 });
 
+export const posTerminalRuntimeAppUpdateStatusValidator = v.union(
+  v.literal("current"),
+  v.literal("checking"),
+  v.literal("update_ready"),
+  v.literal("update_ready_unstaged"),
+  v.literal("blocked"),
+  v.literal("applying"),
+  v.literal("detector_failed"),
+  v.literal("unknown"),
+);
+
+export const posTerminalRuntimeAppUpdateStagingStatusValidator = v.union(
+  v.literal("staged"),
+  v.literal("unstaged"),
+  v.literal("unknown"),
+);
+
+export const posTerminalRuntimeAppUpdateDetectorStatusValidator = v.union(
+  v.literal("ok"),
+  v.literal("failed"),
+  v.literal("unknown"),
+);
+
+export const posTerminalRuntimeAppUpdateBlockerCodeValidator = v.union(
+  v.literal("active_sale"),
+  v.literal("active_command"),
+  v.literal("resume_required"),
+  v.literal("unknown"),
+);
+
+export const posTerminalRuntimeAppUpdateValidator = v.object({
+  blockerSummary: v.optional(posTerminalRuntimeAppUpdateBlockerCodeValidator),
+  canApply: v.boolean(),
+  commandExecutionId: v.optional(v.string()),
+  commandId: v.optional(v.string()),
+  commandIssuedAt: v.optional(v.number()),
+  commandNonce: v.optional(v.string()),
+  currentBuildId: v.optional(v.string()),
+  detectorStatus: posTerminalRuntimeAppUpdateDetectorStatusValidator,
+  observedAt: v.number(),
+  pendingBuildId: v.optional(v.string()),
+  selectedBlockerCode: v.optional(
+    posTerminalRuntimeAppUpdateBlockerCodeValidator,
+  ),
+  stagingStatus: v.optional(posTerminalRuntimeAppUpdateStagingStatusValidator),
+  status: posTerminalRuntimeAppUpdateStatusValidator,
+});
+
 export const posTerminalRuntimeBrowserInfoValidator = v.object({
   userAgent: v.optional(v.string()),
   platform: v.optional(v.string()),
@@ -181,6 +229,7 @@ export const posTerminalRuntimeStatusSchema = v.object({
     posTerminalRuntimeAppSessionRecoveryValidator,
   ),
   appShell: v.optional(posTerminalRuntimeAppShellValidator),
+  appUpdate: v.optional(posTerminalRuntimeAppUpdateValidator),
   localStore: posTerminalRuntimeLocalStoreValidator,
   sync: posTerminalRuntimeSyncValidator,
   staffAuthority: posTerminalRuntimeStaffAuthorityValidator,

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -898,6 +898,113 @@ describe("POSTerminalDetailViewContent", () => {
     expect(mocks.toastSuccess).toHaveBeenCalledWith("Terminal command queued.");
   });
 
+  it("issues Update app from active terminals even when update readiness is unknown", async () => {
+    const onIssueTerminalRecoveryCommand = vi.fn(async () => ({
+      data: { _id: "command-update" },
+      kind: "ok" as const,
+    }));
+
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [],
+          recoveryPreview: {
+            appUpdate: {
+              evidenceFresh: false,
+              status: "unknown",
+            },
+            readiness: "healthy_idle",
+          },
+        }}
+        isLoading={false}
+        onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+      />,
+    );
+
+    const updateButton = screen.getByRole("button", { name: "Update app" });
+    expect(updateButton).toBeEnabled();
+    expect(screen.getByText("Update status unknown")).toBeInTheDocument();
+
+    fireEvent.click(updateButton);
+
+    await waitFor(() => {
+      expect(onIssueTerminalRecoveryCommand).toHaveBeenCalledWith({
+        action: expect.objectContaining({
+          commandContext: expect.objectContaining({
+            expectedBlockerType: "app_update",
+          }),
+          commandType: "update_app",
+          expectedEvidence: {},
+          kind: "terminal_command",
+        }),
+        terminalId: "terminal-1",
+      });
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Update app command queued.");
+  });
+
+  it("disables duplicate Update app actions while an equivalent command is active", () => {
+    const onIssueTerminalRecoveryCommand = vi.fn();
+
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [],
+          recoveryPreview: {
+            appUpdate: {
+              evidenceFresh: true,
+              status: "current",
+            },
+            commandStatus: {
+              commandType: "update_app",
+              label: "Update app",
+              status: "pending",
+              verificationStatus: "waiting_for_acknowledgement",
+            },
+            readiness: "healthy_idle",
+          },
+        }}
+        isLoading={false}
+        onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Update app" })).toBeDisabled();
+    expect(
+      screen.getByText(
+        "Update app command is queued for this checkout station.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("disables Update app for inactive terminals", () => {
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [],
+          recoveryPreview: {
+            appUpdate: {
+              evidenceFresh: false,
+              status: "unknown",
+            },
+            readiness: "healthy_idle",
+          },
+          terminal: {
+            ...detail.terminal,
+            status: "revoked",
+          },
+        }}
+        isLoading={false}
+        onIssueTerminalRecoveryCommand={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Update app" })).toBeDisabled();
+  });
+
   it("surfaces a next step when drawer repair verification fails and sync retry is available", () => {
     render(
       <POSTerminalDetailViewContent

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
@@ -1571,6 +1571,26 @@ function RecoveryBlockerAction({
 }
 
 function getRecoveryActionStatusCopy(action: TerminalRecoveryAction) {
+  if (action.commandType === "update_app") {
+    switch (action.status) {
+      case "pending":
+        return "Update app command is queued for this checkout station.";
+      case "claimed":
+        return "Update app command is running on this checkout station.";
+      case "completed":
+      case "waiting_for_check_in":
+        return "Update app command completed locally. Waiting for a fresh check-in.";
+      case "verified":
+        return "App update verified by the latest terminal check-in.";
+      case "expired":
+        return "Update app command expired. Refresh terminal health before sending another command.";
+      case "failed":
+        return "Update app command did not complete. Refresh terminal health before retrying.";
+      case "blocked":
+        return "Update app command is blocked by current terminal evidence.";
+    }
+  }
+
   switch (action.status) {
     case "pending":
       return "Command is queued for this checkout station.";
@@ -1606,6 +1626,83 @@ function normalizeRecoveryActionError(message?: string) {
     return "Terminal recovery evidence changed. Refresh terminal health before retrying.";
   }
   return message;
+}
+
+function AppUpdateActionPanel({
+  appUpdate,
+  onIssueTerminalRecoveryCommand,
+  terminalId,
+}: {
+  appUpdate: ReturnType<typeof buildTerminalRecoveryPresentation>["appUpdate"];
+  onIssueTerminalRecoveryCommand?: POSTerminalDetailViewContentProps["onIssueTerminalRecoveryCommand"];
+  terminalId: Id<"posTerminal"> | string;
+}) {
+  const action = appUpdate.action;
+  const canIssue = action ? isRecoveryActionIssuable(action) : false;
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const submitUpdateApp = async () => {
+    if (!action || !canIssue || !onIssueTerminalRecoveryCommand || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage("");
+    const result = await onIssueTerminalRecoveryCommand({ action, terminalId });
+    setIsSubmitting(false);
+
+    if (result.kind === "ok") {
+      toast.success("Update app command queued.");
+      return;
+    }
+
+    const message = normalizeRecoveryActionError(result.error.message);
+    setErrorMessage(message);
+    toast.error(message);
+  };
+
+  return (
+    <div className="mt-layout-md rounded-md border border-border/80 bg-surface px-layout-md py-layout-md">
+      <div className="grid gap-layout-md md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
+        <div className="min-w-0">
+          <p className="text-xs font-medium uppercase text-muted-foreground">
+            App update
+          </p>
+          <div className="mt-1 flex flex-wrap items-center gap-layout-xs">
+            <p className="text-base font-medium text-foreground">
+              {appUpdate.label}
+            </p>
+            <Badge className={appUpdate.toneClassName} variant="outline">
+              {formatStatusLabel(appUpdate.status)}
+            </Badge>
+          </div>
+          <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+            {appUpdate.description}
+          </p>
+          {action?.status && action.status !== "available" ? (
+            <p className="mt-layout-xs text-xs text-muted-foreground" role="status">
+              {getRecoveryActionStatusCopy(action)}
+            </p>
+          ) : null}
+          {errorMessage ? (
+            <p className="mt-layout-xs text-xs text-danger">{errorMessage}</p>
+          ) : null}
+        </div>
+        <Button
+          disabled={!action || !canIssue || !onIssueTerminalRecoveryCommand || isSubmitting}
+          onClick={() => {
+            void submitUpdateApp();
+          }}
+          size="sm"
+          variant="utility"
+        >
+          <MonitorUp aria-hidden="true" />
+          {isSubmitting ? "Sending..." : "Update app"}
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 function RecoveryPanel({
@@ -1653,6 +1750,12 @@ function RecoveryPanel({
           </div>
         </div>
       </div>
+
+      <AppUpdateActionPanel
+        appUpdate={recovery.appUpdate}
+        onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+        terminalId={detail.terminal._id}
+      />
 
       {hasCurrentRecoveryWork ? (
         <>

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx
@@ -205,6 +205,14 @@ describe("POSTerminalHealthViewContent", () => {
           baseSummary,
           {
             ...baseSummary,
+            recoveryPreview: {
+              appUpdate: {
+                evidenceFresh: true,
+                pendingBuildId: "build-next",
+                status: "update_ready",
+              },
+              readiness: "healthy_idle",
+            },
             runtimeStatus: {
               ...baseSummary.runtimeStatus!,
               sync: {
@@ -305,6 +313,8 @@ describe("POSTerminalHealthViewContent", () => {
       "/acme/store/osu/cash-controls/registers/register-session-1",
     );
     expect(screen.getAllByText("Offline checkout").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("App update").length).toBeGreaterThan(0);
+    expect(screen.getByText("Update ready")).toBeInTheDocument();
     expect(screen.getAllByText("Products and stock").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Register details").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Offline diagnostics need attention").length).toBeGreaterThan(0);

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx
@@ -619,6 +619,10 @@ export function POSTerminalHealthViewContent({
                               }
                             />
                             <TerminalFact
+                              label="App update"
+                              value={recovery.appUpdate.label}
+                            />
+                            <TerminalFact
                               label="Cloud cursor"
                               value={cloudCursorSummary}
                             />

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
@@ -11,6 +11,151 @@ import {
 } from "./terminalHealthPresentation";
 
 describe("terminal health presentation", () => {
+  it("derives app-update state from fresh runtime evidence without creating support blockers", () => {
+    const ready = buildTerminalRecoveryPresentation({
+      recoveryPreview: {
+        appUpdate: {
+          evidenceFresh: true,
+          pendingBuildId: "build-next",
+          status: "update_ready",
+        },
+        readiness: "healthy_idle",
+        runtimeFresh: true,
+      },
+      runtimeStatus: {
+        appUpdate: {
+          observedAt: Date.now(),
+          pendingBuildId: "build-next",
+          status: "update_ready",
+        },
+      },
+      syncEvidence: {},
+      terminal: { _id: "terminal-1", status: "active" },
+    });
+
+    expect(ready.appUpdate).toEqual(
+      expect.objectContaining({
+        action: expect.objectContaining({
+          commandType: "update_app",
+          status: "available",
+        }),
+        label: "Update ready",
+        status: "update_ready",
+      }),
+    );
+    expect(ready.groups.terminalRequired).toEqual([]);
+    expect(ready.readiness.status).toBe("healthy_idle");
+
+    const blocked = buildTerminalRecoveryPresentation({
+      recoveryPreview: {
+        appUpdate: {
+          evidenceFresh: true,
+          status: "blocked",
+          summary: "Refresh is blocked by active checkout work.",
+        },
+        readiness: "healthy_idle",
+        runtimeFresh: true,
+      },
+      runtimeStatus: {
+        appUpdate: {
+          blockerSummary: "payment_screen_pending",
+          observedAt: Date.now(),
+          status: "blocked",
+        },
+      },
+      syncEvidence: {},
+      terminal: { _id: "terminal-1", status: "active" },
+    });
+
+    expect(blocked.appUpdate).toEqual(
+      expect.objectContaining({
+        action: expect.objectContaining({ commandType: "update_app" }),
+        description: "Refresh is blocked by active checkout work.",
+        label: "Update blocked",
+        status: "blocked",
+      }),
+    );
+    expect(blocked.groups.terminalRequired).toEqual([]);
+  });
+
+  it("keeps Update app available for active current, stale, and unknown evidence", () => {
+    for (const [status, label] of [
+      ["current", "App current"],
+      ["stale", "Update status stale"],
+      ["unknown", "Update status unknown"],
+    ] as const) {
+      const presentation = buildTerminalRecoveryPresentation({
+        recoveryPreview: {
+          appUpdate: {
+            evidenceFresh: status !== "stale",
+            status,
+          },
+          readiness: "healthy_idle",
+        },
+        runtimeStatus: null,
+        syncEvidence: {},
+        terminal: { _id: "terminal-1", status: "active" },
+      });
+
+      expect(presentation.appUpdate).toEqual(
+        expect.objectContaining({
+          action: expect.objectContaining({
+            commandType: "update_app",
+            status: "available",
+          }),
+          label,
+          status,
+        }),
+      );
+    }
+  });
+
+  it("disables Update app for duplicate active commands and inactive terminals", () => {
+    const duplicate = buildTerminalRecoveryPresentation({
+      recoveryPreview: {
+        appUpdate: {
+          evidenceFresh: true,
+          status: "unknown",
+        },
+        commandStatus: {
+          commandType: "update_app",
+          label: "Update app",
+          status: "pending",
+          verificationStatus: "waiting_for_acknowledgement",
+        },
+        readiness: "healthy_idle",
+      },
+      runtimeStatus: null,
+      syncEvidence: {},
+      terminal: { _id: "terminal-1", status: "active" },
+    });
+
+    expect(duplicate.appUpdate.action).toEqual(
+      expect.objectContaining({
+        commandType: "update_app",
+        status: "pending",
+      }),
+    );
+    expect(duplicate.safeActions).not.toContainEqual(
+      expect.objectContaining({ commandType: "update_app" }),
+    );
+
+    const inactive = buildTerminalRecoveryPresentation({
+      recoveryPreview: {
+        appUpdate: {
+          evidenceFresh: false,
+          status: "unknown",
+        },
+        readiness: "healthy_idle",
+      },
+      runtimeStatus: null,
+      syncEvidence: {},
+      terminal: { _id: "terminal-1", status: "revoked" },
+    });
+
+    expect(inactive.appUpdate.action).toBeUndefined();
+  });
+
   it("builds recovery readiness from the backend preview and keeps healthy idle distinct from able to transact", () => {
     expect(
       buildTerminalRecoveryPresentation({

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
@@ -10,6 +10,8 @@ import type {
   TerminalRecoveryPreview,
   TerminalRecoveryActionStatus,
   TerminalRecoveryReadinessStatus,
+  TerminalAppUpdatePreview,
+  TerminalAppUpdateStatus,
 } from "./terminalHealthTypes";
 
 export type TerminalHealthClassification = {
@@ -36,6 +38,7 @@ export type TerminalRecoveryReadinessPresentation = {
 };
 
 export type TerminalRecoveryPresentation = {
+  appUpdate: TerminalAppUpdatePresentation;
   commandStatus: {
     commandType?: TerminalRecoveryCommandType;
     label: string;
@@ -54,6 +57,14 @@ export type TerminalRecoveryPresentation = {
     status: string;
     summary: string;
   };
+};
+
+export type TerminalAppUpdatePresentation = {
+  action?: TerminalRecoveryAction;
+  description: string;
+  label: string;
+  status: TerminalAppUpdateStatus;
+  toneClassName: string;
 };
 
 type TerminalHealthClassificationInput = {
@@ -448,6 +459,7 @@ export function buildTerminalRecoveryPresentation(
     ),
   };
   const readiness = buildRecoveryReadiness(summary, groups);
+  const appUpdate = buildTerminalAppUpdatePresentation(summary, recovery);
   const safeActions = blockers
     .map((blocker) => blocker.action)
     .filter((action): action is TerminalRecoveryAction =>
@@ -455,6 +467,7 @@ export function buildTerminalRecoveryPresentation(
     );
 
   return {
+    appUpdate,
     commandStatus: {
       commandType: recovery?.commandStatus?.commandType,
       label: normalizeSupportCopy(recovery?.commandStatus?.label) ?? "No command issued",
@@ -504,6 +517,225 @@ function buildRecoveryBlockers(
 
 function getTerminalRecoveryPreview(summary: TerminalHealthClassificationInput) {
   return summary.recoveryPreview ?? summary.recovery ?? null;
+}
+
+function buildTerminalAppUpdatePresentation(
+  summary: TerminalHealthClassificationInput,
+  recovery: TerminalRecoveryPreview | null | undefined,
+): TerminalAppUpdatePresentation {
+  const preview = getTerminalAppUpdatePreview(summary, recovery);
+  const status = preview.status;
+  const fallback = getAppUpdateStatusFallback(status);
+  const action = buildUpdateAppAction(summary, recovery);
+
+  return {
+    action,
+    description:
+      normalizeSupportCopy(preview.summary) ??
+      getAppUpdateDescription(status, preview),
+    label: fallback.label,
+    status,
+    toneClassName: fallback.toneClassName,
+  };
+}
+
+function getTerminalAppUpdatePreview(
+  summary: TerminalHealthClassificationInput,
+  recovery: TerminalRecoveryPreview | null | undefined,
+): TerminalAppUpdatePreview {
+  if (recovery?.appUpdate) {
+    return normalizeTerminalAppUpdatePreview(recovery.appUpdate);
+  }
+
+  const runtimeStatus = summary.runtimeStatus as
+    | (TerminalHealthClassificationInput["runtimeStatus"] & {
+        appUpdate?: unknown;
+      })
+    | null;
+  return normalizeTerminalAppUpdatePreview(runtimeStatus?.appUpdate);
+}
+
+function normalizeTerminalAppUpdatePreview(
+  value?: unknown,
+): TerminalAppUpdatePreview {
+  if (!value || typeof value !== "object") {
+    return {
+      evidenceFresh: false,
+      status: "unknown",
+    };
+  }
+
+  const record = value as Record<string, unknown>;
+  const status = normalizeAppUpdateStatus(
+    typeof record.status === "string" ? record.status : undefined,
+  );
+  const evidenceFresh =
+    typeof record.evidenceFresh === "boolean"
+      ? record.evidenceFresh
+      : status !== "stale";
+
+  return {
+    commandCorrelated:
+      typeof record.commandCorrelated === "boolean"
+        ? record.commandCorrelated
+        : undefined,
+    currentBuildId:
+      typeof record.currentBuildId === "string"
+        ? record.currentBuildId
+        : typeof record.currentBuildSha === "string"
+          ? record.currentBuildSha
+          : undefined,
+    evidenceFresh,
+    observedAt:
+      typeof record.observedAt === "number" ? record.observedAt : undefined,
+    pendingBuildId:
+      typeof record.pendingBuildId === "string"
+        ? record.pendingBuildId
+        : typeof record.latestBuildId === "string"
+          ? record.latestBuildId
+          : undefined,
+    status,
+    summary:
+      typeof record.summary === "string"
+        ? record.summary
+        : typeof record.blockerSummary === "string"
+          ? normalizeAppUpdateBlockerSummary(record.blockerSummary)
+          : typeof record.selectedBlockerCode === "string"
+            ? normalizeAppUpdateBlockerSummary(record.selectedBlockerCode)
+          : undefined,
+  };
+}
+
+function normalizeAppUpdateStatus(status?: string): TerminalAppUpdateStatus {
+  switch (status) {
+    case "applying":
+      return "applying";
+    case "blocked":
+      return "blocked";
+    case "current":
+      return "current";
+    case "detector-failed":
+    case "detector_failed":
+      return "detector_failed";
+    case "ready":
+    case "staged":
+    case "update_ready":
+      return "update_ready";
+    case "ready_unstaged":
+    case "update_ready_unstaged":
+      return "update_ready_unstaged";
+    case "stale":
+      return "stale";
+    case "unknown":
+    default:
+      return "unknown";
+  }
+}
+
+function buildUpdateAppAction(
+  summary: TerminalHealthClassificationInput,
+  recovery: TerminalRecoveryPreview | null | undefined,
+): TerminalRecoveryAction | undefined {
+  if (summary.terminal.status !== "active" || !summary.terminal._id) {
+    return undefined;
+  }
+
+  const duplicateStatus = getPreviewCommandActionStatus(
+    recovery?.commandStatus,
+    "update_app",
+  );
+
+  return {
+    commandContext: {
+      expectedBlockerType: "app_update",
+      reason: "Support requested an app update check.",
+    },
+    commandType: "update_app",
+    expectedEvidence: {},
+    kind: "terminal_command",
+    label: "Update app",
+    status: duplicateStatus ?? "available",
+  };
+}
+
+function getAppUpdateStatusFallback(status: TerminalAppUpdateStatus) {
+  switch (status) {
+    case "current":
+      return {
+        label: "App current",
+        toneClassName: "border-success/30 bg-success/10 text-success",
+      };
+    case "update_ready":
+      return {
+        label: "Update ready",
+        toneClassName: "border-warning/30 bg-warning/15 text-warning",
+      };
+    case "update_ready_unstaged":
+      return {
+        label: "Update available",
+        toneClassName: "border-warning/30 bg-warning/15 text-warning",
+      };
+    case "blocked":
+      return {
+        label: "Update blocked",
+        toneClassName: "border-warning/30 bg-warning/15 text-warning",
+      };
+    case "applying":
+      return {
+        label: "Update applying",
+        toneClassName: "border-warning/30 bg-warning/15 text-warning",
+      };
+    case "detector_failed":
+      return {
+        label: "Update check failed",
+        toneClassName: "border-warning/30 bg-warning/15 text-warning",
+      };
+    case "stale":
+      return {
+        label: "Update status stale",
+        toneClassName: "border-muted bg-muted/40 text-muted-foreground",
+      };
+    case "unknown":
+    default:
+      return {
+        label: "Update status unknown",
+        toneClassName: "border-muted bg-muted/40 text-muted-foreground",
+      };
+  }
+}
+
+function getAppUpdateDescription(
+  status: TerminalAppUpdateStatus,
+  appUpdate: TerminalAppUpdatePreview,
+) {
+  switch (status) {
+    case "current":
+      return "This checkout station reports the current app build.";
+    case "update_ready":
+      return "An app update is ready. The checkout station will refresh only when local work is safe.";
+    case "update_ready_unstaged":
+      return "An app update is available but not ready to refresh yet.";
+    case "blocked":
+      return "Refresh is blocked by active checkout work.";
+    case "applying":
+      return "The checkout station accepted the update. Waiting for a fresh check-in.";
+    case "detector_failed":
+      return "Athena could not confirm this checkout station's app update state.";
+    case "stale":
+      return "The latest app update evidence is stale. Send Update app to ask the checkout station to check again.";
+    case "unknown":
+    default:
+      return appUpdate.evidenceFresh
+        ? "This checkout station has not reported app update readiness."
+        : "App update readiness has not been reported yet.";
+  }
+}
+
+function normalizeAppUpdateBlockerSummary(value: string) {
+  if (/sale|payment|checkout|drawer|sync|review|work/i.test(value)) {
+    return "Refresh is blocked by active checkout work.";
+  }
+  return "Refresh is blocked by local app work.";
 }
 
 function hasStructuredRecoveryPreview(recovery: TerminalRecoveryPreview) {
@@ -811,6 +1043,8 @@ function getTerminalCommandActionLabel(
   commandType: NonNullable<TerminalRecoveryAction["commandType"]>,
 ) {
   switch (commandType) {
+    case "update_app":
+      return "Update app";
     case "repair_terminal_seed":
       return "Send terminal setup repair";
     case "clear_stale_drawer_authority":
@@ -830,6 +1064,8 @@ function getTerminalCommandTitle(
   commandType: NonNullable<TerminalRecoveryAction["commandType"]>,
 ) {
   switch (commandType) {
+    case "update_app":
+      return "App update";
     case "repair_terminal_seed":
       return "Terminal setup repair";
     case "clear_stale_drawer_authority":
@@ -850,7 +1086,9 @@ function getTerminalCommandRecoverySummary(
   status?: TerminalRecoveryActionStatus,
 ) {
   const commandName =
-    commandType === "clear_stale_drawer_authority"
+    commandType === "update_app"
+      ? "Update app command"
+      : commandType === "clear_stale_drawer_authority"
       ? "Drawer repair command"
       : commandType === "retry_sync"
         ? "Sync retry command"

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
@@ -22,6 +22,7 @@ export type TerminalRecord = {
 export type TerminalRuntimeStatus = {
   _creationTime?: number;
   _id?: string;
+  appUpdate?: TerminalRuntimeAppUpdateEvidence;
   appSessionRecovery?: {
     status:
       | "ready"
@@ -123,6 +124,44 @@ export type TerminalRuntimeStatus = {
     registerNumber?: string;
     status: "open" | "active" | "closing" | "closed" | string;
   };
+};
+
+export type TerminalRuntimeAppUpdateEvidence = {
+  blockerSummary?: string;
+  canApply?: boolean;
+  command?: {
+    executionId?: string;
+    issuedAt?: number;
+    nonce?: string;
+  };
+  currentBuildId?: string;
+  currentBuildSha?: string;
+  detectorStatus?: "failed" | "ok" | "unknown" | string;
+  errorCode?: string;
+  latestBuildId?: string;
+  observedAt?: number;
+  pendingBuildId?: string;
+  selectedBlockerCode?:
+    | "active_command"
+    | "active_sale"
+    | "resume_required"
+    | "unknown"
+    | string;
+  stagingStatus?: "staged" | "unknown" | "unstaged" | string;
+  status:
+    | "applying"
+    | "blocked"
+    | "checking"
+    | "current"
+    | "detector_failed"
+    | "detector-failed"
+    | "ready"
+    | "ready_unstaged"
+    | "staged"
+    | "update_ready"
+    | "update_ready_unstaged"
+    | "unknown"
+    | string;
 };
 
 export type TerminalSyncEvent = {
@@ -255,7 +294,8 @@ export type TerminalRecoveryCommandType =
   | "clear_stale_drawer_authority"
   | "refresh_staff_authority"
   | "refresh_snapshots"
-  | "report_diagnostics";
+  | "report_diagnostics"
+  | "update_app";
 
 export type TerminalRecoveryCommandContext = {
   cloudRegisterSessionId?: string;
@@ -267,6 +307,15 @@ export type TerminalRecoveryCommandContext = {
 };
 
 export type TerminalRecoveryExpectedEvidence = {
+  appUpdateCommandExecutionId?: string;
+  appUpdateStatus?:
+    | "applying"
+    | "blocked"
+    | "current"
+    | "detector_failed"
+    | "unknown"
+    | "update_ready"
+    | "update_ready_unstaged";
   drawerAuthorityStatus?: "healthy" | "blocked";
   localRegisterSessionId?: string;
   localStoreAvailable?: boolean;
@@ -306,6 +355,7 @@ export type TerminalRecoveryBlocker = {
 };
 
 export type TerminalRecoveryPreview = {
+  appUpdate?: TerminalAppUpdatePreview | null;
   blockers?: TerminalRecoveryBlocker[];
   cloudRepair?: {
     preconditionHash: string;
@@ -347,6 +397,26 @@ export type TerminalRecoveryPreview = {
     status?: TerminalRecoveryActionStatus;
     summary?: string;
   } | null;
+};
+
+export type TerminalAppUpdateStatus =
+  | "applying"
+  | "blocked"
+  | "current"
+  | "detector_failed"
+  | "stale"
+  | "unknown"
+  | "update_ready"
+  | "update_ready_unstaged";
+
+export type TerminalAppUpdatePreview = {
+  commandCorrelated?: boolean;
+  currentBuildId?: string;
+  evidenceFresh: boolean;
+  observedAt?: number;
+  pendingBuildId?: string;
+  status: TerminalAppUpdateStatus;
+  summary?: string;
 };
 
 export type TerminalHealthSummary = {

--- a/packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.test.tsx
+++ b/packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.test.tsx
@@ -7,6 +7,7 @@ const useMutationMock = vi.fn();
 const useQueryMock = vi.fn();
 const usePosLocalSyncRuntimeStatusMock = vi.fn();
 const useRemoteAssistRuntimeTransportMock = vi.fn();
+const useOptionalUpdateCoordinatorMock = vi.fn();
 
 vi.mock("convex/react", () => ({
   useMutation: () => useMutationMock,
@@ -16,6 +17,10 @@ vi.mock("convex/react", () => ({
 vi.mock("@/lib/pos/infrastructure/local/usePosLocalSyncRuntime", () => ({
   usePosLocalSyncRuntimeStatus: (input: Record<string, unknown>) =>
     usePosLocalSyncRuntimeStatusMock(input),
+}));
+
+vi.mock("@/lib/app-update/UpdateCoordinatorProvider", () => ({
+  useOptionalUpdateCoordinator: () => useOptionalUpdateCoordinatorMock(),
 }));
 
 vi.mock("@/lib/remote-assist", async () => {
@@ -34,6 +39,7 @@ describe("PosRemoteAssistRuntimeHost", () => {
     vi.clearAllMocks();
     useMutationMock.mockResolvedValue(null);
     useQueryMock.mockReturnValue(null);
+    useOptionalUpdateCoordinatorMock.mockReturnValue(null);
     useRemoteAssistRuntimeTransportMock.mockReturnValue({
       connectionState: "connected",
     });
@@ -61,6 +67,26 @@ describe("PosRemoteAssistRuntimeHost", () => {
         mode: "drain-enabled",
         storeId: "store-1",
         terminalId: "terminal-cloud-1",
+      }),
+    );
+  });
+
+  it("passes the app update coordinator adapter into the local sync runtime", () => {
+    const applyUpdate = vi.fn();
+    const getSnapshot = vi.fn();
+    useOptionalUpdateCoordinatorMock.mockReturnValue({
+      applyUpdate,
+      getSnapshot,
+    });
+
+    render(<PosRemoteAssistRuntimeHost entryContext={readyEntryContext()} />);
+
+    expect(usePosLocalSyncRuntimeStatusMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appUpdateCoordinator: {
+          applyUpdate,
+          getSnapshot,
+        },
       }),
     );
   });

--- a/packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx
+++ b/packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx
@@ -1,8 +1,10 @@
 import { useMutation, useQuery } from "convex/react";
+import { useMemo } from "react";
 
 import { RemoteAssistRuntimeShell } from "./RemoteAssistRuntimeShell";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
+import { useOptionalUpdateCoordinator } from "@/lib/app-update/UpdateCoordinatorProvider";
 import type { PosLocalEntryContext } from "@/lib/pos/infrastructure/local/localPosEntryContext";
 import { usePosLocalSyncRuntimeStatus } from "@/lib/pos/infrastructure/local/usePosLocalSyncRuntime";
 import type { PosTerminalRuntimeAppSessionRecoveryInput } from "@/lib/pos/infrastructure/local/terminalRuntimeStatus";
@@ -29,8 +31,20 @@ export function PosRemoteAssistRuntimeHost({
     entryContext.status === "ready" ? entryContext.terminalSeed : null;
   const remoteAssistRuntimeIdentity =
     terminalSeed?.cloudTerminalId ?? terminalSeed?.terminalId;
+  const updateCoordinator = useOptionalUpdateCoordinator();
+  const appUpdateCoordinator = useMemo(
+    () =>
+      updateCoordinator
+        ? {
+            applyUpdate: updateCoordinator.applyUpdate,
+            getSnapshot: updateCoordinator.getSnapshot,
+          }
+        : null,
+    [updateCoordinator],
+  );
 
   usePosLocalSyncRuntimeStatus({
+    appUpdateCoordinator,
     appSessionRecovery,
     mode: "drain-enabled",
     storeId: terminalSeed?.storeId,

--- a/packages/athena-webapp/src/lib/app-update/UpdateCoordinatorProvider.tsx
+++ b/packages/athena-webapp/src/lib/app-update/UpdateCoordinatorProvider.tsx
@@ -19,6 +19,7 @@ import {
 
 type UpdateCoordinatorContextValue = {
   snapshot: UpdateCoordinatorSnapshot;
+  getSnapshot: () => UpdateCoordinatorSnapshot;
   reportChecking: () => void;
   reportUpdateDetected: (input: UpdateDetectedInput) => void;
   reportDetectorFailed: () => void;
@@ -80,6 +81,7 @@ export function UpdateCoordinatorProvider({
   const value = useMemo<UpdateCoordinatorContextValue>(
     () => ({
       snapshot,
+      getSnapshot: store.getSnapshot,
       reportChecking: store.reportChecking,
       reportUpdateDetected: store.reportUpdateDetected,
       reportDetectorFailed: store.reportDetectorFailed,
@@ -105,6 +107,10 @@ export function useUpdateCoordinator() {
     );
   }
   return context;
+}
+
+export function useOptionalUpdateCoordinator() {
+  return useContext(UpdateCoordinatorContext);
 }
 
 export function useUpdateCoordinatorSnapshot() {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeStatusPublisher.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeStatusPublisher.ts
@@ -29,7 +29,7 @@ export function getRuntimeStatusSignature(input: {
   terminalId: string;
 }) {
   return JSON.stringify({
-    runtimeStatus: input.runtimeStatus,
+    runtimeStatus: normalizeRuntimeStatusSignature(input.runtimeStatus),
     storeId: input.storeId,
     terminalId: input.terminalId,
   });
@@ -42,7 +42,7 @@ export function getRuntimeStatusPublishSignature(input: {
   terminalId: string;
 }) {
   const stableStatus: Partial<PosTerminalRuntimeStatusPayload> = {
-    ...input.runtimeStatus,
+    ...normalizeRuntimeStatusSignature(input.runtimeStatus),
   };
   delete stableStatus.reportedAt;
   delete stableStatus.snapshots;
@@ -53,6 +53,20 @@ export function getRuntimeStatusPublishSignature(input: {
     storeId: input.storeId,
     terminalId: input.terminalId,
   });
+}
+
+function normalizeRuntimeStatusSignature(
+  runtimeStatus: PosTerminalRuntimeStatusPayload,
+): PosTerminalRuntimeStatusPayload {
+  if (!runtimeStatus.appUpdate) return runtimeStatus;
+
+  return {
+    ...runtimeStatus,
+    appUpdate: {
+      ...runtimeStatus.appUpdate,
+      observedAt: 0,
+    },
+  };
 }
 
 export function getRuntimeCheckInNotReadyReason(input: {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts
@@ -112,6 +112,326 @@ describe("terminalRecoveryCommands", () => {
     expect(JSON.stringify(result)).not.toContain("new-sync-secret-material");
   });
 
+  it("maps a current app update snapshot to a completed no-op without applying", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    const applyUpdate = vi.fn();
+
+    const result = await executeTerminalRecoveryCommand({
+      appUpdateCoordinator: {
+        applyUpdate,
+        getSnapshot: () => ({
+          blockers: [],
+          canApply: false,
+          currentBuildId: "build-1",
+          status: "current",
+        }),
+      },
+      command: buildCommand({ type: "update_app" }),
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(result).toMatchObject({
+      diagnostics: {
+        appUpdateCanApply: false,
+        appUpdateStatus: "current",
+        currentBuildId: "build-1",
+      },
+      message: "The terminal is already running the current app.",
+      status: "completed",
+      type: "update_app",
+    });
+    expect(result.postAcknowledge).toBeUndefined();
+    expect(applyUpdate).not.toHaveBeenCalled();
+  });
+
+  it("prepares an app update apply effect only when the coordinator can apply", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    const applyUpdate = vi.fn(() => true);
+
+    const result = await executeTerminalRecoveryCommand({
+      appUpdateCoordinator: {
+        applyUpdate,
+        getSnapshot: () => ({
+          blockers: [],
+          canApply: true,
+          currentBuildId: "build-1",
+          pendingBuildId: "build-2",
+          status: "ready",
+        }),
+      },
+      command: buildCommand({ type: "update_app" }),
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(result).toMatchObject({
+      diagnostics: {
+        appUpdateCanApply: true,
+        appUpdateStatus: "applying",
+        pendingBuildId: "build-2",
+      },
+      status: "completed",
+      type: "update_app",
+    });
+    expect(applyUpdate).not.toHaveBeenCalled();
+
+    await expect(Promise.resolve(result.postAcknowledge?.())).resolves.toEqual({
+      applied: true,
+    });
+
+    expect(applyUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the update command latch when acknowledgement fails", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    const applyUpdate = vi.fn(() => true);
+    const coordinator = {
+      applyUpdate,
+      getSnapshot: () => ({
+        blockers: [],
+        canApply: true,
+        pendingBuildId: "build-2",
+        status: "ready" as const,
+      }),
+    };
+    const command = buildCommand({
+      commandId: "command-latch",
+      type: "update_app",
+    });
+
+    const first = await executeTerminalRecoveryCommand({
+      appUpdateCoordinator: coordinator,
+      command,
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+    const duplicateWhileClaimed = await executeTerminalRecoveryCommand({
+      appUpdateCoordinator: coordinator,
+      command,
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    first.onAcknowledgeFailed?.();
+
+    const retryAfterAckFailure = await executeTerminalRecoveryCommand({
+      appUpdateCoordinator: coordinator,
+      command,
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(duplicateWhileClaimed.status).toBe("precondition_failed");
+    expect(retryAfterAckFailure.status).toBe("completed");
+    expect(retryAfterAckFailure.postAcknowledge).toBeDefined();
+  });
+
+  it("reports post-ack app update blockers and releases the latch", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    const applyUpdate = vi.fn(() => false);
+    const command = buildCommand({
+      commandId: "command-post-ack-blocked",
+      type: "update_app",
+    });
+
+    const result = await executeTerminalRecoveryCommand({
+      appUpdateCoordinator: {
+        applyUpdate,
+        getSnapshot: () => ({
+          blockers: [],
+          canApply: true,
+          pendingBuildId: "build-2",
+          status: "ready",
+        }),
+      },
+      command,
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    await expect(Promise.resolve(result.postAcknowledge?.())).resolves.toEqual({
+      applied: false,
+      message:
+        "App update was accepted, but refresh is now blocked by local work.",
+    });
+
+    const retryAfterBlockedApply = await executeTerminalRecoveryCommand({
+      appUpdateCoordinator: {
+        applyUpdate,
+        getSnapshot: () => ({
+          blockers: [],
+          canApply: true,
+          pendingBuildId: "build-2",
+          status: "ready",
+        }),
+      },
+      command,
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(applyUpdate).toHaveBeenCalledTimes(1);
+    expect(retryAfterBlockedApply.status).toBe("completed");
+  });
+
+  it("does not apply blocked or ready-unstaged app updates", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    const applyUpdate = vi.fn();
+
+    const blocked = await executeTerminalRecoveryCommand({
+      appUpdateCoordinator: {
+        applyUpdate,
+        getSnapshot: () => ({
+          blockers: [
+            {
+              generation: 1,
+              guidance: "Finish the sale before refreshing.",
+              label: "Register sale",
+              ownerTabId: "tab-a",
+              priority: "critical-workflow",
+              surfaceId: "pos-register",
+              updatedAt: 1_000,
+            },
+          ],
+          canApply: false,
+          pendingBuildId: "build-2",
+          status: "blocked",
+        }),
+      },
+      command: buildCommand({ commandId: "command-blocked", type: "update_app" }),
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    const unstaged = await executeTerminalRecoveryCommand({
+      appUpdateCoordinator: {
+        applyUpdate,
+        getSnapshot: () => ({
+          blockers: [],
+          canApply: false,
+          pendingBuildId: "build-2",
+          status: "ready-unstaged",
+        }),
+      },
+      command: buildCommand({ commandId: "command-unstaged", type: "update_app" }),
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(blocked).toMatchObject({
+      diagnostics: { appUpdateStatus: "blocked" },
+      message: "The terminal has active work that is blocking app refresh.",
+      status: "completed",
+    });
+    expect(unstaged).toMatchObject({
+      diagnostics: { appUpdateStatus: "update_ready_unstaged" },
+      message: "An app update is available but is not ready to refresh yet.",
+      status: "completed",
+    });
+    expect(applyUpdate).not.toHaveBeenCalled();
+  });
+
+  it("reports detector failure and unavailable coordinator without applying", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    const applyUpdate = vi.fn();
+
+    const detectorFailed = await executeTerminalRecoveryCommand({
+      appUpdateCoordinator: {
+        applyUpdate,
+        getSnapshot: () => ({
+          blockers: [],
+          canApply: false,
+          status: "detector-failed",
+        }),
+      },
+      command: buildCommand({ commandId: "command-detector", type: "update_app" }),
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+    const unavailable = await executeTerminalRecoveryCommand({
+      appUpdateCoordinator: null,
+      command: buildCommand({ commandId: "command-unavailable", type: "update_app" }),
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(detectorFailed).toMatchObject({
+      diagnostics: { appUpdateStatus: "detector_failed" },
+      status: "completed",
+    });
+    expect(unavailable).toMatchObject({
+      diagnostics: { appUpdateStatus: "unknown" },
+      status: "completed",
+    });
+    expect(applyUpdate).not.toHaveBeenCalled();
+  });
+
+  it("reports detector failure when the app update snapshot cannot be read", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    const applyUpdate = vi.fn();
+
+    const result = await executeTerminalRecoveryCommand({
+      appUpdateCoordinator: {
+        applyUpdate,
+        getSnapshot: () => {
+          throw new Error("coordinator unavailable");
+        },
+      },
+      command: buildCommand({ commandId: "command-snapshot-error", type: "update_app" }),
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(result).toMatchObject({
+      diagnostics: {
+        appUpdateStatus: "detector_failed",
+      },
+      message: "coordinator unavailable",
+      status: "completed",
+      type: "update_app",
+    });
+    expect(applyUpdate).not.toHaveBeenCalled();
+  });
+
   it("repairs terminal seed from safe backend command context without shipping seed material", async () => {
     const store = createPosLocalStore({
       adapter: createMemoryPosLocalStorageAdapter(),

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts
@@ -7,6 +7,7 @@ import type {
   PosProvisionedTerminalSeed,
   createPosLocalStore,
 } from "./posLocalStore";
+import type { UpdateCoordinatorSnapshot } from "@/lib/app-update/updateCoordinator";
 
 export type PosTerminalRecoveryCommandType =
   | "retry_sync"
@@ -14,13 +15,15 @@ export type PosTerminalRecoveryCommandType =
   | "clear_stale_drawer_authority"
   | "refresh_staff_authority"
   | "refresh_snapshots"
-  | "report_diagnostics";
+  | "report_diagnostics"
+  | "update_app";
 
 export type PosTerminalRecoveryCommand = {
   _id?: string;
   commandContext?: unknown;
   commandId?: string;
   commandType?: PosTerminalRecoveryCommandType;
+  executionId?: string;
   expectedEvidence?: unknown;
   storeId: string;
   terminalId: string;
@@ -33,6 +36,11 @@ export type PosTerminalRecoveryCommandResult = {
   commandId: string;
   diagnostics?: Record<string, string | number | boolean | null>;
   message?: string;
+  onAcknowledgeFailed?: () => void;
+  postAcknowledge?: () =>
+    | { applied?: boolean; message?: string }
+    | void
+    | Promise<{ applied?: boolean; message?: string } | void>;
   reason?:
     | "local_store_failure"
     | "missing_callback"
@@ -52,6 +60,11 @@ export type PosTerminalRecoveryCommandCallbackResult = {
 };
 
 type PosLocalRuntimeStore = ReturnType<typeof createPosLocalStore>;
+
+export type PosAppUpdateCoordinatorAdapter = {
+  applyUpdate: () => boolean;
+  getSnapshot: () => UpdateCoordinatorSnapshot;
+};
 
 export type PosTerminalRecoveryCommandContext = {
   command: PosTerminalRecoveryCommand;
@@ -80,6 +93,7 @@ export type PosTerminalRecoveryCommandContext = {
         | Promise<PosTerminalRecoveryCommandCallbackResult>
         | PosTerminalRecoveryCommandCallbackResult)
     | null;
+  appUpdateCoordinator?: PosAppUpdateCoordinatorAdapter | null;
   store: PosLocalRuntimeStore;
   storeId: string;
   terminalId: string;
@@ -108,7 +122,10 @@ const SUPPORTED_COMMAND_TYPES = new Set<string>([
   "refresh_staff_authority",
   "refresh_snapshots",
   "report_diagnostics",
+  "update_app",
 ]);
+
+const activeUpdateAppCommands = new Set<string>();
 
 export async function executeTerminalRecoveryCommand(
   context: PosTerminalRecoveryCommandContext,
@@ -145,6 +162,8 @@ export async function executeTerminalRecoveryCommand(
         return executeCallbackCommand(context, context.reportDiagnostics, {
           allowMissingCallback: true,
         });
+      case "update_app":
+        return executeUpdateApp(context);
       default:
         return failed(command, "unsupported_command");
     }
@@ -153,6 +172,86 @@ export async function executeTerminalRecoveryCommand(
       message: safeRecoveryMessage(error),
     });
   }
+}
+
+async function executeUpdateApp(
+  context: PosTerminalRecoveryCommandContext,
+): Promise<PosTerminalRecoveryCommandResult> {
+  const commandKey = getCommandExecutionKey(context.command);
+  if (activeUpdateAppCommands.has(commandKey)) {
+    return preconditionFailed(context.command);
+  }
+
+  const coordinator = context.appUpdateCoordinator;
+  if (!coordinator) {
+    return completed(context.command, {
+      diagnostics: {
+        appUpdateStatus: "unknown",
+        terminalId: context.terminalId,
+      },
+      message: "App update status is not available on this terminal.",
+    });
+  }
+
+  activeUpdateAppCommands.add(commandKey);
+  const releaseLock = () => activeUpdateAppCommands.delete(commandKey);
+  let snapshot: UpdateCoordinatorSnapshot;
+  try {
+    snapshot = coordinator.getSnapshot();
+  } catch (error) {
+    releaseLock();
+    return completed(context.command, {
+      diagnostics: {
+        appUpdateStatus: "detector_failed",
+        terminalId: context.terminalId,
+      },
+      message: safeRecoveryMessage(error),
+    });
+  }
+
+  const appUpdateStatus = toCanonicalAppUpdateStatus(snapshot);
+  const baseDiagnostics = {
+    appUpdateCanApply: snapshot.canApply,
+    appUpdateStatus,
+    ...(snapshot.currentBuildId
+      ? { currentBuildId: snapshot.currentBuildId }
+      : {}),
+    ...(snapshot.pendingBuildId
+      ? { pendingBuildId: snapshot.pendingBuildId }
+      : {}),
+    terminalId: context.terminalId,
+  };
+
+  if (!snapshot.canApply) {
+    releaseLock();
+    return completed(context.command, {
+      diagnostics: baseDiagnostics,
+      message: getAppUpdateEvaluationMessage(appUpdateStatus),
+    });
+  }
+
+  return completed(context.command, {
+    diagnostics: {
+      ...baseDiagnostics,
+      appUpdateStatus: "applying",
+    },
+    message: "App update accepted and will apply when the terminal is safe to refresh.",
+    onAcknowledgeFailed: releaseLock,
+    postAcknowledge: () => {
+      try {
+        const applied = coordinator.applyUpdate();
+        return applied
+          ? { applied: true }
+          : {
+              applied: false,
+              message:
+                "App update was accepted, but refresh is now blocked by local work.",
+            };
+      } finally {
+        releaseLock();
+      }
+    },
+  });
 }
 
 async function executeRetrySync(
@@ -521,6 +620,8 @@ function completed(
   options: {
     diagnostics?: Record<string, string | number | boolean | null>;
     message?: string;
+    onAcknowledgeFailed?: () => void;
+    postAcknowledge?: PosTerminalRecoveryCommandResult["postAcknowledge"];
   } = {},
 ): PosTerminalRecoveryCommandResult {
   return {
@@ -530,6 +631,12 @@ function completed(
       : {}),
     ...(options.message
       ? { message: safeRecoveryMessage(options.message) }
+      : {}),
+    ...(options.onAcknowledgeFailed
+      ? { onAcknowledgeFailed: options.onAcknowledgeFailed }
+      : {}),
+    ...(options.postAcknowledge
+      ? { postAcknowledge: options.postAcknowledge }
       : {}),
     status: "completed",
     type: getCommandType(command) ?? "unknown_command",
@@ -585,8 +692,53 @@ function getCommandId(command: PosTerminalRecoveryCommand) {
   return command.commandId ?? command._id ?? "unknown-command";
 }
 
+function getCommandExecutionKey(command: PosTerminalRecoveryCommand) {
+  return getCommandId(command);
+}
+
 function getCommandType(command: PosTerminalRecoveryCommand) {
   return command.type ?? command.commandType;
+}
+
+function toCanonicalAppUpdateStatus(snapshot: UpdateCoordinatorSnapshot) {
+  if (snapshot.status === "current" || snapshot.status === "checking") {
+    return "current";
+  }
+  if (snapshot.status === "ready") {
+    return snapshot.canApply ? "update_ready" : "blocked";
+  }
+  if (snapshot.status === "ready-unstaged") {
+    return snapshot.canApply ? "update_ready" : "update_ready_unstaged";
+  }
+  if (snapshot.status === "blocked") {
+    return "blocked";
+  }
+  if (snapshot.status === "applying") {
+    return "applying";
+  }
+  if (snapshot.status === "detector-failed") {
+    return "detector_failed";
+  }
+  return "unknown";
+}
+
+function getAppUpdateEvaluationMessage(status: string) {
+  if (status === "current") {
+    return "The terminal is already running the current app.";
+  }
+  if (status === "blocked") {
+    return "The terminal has active work that is blocking app refresh.";
+  }
+  if (status === "update_ready_unstaged") {
+    return "An app update is available but is not ready to refresh yet.";
+  }
+  if (status === "detector_failed") {
+    return "The terminal could not determine app update status.";
+  }
+  if (status === "applying") {
+    return "The terminal is already applying an app update.";
+  }
+  return "App update status is not available on this terminal.";
 }
 
 function getCommandPayload(command: PosTerminalRecoveryCommand) {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts
@@ -339,6 +339,152 @@ describe("terminalRuntimeStatus", () => {
     });
   });
 
+  it.each([
+    {
+      name: "current",
+      appUpdate: {
+        canApply: false,
+        currentBuildId: "build-current",
+        detectorStatus: "ok",
+        status: "current",
+      },
+      expected: {
+        canApply: false,
+        currentBuildId: "build-current",
+        detectorStatus: "ok",
+        observedAt: 2_000,
+        status: "current",
+      },
+    },
+    {
+      name: "update_ready",
+      appUpdate: {
+        canApply: true,
+        currentBuildId: "build-current",
+        detectorStatus: "ok",
+        pendingBuildId: "build-next",
+        stagingStatus: "staged",
+        status: "update_ready",
+      },
+      expected: {
+        canApply: true,
+        currentBuildId: "build-current",
+        detectorStatus: "ok",
+        observedAt: 2_000,
+        pendingBuildId: "build-next",
+        stagingStatus: "staged",
+        status: "update_ready",
+      },
+    },
+    {
+      name: "blocked",
+      appUpdate: {
+        canApply: false,
+        currentBuildId: "build-current",
+        detectorStatus: "ok",
+        pendingBuildId: "build-next",
+        selectedBlockerCode: "active_sale",
+        stagingStatus: "staged",
+        status: "blocked",
+      },
+      expected: {
+        blockerSummary: "active_sale",
+        canApply: false,
+        currentBuildId: "build-current",
+        detectorStatus: "ok",
+        observedAt: 2_000,
+        pendingBuildId: "build-next",
+        selectedBlockerCode: "active_sale",
+        stagingStatus: "staged",
+        status: "blocked",
+      },
+    },
+    {
+      name: "detector failed",
+      appUpdate: {
+        canApply: false,
+        currentBuildId: "build-current",
+        detectorStatus: "failed",
+        status: "detector_failed",
+      },
+      expected: {
+        canApply: false,
+        currentBuildId: "build-current",
+        detectorStatus: "failed",
+        observedAt: 2_000,
+        status: "detector_failed",
+      },
+    },
+  ] satisfies Array<{
+    name: string;
+    appUpdate: PosTerminalRuntimeStatusInput["appUpdate"];
+    expected: NonNullable<
+      ReturnType<typeof buildPosTerminalRuntimeStatus>["appUpdate"]
+    >;
+  }>)(
+    "reports sanitized app-update runtime evidence for $name state",
+    ({ appUpdate, expected }) => {
+      const status = buildPosTerminalRuntimeStatus({
+        appUpdate,
+        clock: () => 2_000,
+        events: [],
+        source: "register",
+      });
+
+      expect(status.appUpdate).toEqual(expected);
+    },
+  );
+
+  it("reports command-correlated app-update evidence without local payload or blocker text", () => {
+    const status = buildPosTerminalRuntimeStatus({
+      appUpdate: {
+        canApply: false,
+        command: {
+          executionId: "exec-123",
+          issuedAt: 1_900,
+          nonce: "nonce-abc",
+        },
+        currentBuildId: "build-current",
+        detectorStatus: "ok",
+        pendingBuildId: "build-next",
+        selectedBlockerCode: "active_sale",
+        stagingStatus: "staged",
+        status: "blocked",
+        blockerLabel: "Customer checkout token secret raw backend error",
+        localPayload: {
+          customerEmail: "customer@example.com",
+          payments: [{ amount: 10_000 }],
+          staffProofToken: "proof-token",
+        },
+      } as PosTerminalRuntimeStatusInput["appUpdate"],
+      clock: () => 2_000,
+      events: [],
+      source: "register",
+    });
+
+    expect(status.appUpdate).toEqual({
+      blockerSummary: "active_sale",
+      canApply: false,
+      commandExecutionId: "exec-123",
+      commandIssuedAt: 1_900,
+      commandNonce: "nonce-abc",
+      currentBuildId: "build-current",
+      detectorStatus: "ok",
+      observedAt: 2_000,
+      pendingBuildId: "build-next",
+      selectedBlockerCode: "active_sale",
+      stagingStatus: "staged",
+      status: "blocked",
+    });
+
+    const serialized = JSON.stringify(status.appUpdate);
+    expect(serialized).not.toContain("Customer checkout");
+    expect(serialized).not.toContain("customer@example.com");
+    expect(serialized).not.toContain("payments");
+    expect(serialized).not.toContain("proof-token");
+    expect(serialized).not.toContain("raw backend error");
+  });
+
   it("reports sale authority when the local terminal can transact now", () => {
     const status = buildPosTerminalRuntimeStatus({
       clock: () => 2_000,

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
@@ -71,6 +71,7 @@ export type PosTerminalRuntimeStatusPayload =
   ReportTerminalRuntimeStatusPayload & {
     activeRegisterSession?: PosTerminalRuntimeActiveRegisterSessionDiagnostics;
     appShell?: PosTerminalRuntimeAppShellDiagnostics;
+    appUpdate?: PosTerminalRuntimeAppUpdateDiagnostics;
     appSessionRecovery?: PosTerminalRuntimeAppSessionRecoveryDiagnostics;
   };
 export type PosTerminalRuntimeStatusSyncStatus =
@@ -123,9 +124,63 @@ export type PosTerminalRuntimeAppShellDiagnostics =
     observedAt: number;
   };
 
+export type PosTerminalRuntimeAppUpdateStatus =
+  | "current"
+  | "checking"
+  | "update_ready"
+  | "update_ready_unstaged"
+  | "blocked"
+  | "applying"
+  | "detector_failed"
+  | "unknown";
+
+export type PosTerminalRuntimeAppUpdateStagingStatus =
+  | "staged"
+  | "unstaged"
+  | "unknown";
+
+export type PosTerminalRuntimeAppUpdateDetectorStatus =
+  | "ok"
+  | "failed"
+  | "unknown";
+
+export type PosTerminalRuntimeAppUpdateBlockerCode =
+  | "active_sale"
+  | "active_command"
+  | "resume_required"
+  | "unknown";
+
+export type PosTerminalRuntimeAppUpdateCommandCorrelation = {
+  executionId?: string;
+  issuedAt?: number;
+  nonce?: string;
+};
+
+export type PosTerminalRuntimeAppUpdateInput = {
+  canApply: boolean;
+  command?: PosTerminalRuntimeAppUpdateCommandCorrelation | null;
+  commandExecutionId?: string;
+  commandId?: string;
+  commandIssuedAt?: number;
+  commandNonce?: string;
+  currentBuildId?: string;
+  detectorStatus: PosTerminalRuntimeAppUpdateDetectorStatus;
+  pendingBuildId?: string;
+  selectedBlockerCode?: PosTerminalRuntimeAppUpdateBlockerCode;
+  stagingStatus?: PosTerminalRuntimeAppUpdateStagingStatus;
+  status: PosTerminalRuntimeAppUpdateStatus;
+};
+
+export type PosTerminalRuntimeAppUpdateDiagnostics =
+  PosTerminalRuntimeAppUpdateInput & {
+    command?: PosTerminalRuntimeAppUpdateCommandCorrelation;
+    observedAt: number;
+  };
+
 export type PosTerminalRuntimeStatusInput = {
   activeRegisterSession?: PosTerminalRuntimeActiveRegisterSessionInput | null;
   appShell?: PosTerminalRuntimeAppShellInput | null;
+  appUpdate?: PosTerminalRuntimeAppUpdateInput | null;
   appVersion?: string;
   appSessionRecovery?: PosTerminalRuntimeAppSessionRecoveryInput | null;
   browserInfo?: PosTerminalRuntimeBrowserInfo;
@@ -237,6 +292,32 @@ type PosTerminalRuntimeSyncMetrics = {
   uploadableEventCount: number;
 };
 
+const appUpdateStatuses = new Set<PosTerminalRuntimeAppUpdateStatus>([
+  "current",
+  "checking",
+  "update_ready",
+  "update_ready_unstaged",
+  "blocked",
+  "applying",
+  "detector_failed",
+  "unknown",
+]);
+
+const appUpdateStagingStatuses = new Set<
+  PosTerminalRuntimeAppUpdateStagingStatus | undefined
+>(["staged", "unstaged", "unknown", undefined]);
+
+const appUpdateDetectorStatuses =
+  new Set<PosTerminalRuntimeAppUpdateDetectorStatus>([
+    "ok",
+    "failed",
+    "unknown",
+  ]);
+
+const appUpdateBlockerCodes = new Set<
+  PosTerminalRuntimeAppUpdateBlockerCode | undefined
+>(["active_sale", "active_command", "resume_required", "unknown", undefined]);
+
 export function buildPosTerminalRuntimeStatus(
   input: PosTerminalRuntimeStatusInput,
 ): PosTerminalRuntimeStatusPayload {
@@ -250,12 +331,14 @@ export function buildPosTerminalRuntimeStatus(
   const appSessionRecovery = toSafeAppSessionRecoveryDiagnostics(
     input.appSessionRecovery,
   );
+  const appUpdate = toSafeAppUpdateDiagnostics(input.appUpdate, now);
 
   return {
     ...(input.appVersion ? { appVersion: input.appVersion } : {}),
     ...(input.buildSha ? { buildSha: input.buildSha } : {}),
     ...(input.browserInfo ? { browserInfo: input.browserInfo } : {}),
     ...(appSessionRecovery ? { appSessionRecovery } : {}),
+    ...(appUpdate ? { appUpdate } : {}),
     ...(input.appShell
       ? {
           appShell: {
@@ -680,6 +763,65 @@ function toSafeAppSessionRecoveryLabel(
   return "blocked_terminal";
 }
 
+function toSafeAppUpdateDiagnostics(
+  appUpdate: PosTerminalRuntimeAppUpdateInput | null | undefined,
+  observedAt: number,
+): PosTerminalRuntimeAppUpdateDiagnostics | undefined {
+  if (!appUpdate) return undefined;
+
+  return omitUndefined({
+    canApply: appUpdate.canApply === true,
+    blockerSummary: appUpdateBlockerCodes.has(appUpdate.selectedBlockerCode)
+      ? appUpdate.selectedBlockerCode
+      : undefined,
+    commandExecutionId: toSafeRuntimeString(
+      appUpdate.commandExecutionId ?? appUpdate.command?.executionId,
+      120,
+    ),
+    commandId: toSafeRuntimeString(appUpdate.commandId, 120),
+    commandIssuedAt:
+      positiveRuntimeTimestamp(appUpdate.commandIssuedAt) ??
+      positiveRuntimeTimestamp(appUpdate.command?.issuedAt),
+    commandNonce: toSafeRuntimeString(
+      appUpdate.commandNonce ?? appUpdate.command?.nonce,
+      120,
+    ),
+    currentBuildId: toSafeBuildId(appUpdate.currentBuildId),
+    detectorStatus: appUpdateDetectorStatuses.has(appUpdate.detectorStatus)
+      ? appUpdate.detectorStatus
+      : "unknown",
+    observedAt,
+    pendingBuildId: toSafeBuildId(appUpdate.pendingBuildId),
+    selectedBlockerCode: appUpdateBlockerCodes.has(
+      appUpdate.selectedBlockerCode,
+    )
+      ? appUpdate.selectedBlockerCode
+      : undefined,
+    stagingStatus: appUpdateStagingStatuses.has(appUpdate.stagingStatus)
+      ? appUpdate.stagingStatus
+      : undefined,
+    status: appUpdateStatuses.has(appUpdate.status)
+      ? appUpdate.status
+      : "unknown",
+  });
+}
+
+function positiveRuntimeTimestamp(value: number | undefined) {
+  return Number.isFinite(value) && value !== undefined && value > 0
+    ? value
+    : undefined;
+}
+
+function toSafeBuildId(value: string | undefined) {
+  return toSafeRuntimeString(value, 120);
+}
+
+function toSafeRuntimeString(value: string | undefined, maxLength: number) {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return trimmed.slice(0, maxLength);
+}
+
 function snapshotAges(
   snapshots: PosTerminalRuntimeSnapshotReadiness | undefined,
   now: number,
@@ -780,4 +922,15 @@ function toSafeFailureMessage(message?: string | null) {
     )
     .replace(/[A-Za-z0-9_-]{24,}/g, "[redacted]")
     .slice(0, 240);
+}
+
+function omitUndefined<T extends Record<string, unknown>>(input: T) {
+  return Object.fromEntries(
+    Object.entries(input).filter(([, value]) => value !== undefined),
+  ) as {
+    [Key in keyof T as undefined extends T[Key] ? Key : Key]: Exclude<
+      T[Key],
+      undefined
+    >;
+  };
 }

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -2669,6 +2669,73 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     );
   });
 
+  it("publishes app update coordinator evidence with runtime check-ins", async () => {
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+    };
+    const appUpdateCoordinator = {
+      applyUpdate: vi.fn(() => true),
+      getSnapshot: vi.fn(() => ({
+        blockers: [],
+        canApply: true,
+        currentBuildId: "build-current",
+        pendingBuildId: "build-next",
+        status: "ready" as const,
+      })),
+    };
+
+    const { result } = renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        appUpdateCoordinator,
+        mode: "status-only",
+        source: "register",
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current?.runtimeStatus?.appUpdate).toEqual(
+        expect.objectContaining({
+          canApply: true,
+          currentBuildId: "build-current",
+          detectorStatus: "ok",
+          pendingBuildId: "build-next",
+          stagingStatus: "staged",
+          status: "update_ready",
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(mocks.reportTerminalRuntimeStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: expect.objectContaining({
+            appUpdate: expect.objectContaining({
+              pendingBuildId: "build-next",
+              status: "update_ready",
+            }),
+          }),
+        }),
+      ),
+    );
+  });
+
   it("exposes rejected runtime check-in publishes in debug state", async () => {
     mocks.reportTerminalRuntimeStatus.mockResolvedValue({
       kind: "user_error",
@@ -3340,6 +3407,58 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         runtimeStatus: {
           ...runtimeStatus,
           reportedAt: 200,
+        } as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+  });
+
+  it("normalizes volatile app-update observation timestamps in publish signatures", () => {
+    const runtimeStatus = {
+      appUpdate: {
+        canApply: true,
+        currentBuildId: "build-current",
+        detectorStatus: "ok",
+        observedAt: 100,
+        pendingBuildId: "build-next",
+        stagingStatus: "staged",
+        status: "update_ready",
+      },
+      localStore: {
+        available: true,
+        terminalSeedReady: true,
+      },
+      reportedAt: 100,
+      snapshots: {},
+      source: "sync-runtime",
+      staffAuthority: {
+        status: "unknown",
+      },
+      sync: {
+        failedEventCount: 0,
+        localOnlyEventCount: 0,
+        pendingEventCount: 0,
+        reviewEventCount: 0,
+        status: "idle",
+        uploadableEventCount: 0,
+      },
+    };
+
+    expect(
+      getRuntimeStatusSignature({
+        runtimeStatus: runtimeStatus as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    ).toEqual(
+      getRuntimeStatusSignature({
+        runtimeStatus: {
+          ...runtimeStatus,
+          appUpdate: {
+            ...runtimeStatus.appUpdate,
+            observedAt: 200,
+          },
         } as never,
         storeId: "store-1",
         terminalId: "terminal-cloud-1",
@@ -4171,6 +4290,251 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       }),
     );
     expect(retry).toHaveBeenCalled();
+  });
+
+  it("acknowledges update_app before invoking the app update coordinator apply latch", async () => {
+    const command = buildRecoveryCommand({
+      commandType: "update_app",
+      executionId: "command-1:2000100",
+    });
+    const ack = deferred<{ kind: "ok"; data: Record<string, never> }>();
+    const applyUpdate = vi.fn(() => true);
+    const appUpdateCoordinator = {
+      applyUpdate,
+      getSnapshot: () => ({
+        blockers: [],
+        canApply: true,
+        currentBuildId: "build-1",
+        pendingBuildId: "build-2",
+        status: "ready" as const,
+      }),
+    };
+    const storeFactory = () => buildRecoveryCommandStore() as never;
+    const commandResult = { kind: "ok", data: [command] };
+    mocks.listTerminalRecoveryCommands.mockImplementation((args) =>
+      args === "skip" ? undefined : commandResult,
+    );
+    mocks.claimTerminalRecoveryCommand.mockResolvedValue({
+      kind: "ok",
+      data: command,
+    });
+    mocks.acknowledgeTerminalRecoveryCommand.mockReturnValue(ack.promise);
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        appUpdateCoordinator,
+        mode: "status-only",
+        storeFactory,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.acknowledgeTerminalRecoveryCommand).toHaveBeenCalledWith({
+        commandId: "command-1",
+        executionId: "command-1:2000100",
+        message:
+          "App update accepted and will apply when the terminal is safe to refresh.",
+        result: "completed",
+        storeId: "store-1",
+        syncSecretHash: "sync-secret-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+    expect(applyUpdate).not.toHaveBeenCalled();
+
+    await act(async () => {
+      ack.resolve({ kind: "ok", data: {} });
+      await ack.promise;
+    });
+
+    await waitFor(() => expect(applyUpdate).toHaveBeenCalledTimes(1));
+  });
+
+  it("publishes a fresh runtime observation when update_app apply returns false after acknowledgement", async () => {
+    const command = buildRecoveryCommand({
+      commandType: "update_app",
+      executionId: "command-1:2000100",
+    });
+    const applyUpdate = vi.fn(() => false);
+    const appUpdateCoordinator = {
+      applyUpdate,
+      getSnapshot: () => ({
+        blockers: [],
+        canApply: true,
+        currentBuildId: "build-1",
+        pendingBuildId: "build-2",
+        status: "ready" as const,
+      }),
+    };
+    const storeFactory = () => buildRecoveryCommandStore() as never;
+    const commandResult = { kind: "ok", data: [command] };
+    mocks.listTerminalRecoveryCommands.mockImplementation((args) =>
+      args === "skip" ? undefined : commandResult,
+    );
+    mocks.claimTerminalRecoveryCommand.mockResolvedValue({
+      kind: "ok",
+      data: command,
+    });
+    const initialReportCount = mocks.reportTerminalRuntimeStatus.mock.calls.length;
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        appUpdateCoordinator,
+        mode: "status-only",
+        storeFactory,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() => expect(applyUpdate).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      const publishedAppUpdate = mocks.reportTerminalRuntimeStatus.mock.calls
+        .slice(initialReportCount)
+        .map((call) => call[0]?.status?.appUpdate)
+        .find(
+          (appUpdate) =>
+            appUpdate?.commandExecutionId === "command-1:2000100",
+        );
+
+      expect(publishedAppUpdate).toEqual(
+        expect.objectContaining({
+          commandExecutionId: "command-1:2000100",
+          commandId: "command-1",
+          status: "update_ready",
+        }),
+      );
+    });
+  });
+
+  it("runs update_app post-ack cleanup even when the hook unmounts during acknowledgement", async () => {
+    const command = buildRecoveryCommand({
+      commandType: "update_app",
+      executionId: "command-1:2000100",
+    });
+    const ack = deferred<{ kind: "ok"; data: Record<string, never> }>();
+    const applyUpdate = vi.fn(() => true);
+    const storage = {
+      getItem: vi.fn(() => null),
+      removeItem: vi.fn(),
+      setItem: vi.fn(),
+    };
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      value: storage,
+    });
+    const appUpdateCoordinator = {
+      applyUpdate,
+      getSnapshot: () => ({
+        blockers: [],
+        canApply: true,
+        currentBuildId: "build-1",
+        pendingBuildId: "build-2",
+        status: "ready" as const,
+      }),
+    };
+    const storeFactory = () => buildRecoveryCommandStore() as never;
+    const commandResult = { kind: "ok", data: [command] };
+    mocks.listTerminalRecoveryCommands.mockImplementation((args) =>
+      args === "skip" ? undefined : commandResult,
+    );
+    mocks.claimTerminalRecoveryCommand.mockResolvedValue({
+      kind: "ok",
+      data: command,
+    });
+    mocks.acknowledgeTerminalRecoveryCommand.mockReturnValue(ack.promise);
+
+    const { unmount } = renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        appUpdateCoordinator,
+        mode: "status-only",
+        storeFactory,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.acknowledgeTerminalRecoveryCommand).toHaveBeenCalled(),
+    );
+    unmount();
+
+    await act(async () => {
+      ack.resolve({ kind: "ok", data: {} });
+      await ack.promise;
+    });
+
+    expect(storage.setItem).toHaveBeenCalled();
+    expect(applyUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload when update_app reload correlation cannot be stored", async () => {
+    const command = buildRecoveryCommand({
+      commandType: "update_app",
+      executionId: "command-1:2000100",
+    });
+    const applyUpdate = vi.fn(() => true);
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      value: {
+        getItem: vi.fn(() => null),
+        removeItem: vi.fn(),
+        setItem: vi.fn(() => {
+          throw new Error("storage unavailable");
+        }),
+      },
+    });
+    const appUpdateCoordinator = {
+      applyUpdate,
+      getSnapshot: () => ({
+        blockers: [],
+        canApply: true,
+        currentBuildId: "build-1",
+        pendingBuildId: "build-2",
+        status: "ready" as const,
+      }),
+    };
+    const storeFactory = () => buildRecoveryCommandStore() as never;
+    const commandResult = { kind: "ok", data: [command] };
+    mocks.listTerminalRecoveryCommands.mockImplementation((args) =>
+      args === "skip" ? undefined : commandResult,
+    );
+    mocks.claimTerminalRecoveryCommand.mockResolvedValue({
+      kind: "ok",
+      data: command,
+    });
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        appUpdateCoordinator,
+        mode: "status-only",
+        storeFactory,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.acknowledgeTerminalRecoveryCommand).toHaveBeenCalled(),
+    );
+    await waitFor(() => {
+      const publishedAppUpdate = mocks.reportTerminalRuntimeStatus.mock.calls
+        .map((call) => call[0]?.status?.appUpdate)
+        .find(
+          (appUpdate) =>
+            appUpdate?.commandExecutionId === "command-1:2000100",
+        );
+
+      expect(publishedAppUpdate).toEqual(
+        expect.objectContaining({
+          commandExecutionId: "command-1:2000100",
+          status: "update_ready",
+        }),
+      );
+    });
+    expect(applyUpdate).not.toHaveBeenCalled();
   });
 
   it("refreshes drawer authority before publishing the post-recovery check-in", async () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -63,6 +63,7 @@ import {
   buildPosTerminalRuntimeCopyDiagnostics,
   buildPosTerminalRuntimeStatus,
   toReportablePosTerminalRuntimeStatus,
+  type PosTerminalRuntimeAppUpdateInput,
   type PosTerminalRuntimeAppSessionRecoveryInput,
   type PosTerminalRuntimeCopyDiagnostics,
   type PosTerminalRuntimeStatusPayload,
@@ -71,10 +72,20 @@ import {
 } from "./terminalRuntimeStatus";
 import {
   executeTerminalRecoveryCommand,
+  type PosAppUpdateCoordinatorAdapter,
   type PosTerminalRecoveryCommandResult,
 } from "./terminalRecoveryCommands";
 
 export { getRuntimeStatusSignature } from "./runtimeStatusPublisher";
+
+const APP_UPDATE_COMMAND_CORRELATION_STORAGE_KEY =
+  "athena-pos-app-update-command-correlation";
+
+type AppUpdateCommandCorrelation = {
+  commandExecutionId: string;
+  commandId?: string;
+  commandIssuedAt?: number;
+};
 
 export type PosLocalRuntimeSyncStatusSource = {
   copyDiagnostics?: PosTerminalRuntimeCopyDiagnostics;
@@ -163,6 +174,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
   onLocalEventsChanged?: (() => void) | null;
   onRetrySync?: (() => void) | null;
   source?: PosTerminalRuntimeStatusSource;
+  appUpdateCoordinator?: PosAppUpdateCoordinatorAdapter | null;
   staffProfileId?: string | null;
   staffAuthorityStatus?: PosLocalStaffAuthorityReadiness | "unknown";
   storeFactory?: (() => PosLocalRuntimeStore) | null;
@@ -188,6 +200,10 @@ export function usePosLocalSyncRuntimeStatus(input: {
   const [manualRetryToken, setManualRetryToken] = useState(0);
   const [runtimeStatusObservationToken, setRuntimeStatusObservationToken] =
     useState(0);
+  const [appUpdateCommandCorrelation, setAppUpdateCommandCorrelation] =
+    useState<AppUpdateCommandCorrelation | null>(() =>
+      readStoredAppUpdateCommandCorrelation(),
+    );
   const [runtimeBuildMetadata, setRuntimeBuildMetadata] = useState(
     getInitialRuntimeBuildMetadata,
   );
@@ -202,6 +218,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
   const drainOnAppend = input.drainOnAppend ?? false;
   const eventAppendToken = input.eventAppendToken ?? 0;
   const mode = input.mode ?? "drain-enabled";
+  const appUpdateCoordinator = input.appUpdateCoordinator;
   const onLocalEventsChanged = input.onLocalEventsChanged;
   const onRetrySync = input.onRetrySync;
   const source = input.source ?? "sync-runtime";
@@ -794,12 +811,21 @@ export function usePosLocalSyncRuntimeStatus(input: {
       debug.schedulerRunning,
     ],
   );
+  const runtimeAppUpdate = useMemo(
+    () =>
+      buildRuntimeAppUpdateInput({
+        appUpdateCoordinator,
+        commandCorrelation: appUpdateCommandCorrelation,
+      }),
+    [appUpdateCommandCorrelation, appUpdateCoordinator],
+  );
 
   const runtimeStatusInput = useMemo(
     () => ({
       activeRegisterSession: runtimeReadiness.activeRegisterSession,
       appShell: runtimeReadiness.appShell,
       appSessionRecovery: input.appSessionRecovery,
+      appUpdate: runtimeAppUpdate,
       appVersion: runtimeBuildMetadata.appVersion,
       buildSha: runtimeBuildMetadata.buildSha,
       browserInfo: getRuntimeBrowserInfo(isOnline),
@@ -821,6 +847,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
       input.staffAuthorityStatus,
       isOnline,
       readError,
+      runtimeAppUpdate,
       runtimeReadiness.activeRegisterSession,
       runtimeReadiness.appShell,
       runtimeBuildMetadata.appVersion,
@@ -928,6 +955,10 @@ export function usePosLocalSyncRuntimeStatus(input: {
         if (!isCurrentPublishScope()) return;
 
         if (result.kind === "ok") {
+          if (appUpdateCommandCorrelation) {
+            clearStoredAppUpdateCommandCorrelation();
+            setAppUpdateCommandCorrelation(null);
+          }
           if (runtimeReadiness.terminalSeed) {
             const authorityStore =
               storeFactory?.() ??
@@ -1061,6 +1092,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
     reportTerminalRuntimeStatus,
     events.length,
     readError,
+    appUpdateCommandCorrelation,
     runtimeStatus,
     runtimeStatusObservationToken,
     runtimeReadiness.terminalIntegrity,
@@ -1137,6 +1169,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
 
         const localResult = await executeTerminalRecoveryCommand({
           command: claimResult.data,
+          appUpdateCoordinator,
           onRetrySync: requestRetry,
           refreshStaffAuthority: async ({ storeId, terminalId }) => {
             if (typeof store.replaceStaffAuthoritySnapshot !== "function") {
@@ -1192,6 +1225,12 @@ export function usePosLocalSyncRuntimeStatus(input: {
           terminalId: runtimeStatusTerminalId,
           terminalSeed: runtimeReadiness.terminalSeed,
         });
+        const updateAppCorrelation = buildAppUpdateCommandCorrelation(
+          claimResult.data,
+        );
+        if (updateAppCorrelation) {
+          setAppUpdateCommandCorrelation(updateAppCorrelation);
+        }
 
         if (localResult.status === "ignored") {
           observedRecoveryCommandIdsRef.current.delete(command._id);
@@ -1208,8 +1247,13 @@ export function usePosLocalSyncRuntimeStatus(input: {
         }
 
         const ackResult = toTerminalRecoveryCommandAckResult(localResult);
+        const executionId =
+          typeof claimResult.data.executionId === "string"
+            ? claimResult.data.executionId
+            : undefined;
         const acknowledged = await acknowledgeTerminalRecoveryCommand({
           commandId: claimResult.data._id,
+          ...(executionId ? { executionId } : {}),
           message: localResult.message,
           result: ackResult,
           storeId: storeId as Id<"store">,
@@ -1217,14 +1261,34 @@ export function usePosLocalSyncRuntimeStatus(input: {
           terminalId: runtimeStatusTerminalId as Id<"posTerminal">,
         });
         if (acknowledged.kind !== "ok") {
+          localResult.onAcknowledgeFailed?.();
+          if (updateAppCorrelation) {
+            clearStoredAppUpdateCommandCorrelation();
+            setAppUpdateCommandCorrelation(null);
+          }
           observedRecoveryCommandIdsRef.current.delete(command._id);
           if (!isStale) {
             setRecoveryCommandRetryToken((current) => current + 1);
           }
         }
-        if (isStale) return;
-
+        let postAcknowledgeMessage: string | undefined;
         if (acknowledged.kind === "ok") {
+          const persistedReloadCorrelation = updateAppCorrelation
+            ? storeAppUpdateCommandCorrelation(updateAppCorrelation)
+            : true;
+          const postAcknowledgeResult = persistedReloadCorrelation
+            ? await localResult.postAcknowledge?.()
+            : {
+                applied: false,
+                message:
+                  "App update was accepted, but refresh evidence could not be saved.",
+              };
+          postAcknowledgeMessage = postAcknowledgeResult?.message;
+          if (postAcknowledgeResult?.applied === false) {
+            clearStoredAppUpdateCommandCorrelation();
+          }
+          if (isStale) return;
+
           const readiness = await refreshTerminalRuntimeReadiness({
             store,
             storeId,
@@ -1241,7 +1305,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
           terminalRecoveryCommandCompletedAt: Date.now(),
           terminalRecoveryCommandMessage:
             acknowledged.kind === "ok"
-              ? localResult.message
+              ? (postAcknowledgeMessage ?? localResult.message)
               : acknowledged.kind === "user_error"
                 ? acknowledged.error.message
                 : "Recovery command acknowledgement failed.",
@@ -1272,6 +1336,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
   }, [
     acknowledgeTerminalRecoveryCommand,
     claimTerminalRecoveryCommand,
+    appUpdateCoordinator,
     onLocalEventsChanged,
     recoveryCommandRetryToken,
     recoveryCommands,
@@ -1845,6 +1910,149 @@ function hasPendingSyncableExpenseEvents(
         event.sync.status === "failed") &&
       isSyncablePosLocalEvent(event, uploadSupport),
   );
+}
+
+function buildRuntimeAppUpdateInput({
+  appUpdateCoordinator,
+  commandCorrelation,
+}: {
+  appUpdateCoordinator?: PosAppUpdateCoordinatorAdapter | null;
+  commandCorrelation?: AppUpdateCommandCorrelation | null;
+}): PosTerminalRuntimeAppUpdateInput | null {
+  if (!appUpdateCoordinator) return null;
+
+  try {
+    const snapshot = appUpdateCoordinator.getSnapshot();
+    return {
+      canApply: snapshot.canApply,
+      commandExecutionId: commandCorrelation?.commandExecutionId,
+      commandId: commandCorrelation?.commandId,
+      commandIssuedAt: commandCorrelation?.commandIssuedAt,
+      currentBuildId: snapshot.currentBuildId,
+      detectorStatus: snapshot.status === "detector-failed" ? "failed" : "ok",
+      pendingBuildId: snapshot.pendingBuildId,
+      selectedBlockerCode: toRuntimeAppUpdateBlockerCode(
+        snapshot.selectedBlocker?.priority,
+      ),
+      stagingStatus:
+        snapshot.status === "ready"
+          ? "staged"
+          : snapshot.status === "ready-unstaged"
+            ? "unstaged"
+            : "unknown",
+      status: toRuntimeAppUpdateStatus(snapshot.status),
+    };
+  } catch {
+    return {
+      canApply: false,
+      commandExecutionId: commandCorrelation?.commandExecutionId,
+      commandId: commandCorrelation?.commandId,
+      commandIssuedAt: commandCorrelation?.commandIssuedAt,
+      detectorStatus: "failed",
+      stagingStatus: "unknown",
+      status: "detector_failed",
+    };
+  }
+}
+
+function toRuntimeAppUpdateStatus(
+  status: ReturnType<PosAppUpdateCoordinatorAdapter["getSnapshot"]>["status"],
+): PosTerminalRuntimeAppUpdateInput["status"] {
+  if (status === "ready") return "update_ready";
+  if (status === "ready-unstaged") return "update_ready_unstaged";
+  if (status === "detector-failed") return "detector_failed";
+  return status;
+}
+
+function toRuntimeAppUpdateBlockerCode(
+  priority?: "critical-workflow" | "active-command" | "resume-required",
+): PosTerminalRuntimeAppUpdateInput["selectedBlockerCode"] {
+  if (priority === "critical-workflow") return "active_sale";
+  if (priority === "active-command") return "active_command";
+  if (priority === "resume-required") return "resume_required";
+  return undefined;
+}
+
+function buildAppUpdateCommandCorrelation(command: {
+  _id?: unknown;
+  commandId?: unknown;
+  commandType?: unknown;
+  executionId?: unknown;
+  issuedAt?: unknown;
+  type?: unknown;
+}): AppUpdateCommandCorrelation | null {
+  const commandType = command.type ?? command.commandType;
+  if (commandType !== "update_app" || typeof command.executionId !== "string") {
+    return null;
+  }
+
+  return {
+    commandExecutionId: command.executionId,
+    commandId:
+      typeof command.commandId === "string"
+        ? command.commandId
+        : typeof command._id === "string"
+          ? command._id
+          : undefined,
+    commandIssuedAt:
+      typeof command.issuedAt === "number" && Number.isFinite(command.issuedAt)
+        ? command.issuedAt
+        : undefined,
+  };
+}
+
+function readStoredAppUpdateCommandCorrelation() {
+  if (typeof sessionStorage === "undefined") return null;
+
+  try {
+    const stored = sessionStorage.getItem(
+      APP_UPDATE_COMMAND_CORRELATION_STORAGE_KEY,
+    );
+    if (!stored) return null;
+
+    const parsed = JSON.parse(stored) as Partial<AppUpdateCommandCorrelation>;
+    return typeof parsed.commandExecutionId === "string" &&
+      parsed.commandExecutionId.length > 0
+      ? {
+          commandExecutionId: parsed.commandExecutionId,
+          ...(typeof parsed.commandId === "string"
+            ? { commandId: parsed.commandId }
+            : {}),
+          ...(typeof parsed.commandIssuedAt === "number" &&
+          Number.isFinite(parsed.commandIssuedAt)
+            ? { commandIssuedAt: parsed.commandIssuedAt }
+            : {}),
+        }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function storeAppUpdateCommandCorrelation(
+  correlation: AppUpdateCommandCorrelation,
+) {
+  if (typeof sessionStorage === "undefined") return false;
+
+  try {
+    sessionStorage.setItem(
+      APP_UPDATE_COMMAND_CORRELATION_STORAGE_KEY,
+      JSON.stringify(correlation),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function clearStoredAppUpdateCommandCorrelation() {
+  if (typeof sessionStorage === "undefined") return;
+
+  try {
+    sessionStorage.removeItem(APP_UPDATE_COMMAND_CORRELATION_STORAGE_KEY);
+  } catch {
+    // Best effort only.
+  }
 }
 
 function hasPendingLocalCloseout(events: PosLocalEventRecord[]) {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterLocalRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterLocalRuntime.test.ts
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => {
     usePosTerminalAppSessionRecoveryRuntimeInput: vi.fn(() => ({
       status: "idle",
     })),
+    useOptionalUpdateCoordinator: vi.fn(() => null),
   };
 });
 
@@ -48,6 +49,10 @@ vi.mock("@/lib/pos/infrastructure/local/localRegisterReader", () => ({
 
 vi.mock("@/lib/pos/infrastructure/local/usePosLocalSyncRuntime", () => ({
   usePosLocalSyncRuntimeStatus: mocks.usePosLocalSyncRuntimeStatus,
+}));
+
+vi.mock("@/lib/app-update/UpdateCoordinatorProvider", () => ({
+  useOptionalUpdateCoordinator: mocks.useOptionalUpdateCoordinator,
 }));
 
 vi.mock(
@@ -121,6 +126,7 @@ describe("useRegisterLocalRuntime", () => {
       ok: true,
       value: { canSell: true },
     });
+    mocks.useOptionalUpdateCoordinator.mockReturnValue(null);
   });
 
   it("creates a stable local store and gateway while terminal identity is unchanged", async () => {
@@ -174,6 +180,26 @@ describe("useRegisterLocalRuntime", () => {
     });
 
     expect(result.current.localSyncEventAppendToken).toBe(1);
+  });
+
+  it("passes the app update coordinator adapter into the local sync runtime", () => {
+    const applyUpdate = vi.fn();
+    const getSnapshot = vi.fn();
+    mocks.useOptionalUpdateCoordinator.mockReturnValue({
+      applyUpdate,
+      getSnapshot,
+    } as never);
+
+    renderRuntime();
+
+    expect(mocks.usePosLocalSyncRuntimeStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appUpdateCoordinator: {
+          applyUpdate,
+          getSnapshot,
+        },
+      }),
+    );
   });
 
   it("refreshes the projected local register read model through the runtime bridge", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterLocalRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterLocalRuntime.ts
@@ -3,6 +3,7 @@ import type { MutableRefObject } from "react";
 
 import type { Id } from "~/convex/_generated/dataModel";
 
+import { useOptionalUpdateCoordinator } from "@/lib/app-update/UpdateCoordinatorProvider";
 import {
   createIndexedDbPosLocalStorageAdapter,
   createPosLocalStore,
@@ -132,6 +133,17 @@ export function useRegisterLocalRuntime(input: {
   );
 
   const appSessionRecovery = usePosTerminalAppSessionRecoveryRuntimeInput();
+  const updateCoordinator = useOptionalUpdateCoordinator();
+  const appUpdateCoordinator = useMemo(
+    () =>
+      updateCoordinator
+        ? {
+            applyUpdate: updateCoordinator.applyUpdate,
+            getSnapshot: updateCoordinator.getSnapshot,
+          }
+        : null,
+    [updateCoordinator],
+  );
   const localSaleValidationMetadata = useMemo(
     () => buildLocalSaleValidationMetadata(appSessionRecovery?.status),
     [appSessionRecovery?.status],
@@ -239,6 +251,7 @@ export function useRegisterLocalRuntime(input: {
 
   const localRuntimeStoreFactory = useCallback(() => localStore, [localStore]);
   const localRuntimeSyncSource = usePosLocalSyncRuntimeStatus({
+    appUpdateCoordinator,
     appSessionRecovery,
     drainOnAppend: true,
     eventAppendToken: localSyncEventAppendToken,


### PR DESCRIPTION
## Summary
- Adds the update_app terminal recovery command contract, execution correlation, and stale-client filtering so old terminals do not claim unsupported commands.
- Publishes app-update runtime evidence from POS and Remote Assist hosts, including command execution IDs across reloads.
- Exposes terminal update state and an Update app action in Terminal Health, with docs and Graphify refreshed.

## Linear
- V26-769 Add update_app terminal command contract
- V26-770 Publish app-update runtime evidence for terminals
- V26-771 Execute update_app through app-update coordinator
- V26-772 Derive Terminal Health update state from runtime evidence
- V26-773 Expose Update app action in Terminal Health
- V26-774 Document and route remote Update app validation

## Validation
- Reviewer loop: API contract, security, correctness, reliability, and testing reviewers approved unanimously.
- bun run pr:athena
- Focused suites for terminal recovery commands, runtime status, local sync runtime, Terminal Health presentation/detail views, public terminal APIs, and query preview correlation.