### PR TITLE
Improve update retry and daily close expense links

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7110 nodes · 8101 edges · 1905 communities detected
+- 7111 nodes · 8103 edges · 1905 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1944,7 +1944,7 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.04
-Nodes (51): buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), formatDailyCloseMoney(), formatMetadataDisplayValue(), formatMetadataValue(), formatTimestampMetadata(), getBucketConfigs() (+43 more)
+Nodes (52): buildDailyCloseExpenseSearch(), buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), formatDailyCloseMoney(), formatMetadataDisplayValue(), formatMetadataValue(), formatTimestampMetadata() (+44 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.06
@@ -2683,24 +2683,24 @@ Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
 ### Community 185 - "Community 185"
+Cohesion: 0.32
+Nodes (4): createVersionChecker(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 186 - "Community 186"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
-
-### Community 189 - "Community 189"
-Cohesion: 0.32
-Nodes (4): createVersionChecker(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 190 - "Community 190"
 Cohesion: 0.39
@@ -2851,16 +2851,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 227 - "Community 227"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 228 - "Community 228"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 229 - "Community 229"
+### Community 228 - "Community 228"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 229 - "Community 229"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 230 - "Community 230"
 Cohesion: 0.43
@@ -2987,8 +2987,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 261 - "Community 261"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.33
@@ -3007,76 +3007,76 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 266 - "Community 266"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 267 - "Community 267"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 268 - "Community 268"
-Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 269 - "Community 269"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 270 - "Community 270"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 271 - "Community 271"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 272 - "Community 272"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 273 - "Community 273"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 274 - "Community 274"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 272 - "Community 272"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 273 - "Community 273"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 274 - "Community 274"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
 ### Community 275 - "Community 275"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 276 - "Community 276"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 277 - "Community 277"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 278 - "Community 278"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 279 - "Community 279"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 280 - "Community 280"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 281 - "Community 281"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 283 - "Community 283"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 284 - "Community 284"
 Cohesion: 0.53

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,12 +8,12 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1977
-- Graph nodes: 7110
-- Graph edges: 8101
+- Graph nodes: 7111
+- Graph edges: 8103
 - Communities: 1905
 
 ## Graph Hotspots
-- `DailyCloseView.tsx` (87 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `DailyCloseView.tsx` (88 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-inferential-review.ts` (54 edges, Community 3) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 2) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,7 +17,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `DailyCloseView.tsx` (87 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `DailyCloseView.tsx` (88 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 2) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 - `projectLocalEvents.ts` (53 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -1116,6 +1116,12 @@ describe("DailyCloseViewContent", () => {
       "href",
       "/wigclub/store/osu/pos/transactions?o=%252Fwigclub%252Fstore%252Fosu%252Foperations%252Fdaily-close&operatingDate=2026-05-07&paymentMethod=card",
     );
+    expect(
+      screen.getByRole("link", { name: "Open expense reports" }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/pos/expense-reports?o=%252Fwigclub%252Fstore%252Fosu%252Foperations%252Fdaily-close&operatingDate=2026-05-07",
+    );
   });
 
   it("redacts EOD Review financial details without manager access", async () => {

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -684,6 +684,13 @@ function buildDailyCloseTransactionSearch({
   };
 }
 
+function buildDailyCloseExpenseSearch(operatingDate: string) {
+  return {
+    o: getOrigin(),
+    ...(operatingDate !== getLocalOperatingDate() ? { operatingDate } : {}),
+  };
+}
+
 function getDailyCloseSalesMetricLabels(operatingDate: string) {
   const isCurrentOperatingDate = operatingDate === getLocalOperatingDate();
 
@@ -2492,6 +2499,15 @@ export function DailyCloseReadOnlyReport({
                 getExpenseTransactionCount(displaySnapshot.summary),
               )}
               label="Expenses"
+              link={{
+                ariaLabel: "Open expense reports",
+                orgUrlSlug,
+                search: buildDailyCloseExpenseSearch(
+                  displaySnapshot.operatingDate,
+                ),
+                storeUrlSlug,
+                to: "/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports",
+              }}
               value={
                 <DailyCloseFinancialValue
                   amount={displaySnapshot.summary.expenseTotal}
@@ -3292,6 +3308,15 @@ export function DailyCloseViewContent({
                   getExpenseTransactionCount(displaySnapshot.summary),
                 )}
                 label="Expenses"
+                link={{
+                  ariaLabel: "Open expense reports",
+                  orgUrlSlug,
+                  search: buildDailyCloseExpenseSearch(
+                    displaySnapshot.operatingDate,
+                  ),
+                  storeUrlSlug,
+                  to: "/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports",
+                }}
                 value={
                   <DailyCloseFinancialValue
                     amount={displaySnapshot.summary.expenseTotal}

--- a/packages/athena-webapp/src/main.tsx
+++ b/packages/athena-webapp/src/main.tsx
@@ -66,7 +66,8 @@ function App() {
 }
 
 function VersionCheckerBridge() {
-  const { reportUpdateDetected, reportDetectorFailed } = useUpdateCoordinator();
+  const { getSnapshot, reportUpdateDetected, reportDetectorFailed } =
+    useUpdateCoordinator();
 
   useEffect(() => {
     const sequencer = createUpdateDetectionSequencer({
@@ -80,6 +81,13 @@ function VersionCheckerBridge() {
       },
       onUpdateDetected: (event) => {
         void sequencer.handle(event);
+      },
+      shouldReportDuplicateUpdate: (event) => {
+        const snapshot = getSnapshot();
+        return (
+          snapshot.pendingBuildId === event.pendingBuildId &&
+          snapshot.status === "ready-unstaged"
+        );
       },
     });
 
@@ -115,7 +123,7 @@ function VersionCheckerBridge() {
       sequencer.stop();
       versionChecker.stop();
     };
-  }, [reportDetectorFailed, reportUpdateDetected]);
+  }, [getSnapshot, reportDetectorFailed, reportUpdateDetected]);
 
   return null;
 }

--- a/packages/athena-webapp/src/utils/versionChecker.test.ts
+++ b/packages/athena-webapp/src/utils/versionChecker.test.ts
@@ -127,6 +127,41 @@ describe("versionChecker", () => {
     checker.stop();
   });
 
+  it("can retry duplicate update detections while staging is still unresolved", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input).startsWith("/deploy.json")) {
+          return new Response("not found", { status: 404 });
+        }
+
+        return new Response(
+          '<html><head><script type="module" src="/assets/index-new.js"></script></head></html>',
+        );
+      }),
+    );
+    const { createVersionChecker } = await importVersionChecker();
+    const onUpdateDetected = vi.fn();
+    const shouldReportDuplicateUpdate = vi
+      .fn()
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false);
+    const checker = createVersionChecker({
+      onUpdateDetected,
+      pollingIntervalMs: 60_000,
+      shouldReportDuplicateUpdate,
+    });
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(onUpdateDetected).toHaveBeenCalledTimes(2);
+    expect(shouldReportDuplicateUpdate).toHaveBeenCalledTimes(2);
+
+    checker.stop();
+  });
+
 
   it("prefers deploy metadata when it exposes a changed build identity", async () => {
     vi.stubGlobal(

--- a/packages/athena-webapp/src/utils/versionChecker.ts
+++ b/packages/athena-webapp/src/utils/versionChecker.ts
@@ -35,6 +35,7 @@ export function createVersionChecker({
   fetchImpl = fetch,
   onUpdateDetected,
   onDetectorFailed,
+  shouldReportDuplicateUpdate,
 }: {
   currentBuildId?: string;
   currentDeployBuildId?: string;
@@ -43,6 +44,9 @@ export function createVersionChecker({
   onUpdateDetected: (event: VersionCheckerUpdateDetectedEvent) => void;
   onDetectorFailed?: (error: Error) => void;
   onApplyUpdate?: () => void;
+  shouldReportDuplicateUpdate?: (
+    event: VersionCheckerUpdateDetectedEvent,
+  ) => boolean;
 }) {
   let lastReportedBuildId: string | undefined;
 
@@ -98,9 +102,12 @@ export function createVersionChecker({
 
   function reportOnce(event: VersionCheckerUpdateDetectedEvent) {
     if (lastReportedBuildId === event.pendingBuildId) {
-      return;
+      if (!shouldReportDuplicateUpdate?.(event)) {
+        return;
+      }
+    } else {
+      lastReportedBuildId = event.pendingBuildId;
     }
-    lastReportedBuildId = event.pendingBuildId;
     console.log("New version detected");
     onUpdateDetected(event);
   }


### PR DESCRIPTION
## Summary
- allow version checker duplicate detections to retry while update staging is still unresolved
- link Daily Close expense totals to the matching POS expense reports view
- refresh Graphify outputs

## Validation
- bun run --filter '@athena/webapp' test src/utils/versionChecker.test.ts src/components/operations/DailyCloseView.test.tsx
- bun run graphify:rebuild
- bun run pr:athena