### PR TITLE
Fix terminal health command status return validator

### DIFF
--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -1109,6 +1109,7 @@ describe("POS terminal public mutations", () => {
       "latestReviewEvent",
       "latestReviewEventsByStatus",
       "appUpdate",
+      "appUpdateCommandExecutionId",
       "commandCorrelated",
       "evidenceFresh",
       "pendingBuildId",

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -354,6 +354,7 @@ const terminalHealthSummaryReturnValidator = v.object({
       }),
       commandStatus: v.union(
         v.object({
+          appUpdateCommandExecutionId: v.optional(v.string()),
           commandId: v.optional(v.id("posTerminalRecoveryCommand")),
           commandType: posTerminalRecoveryCommandTypeValidator,
           label: v.string(),


### PR DESCRIPTION
## Summary
- Allows `recoveryPreview.commandStatus.appUpdateCommandExecutionId` in the public terminal health return validator.
- Extends the validator export regression test to cover that field.
- Refreshes Graphify after the Convex code change.

## Production
- Deployed Convex hotfix directly to prod to stop the terminal health route `ReturnsValidationError`.
- Filtered prod log watch after deploy did not emit the matching terminal-health validator signature.

## Validation
- `bun run --filter @athena/webapp test -- convex/pos/public/terminals.test.ts`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run --filter @athena/webapp lint:convex:changed`
- `scripts/deploy-vps.sh convex-prod`
- Direct main push was stopped because main is protected; branch pushed with GitHub CI as the merge gate.