### PR TITLE
[V26-779][V26-780][V26-781] Guard Convex query write boundaries

### DIFF
--- a/docs/plans/2026-06-18-003-fix-convex-query-write-boundary-guard-plan.html
+++ b/docs/plans/2026-06-18-003-fix-convex-query-write-boundary-guard-plan.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>fix: Guard Convex query write-boundary drift</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --ink: #17212b;
+        --muted: #53616f;
+        --line: #d9e0e7;
+        --panel: #f7f9fb;
+        --accent: #0f6b5f;
+      }
+      body {
+        margin: 0;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        color: var(--ink);
+        background: #ffffff;
+        line-height: 1.55;
+      }
+      main {
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 48px 24px 72px;
+      }
+      header {
+        border-bottom: 1px solid var(--line);
+        margin-bottom: 32px;
+        padding-bottom: 20px;
+      }
+      h1 {
+        font-size: 32px;
+        line-height: 1.15;
+        margin: 0 0 10px;
+        letter-spacing: 0;
+      }
+      h2 {
+        font-size: 22px;
+        margin: 34px 0 12px;
+        letter-spacing: 0;
+      }
+      h3 {
+        font-size: 17px;
+        margin: 24px 0 8px;
+        letter-spacing: 0;
+      }
+      p, li {
+        font-size: 15px;
+      }
+      .meta {
+        color: var(--muted);
+        font-size: 14px;
+      }
+      .summary, .unit {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 18px 20px;
+      }
+      .unit {
+        margin: 14px 0;
+      }
+      code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+        font-size: 0.94em;
+        background: #eef3f7;
+        border-radius: 4px;
+        padding: 1px 4px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 16px 0;
+      }
+      th, td {
+        border: 1px solid var(--line);
+        padding: 10px 12px;
+        text-align: left;
+        vertical-align: top;
+      }
+      th {
+        background: var(--panel);
+      }
+      .badge {
+        display: inline-block;
+        color: #ffffff;
+        background: var(--accent);
+        border-radius: 4px;
+        padding: 2px 8px;
+        font-size: 12px;
+        font-weight: 600;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="badge">Plan</div>
+        <h1>fix: Guard Convex query write-boundary drift</h1>
+        <div class="meta">Date: 2026-06-18 · Status: active · Type: fix</div>
+      </header>
+
+      <section class="summary">
+        <h2>Summary</h2>
+        <p>Add a type-level and harness-level guard so Convex query handlers cannot obtain mutation-only DB capabilities through shared repositories or services. The immediate terminal-recovery hotfix removed the read-path write; this plan closes the broader production gap.</p>
+      </section>
+
+      <section>
+        <h2>Problem Frame</h2>
+        <p>Production hit <code>t.db.patch is not a function</code> from a repository method while serving <code>listTerminalRecoveryCommands</code>, a public Convex query. The query passed <code>QueryCtx</code> into a write-capable repository factory that accepted <code>QueryCtx | MutationCtx</code> and cast to <code>MutationCtx</code> inside write methods.</p>
+      </section>
+
+      <section>
+        <h2>Requirements</h2>
+        <ul>
+          <li>Keep terminal-recovery listing read-only and filter expired commands without persistence.</li>
+          <li>Split terminal-recovery repository capability into read-only and mutation-capable factories.</li>
+          <li>Split query-safe listing behavior from mutation-side expiry and command writes.</li>
+          <li>Add incident regression tests using query-shaped db objects without write APIs.</li>
+          <li>Add a deterministic <code>harness:inferential-review</code> guard for changed Convex query/write-boundary violations, including alias/cast fixtures and changed query-facing service or repository paths.</li>
+          <li>Update generated validation guidance and rebuild Graphify.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Implementation Units</h2>
+        <article class="unit">
+          <h3>U1. Terminal Recovery Repository Capability Split</h3>
+          <p>Introduce a read-only repository interface and factory for query paths, keep write methods behind a <code>MutationCtx</code>-only factory, and update public terminal recovery query/mutation call sites accordingly.</p>
+        </article>
+        <article class="unit">
+          <h3>U2. Public Query Regression Coverage</h3>
+          <p>Add service, repository, and public module tests proving terminal recovery listing does not call write methods and works with a query-shaped context.</p>
+        </article>
+        <article class="unit">
+          <h3>U3. Deterministic Inferential-Review Guard</h3>
+          <p>Fail changed Convex query files that directly call mutation-only DB APIs, and fail changed query-facing repositories or services that mix <code>QueryCtx | MutationCtx</code> with <code>MutationCtx</code> casts and write calls.</p>
+        </article>
+        <article class="unit">
+          <h3>U4. Harness Guidance, Generated Docs, and Learning</h3>
+          <p>Document the new rule through the harness registry, regenerate package guidance, rebuild Graphify, and add a solution learning for the production bug class.</p>
+        </article>
+      </section>
+
+      <section>
+        <h2>Validation Plan</h2>
+        <ul>
+          <li><code>bun test scripts/harness-inferential-review.test.ts</code></li>
+          <li><code>bun run --filter '@athena/webapp' test -- convex/pos/application/terminalRecovery/terminalCommandService.test.ts convex/pos/infrastructure/repositories/terminalRecoveryRepository.test.ts convex/pos/public/terminals.test.ts</code></li>
+          <li><code>bun run --filter '@athena/webapp' audit:convex</code></li>
+          <li><code>bun run --filter '@athena/webapp' lint:convex:changed</code></li>
+          <li><code>bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json</code></li>
+          <li><code>bun run graphify:rebuild</code></li>
+          <li><code>bun run pr:athena</code></li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Risks</h2>
+        <table>
+          <thead>
+            <tr><th>Risk</th><th>Mitigation</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>False positives on read helpers</td><td>Scope findings to changed files that combine mixed ctx with mutation casts or write calls.</td></tr>
+            <tr><td>Static detection misses an alias</td><td>Type-level repository split protects the observed incident path; future AST depth can be added if needed.</td></tr>
+            <tr><td>Root checkout dirt disturbed</td><td>Continue in the existing hotfix worktree and fast-forward root only after merge with stash-safe posture.</td></tr>
+          </tbody>
+        </table>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/plans/2026-06-18-003-fix-convex-query-write-boundary-guard-plan.md
+++ b/docs/plans/2026-06-18-003-fix-convex-query-write-boundary-guard-plan.md
@@ -1,0 +1,283 @@
+---
+title: fix: Guard Convex query write-boundary drift
+type: fix
+status: active
+date: 2026-06-18
+---
+
+# fix: Guard Convex query write-boundary drift
+
+## Summary
+
+Add a type-level and harness-level guard so Convex query handlers cannot obtain mutation-only DB capabilities through shared repositories or services. The immediate terminal-recovery hotfix removed the read-path write, but the durable fix is to make read/write repository capability explicit and fail local validation when changed query code can reach `db.patch`, `db.insert`, `db.replace`, or `db.delete`.
+
+---
+
+## Problem Frame
+
+Production hit `Uncaught TypeError: t.db.patch is not a function` from `terminalRecoveryRepository.ts` while serving `listTerminalRecoveryCommands`, a public Convex query. The query passed `QueryCtx` into `createTerminalRecoveryCommandRepository(ctx)`. That repository accepted `QueryCtx | MutationCtx`, exposed write methods, and cast to `MutationCtx` inside `patchCommand`.
+
+The hotfix made `listClaimableTerminalRecoveryCommands` filter expired commands without patching during listing. That fixes the current crash, but the broader production gap is that local sensors allowed query code to receive a write-capable repository until runtime.
+
+---
+
+## Requirements
+
+- R1. Preserve the terminal-recovery hotfix behavior: query/list paths filter expired commands without persisting status changes.
+- R2. Split terminal-recovery command repository capability so query handlers can only receive read methods, while mutations keep write methods.
+- R3. Split terminal-recovery service behavior so query-safe listing computes claimability without persistence, while mutation-only flows own expiry, insert, claim, acknowledgement, and verification writes.
+- R4. Add focused regression tests proving the query-shaped read path works without `db.patch` or `db.insert`.
+- R5. Add a deterministic `harness:inferential-review` guard for changed Convex code that reintroduces query-to-write-boundary violations.
+- R6. Keep the guard analogous to the recent Convex return-validator guard: fail locally in `pr:athena`, emit structured remediation, and document the new sensor in generated validation guidance.
+- R7. Preserve Athena delivery posture: Graphify rebuilt after code edits, focused tests first, then `pr:athena` before merge.
+
+---
+
+## Scope Boundaries
+
+- Active scope is Convex query purity around mutation-only DB methods and write-capable repositories/services.
+- The first type-level refactor is terminal-recovery command repositories because that is the observed production crash path.
+- The harness guard should apply to changed Convex files rather than sweeping every historical mixed repository in one PR.
+- This plan does not add a cron job to expire stale terminal recovery commands. Listing remains read-only; mutation paths still persist expiry when they claim or issue commands.
+- This plan does not attempt a full TypeScript call graph. It uses targeted deterministic checks for the dangerous patterns that produced this incident.
+
+### Deferred to Follow-Up Work
+
+- Broader migration of unrelated repositories to explicit read/write factories can be planned separately if the new guard surfaces existing drift during future changes.
+- A deeper AST or TypeScript program-analysis guard can replace the heuristic detector later if false negatives appear.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/convex/pos/public/terminals.ts` exports the public terminal recovery query and mutations.
+- `packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts` owns command issuing, listing, claiming, acknowledgement, and verification behavior.
+- `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts` currently accepts `QueryCtx | MutationCtx` and casts to `MutationCtx` for write methods.
+- `scripts/harness-inferential-review.ts` already hosts deterministic repo blockers, including the recent public Convex return-validator proof guard.
+- `scripts/harness-inferential-review.test.ts` has fixture-driven tests that prove blocking findings for changed Convex files.
+- `scripts/harness-app-registry.ts` owns generated validation guidance for Athena package docs.
+
+### Institutional Learnings
+
+- `docs/solutions/harness/convex-return-validator-contract-proof-2026-06-18.md` established the pattern for turning a production-only Convex server crash class into executable proof plus an inferential-review blocker.
+- `docs/plans/2026-06-18-002-fix-convex-return-contract-guard-plan.md` used `harness:inferential-review` as the repo-level enforcement point because it already runs under `pr:athena`.
+- `docs/solutions/logic-errors/athena-command-approval-policy-boundary-2026-05-01.md` reinforces that write behavior belongs behind command/mutation boundaries, not query-facing shared helpers.
+- `packages/athena-webapp/docs/agent/validation-guide.md` already treats Convex boundary changes as focused validation-map surfaces that must run `audit:convex`, changed Convex lint, and typecheck.
+
+### Subagent Findings
+
+- The repo research agent recommended splitting terminal-recovery command repositories into read and write capabilities, then adding a changed-file inferential guard for query handlers and mixed `QueryCtx | MutationCtx` repositories.
+- The learnings agent found no prior solution doc directly naming repository write methods reachable from query handlers, so this delivery should add a new solution learning after implementation.
+- The spec-flow agent identified the core acceptance criteria: changed queries must fail local validation for direct mutation-only DB calls and the known mixed `QueryCtx | MutationCtx` repository/cast pattern, while mutations using write repositories remain allowed. Broader indirect call-graph reachability is intentionally deferred unless it is covered by those patterns or by a query-facing service/repository fixture.
+
+---
+
+## Assumptions
+
+*This plan was produced in an execution pipeline without a separate user confirmation pause. The items below are agent inferences that should be reviewed during implementation and code review.*
+
+- Read-time stale terminal recovery cleanup should stay as filtering, not persistence.
+- Query handlers should be allowed to use repositories only when the repository factory returns a statically read-only interface.
+- The first deterministic guard should focus on changed files and known-dangerous patterns to avoid turning this PR into a broad historical cleanup.
+- `harness:inferential-review` is the correct enforcement point because it already fails `pr:athena` and has precedent from the return-validator guard.
+
+---
+
+## Key Technical Decisions
+
+- Use type separation as the first line of defense: read repositories accept `QueryCtx | MutationCtx`; write repositories require `MutationCtx`.
+- Keep terminal recovery listing read-only even when it encounters expired commands; mutation paths such as issue/claim/acknowledge remain responsible for persisted status changes.
+- Add focused runtime-shaped tests for the production incident, not only service mocks, because the prod crash came from passing a query-shaped ctx through a write-capable abstraction.
+- Add a deterministic inferential-review guard rather than relying on reviewer attention. The guard should produce actionable remediation: split read/write repositories or require `MutationCtx` for write-capable factories.
+- Update generated validation guidance through the registry so future agents see this as a Convex boundary rule.
+
+---
+
+## Implementation Units
+
+### U1. Terminal Recovery Repository Capability Split
+
+**Goal:** Make terminal recovery command reads usable from queries while write methods require mutation context.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts`
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.ts`
+
+**Approach:**
+- Introduce a read-only terminal recovery command repository interface for `getCommand` and `listCommandsForTerminal`.
+- Keep the write-capable repository interface for `insertCommand` and `patchCommand`.
+- Add a read repository factory accepting `QueryCtx | MutationCtx`.
+- Change the write repository factory to require `MutationCtx`.
+- Update `listClaimableTerminalRecoveryCommands` to accept only the read interface.
+- Keep query-safe listing functions limited to computing expired/claimable state without patching.
+- Keep mutation-side command functions responsible for expiry persistence, insert, claim, acknowledgement, and runtime verification writes.
+- Update public query call sites to use the read factory and mutation call sites to use the write factory.
+
+**Execution posture:** Test-first for the read-only query-path behavior, then implementation.
+
+**Test scenarios:**
+- Listing expired pending/claimed commands returns only valid claimable commands and does not call `patchCommand`.
+- A query-shaped ctx with no `patch` or `insert` can list terminal recovery commands through the read repository.
+- Issue, claim, acknowledge, and verification flows still use write-capable repositories and persist expected patches.
+
+**Verification:**
+- Focused terminal recovery service and repository tests pass.
+- Typecheck fails if a query passes `QueryCtx` into the write factory.
+
+### U2. Public Query Regression Coverage
+
+**Goal:** Ensure the public terminal recovery query path cannot regress to a write-capable repository without a test failure.
+
+**Requirements:** R1, R3
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts`
+
+**Approach:**
+- Keep the existing service-level expectation that listing expired commands filters without patching.
+- Add repository-level coverage for read repositories backed by a query-shaped db.
+- Add public-module coverage that `listTerminalRecoveryCommands` is wired to a read repository while command mutations retain write wiring.
+
+**Execution posture:** Test-first.
+
+**Test scenarios:**
+- Public list query returns claimable commands when the db object lacks write APIs.
+- Public list query filters unsupported app-update commands based on runtime capability without writing.
+- Claiming an expired command still patches the command to expired in mutation context.
+
+**Verification:**
+- Focused public terminals test suite passes.
+
+### U3. Deterministic Inferential-Review Guard
+
+**Goal:** Block changed Convex code that reintroduces query-to-write-boundary violations before it can merge.
+
+**Requirements:** R4, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `scripts/harness-inferential-review.ts`
+- Modify: `scripts/harness-inferential-review.test.ts`
+
+**Approach:**
+- Detect changed Convex `query` and `internalQuery` modules that directly call mutation-only DB methods from handler code.
+- Detect changed repository modules that combine `QueryCtx | MutationCtx` with casts to `MutationCtx` and mutation-only DB methods.
+- Detect changed query-facing service or repository files that expose write methods while accepting query-compatible inputs, including the incident pattern where an unchanged query imports a changed service that can call `repository.patchCommand`.
+- Make aliases and casts first-class fixtures: type aliases for mixed ctx, `ctx as MutationCtx`, `ctx as unknown as MutationCtx`, and `Pick<QueryCtx | MutationCtx, "db">` style ctx shapes should be represented in tests.
+- Ignore generated files, schema-only files, tests, and changed mutation-only code.
+- Emit a high-severity structured finding with remediation that names read/write repository splitting and `MutationCtx`-only write factories.
+- Keep the rule deterministic and changed-file scoped, with rollout semantics that fail newly introduced mixed write surfaces or changed query-facing write methods rather than forcing historical cleanup in this PR.
+
+**Execution posture:** Test-first with fixture repositories.
+
+**Test scenarios:**
+- Fails: changed public query directly calls `ctx.db.patch`.
+- Fails: changed internal query casts `ctx` or `ctx.db` to a write-capable shape before patching.
+- Fails: changed repository accepts `QueryCtx | MutationCtx`, casts to `MutationCtx`, and writes.
+- Fails: changed service or repository path reachable from a query-facing module accepts a query-compatible repository and calls a write method.
+- Fails: aliases and double casts hide the mixed ctx/write method shape.
+- Passes: changed query uses a read-only repository with no write methods.
+- Passes: changed mutation uses a write-capable repository.
+- Passes: changed read helper accepts `QueryCtx | MutationCtx` but performs only reads.
+- Passes: read-only edits to an existing mixed repository do not fail unless they introduce or change a query-facing write surface.
+
+**Verification:**
+- `bun test scripts/harness-inferential-review.test.ts`
+- `bun run harness:inferential-review`
+
+### U4. Harness Guidance, Generated Docs, and Learning
+
+**Goal:** Make the new prevention rule discoverable and keep generated repo artifacts current.
+
+**Requirements:** R5, R6
+
+**Dependencies:** U3
+
+**Files:**
+- Modify: `scripts/harness-app-registry.ts`
+- Generated: `packages/athena-webapp/docs/agent/testing.md`
+- Generated: `packages/athena-webapp/docs/agent/validation-guide.md`
+- Generated: `packages/athena-webapp/docs/agent/validation-map.json`
+- Generated: `graphify-out/graph.json`
+- Create: `docs/solutions/harness/convex-query-write-boundary-proof-2026-06-18.md`
+
+**Approach:**
+- Add guidance that query handlers must not reach mutation-only DB APIs directly or through write-capable repositories.
+- Regenerate package agent docs through the existing harness generator.
+- Rebuild Graphify after code edits.
+- Add a compact solution doc recording the new production class and prevention pattern.
+
+**Execution posture:** Sensor-only for generated docs; documentation as compounding work.
+
+**Test scenarios:**
+- Generated validation guidance includes the new query/write boundary rule.
+- Graphify check passes after rebuild.
+
+**Verification:**
+- `bun run graphify:rebuild`
+- `git diff --check`
+
+---
+
+## System-Wide Impact
+
+- **Runtime behavior:** Terminal recovery listing remains read-only and avoids production query-context write crashes.
+- **Type safety:** Query code can no longer accidentally receive terminal recovery write methods through the primary repository factory.
+- **Validation:** `pr:athena` gains a changed-file guard for the broader query/write-boundary class.
+- **Operations:** No persistent data migration and no schema changes.
+- **API contracts:** Public Convex queries remain thin read boundaries; mutation behavior stays behind mutation handlers.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Harness false positives on legitimate read helpers using `QueryCtx | MutationCtx` | Flag only changed files that combine mixed ctx with mutation casts or mutation-only DB calls. |
+| Static detection misses a renamed write helper | Type-level read/write split covers the immediate incident path; future deeper AST work can improve coverage if needed. |
+| Public query tests over-mock repository wiring | Add repository tests using query-shaped db objects and keep service tests focused on no-patch listing semantics. |
+| Generated docs drift | Update registry and run the documented generator plus Graphify rebuild before final validation. |
+| Existing root checkout dirt is disturbed | Continue work in the existing hotfix worktree and use stash/fast-forward-safe root alignment only after merge. |
+
+---
+
+## Validation Plan
+
+Run focused sensors first:
+
+- `bun test scripts/harness-inferential-review.test.ts`
+- `bun run harness:inferential-review`
+- `bun run --filter '@athena/webapp' test -- convex/pos/application/terminalRecovery/terminalCommandService.test.ts convex/pos/infrastructure/repositories/terminalRecoveryRepository.test.ts convex/pos/public/terminals.test.ts`
+- `bun run --filter '@athena/webapp' audit:convex`
+- `bun run --filter '@athena/webapp' lint:convex:changed`
+- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
+- `git diff --check`
+
+Then run merge-grade sensors:
+
+- `bun run graphify:rebuild`
+- `bun run pr:athena`
+
+---
+
+## Tracking Plan
+
+Create atomic Linear issues for:
+
+- Terminal recovery read/write repository split and regression tests.
+- Inferential-review query write-boundary guard and harness tests.
+- Generated validation guidance, solution learning, Graphify rebuild, and final integration validation.
+
+The issues should be dependency-linked in that order, with the implementation allowed to land as one coordinated PR because the guard and refactor validate the same production incident class.

--- a/docs/solutions/harness/convex-query-write-boundary-proof-2026-06-18.md
+++ b/docs/solutions/harness/convex-query-write-boundary-proof-2026-06-18.md
@@ -1,0 +1,57 @@
+---
+title: Convex Query Paths Must Not Reach Write-Capable Repositories
+date: 2026-06-18
+category: harness
+module: athena-webapp
+problem_type: convex_query_write_boundary_drift
+component: convex
+resolution_type: read_write_repository_split_and_inferential_guard
+severity: high
+tags:
+  - convex
+  - harness
+  - public-contracts
+  - regression-tests
+---
+
+# Convex Query Paths Must Not Reach Write-Capable Repositories
+
+## Problem
+
+Convex query contexts do not expose mutation-only database methods such as
+`db.patch`, `db.insert`, `db.replace`, or `db.delete`. A query can still reach
+those methods indirectly when shared repositories accept `QueryCtx | MutationCtx`
+and cast to `MutationCtx` inside write methods.
+
+The production symptom was `t.db.patch is not a function` while serving the
+terminal recovery command list query. The public query passed `QueryCtx` into a
+write-capable terminal recovery repository, and the service path attempted to
+expire stale commands by patching during a read.
+
+## Solution
+
+Make Convex repository capability explicit:
+
+- Query-safe repository factories may accept `QueryCtx | MutationCtx`, but they
+  should return read-only interfaces.
+- Write-capable repository factories should require `MutationCtx`.
+- Query/list services should compute filtered read models without persisting
+  cleanup side effects.
+- Mutation services should own expiry persistence, inserts, claims,
+  acknowledgements, and verification writes.
+- Focused tests should exercise query-shaped contexts that omit write methods,
+  not only mocks that happen to provide `patch` or `insert`.
+
+## Prevention
+
+Use deterministic inferential review for changed Convex boundary code:
+
+- Flag changed queries that directly call mutation-only DB methods.
+- Flag changed query-facing services or repositories that accept query-compatible
+  inputs and expose or call write methods.
+- Include alias and cast fixtures because the risky shape often hides behind
+  `type SomeCtx = QueryCtx | MutationCtx`, `ctx as MutationCtx`, or
+  `ctx as unknown as MutationCtx`.
+- Keep rollout changed-file scoped so existing mixed repositories can be
+  migrated intentionally, while new or changed query-facing write surfaces fail
+  before `pr:athena` passes.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7111 nodes · 8103 edges · 1905 communities detected
+- 7148 nodes · 8196 edges · 1905 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1919,14 +1919,14 @@
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
 2. `buildDailyCloseSnapshotWithCtx()` - 28 edges
-3. `projectLocalRegisterReadModel()` - 26 edges
-4. `buildDailyOpeningSnapshotWithCtx()` - 17 edges
-5. `getStoreConfigV2()` - 17 edges
-6. `createConflict()` - 16 edges
-7. `DataTableViewOptions()` - 16 edges
-8. `submitTerminalRuntimeStatus()` - 15 edges
-9. `importInventoryRowsWithCtx()` - 14 edges
-10. `validatePendingCheckoutItemDefinedPayload()` - 14 edges
+3. `collectConvexQueryWriteBoundaryFindings()` - 28 edges
+4. `projectLocalRegisterReadModel()` - 26 edges
+5. `buildDailyOpeningSnapshotWithCtx()` - 17 edges
+6. `getStoreConfigV2()` - 17 edges
+7. `createConflict()` - 16 edges
+8. `DataTableViewOptions()` - 16 edges
+9. `submitTerminalRuntimeStatus()` - 15 edges
+10. `importInventoryRowsWithCtx()` - 14 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `getAmountPaidForOrder()` --calls--> `getDiscountValue()`  [EXTRACTED]
@@ -1948,15 +1948,15 @@ Nodes (52): buildDailyCloseExpenseSearch(), buildDailyCloseTransactionSearch(), 
 
 ### Community 1 - "Community 1"
 Cohesion: 0.06
-Nodes (56): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildDailyCloseApprovalSubject(), buildDailyCloseCompletionApprovalRequirement() (+48 more)
+Nodes (84): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectConvexQueryWriteBoundaryFindings(), collectConvexReturnValidatorContractFindings(), collectHandlerDbAliases() (+76 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.09
-Nodes (46): buildLocalSyncEventRecordInput(), canonicalize(), canonicalJson(), createLocalSyncIngestionService(), getLocalSyncCursorIdentity(), getLocalSyncScope(), ingestLocalEventsWithCtx(), isNonEmptyString() (+38 more)
+Cohesion: 0.06
+Nodes (56): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildDailyCloseApprovalSubject(), buildDailyCloseCompletionApprovalRequirement() (+48 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.09
-Nodes (53): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectConvexReturnValidatorContractFindings(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings() (+45 more)
+Nodes (46): buildLocalSyncEventRecordInput(), canonicalize(), canonicalJson(), createLocalSyncIngestionService(), getLocalSyncCursorIdentity(), getLocalSyncScope(), ingestLocalEventsWithCtx(), isNonEmptyString() (+38 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.11
@@ -2199,24 +2199,24 @@ Cohesion: 0.18
 Nodes (11): getTransactionById(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile(), loadPendingItemAdjustmentApprovals(), normalizeAdjustmentLineItem(), normalizeAdjustmentMetadata() (+3 more)
 
 ### Community 64 - "Community 64"
+Cohesion: 0.12
+Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
+
+### Community 65 - "Community 65"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.16
 Nodes (8): asCloudOperableSession(), countPendingSyncableLocalEventsForStaff(), hasSyncedSaleLocalEventsForStaff(), hasUploadedLocalEventsForStaff(), isCloudOperableSession(), isEmptyLocalSaleShell(), trimOptional(), useRegisterViewModel()
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.23
 Nodes (17): assertPrAthenaProofReady(), collectFilesUnder(), collectProofSnapshot(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof(), formatPathList() (+9 more)
-
-### Community 68 - "Community 68"
-Cohesion: 0.12
-Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
 
 ### Community 69 - "Community 69"
 Cohesion: 0.24
@@ -2851,16 +2851,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 227 - "Community 227"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 228 - "Community 228"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 229 - "Community 229"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 230 - "Community 230"
 Cohesion: 0.43
@@ -2899,72 +2899,72 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 239 - "Community 239"
+Cohesion: 0.4
+Nodes (2): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository()
+
+### Community 240 - "Community 240"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 246 - "Community 246"
+### Community 247 - "Community 247"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.4
 Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.4
 Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 255 - "Community 255"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 256 - "Community 256"
 Cohesion: 0.33
@@ -2972,27 +2972,27 @@ Nodes (0):
 
 ### Community 257 - "Community 257"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 258 - "Community 258"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 259 - "Community 259"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 260 - "Community 260"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 262 - "Community 262"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 263 - "Community 263"
 Cohesion: 0.33
@@ -3011,124 +3011,124 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 267 - "Community 267"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 268 - "Community 268"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 269 - "Community 269"
-Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 270 - "Community 270"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 271 - "Community 271"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 272 - "Community 272"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 273 - "Community 273"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 274 - "Community 274"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 275 - "Community 275"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 273 - "Community 273"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 274 - "Community 274"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 275 - "Community 275"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
 ### Community 276 - "Community 276"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 277 - "Community 277"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 278 - "Community 278"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 279 - "Community 279"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 280 - "Community 280"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 281 - "Community 281"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 282 - "Community 282"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 284 - "Community 284"
+### Community 285 - "Community 285"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 285 - "Community 285"
+### Community 286 - "Community 286"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 286 - "Community 286"
+### Community 287 - "Community 287"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 287 - "Community 287"
+### Community 288 - "Community 288"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 288 - "Community 288"
+### Community 289 - "Community 289"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 289 - "Community 289"
+### Community 290 - "Community 290"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 290 - "Community 290"
+### Community 291 - "Community 291"
 Cohesion: 0.5
 Nodes (2): createAuthorizedRegisterDepositCtx(), createQueryCtx()
 
-### Community 291 - "Community 291"
+### Community 292 - "Community 292"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 292 - "Community 292"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 293 - "Community 293"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 294 - "Community 294"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 295 - "Community 295"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 295 - "Community 295"
+### Community 296 - "Community 296"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
-
-### Community 296 - "Community 296"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 297 - "Community 297"
 Cohesion: 0.4
@@ -3139,16 +3139,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 299 - "Community 299"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 300 - "Community 300"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 300 - "Community 300"
+### Community 301 - "Community 301"
 Cohesion: 0.6
 Nodes (3): isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult()
-
-### Community 301 - "Community 301"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 302 - "Community 302"
 Cohesion: 0.4
@@ -3372,43 +3372,43 @@ Nodes (0):
 
 ### Community 357 - "Community 357"
 Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
 
 ### Community 358 - "Community 358"
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+
+### Community 359 - "Community 359"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 359 - "Community 359"
+### Community 360 - "Community 360"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 360 - "Community 360"
+### Community 361 - "Community 361"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 361 - "Community 361"
+### Community 362 - "Community 362"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 362 - "Community 362"
+### Community 363 - "Community 363"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 363 - "Community 363"
+### Community 364 - "Community 364"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 364 - "Community 364"
+### Community 365 - "Community 365"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 365 - "Community 365"
+### Community 366 - "Community 366"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 366 - "Community 366"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 367 - "Community 367"
 Cohesion: 0.5
@@ -3431,72 +3431,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 372 - "Community 372"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 373 - "Community 373"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 373 - "Community 373"
+### Community 374 - "Community 374"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 375 - "Community 375"
+### Community 376 - "Community 376"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 376 - "Community 376"
+### Community 377 - "Community 377"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 377 - "Community 377"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 378 - "Community 378"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 379 - "Community 379"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 380 - "Community 380"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 381 - "Community 381"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 381 - "Community 381"
+### Community 382 - "Community 382"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 382 - "Community 382"
+### Community 383 - "Community 383"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 383 - "Community 383"
+### Community 384 - "Community 384"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 384 - "Community 384"
+### Community 385 - "Community 385"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 385 - "Community 385"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 386 - "Community 386"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 387 - "Community 387"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 388 - "Community 388"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 389 - "Community 389"
 Cohesion: 0.5
@@ -3508,55 +3508,55 @@ Nodes (0):
 
 ### Community 391 - "Community 391"
 Cohesion: 0.67
-Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
+Nodes (2): buildCtx(), buildQueryCtx()
 
 ### Community 392 - "Community 392"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 393 - "Community 393"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
 ### Community 394 - "Community 394"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 395 - "Community 395"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 396 - "Community 396"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 397 - "Community 397"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 398 - "Community 398"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 399 - "Community 399"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 398 - "Community 398"
+### Community 400 - "Community 400"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 399 - "Community 399"
+### Community 401 - "Community 401"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 400 - "Community 400"
+### Community 402 - "Community 402"
 Cohesion: 0.83
 Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
-### Community 401 - "Community 401"
+### Community 403 - "Community 403"
 Cohesion: 0.83
 Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
-
-### Community 402 - "Community 402"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 403 - "Community 403"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 404 - "Community 404"
 Cohesion: 0.5
@@ -3567,24 +3567,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 406 - "Community 406"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 407 - "Community 407"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 408 - "Community 408"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 409 - "Community 409"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 410 - "Community 410"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 411 - "Community 411"
 Cohesion: 0.5
@@ -3603,72 +3603,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 415 - "Community 415"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 416 - "Community 416"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 417 - "Community 417"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 416 - "Community 416"
+### Community 418 - "Community 418"
 Cohesion: 0.67
 Nodes (2): CashierAuthDialog(), getStaffDisplayName()
-
-### Community 417 - "Community 417"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 418 - "Community 418"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 419 - "Community 419"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 420 - "Community 420"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 421 - "Community 421"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 422 - "Community 422"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 423 - "Community 423"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 424 - "Community 424"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 425 - "Community 425"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 426 - "Community 426"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
+
+### Community 427 - "Community 427"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 427 - "Community 427"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
 ### Community 428 - "Community 428"
-Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 429 - "Community 429"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 430 - "Community 430"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 431 - "Community 431"
 Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
 ### Community 432 - "Community 432"
 Cohesion: 0.5
@@ -3676,67 +3676,67 @@ Nodes (0):
 
 ### Community 433 - "Community 433"
 Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 434 - "Community 434"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 435 - "Community 435"
+Cohesion: 0.67
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
+
+### Community 436 - "Community 436"
 Cohesion: 0.67
 Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
-### Community 435 - "Community 435"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 436 - "Community 436"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 437 - "Community 437"
-Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 438 - "Community 438"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 439 - "Community 439"
-Cohesion: 0.83
-Nodes (3): completedEvent(), event(), item()
+Cohesion: 0.67
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
 ### Community 440 - "Community 440"
-Cohesion: 0.67
-Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 441 - "Community 441"
 Cohesion: 0.83
-Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
+Nodes (3): completedEvent(), event(), item()
 
 ### Community 442 - "Community 442"
 Cohesion: 0.67
-Nodes (2): refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
 ### Community 443 - "Community 443"
 Cohesion: 0.83
-Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
+Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
 ### Community 444 - "Community 444"
-Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+Cohesion: 0.67
+Nodes (2): refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
 ### Community 445 - "Community 445"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
 ### Community 446 - "Community 446"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
 ### Community 447 - "Community 447"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 448 - "Community 448"
-Cohesion: 0.83
-Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 449 - "Community 449"
 Cohesion: 0.5
@@ -3744,23 +3744,23 @@ Nodes (0):
 
 ### Community 450 - "Community 450"
 Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
 ### Community 451 - "Community 451"
-Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 452 - "Community 452"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 453 - "Community 453"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 454 - "Community 454"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 455 - "Community 455"
 Cohesion: 0.5
@@ -3787,76 +3787,76 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 461 - "Community 461"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 462 - "Community 462"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 463 - "Community 463"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 462 - "Community 462"
+### Community 464 - "Community 464"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 463 - "Community 463"
+### Community 465 - "Community 465"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 464 - "Community 464"
+### Community 466 - "Community 466"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 465 - "Community 465"
+### Community 467 - "Community 467"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 466 - "Community 466"
+### Community 468 - "Community 468"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 467 - "Community 467"
+### Community 469 - "Community 469"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 468 - "Community 468"
+### Community 470 - "Community 470"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 469 - "Community 469"
+### Community 471 - "Community 471"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 470 - "Community 470"
+### Community 472 - "Community 472"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 471 - "Community 471"
+### Community 473 - "Community 473"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 472 - "Community 472"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 473 - "Community 473"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 474 - "Community 474"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 475 - "Community 475"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 476 - "Community 476"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 477 - "Community 477"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 478 - "Community 478"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 479 - "Community 479"
 Cohesion: 0.67
@@ -3891,16 +3891,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 487 - "Community 487"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 488 - "Community 488"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 489 - "Community 489"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 490 - "Community 490"
 Cohesion: 0.67
@@ -3911,8 +3911,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 492 - "Community 492"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 493 - "Community 493"
 Cohesion: 0.67
@@ -3920,15 +3920,15 @@ Nodes (0):
 
 ### Community 494 - "Community 494"
 Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 495 - "Community 495"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 496 - "Community 496"
-Cohesion: 0.67
-Nodes (1): PosServerError
+Cohesion: 1.0
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 497 - "Community 497"
 Cohesion: 0.67
@@ -3936,7 +3936,7 @@ Nodes (0):
 
 ### Community 498 - "Community 498"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 499 - "Community 499"
 Cohesion: 0.67
@@ -3947,16 +3947,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 501 - "Community 501"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 502 - "Community 502"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 503 - "Community 503"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 504 - "Community 504"
 Cohesion: 0.67
@@ -3975,16 +3975,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 508 - "Community 508"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 509 - "Community 509"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 510 - "Community 510"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 511 - "Community 511"
 Cohesion: 0.67
@@ -3995,44 +3995,44 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 513 - "Community 513"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 514 - "Community 514"
-Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 515 - "Community 515"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 516 - "Community 516"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 517 - "Community 517"
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+
+### Community 518 - "Community 518"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 518 - "Community 518"
+### Community 519 - "Community 519"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 520 - "Community 520"
 Cohesion: 1.0
 Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
-### Community 519 - "Community 519"
+### Community 521 - "Community 521"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 520 - "Community 520"
-Cohesion: 0.67
-Nodes (1): View()
-
-### Community 521 - "Community 521"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 522 - "Community 522"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 523 - "Community 523"
 Cohesion: 0.67
@@ -4043,36 +4043,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 525 - "Community 525"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 526 - "Community 526"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 527 - "Community 527"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 528 - "Community 528"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 529 - "Community 529"
-Cohesion: 1.0
-Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 530 - "Community 530"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 531 - "Community 531"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
 ### Community 532 - "Community 532"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 533 - "Community 533"
 Cohesion: 0.67
@@ -4080,35 +4080,35 @@ Nodes (0):
 
 ### Community 534 - "Community 534"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 535 - "Community 535"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 536 - "Community 536"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 537 - "Community 537"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 538 - "Community 538"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 539 - "Community 539"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 540 - "Community 540"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 541 - "Community 541"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 542 - "Community 542"
 Cohesion: 0.67
@@ -4139,16 +4139,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 549 - "Community 549"
-Cohesion: 1.0
-Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 550 - "Community 550"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 551 - "Community 551"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
 
 ### Community 552 - "Community 552"
 Cohesion: 0.67
@@ -4164,83 +4164,83 @@ Nodes (0):
 
 ### Community 555 - "Community 555"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 556 - "Community 556"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 557 - "Community 557"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 558 - "Community 558"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 559 - "Community 559"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 560 - "Community 560"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 561 - "Community 561"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TableSkeleton()
 
 ### Community 562 - "Community 562"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): TransactionsSkeleton()
 
 ### Community 563 - "Community 563"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): NotFound()
 
 ### Community 564 - "Community 564"
-Cohesion: 0.67
-Nodes (1): Badge()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 565 - "Community 565"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): AppContextMenu()
 
 ### Community 566 - "Community 566"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): Badge()
 
 ### Community 567 - "Community 567"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (0):
 
 ### Community 568 - "Community 568"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): LoadingButton()
 
 ### Community 569 - "Community 569"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): onChange()
 
 ### Community 570 - "Community 570"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): AlertModal()
 
 ### Community 571 - "Community 571"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): OverlayModal()
 
 ### Community 572 - "Community 572"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Skeleton()
 
 ### Community 573 - "Community 573"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 574 - "Community 574"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 575 - "Community 575"
 Cohesion: 0.67
@@ -4268,7 +4268,7 @@ Nodes (0):
 
 ### Community 581 - "Community 581"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 582 - "Community 582"
 Cohesion: 0.67
@@ -4276,7 +4276,7 @@ Nodes (0):
 
 ### Community 583 - "Community 583"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 584 - "Community 584"
 Cohesion: 0.67
@@ -4295,20 +4295,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 588 - "Community 588"
-Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
-
-### Community 589 - "Community 589"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
-### Community 590 - "Community 590"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 591 - "Community 591"
+### Community 589 - "Community 589"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 590 - "Community 590"
 Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
+Nodes (2): getApprovalGuidance(), presentCommandToast()
+
+### Community 591 - "Community 591"
+Cohesion: 0.67
+Nodes (1): isInMaintenanceMode()
 
 ### Community 592 - "Community 592"
 Cohesion: 0.67
@@ -4316,27 +4316,27 @@ Nodes (0):
 
 ### Community 593 - "Community 593"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 594 - "Community 594"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 595 - "Community 595"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 596 - "Community 596"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 597 - "Community 597"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 598 - "Community 598"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 599 - "Community 599"
 Cohesion: 0.67
@@ -4359,40 +4359,40 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 604 - "Community 604"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 605 - "Community 605"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 606 - "Community 606"
 Cohesion: 1.0
 Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
-### Community 605 - "Community 605"
+### Community 607 - "Community 607"
 Cohesion: 1.0
 Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
-### Community 606 - "Community 606"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 607 - "Community 607"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 608 - "Community 608"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 609 - "Community 609"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 610 - "Community 610"
 Cohesion: 1.0
 Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
-### Community 609 - "Community 609"
+### Community 611 - "Community 611"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 610 - "Community 610"
-Cohesion: 0.67
-Nodes (1): hashPassword()
-
-### Community 611 - "Community 611"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 612 - "Community 612"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): hashPassword()
 
 ### Community 613 - "Community 613"
 Cohesion: 0.67
@@ -4400,11 +4400,11 @@ Nodes (0):
 
 ### Community 614 - "Community 614"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 615 - "Community 615"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 616 - "Community 616"
 Cohesion: 0.67
@@ -4412,19 +4412,19 @@ Nodes (0):
 
 ### Community 617 - "Community 617"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 618 - "Community 618"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 619 - "Community 619"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 620 - "Community 620"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 621 - "Community 621"
 Cohesion: 0.67
@@ -4435,32 +4435,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 623 - "Community 623"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 624 - "Community 624"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 625 - "Community 625"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 626 - "Community 626"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 627 - "Community 627"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 628 - "Community 628"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 629 - "Community 629"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 630 - "Community 630"
 Cohesion: 0.67
@@ -4523,8 +4523,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 645 - "Community 645"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 646 - "Community 646"
 Cohesion: 0.67
@@ -4532,11 +4532,11 @@ Nodes (0):
 
 ### Community 647 - "Community 647"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
 ### Community 648 - "Community 648"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 649 - "Community 649"
 Cohesion: 1.0
@@ -4551,20 +4551,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 652 - "Community 652"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 653 - "Community 653"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 654 - "Community 654"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 655 - "Community 655"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 656 - "Community 656"
 Cohesion: 1.0
@@ -9565,115 +9565,113 @@ Nodes (0):
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 655`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 656`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 657`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 658`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 659`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 660`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 661`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 662`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 663`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 664`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 665`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 666`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 667`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 668`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 669`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 670`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 671`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `createMutationCtx()`, `catalogImport.test.ts`
+- **Thin community `Community 672`** (2 nodes): `createMutationCtx()`, `catalogImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 673`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 674`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 675`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 676`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 677`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 678`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 679`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 680`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 681`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 682`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 683`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 684`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 685`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 686`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 687`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 688`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 689`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 690`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 691`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 692`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 693`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 694`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 695`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 696`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 697`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 698`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 699`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 700`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 701`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `resolveTerminalCloudRepair.ts`, `resolveTerminalCloudRepair()`
+- **Thin community `Community 702`** (2 nodes): `resolveTerminalCloudRepair.ts`, `resolveTerminalCloudRepair()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 703`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 704`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 705`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 706`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 707`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 708`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `terminalRecoveryRepository.test.ts`, `buildCtx()`
+- **Thin community `Community 709`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 710`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -12076,7 +12074,7 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**
-  _Cohesion score 0.09 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,15 +8,15 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1977
-- Graph nodes: 7111
-- Graph edges: 8103
+- Graph nodes: 7148
+- Graph edges: 8196
 - Communities: 1905
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (88 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `harness-inferential-review.ts` (54 edges, Community 3) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `ingestLocalEvents.ts` (54 edges, Community 2) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
+- `harness-inferential-review.ts` (85 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
+- `dailyClose.ts` (65 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `ingestLocalEvents.ts` (54 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 - `projectLocalEvents.ts` (53 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `terminalHealthPresentation.ts` (49 edges, Community 5) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `posLocalStore.ts` (48 edges, Community 6) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -18,8 +18,8 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (88 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `ingestLocalEvents.ts` (54 edges, Community 2) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
+- `dailyClose.ts` (65 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `ingestLocalEvents.ts` (54 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 - `projectLocalEvents.ts` (53 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `terminalHealthPresentation.ts` (49 edges, Community 5) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.ts
@@ -13,9 +13,9 @@ import {
   type TerminalSyncEvidence,
 } from "../../infrastructure/repositories/terminalRepository";
 import {
+  createTerminalRecoveryCommandReadRepository,
   getTerminalRecoverySourceEvent,
   listTerminalRecoveryConflictsForRepair,
-  createTerminalRecoveryCommandRepository,
 } from "../../infrastructure/repositories/terminalRecoveryRepository";
 import {
   buildTerminalCloudRepairPreview,
@@ -682,7 +682,7 @@ async function buildTerminalRecoveryCommandStatus(
   },
 ): Promise<TerminalRecoveryPreview["commandStatus"]> {
   const commands =
-    await createTerminalRecoveryCommandRepository(ctx).listCommandsForTerminal({
+    await createTerminalRecoveryCommandReadRepository(ctx).listCommandsForTerminal({
       storeId: args.storeId,
       terminalId: args.terminalId,
     });

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts
@@ -447,9 +447,7 @@ describe("terminal command service", () => {
       terminalId,
     });
 
-    expect(repository.patchCommand).toHaveBeenCalledWith("command-1", {
-      status: "expired",
-    });
+    expect(repository.patchCommand).not.toHaveBeenCalled();
     expect(repository.insertCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         commandType: "clear_stale_drawer_authority",
@@ -498,9 +496,7 @@ describe("terminal command service", () => {
       terminalId,
     });
 
-    expect(repository.patchCommand).toHaveBeenCalledWith("command-1", {
-      status: "expired",
-    });
+    expect(repository.patchCommand).not.toHaveBeenCalled();
     expect(repository.insertCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         commandType: "repair_terminal_seed",
@@ -550,9 +546,7 @@ describe("terminal command service", () => {
       terminalId,
     });
 
-    expect(repository.patchCommand).toHaveBeenCalledWith("command-1", {
-      status: "expired",
-    });
+    expect(repository.patchCommand).not.toHaveBeenCalled();
     expect(repository.insertCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         commandType: "repair_terminal_seed",
@@ -597,11 +591,11 @@ describe("terminal command service", () => {
         }),
       }),
     );
-    const patch = vi.mocked(repository.patchCommand).mock.calls.at(-1)?.[1];
+    const patch = repository.patchCommand.mock.calls.at(-1)?.[1];
     expect(patch?.acknowledgement?.message).toHaveLength(240);
   });
 
-  it("expires pending commands during listing and rejects expired claims", async () => {
+  it("filters expired pending commands during listing and rejects expired claims", async () => {
     const repository = buildRepository({
       commands: [
         buildCommand({
@@ -617,9 +611,7 @@ describe("terminal command service", () => {
         terminalId,
       }),
     ).resolves.toEqual([]);
-    expect(repository.patchCommand).toHaveBeenCalledWith("command-1", {
-      status: "expired",
-    });
+    expect(repository.patchCommand).not.toHaveBeenCalled();
 
     await expect(
       claimTerminalRecoveryCommand(repository, {
@@ -634,6 +626,41 @@ describe("terminal command service", () => {
       },
       kind: "user_error",
     });
+    expect(repository.patchCommand).toHaveBeenCalledWith("command-1", {
+      status: "expired",
+    });
+  });
+
+  it("filters expired pending and claimed commands through a read-only repository", async () => {
+    const activeCommand = buildCommand({
+      _id: "command-active" as Id<"posTerminalRecoveryCommand">,
+    });
+    const repository = {
+      getCommand: vi.fn(),
+      listCommandsForTerminal: vi.fn(async () => [
+        buildCommand({
+          _id: "command-expired-pending" as Id<"posTerminalRecoveryCommand">,
+          expiresAt: now - 1,
+          status: "pending",
+        }),
+        buildCommand({
+          _id: "command-expired-claimed" as Id<"posTerminalRecoveryCommand">,
+          expiresAt: now - 1,
+          status: "claimed",
+        }),
+        activeCommand,
+      ]),
+    };
+
+    await expect(
+      listClaimableTerminalRecoveryCommands(repository, {
+        now,
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toEqual([activeCommand]);
+    expect("patchCommand" in repository).toBe(false);
+    expect("insertCommand" in repository).toBe(false);
   });
 
   it("rejects non-claimable and non-acknowledgeable command states", async () => {
@@ -828,7 +855,26 @@ function buildRepository(seed: {
         return command._id;
       },
     ),
-    listCommandsForTerminal: vi.fn(async () => commands),
+    listCommandsForTerminal: vi.fn(async (args) =>
+      commands.filter((command) => {
+        if (command.storeId !== args.storeId || command.terminalId !== args.terminalId) {
+          return false;
+        }
+        if (
+          args.statuses !== undefined &&
+          !args.statuses.includes(command.status)
+        ) {
+          return false;
+        }
+        if (
+          args.expiresAfter !== undefined &&
+          command.expiresAt <= args.expiresAfter
+        ) {
+          return false;
+        }
+        return true;
+      }),
+    ),
     patchCommand: vi.fn(
       async (
         commandId: Id<"posTerminalRecoveryCommand">,

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts
@@ -29,17 +29,22 @@ const SECRET_LIKE_KEYS = [
 const SECRET_LIKE_KEY_PATTERN = SECRET_LIKE_KEYS.join("|");
 const SECRET_LIKE_FIELD_PATTERN = String.raw`\b[A-Za-z0-9_-]*(?:${SECRET_LIKE_KEY_PATTERN})[A-Za-z0-9_-]*\b`;
 
-export type TerminalRecoveryCommandRepository = {
+export type TerminalRecoveryCommandReadRepository = {
   getCommand(
     commandId: Id<"posTerminalRecoveryCommand">,
   ): Promise<Doc<"posTerminalRecoveryCommand"> | null>;
+  listCommandsForTerminal(args: {
+    expiresAfter?: number;
+    storeId: Id<"store">;
+    statuses?: Array<Doc<"posTerminalRecoveryCommand">["status"]>;
+    terminalId: Id<"posTerminal">;
+  }): Promise<Doc<"posTerminalRecoveryCommand">[]>;
+};
+
+export type TerminalRecoveryCommandRepository = TerminalRecoveryCommandReadRepository & {
   insertCommand(
     input: Omit<Doc<"posTerminalRecoveryCommand">, "_id" | "_creationTime">,
   ): Promise<Id<"posTerminalRecoveryCommand">>;
-  listCommandsForTerminal(args: {
-    storeId: Id<"store">;
-    terminalId: Id<"posTerminal">;
-  }): Promise<Doc<"posTerminalRecoveryCommand">[]>;
   patchCommand(
     commandId: Id<"posTerminalRecoveryCommand">,
     patch: Partial<Doc<"posTerminalRecoveryCommand">>,
@@ -80,7 +85,9 @@ export async function issueTerminalRecoveryCommand(
   const commandContext = pruneUndefined(args.commandContext);
   const expectedEvidence = pruneUndefined(args.expectedEvidence);
   const existingCommands = await repository.listCommandsForTerminal({
+    expiresAfter: args.issuedAt,
     storeId: args.storeId,
+    statuses: ["pending", "claimed", "completed"],
     terminalId: args.terminalId,
   });
   for (const command of existingCommands) {
@@ -89,10 +96,6 @@ export async function issueTerminalRecoveryCommand(
       command.commandType === "update_app" &&
       isUpdateAppActiveCommand(command)
     ) {
-      if (command.expiresAt <= args.issuedAt) {
-        await repository.patchCommand(command._id, { status: "expired" });
-        continue;
-      }
       return ok(command);
     }
     if (!isEquivalentCommand(command, {
@@ -100,10 +103,6 @@ export async function issueTerminalRecoveryCommand(
       commandType: args.commandType,
       expectedEvidence,
     })) {
-      continue;
-    }
-    if (command.expiresAt <= args.issuedAt && isActiveCommand(command)) {
-      await repository.patchCommand(command._id, { status: "expired" });
       continue;
     }
     if (isActiveCommand(command)) {
@@ -129,7 +128,7 @@ export async function issueTerminalRecoveryCommand(
 }
 
 export async function listClaimableTerminalRecoveryCommands(
-  repository: TerminalRecoveryCommandRepository,
+  repository: TerminalRecoveryCommandReadRepository,
   args: {
     now: number;
     storeId: Id<"store">;
@@ -137,7 +136,9 @@ export async function listClaimableTerminalRecoveryCommands(
   },
 ) {
   const commands = await repository.listCommandsForTerminal({
+    expiresAfter: args.now,
     storeId: args.storeId,
+    statuses: ["pending", "claimed"],
     terminalId: args.terminalId,
   });
   const claimable: Doc<"posTerminalRecoveryCommand">[] = [];
@@ -146,7 +147,6 @@ export async function listClaimableTerminalRecoveryCommands(
       command.expiresAt <= args.now &&
       (command.status === "pending" || command.status === "claimed")
     ) {
-      await repository.patchCommand(command._id, { status: "expired" });
       continue;
     }
     if (
@@ -330,6 +330,7 @@ export async function verifyTerminalRecoveryCommandsFromRuntime(
 ) {
   const commands = await repository.listCommandsForTerminal({
     storeId: args.storeId,
+    statuses: ["completed"],
     terminalId: args.terminalId,
   });
   const verifiedCommandIds: Array<Id<"posTerminalRecoveryCommand">> = [];

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -12,6 +12,10 @@ import {
   listTerminalHealthSummaries,
 } from "./queries/terminals";
 import {
+  type TerminalRecoveryCommandReadRepository,
+  type TerminalRecoveryCommandRepository,
+} from "./terminalRecovery/terminalCommandService";
+import {
   getLatestRuntimeStatusForTerminal,
   getTerminalByFingerprint,
   getTerminalById,
@@ -25,6 +29,7 @@ import {
   upsertLatestRuntimeStatus,
 } from "../infrastructure/repositories/terminalRepository";
 import {
+  createTerminalRecoveryCommandReadRepository,
   createTerminalRecoveryCommandRepository,
   getTerminalRecoverySourceEvent,
   listTerminalRecoveryConflictsForRepair,
@@ -79,6 +84,7 @@ vi.mock("../infrastructure/repositories/terminalRepository", () => ({
 }));
 
 vi.mock("../infrastructure/repositories/terminalRecoveryRepository", () => ({
+  createTerminalRecoveryCommandReadRepository: vi.fn(),
   createTerminalRecoveryCommandRepository: vi.fn(),
   getTerminalRecoverySourceEvent: vi.fn(),
   listTerminalRecoveryConflictsForRepair: vi.fn(),
@@ -614,9 +620,18 @@ describe("terminal health summaries", () => {
     vi.mocked(hasActiveRegisterSessionForTerminal).mockResolvedValue(false);
     vi.mocked(listTerminalRecoveryConflictsForRepair).mockResolvedValue([]);
     vi.mocked(getTerminalRecoverySourceEvent).mockResolvedValue(null);
-    vi.mocked(createTerminalRecoveryCommandRepository).mockReturnValue({
+    const readRepository = {
+      getCommand: vi.fn().mockResolvedValue(null),
       listCommandsForTerminal: vi.fn().mockResolvedValue([]),
-    } as never);
+    } satisfies TerminalRecoveryCommandReadRepository;
+    const writeRepository = {
+      ...readRepository,
+      insertCommand: vi.fn(),
+      patchCommand: vi.fn(),
+      listCommandsForTerminal: vi.fn().mockResolvedValue([]),
+    } satisfies TerminalRecoveryCommandRepository;
+    vi.mocked(createTerminalRecoveryCommandReadRepository).mockReturnValue(readRepository);
+    vi.mocked(createTerminalRecoveryCommandRepository).mockReturnValue(writeRepository);
   });
 
   afterEach(() => {

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.test.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { Id } from "../../../_generated/dataModel";
 import {
+  createTerminalRecoveryCommandReadRepository,
   createTerminalRecoveryCommandRepository,
   getTerminalRecoverySourceEvent,
   listTerminalRecoveryConflictsForRepair,
@@ -18,7 +19,7 @@ describe("terminalRecoveryRepository", () => {
     const ctx = buildCtx({
       posTerminalRecoveryCommand: [command],
     });
-    const repository = createTerminalRecoveryCommandRepository(ctx as never);
+    const repository = createTerminalRecoveryCommandReadRepository(ctx as never);
 
     const result = await repository.listCommandsForTerminal({
       storeId: "store-1" as Id<"store">,
@@ -34,9 +35,102 @@ describe("terminalRecoveryRepository", () => {
     ]);
   });
 
+  it("lists command documents with a query-shaped db that has no write APIs", async () => {
+    const command = {
+      _id: "command-1" as Id<"posTerminalRecoveryCommand">,
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+    };
+    const ctx = buildQueryCtx({
+      posTerminalRecoveryCommand: [command],
+    });
+    const repository = createTerminalRecoveryCommandReadRepository(ctx as never);
+
+    const result = await repository.listCommandsForTerminal({
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+    });
+
+    expect(result).toEqual([command]);
+    expect("patch" in ctx.db).toBe(false);
+    expect("insert" in ctx.db).toBe(false);
+  });
+
+  it("lists active command documents through status and expiry indexes", async () => {
+    const expiredCommands = Array.from({ length: 75 }, (_, index) => ({
+      _id: `command-expired-${index}` as Id<"posTerminalRecoveryCommand">,
+      expiresAt: 100,
+      status: "pending",
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+    }));
+    const activeCommand = {
+      _id: "command-active" as Id<"posTerminalRecoveryCommand">,
+      expiresAt: 1_000,
+      status: "pending",
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+    };
+    const ctx = buildQueryCtx({
+      posTerminalRecoveryCommand: [...expiredCommands, activeCommand],
+    });
+    const repository = createTerminalRecoveryCommandReadRepository(ctx as never);
+
+    const result = await repository.listCommandsForTerminal({
+      expiresAfter: 500,
+      statuses: ["pending"],
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+    });
+
+    expect(result).toEqual([activeCommand]);
+    expect(ctx.queryLog).toContain("by_store_terminal_status_expiresAt");
+    expect(ctx.eqLog).toEqual([
+      ["storeId", "store-1"],
+      ["terminalId", "terminal-1"],
+      ["status", "pending"],
+    ]);
+    expect(ctx.gtLog).toEqual([["expiresAt", 500]]);
+  });
+
+  it("writes command documents only through the mutation repository", async () => {
+    const ctx = buildCtx();
+    const repository = createTerminalRecoveryCommandRepository(ctx as never);
+    const input = {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      commandType: "retry_sync" as const,
+      status: "pending" as const,
+      verificationStatus: "waiting_for_acknowledgement" as const,
+      commandContext: { reason: "Support requested sync retry." },
+      expectedEvidence: {},
+      issuedByUserId: "user-1" as Id<"athenaUser">,
+      issuedAt: 1,
+      expiresAt: 2,
+    };
+
+    await repository.insertCommand(input);
+    await repository.patchCommand("command-1" as Id<"posTerminalRecoveryCommand">, {
+      status: "expired",
+    });
+
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      "posTerminalRecoveryCommand",
+      input,
+    );
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "posTerminalRecoveryCommand",
+      "command-1",
+      { status: "expired" },
+    );
+  });
+
   it("lists repair conflicts through the scoped conflict status index", async () => {
     const conflict = {
       _id: "conflict-1" as Id<"posLocalSyncConflict">,
+      status: "needs_review",
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
     };
     const ctx = buildCtx({
       posLocalSyncConflict: [conflict],
@@ -61,6 +155,8 @@ describe("terminalRecoveryRepository", () => {
     const event = {
       _id: "event-1" as Id<"posLocalSyncEvent">,
       localEventId: "local-event-1",
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
     };
     const ctx = buildCtx({
       posLocalSyncEvent: [event],
@@ -102,6 +198,7 @@ describe("terminalRecoveryRepository", () => {
 function buildCtx(tables: Record<string, unknown[]> = {}) {
   const queryLog: string[] = [];
   const eqLog: Array<[string, unknown]> = [];
+  const gtLog: Array<[string, unknown]> = [];
   const ctx = {
     db: {
       get: vi.fn(),
@@ -110,22 +207,60 @@ function buildCtx(tables: Record<string, unknown[]> = {}) {
       query: vi.fn((tableName: string) => ({
         withIndex(indexName: string, callback: (q: unknown) => unknown) {
           queryLog.push(indexName);
+          const filters: Array<(row: Record<string, unknown>) => boolean> = [];
           const q = {
             eq(fieldName: string, value: unknown) {
               eqLog.push([fieldName, value]);
+              filters.push((row) => row[fieldName] === value);
+              return q;
+            },
+            gt(fieldName: string, value: unknown) {
+              gtLog.push([fieldName, value]);
+              filters.push(
+                (row) =>
+                  typeof row[fieldName] === "number" &&
+                  typeof value === "number" &&
+                  row[fieldName] > value,
+              );
               return q;
             },
           };
           callback(q);
           return {
-            first: vi.fn(async () => tables[tableName]?.[0] ?? null),
-            take: vi.fn(async () => tables[tableName] ?? []),
+            first: vi.fn(async () => filterRows(tables[tableName], filters)[0] ?? null),
+            take: vi.fn(async (limit?: number) =>
+              filterRows(tables[tableName], filters).slice(0, limit),
+            ),
           };
         },
       })),
     },
     eqLog,
+    gtLog,
     queryLog,
   };
   return ctx;
+}
+
+function buildQueryCtx(tables: Record<string, unknown[]> = {}) {
+  const writableCtx = buildCtx(tables);
+  const { get, query } = writableCtx.db;
+  return {
+    db: {
+      get,
+      query,
+    },
+    eqLog: writableCtx.eqLog,
+    gtLog: writableCtx.gtLog,
+    queryLog: writableCtx.queryLog,
+  };
+}
+
+function filterRows(
+  rows: unknown[] | undefined,
+  filters: Array<(row: Record<string, unknown>) => boolean>,
+) {
+  return (rows ?? []).filter((row) =>
+    filters.every((filter) => filter(row as Record<string, unknown>)),
+  );
 }

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts
@@ -1,24 +1,52 @@
 import type { Doc, Id } from "../../../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../../../_generated/server";
-import type { TerminalRecoveryCommandRepository } from "../../application/terminalRecovery/terminalCommandService";
+import type {
+  TerminalRecoveryCommandReadRepository,
+  TerminalRecoveryCommandRepository,
+} from "../../application/terminalRecovery/terminalCommandService";
 
 type TerminalRecoveryCtx = QueryCtx | MutationCtx;
 export type TerminalRecoveryConflictRepositoryCtx = QueryCtx | MutationCtx;
 
-export function createTerminalRecoveryCommandRepository(
+export function createTerminalRecoveryCommandReadRepository(
   ctx: TerminalRecoveryCtx,
-): TerminalRecoveryCommandRepository {
+): TerminalRecoveryCommandReadRepository {
   return {
     getCommand(commandId) {
       return ctx.db.get("posTerminalRecoveryCommand", commandId);
     },
-    async insertCommand(input) {
-      const mutationCtx = ctx as MutationCtx;
-      return mutationCtx.db.insert("posTerminalRecoveryCommand", input);
-    },
     listCommandsForTerminal(args) {
       if (typeof ctx.db.query !== "function") {
         return Promise.resolve([]);
+      }
+      if (args.statuses !== undefined && args.statuses.length > 0) {
+        return Promise.all(
+          args.statuses.map((status) => {
+            if (args.expiresAfter !== undefined) {
+              const expiresAfter = args.expiresAfter;
+              return ctx.db
+                .query("posTerminalRecoveryCommand")
+                .withIndex("by_store_terminal_status_expiresAt", (q) =>
+                  q
+                    .eq("storeId", args.storeId)
+                    .eq("terminalId", args.terminalId)
+                    .eq("status", status)
+                    .gt("expiresAt", expiresAfter),
+                )
+                .take(50);
+            }
+
+            return ctx.db
+              .query("posTerminalRecoveryCommand")
+              .withIndex("by_store_terminal_status", (q) =>
+                q
+                  .eq("storeId", args.storeId)
+                  .eq("terminalId", args.terminalId)
+                  .eq("status", status),
+              )
+              .take(50);
+          }),
+        ).then((commandsByStatus) => commandsByStatus.flat());
       }
       return ctx.db
         .query("posTerminalRecoveryCommand")
@@ -29,9 +57,19 @@ export function createTerminalRecoveryCommandRepository(
         )
         .take(50);
     },
+  };
+}
+
+export function createTerminalRecoveryCommandRepository(
+  ctx: MutationCtx,
+): TerminalRecoveryCommandRepository {
+  return {
+    ...createTerminalRecoveryCommandReadRepository(ctx),
+    insertCommand(input) {
+      return ctx.db.insert("posTerminalRecoveryCommand", input);
+    },
     async patchCommand(commandId, patch) {
-      const mutationCtx = ctx as MutationCtx;
-      await mutationCtx.db.patch("posTerminalRecoveryCommand", commandId, patch);
+      await ctx.db.patch("posTerminalRecoveryCommand", commandId, patch);
     },
   };
 }

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   acknowledgeTerminalRecoveryCommandService: vi.fn(),
   claimTerminalRecoveryCommandService: vi.fn(),
+  createTerminalRecoveryCommandReadRepository: vi.fn(),
   createTerminalRecoveryCommandRepository: vi.fn(),
   deleteTerminalCommand: vi.fn(),
   getTerminalHealthSummaryQuery: vi.fn(),
@@ -67,6 +68,8 @@ vi.mock("../application/terminalRecovery/terminalCommandService", () => ({
 }));
 
 vi.mock("../infrastructure/repositories/terminalRecoveryRepository", () => ({
+  createTerminalRecoveryCommandReadRepository:
+    mocks.createTerminalRecoveryCommandReadRepository,
   createTerminalRecoveryCommandRepository:
     mocks.createTerminalRecoveryCommandRepository,
 }));
@@ -89,6 +92,7 @@ import {
   listTerminalRecoveryCommands,
   listTerminalHealthSummaries,
   listTerminals,
+  previewTerminalRecovery,
   claimTerminalRecoveryCommand,
   acknowledgeTerminalRecoveryCommand,
   disconnectRemoteAssistSession,
@@ -324,8 +328,11 @@ describe("POS terminal public mutations", () => {
     mocks.listTerminalHealthSummariesQuery.mockResolvedValue([]);
     mocks.getTerminalHealthSummaryQuery.mockResolvedValue(null);
     mocks.getLatestRuntimeStatusForTerminal.mockResolvedValue(null);
+    mocks.createTerminalRecoveryCommandReadRepository.mockReturnValue({
+      repository: "read",
+    });
     mocks.createTerminalRecoveryCommandRepository.mockReturnValue({
-      repository: true,
+      repository: "write",
     });
     mocks.createRemoteAssistRepository.mockReturnValue({
       getClientByRuntime: mocks.remoteAssistGetClientByRuntime,
@@ -1272,6 +1279,57 @@ describe("POS terminal public mutations", () => {
     assertConformsToExportedReturns(getTerminalHealthSummary as never, summary);
   });
 
+  it("validates representative terminal public command results against exported return validators", () => {
+    const terminal = buildPublicTerminal();
+    const provisionedTerminal = {
+      ...terminal,
+      syncSecretHash: "sync-secret-hash",
+    };
+    const recoveryCommand = buildRecoveryCommand();
+    const commandResult = { kind: "ok" as const, data: recoveryCommand };
+
+    assertConformsToExportedReturns(listTerminals as never, [terminal]);
+    assertConformsToExportedReturns(getTerminalByFingerprint as never, terminal);
+    assertConformsToExportedReturns(
+      previewTerminalRecovery as never,
+      buildTerminalHealthSummaryResult().recoveryPreview,
+    );
+    assertConformsToExportedReturns(submitTerminalRuntimeStatus as never, {
+      kind: "ok",
+      data: {
+        terminalId: "terminal-1",
+        reportedAt: 100,
+        receivedAt: 200,
+      },
+    });
+    assertConformsToExportedReturns(getRuntimeRemoteAssistSession as never, null);
+    assertConformsToExportedReturns(disconnectRemoteAssistSession as never, null);
+    assertConformsToExportedReturns(registerTerminal as never, {
+      kind: "ok",
+      data: provisionedTerminal,
+    });
+    assertConformsToExportedReturns(updateTerminal as never, terminal);
+    assertConformsToExportedReturns(deleteTerminal as never, null);
+    assertConformsToExportedReturns(resolveTerminalCloudRepair as never, {
+      kind: "ok",
+      data: {
+        preconditionHash: "terminal-cloud-repair:hash",
+        resolvedConflictIds: ["conflict-1"],
+        skippedConflictIds: [],
+      },
+    });
+    assertConformsToExportedReturns(issueTerminalRecoveryCommand as never, commandResult);
+    assertConformsToExportedReturns(listTerminalRecoveryCommands as never, {
+      kind: "ok",
+      data: [recoveryCommand],
+    });
+    assertConformsToExportedReturns(claimTerminalRecoveryCommand as never, commandResult);
+    assertConformsToExportedReturns(
+      acknowledgeTerminalRecoveryCommand as never,
+      commandResult,
+    );
+  });
+
   it("requires store membership before loading terminal health detail", async () => {
     const ctx = buildCtx();
 
@@ -1350,7 +1408,7 @@ describe("POS terminal public mutations", () => {
       }),
     );
     expect(mocks.issueTerminalRecoveryCommandService).toHaveBeenCalledWith(
-      { repository: true },
+      { repository: "write" },
       expect.objectContaining({
         commandType: "repair_terminal_seed",
         issuedByUserId: "athena-user-1",
@@ -1365,21 +1423,24 @@ describe("POS terminal public mutations", () => {
     {
       action: "list",
       handler: listTerminalRecoveryCommands,
+      repositoryKind: "read",
       service: mocks.listClaimableTerminalRecoveryCommands,
     },
     {
       action: "claim",
       handler: claimTerminalRecoveryCommand,
+      repositoryKind: "write",
       service: mocks.claimTerminalRecoveryCommandService,
     },
     {
       action: "acknowledge",
       handler: acknowledgeTerminalRecoveryCommand,
+      repositoryKind: "write",
       service: mocks.acknowledgeTerminalRecoveryCommandService,
     },
   ])(
     "allows terminal runtime to $action recovery commands with only active sync-secret proof",
-    async ({ handler, service }) => {
+    async ({ handler, repositoryKind, service }) => {
       mocks.requireAuthenticatedAthenaUserWithCtx.mockRejectedValue(
         new Error("not signed in"),
       );
@@ -1403,7 +1464,10 @@ describe("POS terminal public mutations", () => {
       });
 
       expect(mocks.requireOrganizationMemberRoleWithCtx).not.toHaveBeenCalled();
-      expect(service).toHaveBeenCalled();
+      expect(service).toHaveBeenCalledWith(
+        { repository: repositoryKind },
+        expect.any(Object),
+      );
       expect(result.kind).toBe("ok");
     },
   );
@@ -1447,6 +1511,15 @@ describe("POS terminal public mutations", () => {
       kind: "ok",
       data: [expect.objectContaining({ _id: "command-repair" })],
     });
+    expect(mocks.createTerminalRecoveryCommandReadRepository).toHaveBeenCalledWith(ctx);
+    expect(mocks.createTerminalRecoveryCommandRepository).not.toHaveBeenCalled();
+    expect(mocks.listClaimableTerminalRecoveryCommands).toHaveBeenCalledWith(
+      { repository: "read" },
+      expect.objectContaining({
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    );
   });
 
   it("lists update_app commands after the terminal reports app-update runtime evidence", async () => {
@@ -1514,7 +1587,7 @@ describe("POS terminal public mutations", () => {
     );
 
     expect(mocks.acknowledgeTerminalRecoveryCommandService).toHaveBeenCalledWith(
-      { repository: true },
+      { repository: "write" },
       expect.objectContaining({
         commandId: "command-1",
         executionId: "command-1:2000100",
@@ -1700,6 +1773,24 @@ function buildRecoveryCommand(overrides: Record<string, unknown> = {}) {
     issuedByUserId: "athena-user-1",
     issuedAt: 1,
     expiresAt: 901,
+    ...overrides,
+  };
+}
+
+function buildPublicTerminal(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: "terminal-1",
+    _creationTime: 1,
+    storeId: "store-1",
+    fingerprintHash: "fingerprint-1",
+    displayName: "Front register",
+    registerNumber: "1",
+    loginMode: "pos_only",
+    transactionCapability: "products_and_services",
+    registeredByUserId: "athena-user-1",
+    browserInfo: { userAgent: "test" },
+    registeredAt: 1,
+    status: "active",
     ...overrides,
   };
 }

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -31,7 +31,10 @@ import {
   listClaimableTerminalRecoveryCommands,
 } from "../application/terminalRecovery/terminalCommandService";
 import { runAcceptedRuntimeStatusSideEffects } from "../application/terminalRuntime/postRuntimeStatusSideEffects";
-import { createTerminalRecoveryCommandRepository } from "../infrastructure/repositories/terminalRecoveryRepository";
+import {
+  createTerminalRecoveryCommandReadRepository,
+  createTerminalRecoveryCommandRepository,
+} from "../infrastructure/repositories/terminalRecoveryRepository";
 import { getLatestRuntimeStatusForTerminal } from "../infrastructure/repositories/terminalRepository";
 import {
   disconnectRemoteAssistRuntimeSession,
@@ -1028,7 +1031,7 @@ export const listTerminalRecoveryCommands = query({
     }
     const [commands, runtimeStatus] = await Promise.all([
       listClaimableTerminalRecoveryCommands(
-        createTerminalRecoveryCommandRepository(ctx),
+        createTerminalRecoveryCommandReadRepository(ctx),
         {
           now: Date.now(),
           storeId: args.storeId,

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -390,6 +390,12 @@ const schema = defineSchema({
     .index("by_terminal_receivedAt", ["terminalId", "receivedAt"]),
   posTerminalRecoveryCommand: defineTable(posTerminalRecoveryCommandSchema)
     .index("by_store_terminal_status", ["storeId", "terminalId", "status"])
+    .index("by_store_terminal_status_expiresAt", [
+      "storeId",
+      "terminalId",
+      "status",
+      "expiresAt",
+    ])
     .index("by_store_terminal_verification", [
       "storeId",
       "terminalId",

--- a/packages/athena-webapp/docs/agent/validation-guide.md
+++ b/packages/athena-webapp/docs/agent/validation-guide.md
@@ -317,7 +317,7 @@ Behavior scenarios:
 - `athena-convex-storefront-composition`
 - `athena-convex-storefront-failure-visibility`
 
-Any change that can affect Convex HTTP wiring, serviceOps schemas and workflows, shared operational rails, or route-to-backend composition should include the Convex audit pair. When a public Convex function with an explicit `returns` validator changes, add executable return-contract proof with `assertConformsToExportedReturns`; loose `exportReturns()` string checks do not prove the production return contract.
+Any change that can affect Convex HTTP wiring, serviceOps schemas and workflows, shared operational rails, or route-to-backend composition should include the Convex audit pair. When a public Convex function with an explicit `returns` validator changes, add executable return-contract proof with `assertConformsToExportedReturns`; loose `exportReturns()` string checks do not prove the production return contract. Convex query handlers must not reach mutation-only DB APIs directly or through write-capable repositories/services; split read factories from `MutationCtx`-only write factories when shared code crosses query and mutation boundaries.
 
 ## Route runtime or build-pipeline edits
 

--- a/scripts/harness-app-registry.test.ts
+++ b/scripts/harness-app-registry.test.ts
@@ -190,6 +190,12 @@ describe("HARNESS_APP_REGISTRY", () => {
     expect(backendScenario?.note).toContain(
       "loose `exportReturns()` string checks do not prove the production return contract"
     );
+    expect(backendScenario?.note).toContain(
+      "Convex query handlers must not reach mutation-only DB APIs directly or through write-capable repositories/services"
+    );
+    expect(backendScenario?.note).toContain(
+      "split read factories from `MutationCtx`-only write factories"
+    );
   });
 
   it("covers changed Athena frontend source files with changed-file lint", () => {

--- a/scripts/harness-app-registry.ts
+++ b/scripts/harness-app-registry.ts
@@ -924,7 +924,7 @@ export const HARNESS_APP_REGISTRY = [
           "athena-convex-storefront-composition",
           "athena-convex-storefront-failure-visibility",
         ],
-        note: "Any change that can affect Convex HTTP wiring, serviceOps schemas and workflows, shared operational rails, or route-to-backend composition should include the Convex audit pair. When a public Convex function with an explicit `returns` validator changes, add executable return-contract proof with `assertConformsToExportedReturns`; loose `exportReturns()` string checks do not prove the production return contract.",
+        note: "Any change that can affect Convex HTTP wiring, serviceOps schemas and workflows, shared operational rails, or route-to-backend composition should include the Convex audit pair. When a public Convex function with an explicit `returns` validator changes, add executable return-contract proof with `assertConformsToExportedReturns`; loose `exportReturns()` string checks do not prove the production return contract. Convex query handlers must not reach mutation-only DB APIs directly or through write-capable repositories/services; split read factories from `MutationCtx`-only write factories when shared code crosses query and mutation boundaries.",
       },
       {
         title: "Route runtime or build-pipeline edits",

--- a/scripts/harness-inferential-review.test.ts
+++ b/scripts/harness-inferential-review.test.ts
@@ -16,6 +16,25 @@ async function write(relativePath: string, contents: string, rootDir: string) {
   await writeFile(filePath, contents);
 }
 
+async function runFixtureCommand(rootDir: string, command: string[]) {
+  const process = Bun.spawn(command, {
+    cwd: rootDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+
+  if (exitCode !== 0) {
+    throw new Error(
+      `Fixture command failed: ${command.join(" ")}\n${stdout}\n${stderr}`,
+    );
+  }
+}
+
 async function createFixtureRepo() {
   const rootDir = await mkdtemp(
     path.join(tmpdir(), "athena-harness-inferential-review-"),
@@ -117,6 +136,29 @@ async function createFixtureRepo() {
   );
 
   return rootDir;
+}
+
+async function commitFixtureRepo(rootDir: string) {
+  await runFixtureCommand(rootDir, ["git", "init"]);
+  await runFixtureCommand(rootDir, [
+    "git",
+    "config",
+    "user.email",
+    "codex@example.com",
+  ]);
+  await runFixtureCommand(rootDir, [
+    "git",
+    "config",
+    "user.name",
+    "Codex Test",
+  ]);
+  await runFixtureCommand(rootDir, ["git", "add", "."]);
+  await runFixtureCommand(rootDir, [
+    "git",
+    "commit",
+    "-m",
+    "baseline fixture",
+  ]);
 }
 
 afterEach(async () => {
@@ -1061,6 +1103,2283 @@ describe("runHarnessInferentialReview", () => {
     expect(result.machine.findings[0]?.rationale).not.toContain(
       "query listExample",
     );
+  });
+
+  it("fails when a changed Convex query directly calls mutation-only db APIs", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    await ctx.db.patch(\"command-id\" as never, { status: \"expired\" });",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/queryWrites.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.status).toBe("fail");
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-querywrites-ts",
+        severity: "high",
+        filePath: "packages/athena-webapp/convex/pos/public/queryWrites.ts",
+      }),
+    );
+    expect(result.humanReport).toContain("MutationCtx");
+  });
+
+  it("fails when a changed Convex query adds a write through an existing renamed handler ctx", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryRenamedCtxWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (queryCtx) => {",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+    await commitFixtureRepo(rootDir);
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryRenamedCtxWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (queryCtx) => {",
+        "    await queryCtx.db.patch(\"command-id\" as never, { status: \"expired\" });",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      baseRef: "HEAD",
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/queryRenamedCtxWrites.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryrenamedctxwrites-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed Convex query writes through a destructured db alias", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryDestructuredDbWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+    await commitFixtureRepo(rootDir);
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryDestructuredDbWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    const { db, auth }: { db: any; auth: unknown } = ctx as any;",
+        "    await db.patch(\"command-id\" as never, { status: \"expired\" });",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      baseRef: "HEAD",
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/queryDestructuredDbWrites.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-querydestructureddbwrites-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+	it("fails when a changed Convex query adds a write through an existing simple db alias", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingSimpleAliasWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    const db = ctx.db as any;",
+        "    await db.query(\"posTerminalRecoveryCommand\").collect();",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+    await commitFixtureRepo(rootDir);
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryExistingSimpleAliasWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    const db = ctx.db as any;",
+        "    await db.query(\"posTerminalRecoveryCommand\").collect();",
+        "    await db.patch(\"command-id\" as never, { status: \"expired\" });",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      baseRef: "HEAD",
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/queryExistingSimpleAliasWrites.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingsimplealiaswrites-ts",
+        severity: "high",
+      }),
+		);
+	});
+
+	it("fails when a changed Convex query adds a write through an existing multi-declarator db alias", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingMultiDeclaratorAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const ready = true, db = ctx.db as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingMultiDeclaratorAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const ready = true, db = ctx.db as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await db.patch(\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingMultiDeclaratorAliasWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingmultideclaratoraliaswrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query adds a write through an existing typed db alias", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingTypedAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db: any = ctx.db;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingTypedAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db: any = ctx.db;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await db.patch(\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingTypedAliasWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingtypedaliaswrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query adds a write through an existing bracket db alias", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingBracketAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx[\"db\"] as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingBracketAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx[\"db\"] as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await db.patch(\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingBracketAliasWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingbracketaliaswrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query adds a write through an existing parenthesized db alias", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingParenthesizedAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = (ctx).db as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingParenthesizedAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = (ctx).db as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await db.patch(\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingParenthesizedAliasWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingparenthesizedaliaswrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query adds a non-null asserted write through an existing db alias", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingNonNullAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingNonNullAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await db!.patch(\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingNonNullAliasWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingnonnullaliaswrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query adds a bracket method write through an existing db alias", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingBracketMethodAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingBracketMethodAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await db[\"patch\"](\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingBracketMethodAliasWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingbracketmethodaliaswrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query adds an optional bracket method write through an existing db alias", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingOptionalBracketMethodAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingOptionalBracketMethodAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await db?.[\"patch\"](\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingOptionalBracketMethodAliasWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingoptionalbracketmethodaliaswrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query adds a parenthesized write through an existing db alias", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingParenthesizedReceiverAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingParenthesizedReceiverAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await (db).patch(\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingParenthesizedReceiverAliasWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingparenthesizedreceiveraliaswrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query adds a casted receiver write through an existing db alias", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingCastedReceiverAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingCastedReceiverAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await (db as any).patch(\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingCastedReceiverAliasWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingcastedreceiveraliaswrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query adds a satisfies receiver write through an existing db alias", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingSatisfiesReceiverAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingSatisfiesReceiverAliasWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await (db satisfies any).patch(\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingSatisfiesReceiverAliasWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingsatisfiesreceiveraliaswrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query calls an existing bound db write method", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingBoundMethodWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    const patch = db.patch.bind(db);",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingBoundMethodWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    const patch = db.patch.bind(db);",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await patch(\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingBoundMethodWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingboundmethodwrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query calls an existing assigned db write method", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingAssignedMethodWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    const patch = db.patch;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingAssignedMethodWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    const patch = db.patch;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await patch(\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingAssignedMethodWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingassignedmethodwrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query calls an existing renamed assigned db write method", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingRenamedAssignedMethodWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    const patchCommand = db.patch;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingRenamedAssignedMethodWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    const patchCommand = db.patch;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await patchCommand(\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingRenamedAssignedMethodWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingrenamedassignedmethodwrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query calls an existing typed assigned db write method", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingTypedAssignedMethodWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    const patch: any = db.patch;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingTypedAssignedMethodWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    const patch: any = db.patch;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await patch(\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingTypedAssignedMethodWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingtypedassignedmethodwrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query calls an existing multi-declarator assigned db write method", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingMultiDeclaratorAssignedMethodWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    const ready = true, patch = db.patch;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingMultiDeclaratorAssignedMethodWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    const ready = true, patch = db.patch;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await patch(\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingMultiDeclaratorAssignedMethodWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingmultideclaratorassignedmethodwrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query calls an existing destructured db write method", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingDestructuredMethodWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    const { patch } = db;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingDestructuredMethodWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    const { patch } = db;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await patch(\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingDestructuredMethodWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingdestructuredmethodwrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query calls an existing typed destructured db write method", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingTypedDestructuredMethodWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    const { patch }: { patch: (...args: any[]) => Promise<void> } = db;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingTypedDestructuredMethodWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    const { patch }: { patch: (...args: any[]) => Promise<void> } = db;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await patch(\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingTypedDestructuredMethodWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingtypeddestructuredmethodwrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query calls an existing multi-declarator destructured db write method", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingMultiDeclaratorDestructuredMethodWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    const ready = true, { patch } = db;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+		await commitFixtureRepo(rootDir);
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingMultiDeclaratorDestructuredMethodWrites.ts",
+			[
+				'import { query } from "../../../_generated/server";',
+				"",
+				"export const listCommands = query({",
+				"  args: {},",
+				"  handler: async (ctx) => {",
+				"    const db = ctx.db as any;",
+				"    const ready = true, { patch } = db;",
+				"    await db.query(\"posTerminalRecoveryCommand\").collect();",
+				"    await patch(\"command-id\" as never, { status: \"expired\" });",
+				"    return [];",
+				"  },",
+				"});",
+			].join("\n"),
+			rootDir,
+		);
+
+		const result = await runHarnessInferentialReview(rootDir, {
+			baseRef: "HEAD",
+			getChangedFiles: async () => [
+				"packages/athena-webapp/convex/pos/public/queryExistingMultiDeclaratorDestructuredMethodWrites.ts",
+			],
+			nowIso: () => "2026-04-12T05:00:00.000Z",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.machine.findings).toContainEqual(
+			expect.objectContaining({
+				id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingmultideclaratordestructuredmethodwrites-ts",
+				severity: "high",
+			}),
+		);
+	});
+
+	it("fails when a changed Convex query adds a write through an existing destructured db alias", async () => {
+		const rootDir = await createFixtureRepo();
+		await write(
+			"packages/athena-webapp/convex/pos/public/queryExistingDestructuredAliasWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    const { db, auth }: { db: any; auth: unknown } = ctx as any;",
+        "    await db.query(\"posTerminalRecoveryCommand\").collect();",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+    await commitFixtureRepo(rootDir);
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryExistingDestructuredAliasWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    const { db, auth }: { db: any; auth: unknown } = ctx as any;",
+        "    await db.query(\"posTerminalRecoveryCommand\").collect();",
+        "    await db.patch(\"command-id\" as never, { status: \"expired\" });",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      baseRef: "HEAD",
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/queryExistingDestructuredAliasWrites.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryexistingdestructuredaliaswrites-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed Convex query writes through a destructured handler db parameter", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryDestructuredHandlerWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async () => {",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+    await commitFixtureRepo(rootDir);
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryDestructuredHandlerWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async ({ db }: any) => {",
+        "    await db.patch(\"command-id\" as never, { status: \"expired\" });",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      baseRef: "HEAD",
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/queryDestructuredHandlerWrites.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-querydestructuredhandlerwrites-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed Convex query writes through a casted db alias", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryWritesAlias.ts",
+      [
+        'import { query, type MutationCtx } from "../../../_generated/server";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    const db = (ctx as unknown as MutationCtx).db;",
+        "    await db.patch(\"command-id\" as never, { status: \"expired\" });",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/queryWritesAlias.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-querywritesalias-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed Convex query writes through an any db alias", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryWritesAnyAlias.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    const db = ctx.db as any;",
+        "    await db.patch(\"command-id\" as never, { status: \"expired\" });",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/queryWritesAnyAlias.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-querywritesanyalias-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed Convex query creates a write-capable repository", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryFactoryWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        'import { createTerminalRecoveryCommandRepository } from "../infrastructure/repositories/terminalRecoveryRepository";',
+        'import { listClaimableTerminalRecoveryCommands } from "../application/terminalRecovery/terminalCommandService";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    const repository = createTerminalRecoveryCommandRepository(ctx);",
+        "    return await listClaimableTerminalRecoveryCommands(repository, new Date());",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/queryFactoryWrites.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryfactorywrites-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed Convex query creates a write-capable repository from a renamed ctx parameter", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryFactoryRenamedCtx.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        'import { createTerminalRecoveryCommandRepository } from "../infrastructure/repositories/terminalRecoveryRepository";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (queryCtx) => {",
+        "    const repository = createTerminalRecoveryCommandRepository(queryCtx as never);",
+        "    await repository.patchCommand(\"command-id\" as never, { status: \"expired\" });",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/queryFactoryRenamedCtx.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryfactoryrenamedctx-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed Convex query passes ctx to a MutationCtx write helper", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryHelperWrites.ts",
+      [
+        'import { query, type MutationCtx } from "../../../_generated/server";',
+        "",
+        "const expireCommands = async (ctx: MutationCtx): Promise<{ ok: boolean }> => {",
+        "  await ctx.db.patch(\"command-id\" as never, { status: \"expired\" });",
+        "  return { ok: true };",
+        "};",
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    await expireCommands(ctx as never);",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/queryHelperWrites.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryhelperwrites-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed Convex query imports an unchanged MutationCtx write helper", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/application/writeHelpers.ts",
+      [
+        'import type { MutationCtx } from "../../../_generated/server";',
+        "",
+        "export const expireCommands = async (ctx: MutationCtx): Promise<void> => {",
+        "  await ctx.db.patch(\"command-id\" as never, { status: \"expired\" });",
+        "};",
+      ].join("\n"),
+      rootDir,
+    );
+    await commitFixtureRepo(rootDir);
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryImportedExistingHelperWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        'import { expireCommands } from "../application/writeHelpers";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    await expireCommands(ctx as never);",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      baseRef: "HEAD",
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/queryImportedExistingHelperWrites.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryimportedexistinghelperwrites-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed Convex query aliases an unchanged MutationCtx write helper import", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/application/writeHelpers.ts",
+      [
+        'import type { MutationCtx } from "../../../_generated/server";',
+        "",
+        "export async function expireCommands(ctx: MutationCtx): Promise<void> {",
+        "  await ctx.db.patch(\"command-id\" as never, { status: \"expired\" });",
+        "}",
+      ].join("\n"),
+      rootDir,
+    );
+    await commitFixtureRepo(rootDir);
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryImportedAliasHelperWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        'import { expireCommands as expireTerminalCommands } from "../application/writeHelpers";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    await expireTerminalCommands(ctx as never);",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      baseRef: "HEAD",
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/queryImportedAliasHelperWrites.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryimportedaliashelperwrites-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed Convex query adds a call to a pre-existing write-helper import alias", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/application/writeHelpers.ts",
+      [
+        'import type { MutationCtx } from "../../../_generated/server";',
+        "",
+        "export async function expireCommands(ctx: MutationCtx): Promise<void> {",
+        "  await ctx.db.patch(\"command-id\" as never, { status: \"expired\" });",
+        "}",
+      ].join("\n"),
+      rootDir,
+    );
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryImportedAliasHelperWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        'import { expireCommands as expireTerminalCommands } from "../application/writeHelpers";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async () => {",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+    await commitFixtureRepo(rootDir);
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryImportedAliasHelperWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        'import { expireCommands as expireTerminalCommands } from "../application/writeHelpers";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    await expireTerminalCommands(ctx as never);",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      baseRef: "HEAD",
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/queryImportedAliasHelperWrites.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryimportedaliashelperwrites-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed Convex query imports a changed MutationCtx write helper", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/application/writeHelpers.ts",
+      [
+        'import type { MutationCtx } from "../../../_generated/server";',
+        "",
+        "export async function expireCommands(ctx: MutationCtx): Promise<void> {",
+        "  await ctx.db.patch(\"command-id\" as never, { status: \"expired\" });",
+        "}",
+      ].join("\n"),
+      rootDir,
+    );
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryImportedHelperWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        'import { expireCommands } from "../application/writeHelpers";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    await expireCommands(ctx as never);",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/application/writeHelpers.ts",
+        "packages/athena-webapp/convex/pos/public/queryImportedHelperWrites.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryimportedhelperwrites-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed MutationCtx write helper has an unchanged aliased Convex query caller", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/application/writeHelpers.ts",
+      [
+        'import type { QueryCtx } from "../../../_generated/server";',
+        "",
+        "export async function expireCommands(ctx: QueryCtx): Promise<void> {",
+        "  await ctx.db.get(\"command-id\" as never);",
+        "}",
+      ].join("\n"),
+      rootDir,
+    );
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryImportedAliasHelperWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        'import { expireCommands as expireTerminalCommands } from "../application/writeHelpers";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    await expireTerminalCommands(ctx as never);",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+    await commitFixtureRepo(rootDir);
+    await write(
+      "packages/athena-webapp/convex/pos/application/writeHelpers.ts",
+      [
+        'import type { MutationCtx } from "../../../_generated/server";',
+        "",
+        "export async function expireCommands(ctx: MutationCtx): Promise<void> {",
+        "  await ctx.db.patch(\"command-id\" as never, { status: \"expired\" });",
+        "}",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      baseRef: "HEAD",
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/application/writeHelpers.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryimportedaliashelperwrites-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed MutationCtx write helper has an unchanged Convex query caller", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/application/writeHelpers.ts",
+      [
+        'import type { QueryCtx } from "../../../_generated/server";',
+        "",
+        "export const expireCommands = async (ctx: QueryCtx): Promise<void> => {",
+        "  await ctx.db.get(\"command-id\" as never);",
+        "};",
+      ].join("\n"),
+      rootDir,
+    );
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryImportedHelperWrites.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        'import { expireCommands } from "../application/writeHelpers";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    await expireCommands(ctx as never);",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+    await commitFixtureRepo(rootDir);
+    await write(
+      "packages/athena-webapp/convex/pos/application/writeHelpers.ts",
+      [
+        'import type { MutationCtx } from "../../../_generated/server";',
+        "",
+        "export const expireCommands = async (ctx: MutationCtx): Promise<void> => {",
+        "  await ctx.db.patch(\"command-id\" as never, { status: \"expired\" });",
+        "};",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      baseRef: "HEAD",
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/application/writeHelpers.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-queryimportedhelperwrites-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("accepts a changed Convex query with a local read-only helper shadowing an unrelated write helper name", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/application/writeHelpers.ts",
+      [
+        'import type { MutationCtx } from "../../../_generated/server";',
+        "",
+        "export async function createOffer(ctx: MutationCtx): Promise<void> {",
+        "  await ctx.db.patch(\"offer-id\" as never, { status: \"expired\" });",
+        "}",
+      ].join("\n"),
+      rootDir,
+    );
+    await commitFixtureRepo(rootDir);
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryLocalReadHelper.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        "",
+        "async function createOffer(ctx: unknown): Promise<unknown> {",
+        "  return await Promise.resolve(ctx);",
+        "}",
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    await createOffer(ctx);",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      baseRef: "HEAD",
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/queryLocalReadHelper.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("accepts a changed Convex query that creates a read-only repository", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/public/queryReadFactory.ts",
+      [
+        'import { query } from "../../../_generated/server";',
+        'import { createTerminalRecoveryCommandReadRepository } from "../infrastructure/repositories/terminalRecoveryRepository";',
+        'import { listClaimableTerminalRecoveryCommands } from "../application/terminalRecovery/terminalCommandService";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    const repository = createTerminalRecoveryCommandReadRepository(ctx);",
+        "    return await listClaimableTerminalRecoveryCommands(repository, new Date());",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/queryReadFactory.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.machine.status).toBe("pass");
+    expect(result.machine.findings).toEqual([]);
+  });
+
+  it("fails when a staged-only tracked Convex query writes", async () => {
+    const rootDir = await createFixtureRepo();
+    const queryPath =
+      "packages/athena-webapp/convex/pos/public/stagedQueryWrites.ts";
+    await write(
+      queryPath,
+      [
+        'import { query } from "../../../_generated/server";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async () => {",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+    await runFixtureCommand(rootDir, ["git", "init"]);
+    await runFixtureCommand(rootDir, ["git", "config", "user.email", "fixture@example.com"]);
+    await runFixtureCommand(rootDir, ["git", "config", "user.name", "Fixture"]);
+    await runFixtureCommand(rootDir, ["git", "add", "."]);
+    await runFixtureCommand(rootDir, ["git", "commit", "-m", "baseline"]);
+    await write(
+      queryPath,
+      [
+        'import { query } from "../../../_generated/server";',
+        "",
+        "export const listCommands = query({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    await ctx.db.patch(\"command-id\" as never, { status: \"expired\" });",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+    await runFixtureCommand(rootDir, ["git", "add", queryPath]);
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      baseRef: "HEAD",
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.changedFiles).toContain(queryPath);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-public-stagedquerywrites-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed internal query casts ctx to MutationCtx before writing", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/internal/queryWrites.ts",
+      [
+        'import { internalQuery, type MutationCtx } from "../../_generated/server";',
+        "",
+        "export const listCommands = internalQuery({",
+        "  args: {},",
+        "  handler: async (ctx) => {",
+        "    await (ctx as unknown as MutationCtx).db.delete(\"command-id\" as never);",
+        "    return [];",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/internal/queryWrites.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-mutation-db-write-packages-athena-webapp-convex-pos-internal-querywrites-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed mixed QueryCtx alias repository casts to MutationCtx and writes", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/infrastructure/repositories/mixedRepository.ts",
+      [
+        'import type { MutationCtx, QueryCtx } from "../../../_generated/server";',
+        "",
+        "type MixedCtx = QueryCtx | MutationCtx;",
+        "",
+        "export function createMixedRepository(ctx: MixedCtx) {",
+        "  return {",
+        "    async listCommands() {",
+        "      return await ctx.db.query(\"posTerminalRecoveryCommand\").collect();",
+        "    },",
+        "    async patchCommand(id: string, patch: Record<string, unknown>) {",
+        "      await (ctx as MutationCtx).db.patch(id as never, patch);",
+        "    },",
+        "  };",
+        "}",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/infrastructure/repositories/mixedRepository.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-compatible-write-surface-packages-athena-webapp-convex-pos-infrastructure-repositories-mixedrepository-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed arrow mixed QueryCtx repository writes", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/infrastructure/repositories/arrowMixedRepository.ts",
+      [
+        'import type { MutationCtx, QueryCtx } from "../../../_generated/server";',
+        "",
+        "type MixedCtx = QueryCtx | MutationCtx;",
+        "",
+        "export const createMixedRepository = (ctx: MixedCtx) => ({",
+        "  async listCommands() {",
+        "    return await ctx.db.query(\"posTerminalRecoveryCommand\").collect();",
+        "  },",
+        "  async patchCommand(id: string, patch: Record<string, unknown>) {",
+        "    await (ctx as MutationCtx).db.patch(id as never, patch);",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/infrastructure/repositories/arrowMixedRepository.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-compatible-write-surface-packages-athena-webapp-convex-pos-infrastructure-repositories-arrowmixedrepository-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed repository only widens MutationCtx to QueryCtx while retaining writes", async () => {
+    const rootDir = await createFixtureRepo();
+    const repositoryPath =
+      "packages/athena-webapp/convex/pos/infrastructure/repositories/widenedRepository.ts";
+    await write(
+      repositoryPath,
+      [
+        'import type { MutationCtx, QueryCtx } from "../../../_generated/server";',
+        "",
+        "export function createWidenedRepository(ctx: MutationCtx) {",
+        "  return {",
+        "    async patchCommand(id: string, patch: Record<string, unknown>) {",
+        "      await ctx.db.patch(id as never, patch);",
+        "    },",
+        "  };",
+        "}",
+      ].join("\n"),
+      rootDir,
+    );
+    await runFixtureCommand(rootDir, ["git", "init"]);
+    await runFixtureCommand(rootDir, ["git", "config", "user.email", "fixture@example.com"]);
+    await runFixtureCommand(rootDir, ["git", "config", "user.name", "Fixture"]);
+    await runFixtureCommand(rootDir, ["git", "add", "."]);
+    await runFixtureCommand(rootDir, ["git", "commit", "-m", "baseline"]);
+    await write(
+      repositoryPath,
+      [
+        'import type { MutationCtx, QueryCtx } from "../../../_generated/server";',
+        "",
+        "export function createWidenedRepository(ctx: QueryCtx | MutationCtx) {",
+        "  return {",
+        "    async patchCommand(id: string, patch: Record<string, unknown>) {",
+        "      await ctx.db.patch(id as never, patch);",
+        "    },",
+        "  };",
+        "}",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      baseRef: "HEAD",
+      getChangedFiles: async () => [repositoryPath],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-compatible-write-surface-packages-athena-webapp-convex-pos-infrastructure-repositories-widenedrepository-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails for Pick<QueryCtx | MutationCtx, db> style mixed ctx shapes that write", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/infrastructure/repositories/pickRepository.ts",
+      [
+        'import type { MutationCtx, QueryCtx } from "../../../_generated/server";',
+        "",
+        "type DbCtx = Pick<QueryCtx | MutationCtx, \"db\">;",
+        "",
+        "export async function replaceCommand(ctx: DbCtx, id: string) {",
+        "  await (ctx as unknown as MutationCtx).db.replace(id as never, {});",
+        "}",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/infrastructure/repositories/pickRepository.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-compatible-write-surface-packages-athena-webapp-convex-pos-infrastructure-repositories-pickrepository-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("fails when a changed query-facing service calls a write repository method", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/application/terminalRecovery/queryFacingService.ts",
+      [
+        "type CommandRepository = {",
+        "  listCommands(): Promise<unknown[]>;",
+        "  patchCommand(id: string, patch: Record<string, unknown>): Promise<void>;",
+        "};",
+        "",
+        "export async function listClaimableCommands(repository: CommandRepository) {",
+        "  await repository.patchCommand(\"command-id\", { status: \"expired\" });",
+        "  return await repository.listCommands();",
+        "}",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/application/terminalRecovery/queryFacingService.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "convex-query-facing-write-repository-packages-athena-webapp-convex-pos-application-terminalrecovery-queryfacingservice-ts",
+        severity: "high",
+      }),
+    );
+  });
+
+  it("accepts changed mutations that use write repositories", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/public/mutationWrites.ts",
+      [
+        'import { mutation } from "../../../_generated/server";',
+        "",
+        "export const expireCommand = mutation({",
+        "  args: {},",
+        "  handler: async (_ctx) => {",
+        "    const repository = {",
+        "      async patchCommand() {",
+        "        return undefined;",
+        "      },",
+        "    };",
+        "    await repository.patchCommand();",
+        "    return null;",
+        "  },",
+        "});",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/public/mutationWrites.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.machine.status).toBe("pass");
+    expect(result.machine.findings).toEqual([]);
+  });
+
+  it("accepts read-only helpers that accept QueryCtx or MutationCtx", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/convex/pos/infrastructure/repositories/readRepository.ts",
+      [
+        'import type { MutationCtx, QueryCtx } from "../../../_generated/server";',
+        "",
+        "type MixedCtx = QueryCtx | MutationCtx;",
+        "",
+        "export async function listCommands(ctx: MixedCtx) {",
+        "  return await ctx.db.query(\"posTerminalRecoveryCommand\").collect();",
+        "}",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/athena-webapp/convex/pos/infrastructure/repositories/readRepository.ts",
+      ],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.machine.status).toBe("pass");
+    expect(result.machine.findings).toEqual([]);
+  });
+
+  it("accepts read-only edits to an existing mixed repository with historical writes", async () => {
+    const rootDir = await createFixtureRepo();
+    const repositoryPath =
+      "packages/athena-webapp/convex/pos/infrastructure/repositories/existingMixedRepository.ts";
+    await write(
+      repositoryPath,
+      [
+        'import type { MutationCtx, QueryCtx } from "../../../_generated/server";',
+        "",
+        "type MixedCtx = QueryCtx | MutationCtx;",
+        "",
+        "export function createExistingRepository(ctx: MixedCtx) {",
+        "  return {",
+        "    async listCommands() {",
+        "      return await ctx.db.query(\"posTerminalRecoveryCommand\").collect();",
+        "    },",
+        "    async patchCommand(id: string, patch: Record<string, unknown>) {",
+        "      await (ctx as MutationCtx).db.patch(id as never, patch);",
+        "    },",
+        "  };",
+        "}",
+      ].join("\n"),
+      rootDir,
+    );
+    await runFixtureCommand(rootDir, ["git", "init"]);
+    await runFixtureCommand(rootDir, ["git", "config", "user.email", "fixture@example.com"]);
+    await runFixtureCommand(rootDir, ["git", "config", "user.name", "Fixture"]);
+    await runFixtureCommand(rootDir, ["git", "add", "."]);
+    await runFixtureCommand(rootDir, ["git", "commit", "-m", "baseline"]);
+    await write(
+      repositoryPath,
+      [
+        'import type { MutationCtx, QueryCtx } from "../../../_generated/server";',
+        "",
+        "type MixedCtx = QueryCtx | MutationCtx;",
+        "",
+        "export function createExistingRepository(ctx: MixedCtx) {",
+        "  return {",
+        "    async listCommands() {",
+        "      const query = ctx.db.query(\"posTerminalRecoveryCommand\");",
+        "      return await query.collect();",
+        "    },",
+        "    async patchCommand(id: string, patch: Record<string, unknown>) {",
+        "      await (ctx as MutationCtx).db.patch(id as never, patch);",
+        "    },",
+        "  };",
+        "}",
+      ].join("\n"),
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      baseRef: "HEAD",
+      getChangedFiles: async () => [repositoryPath],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.machine.status).toBe("pass");
+    expect(result.machine.findings).toEqual([]);
   });
 
   it("writes machine-readable output with additive shadow data via the default artifact path", async () => {

--- a/scripts/harness-inferential-review.ts
+++ b/scripts/harness-inferential-review.ts
@@ -183,7 +183,7 @@ export async function getChangedFilesForInferentialReview(
     throw new Error(`Base ref check failed for ${baseRef}: ${detail}`);
   }
 
-  const [baseDiff, trackedDiff, untrackedDiff] = await Promise.all([
+  const [baseDiff, trackedDiff, stagedDiff, untrackedDiff] = await Promise.all([
     runCommand(rootDir, [
       "git",
       "diff",
@@ -195,6 +195,15 @@ export async function getChangedFilesForInferentialReview(
     runCommand(rootDir, [
       "git",
       "diff",
+      "--name-only",
+      "--diff-filter=ACDMRTUXB",
+      "HEAD",
+      "--",
+    ]),
+    runCommand(rootDir, [
+      "git",
+      "diff",
+      "--cached",
       "--name-only",
       "--diff-filter=ACDMRTUXB",
       "HEAD",
@@ -217,6 +226,12 @@ export async function getChangedFilesForInferentialReview(
     );
   }
 
+  if (stagedDiff.exitCode !== 0) {
+    throw new Error(
+      stagedDiff.stderr.trim() || "Unable to compute staged index changes.",
+    );
+  }
+
   if (untrackedDiff.exitCode !== 0) {
     throw new Error(
       untrackedDiff.stderr.trim() ||
@@ -227,6 +242,7 @@ export async function getChangedFilesForInferentialReview(
   return sortUnique([
     ...baseDiff.stdout.split("\n"),
     ...trackedDiff.stdout.split("\n"),
+    ...stagedDiff.stdout.split("\n"),
     ...untrackedDiff.stdout.split("\n"),
   ]);
 }
@@ -261,6 +277,17 @@ function isHarnessCriticalFile(filePath: string) {
 }
 
 function isConvexReturnContractSourcePath(filePath: string) {
+  const normalized = normalizeRepoPath(filePath);
+  return (
+    normalized.startsWith("packages/athena-webapp/convex/") &&
+    normalized.endsWith(".ts") &&
+    !normalized.endsWith(".test.ts") &&
+    !normalized.endsWith(".d.ts") &&
+    !normalized.startsWith("packages/athena-webapp/convex/_generated/")
+  );
+}
+
+function isConvexSourcePath(filePath: string) {
   const normalized = normalizeRepoPath(filePath);
   return (
     normalized.startsWith("packages/athena-webapp/convex/") &&
@@ -583,6 +610,11 @@ type ConvexPublicFunctionExport = {
   kind: "action" | "mutation" | "query";
 };
 
+type ConvexFunctionExport = {
+  exportName: string;
+  kind: "internalQuery" | "mutation" | "query";
+};
+
 function extractConvexPublicFunctionsWithReturns(contents: string) {
   const exports: ConvexPublicFunctionExport[] = [];
   const functionPattern =
@@ -610,6 +642,29 @@ function extractConvexPublicFunctionsWithReturns(contents: string) {
   return exports;
 }
 
+function extractConvexFunctionDefinitions(contents: string) {
+  const exports: Array<ConvexFunctionExport & { definitionBody: string }> = [];
+  const functionPattern =
+    /export\s+const\s+([A-Za-z_$][\w$]*)\s*=\s*(query|internalQuery|mutation)\s*\(\s*\{/g;
+
+  for (const match of contents.matchAll(functionPattern)) {
+    const bodyStart = match.index === undefined ? -1 : match.index;
+    if (bodyStart < 0) {
+      continue;
+    }
+
+    const bodyEnd = findMatchingDefinitionEnd(contents, bodyStart);
+    exports.push({
+      exportName: match[1],
+      kind: match[2] as ConvexFunctionExport["kind"],
+      definitionBody:
+        bodyEnd === -1 ? contents.slice(bodyStart) : contents.slice(bodyStart, bodyEnd),
+    });
+  }
+
+  return exports;
+}
+
 function findMatchingDefinitionEnd(contents: string, startIndex: number) {
   const nextExport = contents.indexOf("\nexport const ", startIndex + 1);
   if (nextExport !== -1) {
@@ -617,6 +672,31 @@ function findMatchingDefinitionEnd(contents: string, startIndex: number) {
   }
 
   return contents.length;
+}
+
+function findMatchingBraceBlockEnd(contents: string, startIndex: number) {
+  const openBrace = contents.indexOf("{", startIndex);
+  if (openBrace === -1) {
+    return -1;
+  }
+
+  let depth = 0;
+  for (let index = openBrace; index < contents.length; index += 1) {
+    const char = contents[index];
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+    if (char !== "}") {
+      continue;
+    }
+    depth -= 1;
+    if (depth === 0) {
+      return index + 1;
+    }
+  }
+
+  return -1;
 }
 
 function isRelevantConvexContractProofPath(
@@ -787,6 +867,791 @@ async function collectConvexReturnValidatorContractFindings(
   return findings;
 }
 
+const CONVEX_MUTATION_ONLY_DB_METHODS = [
+  "insert",
+  "patch",
+  "replace",
+  "delete",
+] as const;
+
+const CONVEX_WRITE_METHOD_FRAGMENT =
+  "(?:insert|patch|replace|delete)[A-Za-z0-9_$]*";
+const CONVEX_WRITE_METHOD_ACCESS_FRAGMENT = `(?:\\.\\s*${CONVEX_WRITE_METHOD_FRAGMENT}|\\.?\\s*\\[\\s*(?:["']${CONVEX_WRITE_METHOD_FRAGMENT}["'])?\\s*\\])`;
+
+function hasMutationOnlyDbCall(contents: string) {
+  return new RegExp(
+    `\\.db\\s*\\.\\s*(?:${CONVEX_MUTATION_ONLY_DB_METHODS.join("|")})\\s*\\(`,
+  ).test(contents);
+}
+
+function hasCtxMutationOnlyDbCall(contents: string) {
+  const directCtxPattern = new RegExp(
+    `\\bctx\\s*\\.\\s*db\\s*\\.\\s*(?:${CONVEX_MUTATION_ONLY_DB_METHODS.join("|")})\\s*\\(`,
+  );
+  const castCtxPattern = new RegExp(
+    `\\(\\s*ctx\\s+as\\s+(?:unknown\\s+as\\s+)?MutationCtx\\s*\\)\\s*\\.\\s*db\\s*\\.\\s*(?:${CONVEX_MUTATION_ONLY_DB_METHODS.join("|")})\\s*\\(`,
+  );
+  const castDbPattern = new RegExp(
+    `\\(\\s*ctx\\s*\\.\\s*db\\s+as\\s+[^)]*MutationCtx[^)]*\\)\\s*\\.\\s*(?:${CONVEX_MUTATION_ONLY_DB_METHODS.join("|")})\\s*\\(`,
+  );
+
+  return (
+    directCtxPattern.test(contents) ||
+    castCtxPattern.test(contents) ||
+    castDbPattern.test(contents)
+  );
+}
+
+function extractConvexHandlerParamNames(contents: string) {
+  const paramNames = new Set<string>();
+  const handlerPattern =
+    /\bhandler\s*:\s*(?:async\s*)?\(\s*([A-Za-z_$][\w$]*)\b[^)]*\)\s*=>/g;
+
+  for (const match of contents.matchAll(handlerPattern)) {
+    paramNames.add(match[1]);
+  }
+
+  return paramNames;
+}
+
+function hasHandlerParamMutationOnlyDbCall(
+  contents: string,
+  paramNames: Set<string>,
+) {
+  for (const paramName of paramNames) {
+    const escapedParam = escapeRegExp(paramName);
+    const directPattern = new RegExp(
+      `\\b${escapedParam}\\s*\\.\\s*db\\s*\\.\\s*(?:${CONVEX_MUTATION_ONLY_DB_METHODS.join("|")})\\s*\\(`,
+    );
+    const castDbPattern = new RegExp(
+      `\\(\\s*${escapedParam}\\s*\\.\\s*db\\s+as\\s+[^)]*\\)\\s*\\.\\s*(?:${CONVEX_MUTATION_ONLY_DB_METHODS.join("|")})\\s*\\(`,
+    );
+    const castCtxPattern = new RegExp(
+      `\\(\\s*${escapedParam}\\s+as\\s+[^)]*\\)\\s*\\.\\s*db\\s*\\.\\s*(?:${CONVEX_MUTATION_ONLY_DB_METHODS.join("|")})\\s*\\(`,
+    );
+    if (
+      directPattern.test(contents) ||
+      castDbPattern.test(contents) ||
+      castCtxPattern.test(contents)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasHandlerDbAliasMutationOnlyCall(
+  contents: string,
+  paramNames: Set<string>,
+) {
+  const dbAliases = collectHandlerDbAliases(contents, paramNames);
+
+  for (const alias of dbAliases) {
+    const aliasWritePattern = new RegExp(
+      `(?:\\(\\s*)?\\b${escapeRegExp(alias)}\\b(?:\\s+(?:as|satisfies)\\s+[^)]+)?\\s*\\)?\\s*(?:!|\\?)?\\s*${CONVEX_WRITE_METHOD_ACCESS_FRAGMENT}\\s*\\(`,
+    );
+    if (aliasWritePattern.test(contents)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function collectHandlerDbAliases(contents: string, paramNames: Set<string>) {
+  const aliases = new Set<string>();
+
+  for (const paramName of paramNames) {
+    const escapedParam = escapeRegExp(paramName);
+    const paramDbAccess = `${escapedParam}\\s*\\)?\\s*(?:\\.\\s*db|\\[\\s*(?:["']db["'])?\\s*\\])`;
+		const aliasPattern = new RegExp(
+			`(?:\\b(?:const|let)\\s+|,\\s*)([A-Za-z_$][\\w$]*)\\s*(?::\\s*[^=;\\n]+)?=\\s*(?:\\(?\\s*${paramDbAccess}\\s*(?:as\\s+[^;\\n]+)?\\)?|\\(?\\s*${escapedParam}\\s+as\\s+[^)]*\\)\\s*(?:\\.\\s*db|\\[\\s*(?:["']db["'])?\\s*\\]))`,
+			"g",
+		);
+
+    for (const match of contents.matchAll(aliasPattern)) {
+      aliases.add(match[1]);
+    }
+
+    const destructuredAliasPattern = new RegExp(
+      `\\b(?:const|let)\\s*\\{([^}]+)\\}\\s*(?::\\s*[^=]+)?=\\s*\\(?\\s*${escapedParam}\\b(?:\\s+as\\s+[^;\\n)]+)?\\s*\\)?`,
+      "g",
+    );
+
+    for (const match of contents.matchAll(destructuredAliasPattern)) {
+      const alias = getDestructuredDbAlias(match[1]);
+      if (!alias) {
+        continue;
+      }
+      aliases.add(alias);
+    }
+  }
+
+  return aliases;
+}
+
+function getDestructuredDbAlias(specifiers: string) {
+  const dbSpecifier = specifiers
+    .split(",")
+    .map((specifier) => specifier.trim())
+    .find((specifier) => /^db(?:\s*:|$)/.test(specifier));
+
+  if (!dbSpecifier) {
+    return null;
+  }
+
+  return dbSpecifier.match(/^db\s*:\s*([A-Za-z_$][\w$]*)$/)?.[1] ?? "db";
+}
+
+function hasDestructuredHandlerDbMutationOnlyCall(contents: string) {
+  const handlerPattern =
+    /\bhandler\s*:\s*(?:async\s*)?\(\s*\{([^}]+)\}\s*(?::[^)]*)?\)\s*=>/g;
+
+  for (const match of contents.matchAll(handlerPattern)) {
+    const alias = getDestructuredDbAlias(match[1]);
+    if (!alias) {
+      continue;
+    }
+
+	  const aliasWritePattern = new RegExp(
+	    `(?:\\(\\s*)?\\b${escapeRegExp(alias)}\\b(?:\\s+(?:as|satisfies)\\s+[^)]+)?\\s*\\)?\\s*(?:!|\\?)?\\s*${CONVEX_WRITE_METHOD_ACCESS_FRAGMENT}\\s*\\(`,
+	  );
+	  if (aliasWritePattern.test(contents)) {
+	    return true;
+	  }
+  }
+
+  return false;
+}
+
+function hasHandlerBoundDbMutationOnlyCall(
+  contents: string,
+  paramNames: Set<string>,
+) {
+  const dbAliases = collectHandlerDbAliases(contents, paramNames);
+
+  for (const dbAlias of dbAliases) {
+    const boundMethodPattern = new RegExp(
+      `(?:\\b(?:const|let)\\s+|,\\s*)([A-Za-z_$][\\w$]*)\\s*(?::\\s*[^=;\\n]+)?=\\s*(?:\\(\\s*)?\\b${escapeRegExp(dbAlias)}\\b(?:\\s+(?:as|satisfies)\\s+[^)]+)?\\s*\\)?\\s*(?:!|\\?)?\\s*${CONVEX_WRITE_METHOD_ACCESS_FRAGMENT}(?:\\s*\\.\\s*bind\\s*\\(\\s*${escapeRegExp(dbAlias)}\\s*\\))?`,
+      "g",
+    );
+    for (const match of contents.matchAll(boundMethodPattern)) {
+      const boundName = match[1];
+      const boundCallPattern = new RegExp(
+        `\\b${escapeRegExp(boundName)}\\s*\\(`,
+      );
+      if (boundCallPattern.test(contents)) {
+        return true;
+      }
+    }
+
+    const destructuredMethodPattern = new RegExp(
+      `(?:\\b(?:const|let)\\s*|,\\s*)\\{([^}]+)\\}\\s*(?::[^\\n]*?)?=\\s*(?:\\(\\s*)?\\b${escapeRegExp(dbAlias)}\\b\\s*\\)?`,
+      "g",
+    );
+    for (const match of contents.matchAll(destructuredMethodPattern)) {
+      for (const methodAlias of getDestructuredWriteMethodAliases(match[1])) {
+        const methodCallPattern = new RegExp(
+          `\\b${escapeRegExp(methodAlias)}\\s*\\(`,
+        );
+        if (methodCallPattern.test(contents)) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+function getDestructuredWriteMethodAliases(specifiers: string) {
+  const methodAliases: string[] = [];
+
+  for (const specifier of specifiers.split(",")) {
+    const match = specifier
+      .trim()
+      .match(/^(insert|patch|replace|delete)(?:\s*:\s*([A-Za-z_$][\w$]*))?$/);
+    if (match) {
+      methodAliases.push(match[2] ?? match[1]);
+    }
+  }
+
+  return methodAliases;
+}
+
+function hasMutationCtxCast(contents: string) {
+  return /\bas\s+(?:unknown\s+as\s+)?MutationCtx\b/.test(contents);
+}
+
+function hasWriteLikeMethodCall(contents: string) {
+  return new RegExp(
+    `(?:\\(\\s*)?\\b[A-Za-z_$][\\w$]*\\b(?:\\s+(?:as|satisfies)\\s+[^)]+)?\\s*\\)?\\s*(?:!|\\?)?\\s*${CONVEX_WRITE_METHOD_ACCESS_FRAGMENT}\\s*\\(`,
+  ).test(contents);
+}
+
+function hasFunctionCall(contents: string) {
+  return /\b[A-Za-z_$][\w$]*\s*\(/.test(contents);
+}
+
+function hasQueryCompatibleCtxShape(contents: string) {
+  const directUnion =
+    /\bQueryCtx\s*\|\s*MutationCtx\b/.test(contents) ||
+    /\bMutationCtx\s*\|\s*QueryCtx\b/.test(contents);
+  const pickUnion =
+    /Pick\s*<\s*(?:QueryCtx\s*\|\s*MutationCtx|MutationCtx\s*\|\s*QueryCtx)\s*,/.test(
+      contents,
+    ) ||
+    /Pick\s*<\s*QueryCtx\s*,[^>]+>\s*\|\s*Pick\s*<\s*MutationCtx\s*,/.test(
+      contents,
+    ) ||
+    /Pick\s*<\s*MutationCtx\s*,[^>]+>\s*\|\s*Pick\s*<\s*QueryCtx\s*,/.test(
+      contents,
+    );
+  const aliasUnion =
+    /type\s+[A-Za-z_$][\w$]*\s*=\s*(?:QueryCtx\s*\|\s*MutationCtx|MutationCtx\s*\|\s*QueryCtx)\b/.test(
+      contents,
+    );
+
+  return directUnion || pickUnion || aliasUnion;
+}
+
+function collectQueryCompatibleCtxAliases(contents: string) {
+  const aliases = new Set<string>(["QueryCtx"]);
+  const aliasPattern =
+    /type\s+([A-Za-z_$][\w$]*)\s*=\s*(?:QueryCtx\s*\|\s*MutationCtx|MutationCtx\s*\|\s*QueryCtx|Pick\s*<\s*(?:QueryCtx\s*\|\s*MutationCtx|MutationCtx\s*\|\s*QueryCtx)\s*,[^>]+>)/g;
+
+  for (const match of contents.matchAll(aliasPattern)) {
+    aliases.add(match[1]);
+  }
+
+  return aliases;
+}
+
+function paramsHaveQueryCompatibleCtxShape(
+  params: string,
+  queryCompatibleAliases: Set<string>,
+) {
+  if (
+    /\bQueryCtx\s*\|\s*MutationCtx\b/.test(params) ||
+    /\bMutationCtx\s*\|\s*QueryCtx\b/.test(params) ||
+    /Pick\s*<\s*(?:QueryCtx\s*\|\s*MutationCtx|MutationCtx\s*\|\s*QueryCtx)\s*,/.test(
+      params,
+    ) ||
+    /Pick\s*<\s*QueryCtx\s*,[^>]+>\s*\|\s*Pick\s*<\s*MutationCtx\s*,/.test(
+      params,
+    ) ||
+    /Pick\s*<\s*MutationCtx\s*,[^>]+>\s*\|\s*Pick\s*<\s*QueryCtx\s*,/.test(
+      params,
+    )
+  ) {
+    return true;
+  }
+
+  for (const alias of queryCompatibleAliases) {
+    if (new RegExp(`:\\s*${escapeRegExp(alias)}\\b`).test(params)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function extractFunctionBodiesWithParams(contents: string) {
+  const bodies: Array<{ body: string; name: string; params: string }> = [];
+  const functionPattern =
+    /(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(([^)]*)\)\s*(?::\s*[^{};=]+)?\s*\{/g;
+
+  for (const match of contents.matchAll(functionPattern)) {
+    if (match.index === undefined) {
+      continue;
+    }
+
+    const bodyEnd = findMatchingBraceBlockEnd(contents, match.index);
+    bodies.push({
+      body:
+        bodyEnd === -1
+          ? contents.slice(match.index)
+          : contents.slice(match.index, bodyEnd),
+      name: match[1],
+      params: match[2],
+    });
+  }
+
+  const arrowFunctionPattern =
+    /(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(([^)]*)\)\s*(?::\s*(?:(?!=>)[\s\S])*?)?=>\s*/g;
+
+  for (const match of contents.matchAll(arrowFunctionPattern)) {
+    if (match.index === undefined) {
+      continue;
+    }
+
+    const bodyStart = match.index + match[0].length;
+    const bodyEnd = findMatchingBraceBlockEnd(contents, bodyStart);
+    bodies.push({
+      body:
+        bodyEnd === -1
+          ? contents.slice(match.index)
+          : contents.slice(match.index, bodyEnd),
+      name: match[1],
+      params: match[2],
+    });
+  }
+
+  const functionExpressionPattern =
+    /(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?function\s*\(([^)]*)\)\s*(?::\s*[^{};=]+)?\s*\{/g;
+
+  for (const match of contents.matchAll(functionExpressionPattern)) {
+    if (match.index === undefined) {
+      continue;
+    }
+
+    const bodyEnd = findMatchingBraceBlockEnd(contents, match.index);
+    bodies.push({
+      body:
+        bodyEnd === -1
+          ? contents.slice(match.index)
+          : contents.slice(match.index, bodyEnd),
+      name: match[1],
+      params: match[2],
+    });
+  }
+
+  return bodies;
+}
+
+function hasQueryCompatibleFunctionBodyWithWrite(contents: string) {
+  const queryCompatibleAliases = collectQueryCompatibleCtxAliases(contents);
+  return extractFunctionBodiesWithParams(contents).some(
+    ({ body, params }) =>
+      paramsHaveQueryCompatibleCtxShape(params, queryCompatibleAliases) &&
+      (hasMutationOnlyDbCall(body) ||
+        hasMutationCtxCast(body) ||
+        hasWriteRepositorySurface(body) ||
+        hasWriteLikeMethodCall(body)),
+  );
+}
+
+function collectMutationCtxWriteHelperNames(contents: string) {
+  return new Set(
+    extractFunctionBodiesWithParams(contents)
+      .filter(
+        ({ body, params }) =>
+          /\bMutationCtx\b/.test(params) &&
+          (hasMutationOnlyDbCall(body) ||
+            hasMutationCtxCast(body) ||
+            hasWriteRepositorySurface(body) ||
+            hasWriteLikeMethodCall(body)),
+      )
+      .map(({ name }) => name),
+  );
+}
+
+function hasQueryHandlerPassingCtxToWriteHelper(
+  contents: string,
+  paramNames: Set<string>,
+  helperNames: Set<string>,
+) {
+  const candidateHelperNames = collectQueryCallableWriteHelperNames(
+    contents,
+    helperNames,
+  );
+
+  for (const helperName of candidateHelperNames) {
+    const escapedHelper = escapeRegExp(helperName);
+    for (const paramName of paramNames) {
+      const escapedParam = escapeRegExp(paramName);
+      const helperCallPattern = new RegExp(
+        `\\b${escapedHelper}\\s*\\([^)]*\\b${escapedParam}\\b`,
+      );
+      if (helperCallPattern.test(contents)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function collectQueryCallableWriteHelperNames(
+  contents: string,
+  helperNames: Set<string>,
+) {
+  const localWriteHelperNames = collectMutationCtxWriteHelperNames(contents);
+  const localFunctionNames = new Set(
+    extractFunctionBodiesWithParams(contents).map(({ name }) => name),
+  );
+  const candidateHelperNames = new Set(helperNames);
+
+  for (const aliasName of collectImportedHelperAliasNames(contents, helperNames)) {
+    candidateHelperNames.add(aliasName);
+  }
+
+  for (const localFunctionName of localFunctionNames) {
+    if (!localWriteHelperNames.has(localFunctionName)) {
+      candidateHelperNames.delete(localFunctionName);
+    }
+  }
+
+  return candidateHelperNames;
+}
+
+function collectImportedHelperAliasNames(contents: string, helperNames: Set<string>) {
+  const aliasNames = new Set<string>();
+  const importPattern = /\bimport\s*\{([^}]+)\}\s*from\b/g;
+
+  for (const match of contents.matchAll(importPattern)) {
+    for (const rawSpecifier of match[1].split(",")) {
+      const specifier = rawSpecifier.trim();
+      const specifierMatch = specifier.match(
+        /^([A-Za-z_$][\w$]*)(?:\s+as\s+([A-Za-z_$][\w$]*))?$/,
+      );
+      if (!specifierMatch) {
+        continue;
+      }
+
+      const importedName = specifierMatch[1];
+      const localName = specifierMatch[2] ?? importedName;
+      if (helperNames.has(importedName)) {
+        aliasNames.add(localName);
+      }
+    }
+  }
+
+  return aliasNames;
+}
+
+function hasWriteRepositorySurface(contents: string) {
+  return new RegExp(
+    `\\b(?:repository|repo|service|ctx)\\s*\\.\\s*${CONVEX_WRITE_METHOD_FRAGMENT}\\s*\\(`,
+  ).test(contents);
+}
+
+function hasWriteCapableFactorySurface(
+  contents: string,
+  allowedArgumentNames: Set<string> = new Set(["ctx"]),
+) {
+  const factoryPattern =
+    /\b(create[A-Za-z0-9_$]*(?:Repository|Service|Gateway))\s*\(\s*([A-Za-z_$][\w$]*)\b/g;
+
+  for (const match of contents.matchAll(factoryPattern)) {
+    const factoryName = match[1];
+    const argumentName = match[2];
+    if (
+      allowedArgumentNames.has(argumentName) &&
+      !/(?:Read|ReadOnly)(?:Repository|Service|Gateway)$/.test(factoryName)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function extractQueryFacingFunctionBodies(contents: string) {
+  const bodies: string[] = [];
+  const functionPattern =
+    /(?:export\s+)?(?:async\s+)?function\s+((?:list|get|find|search|read|load)[A-Za-z0-9_$]*)\s*\([^)]*\)\s*\{/g;
+
+  for (const match of contents.matchAll(functionPattern)) {
+    if (match.index === undefined) {
+      continue;
+    }
+
+    const bodyEnd = findMatchingBraceBlockEnd(contents, match.index);
+    bodies.push(
+      bodyEnd === -1 ? contents.slice(match.index) : contents.slice(match.index, bodyEnd),
+    );
+  }
+
+  const arrowFunctionPattern =
+    /(?:export\s+)?const\s+(?:list|get|find|search|read|load)[A-Za-z0-9_$]*\s*=\s*(?:async\s*)?\([^)]*\)\s*(?::\s*(?:(?!=>)[\s\S])*?)?=>\s*/g;
+
+  for (const match of contents.matchAll(arrowFunctionPattern)) {
+    if (match.index === undefined) {
+      continue;
+    }
+
+    const bodyStart = match.index + match[0].length;
+    const bodyEnd = findMatchingBraceBlockEnd(contents, bodyStart);
+    bodies.push(
+      bodyEnd === -1 ? contents.slice(match.index) : contents.slice(match.index, bodyEnd),
+    );
+  }
+
+  const functionExpressionPattern =
+    /(?:export\s+)?const\s+(?:list|get|find|search|read|load)[A-Za-z0-9_$]*\s*=\s*(?:async\s+)?function\s*\([^)]*\)\s*\{/g;
+
+  for (const match of contents.matchAll(functionExpressionPattern)) {
+    if (match.index === undefined) {
+      continue;
+    }
+
+    const bodyEnd = findMatchingBraceBlockEnd(contents, match.index);
+    bodies.push(
+      bodyEnd === -1 ? contents.slice(match.index) : contents.slice(match.index, bodyEnd),
+    );
+  }
+
+  return bodies;
+}
+
+async function readAddedLinesOrNull(
+  rootDir: string,
+  baseRef: string,
+  filePath: string,
+) {
+  const diffCommands = [
+    ["git", "diff", "--unified=0", `${baseRef}...HEAD`, "--", filePath],
+    ["git", "diff", "--unified=0", "HEAD", "--", filePath],
+    ["git", "diff", "--cached", "--unified=0", "HEAD", "--", filePath],
+  ];
+  const addedLines: string[] = [];
+  let sawUsableDiff = false;
+
+  for (const command of diffCommands) {
+    const diff = await runCommand(rootDir, command);
+    if (diff.exitCode !== 0) {
+      continue;
+    }
+
+    sawUsableDiff = true;
+    for (const line of diff.stdout.split(/\r?\n/)) {
+      if (line.startsWith("+++") || !line.startsWith("+")) {
+        continue;
+      }
+
+      addedLines.push(line.slice(1));
+    }
+  }
+
+  if (!sawUsableDiff) {
+    return null;
+  }
+
+  if (addedLines.length === 0) {
+    const lsFiles = await runCommand(rootDir, [
+      "git",
+      "ls-files",
+      "--error-unmatch",
+      "--",
+      filePath,
+    ]);
+    if (lsFiles.exitCode !== 0) {
+      return null;
+    }
+  }
+
+  return addedLines.join("\n");
+}
+
+async function listConvexSourceFiles(rootDir: string, changedFileSet: Set<string>) {
+  const trackedFiles = await runCommand(rootDir, ["git", "ls-files"]);
+  if (trackedFiles.exitCode !== 0) {
+    return [...changedFileSet].filter(isConvexSourcePath);
+  }
+
+  return sortUnique([
+    ...trackedFiles.stdout.split(/\r?\n/),
+    ...changedFileSet,
+  ]).filter(isConvexSourcePath);
+}
+
+async function collectConvexQueryWriteBoundaryFindings(
+  rootDir: string,
+  baseRef: string,
+  changedFiles: string[],
+) {
+  const changedFileSet = new Set(sortUnique(changedFiles));
+  const findings: InferentialFinding[] = [];
+  const allMutationCtxWriteHelperNames = new Set<string>();
+  const changedMutationCtxWriteHelperNames = new Set<string>();
+  const convexSourceFiles = await listConvexSourceFiles(rootDir, changedFileSet);
+
+  for (const convexSourceFile of convexSourceFiles) {
+    const contents = await readUtf8OrNull(path.join(rootDir, convexSourceFile));
+    if (!contents) {
+      continue;
+    }
+
+    for (const helperName of collectMutationCtxWriteHelperNames(
+      stripTypeScriptNonCode(contents),
+    )) {
+      allMutationCtxWriteHelperNames.add(helperName);
+      if (changedFileSet.has(convexSourceFile)) {
+        changedMutationCtxWriteHelperNames.add(helperName);
+      }
+    }
+  }
+
+  for (const changedFile of convexSourceFiles) {
+    const isChangedFile = changedFileSet.has(changedFile);
+    const contents = await readUtf8OrNull(path.join(rootDir, changedFile));
+    if (!contents) {
+      continue;
+    }
+
+    const executableContents = stripTypeScriptNonCode(contents);
+    const addedLines = isChangedFile
+      ? await readAddedLinesOrNull(rootDir, baseRef, changedFile)
+      : null;
+    const executableAddedLines =
+      addedLines === null ? null : stripTypeScriptNonCode(addedLines);
+    const changedSurface = isChangedFile
+      ? executableAddedLines ?? executableContents
+      : "";
+    const queryCallerSurface = isChangedFile
+      ? changedSurface
+      : executableContents;
+    const changedHandlerParamNames = new Set([
+      ...extractConvexHandlerParamNames(changedSurface),
+      ...extractConvexHandlerParamNames(executableContents),
+    ]);
+    const queryCallerHandlerParamNames =
+      extractConvexHandlerParamNames(queryCallerSurface);
+    const helperNamesForQueryCaller = isChangedFile
+      ? allMutationCtxWriteHelperNames
+      : changedMutationCtxWriteHelperNames;
+    const queryCallableWriteHelperNames = collectQueryCallableWriteHelperNames(
+      executableContents,
+      helperNamesForQueryCaller,
+    );
+    const changedQueryWriteSignal =
+      hasCtxMutationOnlyDbCall(changedSurface) ||
+      hasHandlerParamMutationOnlyDbCall(
+        changedSurface,
+        changedHandlerParamNames,
+      ) ||
+      hasHandlerDbAliasMutationOnlyCall(changedSurface, changedHandlerParamNames) ||
+      (hasWriteLikeMethodCall(changedSurface) &&
+        hasHandlerDbAliasMutationOnlyCall(
+          executableContents,
+          changedHandlerParamNames,
+        )) ||
+      (hasFunctionCall(changedSurface) &&
+        hasHandlerBoundDbMutationOnlyCall(
+          executableContents,
+          changedHandlerParamNames,
+        )) ||
+      (hasWriteLikeMethodCall(changedSurface) &&
+        hasDestructuredHandlerDbMutationOnlyCall(executableContents)) ||
+      hasQueryHandlerPassingCtxToWriteHelper(
+        changedSurface,
+        changedHandlerParamNames,
+        queryCallableWriteHelperNames,
+      ) ||
+      (hasMutationCtxCast(changedSurface) &&
+        hasWriteLikeMethodCall(changedSurface)) ||
+      hasWriteCapableFactorySurface(
+        changedSurface,
+        new Set(["ctx", ...changedHandlerParamNames]),
+      ) ||
+      hasQueryHandlerPassingCtxToWriteHelper(
+        queryCallerSurface,
+        queryCallerHandlerParamNames,
+        queryCallableWriteHelperNames,
+      );
+
+    const queryFunctionsWithWrites = changedQueryWriteSignal
+      ? extractConvexFunctionDefinitions(executableContents).filter(
+          (entry) => {
+            if (entry.kind !== "query" && entry.kind !== "internalQuery") {
+              return false;
+            }
+            const handlerParamNames = extractConvexHandlerParamNames(
+              entry.definitionBody,
+            );
+            return (
+              hasCtxMutationOnlyDbCall(entry.definitionBody) ||
+              hasHandlerParamMutationOnlyDbCall(
+                entry.definitionBody,
+                handlerParamNames,
+              ) ||
+              hasHandlerDbAliasMutationOnlyCall(
+                entry.definitionBody,
+                handlerParamNames,
+              ) ||
+              hasHandlerBoundDbMutationOnlyCall(
+                entry.definitionBody,
+                handlerParamNames,
+              ) ||
+              hasDestructuredHandlerDbMutationOnlyCall(entry.definitionBody) ||
+              hasQueryHandlerPassingCtxToWriteHelper(
+                entry.definitionBody,
+                handlerParamNames,
+                queryCallableWriteHelperNames,
+              ) ||
+              (hasMutationCtxCast(entry.definitionBody) &&
+                hasWriteLikeMethodCall(entry.definitionBody)) ||
+              hasWriteCapableFactorySurface(
+                entry.definitionBody,
+                new Set(["ctx", ...handlerParamNames]),
+              )
+            );
+          },
+        )
+      : [];
+
+    if (queryFunctionsWithWrites.length > 0) {
+      findings.push(
+        buildFinding(
+          `convex-query-mutation-db-write-${slugifyForFindingId(changedFile)}`,
+          "high",
+          "Convex query reaches mutation-only db API",
+          changedFile,
+          `This changed Convex module exports ${queryFunctionsWithWrites
+            .map((entry) => `${entry.kind} ${entry.exportName}`)
+            .join(", ")} that directly calls mutation-only ctx.db write APIs from query code.`,
+          "Move persistence behind a Convex mutation/internalMutation. Query handlers must stay read-only and use read repositories; write-capable factories should require `MutationCtx`.",
+        ),
+      );
+      continue;
+    }
+
+    const hasChangedWriteSignal =
+      hasMutationOnlyDbCall(changedSurface) ||
+      hasMutationCtxCast(changedSurface) ||
+      hasWriteRepositorySurface(changedSurface) ||
+      hasWriteCapableFactorySurface(changedSurface) ||
+      hasQueryCompatibleCtxShape(changedSurface);
+    if (!hasChangedWriteSignal) {
+      continue;
+    }
+
+    if (hasQueryCompatibleFunctionBodyWithWrite(executableContents)) {
+      findings.push(
+        buildFinding(
+          `convex-query-compatible-write-surface-${slugifyForFindingId(changedFile)}`,
+          "high",
+          "Query-compatible Convex helper exposes mutation write surface",
+          changedFile,
+          "This changed Convex helper accepts a query-compatible context shape while exposing or calling mutation-only db write APIs.",
+          "Split read and write repositories/services. Read factories may accept `QueryCtx | MutationCtx`, but write methods and factories must require `MutationCtx`.",
+        ),
+      );
+      continue;
+    }
+
+    const queryFacingWriteBody = extractQueryFacingFunctionBodies(
+      executableContents,
+    ).find(hasWriteRepositorySurface);
+    if (queryFacingWriteBody && hasWriteRepositorySurface(changedSurface)) {
+      findings.push(
+        buildFinding(
+          `convex-query-facing-write-repository-${slugifyForFindingId(changedFile)}`,
+          "high",
+          "Query-facing Convex helper calls write-capable repository method",
+          changedFile,
+          "This changed query-facing service or repository function calls a write-like repository/service method from a read-shaped surface.",
+          "Split the query path onto a read-only repository/service interface. Keep insert/patch/replace/delete methods behind mutation-only flows and `MutationCtx`-only factories.",
+        ),
+      );
+    }
+  }
+
+  return findings;
+}
+
 async function runDeterministicSemanticAnalysis(
   input: InferentialProviderInput,
 ): Promise<InferentialDeterministicAnalysisResult> {
@@ -801,6 +1666,11 @@ async function runDeterministicSemanticAnalysis(
     )),
     ...(await collectConvexReturnValidatorContractFindings(
       input.rootDir,
+      input.changedFiles,
+    )),
+    ...(await collectConvexQueryWriteBoundaryFindings(
+      input.rootDir,
+      input.baseRef,
       input.changedFiles,
     )),
   ];


### PR DESCRIPTION
## Summary
- Split terminal recovery command reads from mutation-only writes and moved public query paths to a read-only repository.
- Added status + expiry filtering/indexing so query flows can list claimable recovery commands without mutating expired rows.
- Hardened `harness:inferential-review` against Convex query write-boundary regressions, including direct db writes, ctx casts, aliases, write-capable repository factories, imported MutationCtx helpers, destructured db params, extracted write methods, and staged-only diffs.
- Added plan and solution docs plus refreshed generated harness/Graphify artifacts.

## Validation
- `bun run pr:athena` passed on rebased branch and recorded proof at `.git/worktrees/fix-terminal-recovery-query-patch/codex/pre-push-pr-athena-proof.json`.
- Reviewer subagents: correctness, adversarial, testing, and TypeScript/API all approved.

## Linear
- V26-779
- V26-780
- V26-781