### PR TITLE
Refine register sale sync review

### DIFF
--- a/docs/solutions/logic-errors/athena-cash-controls-sale-sync-review-evidence-2026-06-18.md
+++ b/docs/solutions/logic-errors/athena-cash-controls-sale-sync-review-evidence-2026-06-18.md
@@ -1,0 +1,75 @@
+---
+title: Athena Cash Controls Sale Sync Review Evidence
+date: 2026-06-18
+category: logic-errors
+module: athena-webapp
+problem_type: missing_review_evidence
+component: cash-controls
+symptoms:
+  - "Managers could see that synced sale activity needed review without seeing the sale details behind the decision"
+  - "Register-session review actions used generic sync wording even when the drawer was closed and the action would apply or reject sale activity"
+  - "Expanded sale rows repeated totals in multiple places and could make item totals look inconsistent with the sale total"
+root_cause: sale_sync_review_payload_was_not_promoted_to_operator_evidence
+resolution_type: server_owned_review_evidence_contract
+severity: medium
+tags:
+  - cash-controls
+  - local-sync
+  - register-session
+  - review-ia
+  - pos
+---
+
+# Athena Cash Controls Sale Sync Review Evidence
+
+## Problem
+
+Local POS sale sync can arrive after the cloud register session is already
+closed. That is recoverable, but managers need to understand the exact sale
+activity before applying it to a closed drawer or rejecting it. A generic
+"register was not open" reason is not enough evidence when multiple receipts,
+cashiers, tenders, and item lines are involved.
+
+The failure mode is a trust gap: the review banner says sale activity needs a
+decision, while the visible register-session transaction list may only contain
+already-linked cloud transactions. If the sale-review panel repeats totals in
+separate metric blocks or shows line prices without a clear item subtotal, the
+manager can reasonably question whether the numbers reconcile.
+
+## Solution
+
+Treat sale sync review as a server-owned evidence contract, not a UI-only
+rewording pass:
+
+- Enrich register-session local sync conflicts with a compact sale summary from
+  the original `sale_completed` sync payload: receipt number, cashier, local
+  upload order, completed time, payment methods, cash impact, item count, and
+  item lines.
+- Resolve staff display names on the cash-controls query boundary and pass them
+  into the shared sync-status presentation helper. The browser should render
+  names and operational labels, not infer staff identity from raw IDs.
+- Present multiple reviewed sales as collapsed rows by default. The row summary
+  should answer which receipt, who rang it, when it happened, how it was paid,
+  and the sale amount. Expanded content should be reserved for item lines,
+  impact details, and the review reason.
+- Show item-line math in one place. Render quantity and line total per item,
+  then show a single `Items total` footer that reconciles to the sale total.
+  Avoid repeating the same total in a neighboring impact metric.
+- Use action labels that describe the manager decision: apply reviewed sale
+  activity to the drawer, or reject reviewed sale activity from the review. Keep
+  closeout review copy separate because approving a closeout has different
+  ledger implications than approving late sale activity.
+
+## Prevention
+
+- When a local sync review affects cash controls, promote the source event's
+  operator evidence through the server read model before refining the UI.
+- Do not make managers open support traces to answer basic sale-review
+  questions: receipt, cashier, tender, item count, item total, and upload order
+  belong in the register-session review panel.
+- Keep sale rows collapsed by default so several reviewed sales stay scannable.
+  Expanded panels should add detail without shifting the primary decision
+  summary out of view.
+- Add tests for sale summary enrichment, staff-name mapping, collapsed default
+  state, item-total reconciliation, and action copy whenever register sale
+  review presentation changes.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7183 nodes · 8245 edges · 1909 communities detected
+- 7184 nodes · 8250 edges · 1909 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2015,20 +2015,20 @@ Cohesion: 0.12
 Nodes (32): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+24 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.07
-Nodes (16): formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary(), formatReviewReportedSummary(), formatReviewTypeSummary(), formatTimestamp() (+8 more)
-
-### Community 18 - "Community 18"
 Cohesion: 0.16
 Nodes (33): asRecord(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale() (+25 more)
 
-### Community 19 - "Community 19"
+### Community 18 - "Community 18"
 Cohesion: 0.16
 Nodes (31): completed(), executeCallbackCommand(), executeClearStaleDrawerAuthority(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand(), executeUpdateApp(), failed() (+23 more)
 
-### Community 20 - "Community 20"
+### Community 19 - "Community 19"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
+
+### Community 20 - "Community 20"
+Cohesion: 0.08
+Nodes (11): formatCompactTextList(), formatPaymentMethods(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary(), formatReviewTypeSummary(), formatTimestamp() (+3 more)
 
 ### Community 21 - "Community 21"
 Cohesion: 0.12
@@ -2431,320 +2431,320 @@ Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
 ### Community 121 - "Community 121"
+Cohesion: 0.31
+Nodes (7): arrayDetail(), buildSyncSaleSummary(), listOpenLocalSyncConflictsByRegisterSession(), numberDetail(), recordDetail(), stringDetail(), summarizeSaleItems()
+
+### Community 122 - "Community 122"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.22
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.31
 Nodes (7): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), parseVariantDisplayMoney(), saveProduct(), updateVariantSku()
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.38
 Nodes (8): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason(), persistDrawerAuthorityBlockForReviewEvents()
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.27
 Nodes (5): clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), runProcess(), writePrAthenaProviderEvidence()
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.39
 Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 171 - "Community 171"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 172 - "Community 172"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 173 - "Community 173"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 174 - "Community 174"
 Cohesion: 0.36
 Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 179 - "Community 179"
-Cohesion: 0.29
-Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 180 - "Community 180"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.29
+Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 181 - "Community 181"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 182 - "Community 182"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
-
-### Community 183 - "Community 183"
-Cohesion: 0.39
-Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
-
-### Community 184 - "Community 184"
-Cohesion: 0.29
-Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
-
-### Community 185 - "Community 185"
-Cohesion: 0.29
-Nodes (2): findRegisterCloseoutReviewItem(), readLocalSyncStatus()
-
-### Community 186 - "Community 186"
-Cohesion: 0.46
-Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
-
-### Community 187 - "Community 187"
-Cohesion: 0.32
-Nodes (4): createVersionChecker(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 188 - "Community 188"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 189 - "Community 189"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 190 - "Community 190"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 183 - "Community 183"
+Cohesion: 0.39
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
+
+### Community 184 - "Community 184"
+Cohesion: 0.39
+Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+
+### Community 185 - "Community 185"
+Cohesion: 0.29
+Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
+
+### Community 186 - "Community 186"
+Cohesion: 0.29
+Nodes (2): findRegisterCloseoutReviewItem(), readLocalSyncStatus()
+
+### Community 187 - "Community 187"
+Cohesion: 0.46
+Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
+
+### Community 188 - "Community 188"
+Cohesion: 0.32
+Nodes (4): createVersionChecker(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 189 - "Community 189"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 190 - "Community 190"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
 ### Community 191 - "Community 191"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 192 - "Community 192"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.33
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 199 - "Community 199"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 200 - "Community 200"
 Cohesion: 0.29

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1981
-- Graph nodes: 7183
-- Graph edges: 8245
+- Graph nodes: 7184
+- Graph edges: 8250
 - Communities: 1909
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (14 edges, Community 90) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 162) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 163) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 90) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `createRedisCluster()` (3 edges, Community 90) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `deleteKeysIndividually()` (3 edges, Community 90) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/cashControls/deposits.test.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.test.ts
@@ -24,6 +24,7 @@ import {
   buildRegisterSessionLocalSyncStatus,
   classifyRegisterSessionSyncReview,
 } from "../pos/application/sync/registerSessionSyncReview";
+import { assertConformsToExportedReturns } from "../lib/returnValidatorContract";
 
 function getSource(relativePath: string) {
   return readFileSync(new URL(relativePath, import.meta.url), "utf8");
@@ -262,22 +263,65 @@ describe("cash control deposits", () => {
 
   it("projects sync review classification into register-session local sync status", () => {
     expect(
-      buildRegisterSessionLocalSyncStatus([
-        {
-          _id: "sync_conflict_closeout",
-          conflictType: "permission",
-          createdAt: 1,
-          details: {
-            countedCash: 45000,
-            expectedCash: 50000,
-            variance: -5000,
+      buildRegisterSessionLocalSyncStatus(
+        [
+          {
+            _id: "sync_conflict_closeout",
+            conflictType: "permission",
+            createdAt: 1,
+            details: {
+              countedCash: 45000,
+              expectedCash: 50000,
+              variance: -5000,
+            },
+            localEventId: "local-register-closed-1",
+            sequence: 2,
+            status: "needs_review",
+            summary: "Synced register closeout has a variance.",
           },
-          localEventId: "local-register-closed-1",
-          sequence: 2,
-          status: "needs_review",
-          summary: "Synced register closeout has a variance.",
+          {
+            _id: "sync_conflict_sale",
+            conflictType: "permission",
+            createdAt: 2,
+            localEventId: "event-sale-1",
+            localRegisterSessionId: "local-register-1",
+            sale: {
+              cashAmount: 2200000,
+              itemCount: 2,
+              items: [
+                {
+                  name: "Lace front wig",
+                  quantity: 1,
+                  sku: "WIG-001",
+                  total: 1200000,
+                },
+                {
+                  name: "Wig care kit",
+                  quantity: 1,
+                  sku: "CARE-001",
+                  total: 1000000,
+                },
+              ],
+              localReceiptNumber: "local-receipt-1",
+              localTransactionId: "local-transaction-1",
+              occurredAt: 1_781_623_200_000,
+              paymentMethods: ["cash"],
+              receiptNumber: "R-1001",
+              staffProfileId: "staff_1" as Id<"staffProfile">,
+              total: 2200000,
+              totalPaid: 2200000,
+            },
+            sequence: 12,
+            status: "needs_review",
+            summary: "Register was not open before this sale synced.",
+          },
+        ],
+        {
+          staffNamesById: new Map([
+            ["staff_1" as Id<"staffProfile">, "Skank H."],
+          ]),
         },
-      ]),
+      ),
     ).toEqual({
       status: "needs_review",
       reconciliationItems: [
@@ -286,6 +330,15 @@ describe("cash control deposits", () => {
           id: "sync_conflict_closeout",
           reviewKind: "register_closeout_variance",
           type: "register_closeout",
+        }),
+        expect.objectContaining({
+          id: "sync_conflict_sale",
+          sale: expect.objectContaining({
+            cashAmount: 2200000,
+            receiptNumber: "R-1001",
+            staffName: "Skank H.",
+            total: 2200000,
+          }),
         }),
       ],
     });
@@ -765,6 +818,9 @@ describe("cash control deposits", () => {
         resolvedCount: 1,
       }),
     );
+    expect(() =>
+      assertConformsToExportedReturns(resolveRegisterSessionSyncReview, result),
+    ).not.toThrow();
     expect(ctx.tables.get("posLocalSyncConflict")).toEqual([
       expect.objectContaining({
         _id: "sync_conflict_1",
@@ -3335,20 +3391,26 @@ describe("cash control deposits", () => {
   it("records register-session deposits with authenticated actor refs", async () => {
     const ctx = createAuthorizedRegisterDepositCtx();
 
-    await expect(
-      getHandler(recordRegisterSessionDeposit)(ctx as never, {
+    const result = await getHandler(recordRegisterSessionDeposit)(
+      ctx as never,
+      {
         actorStaffProfileId: "staff_1" as Id<"staffProfile">,
         amount: 100,
         registerSessionId: "session_open" as Id<"registerSession">,
         storeId: "store_1" as Id<"store">,
         submissionKey: "deposit-1",
-      }),
-    ).resolves.toEqual(
+      },
+    );
+
+    expect(result).toEqual(
       expect.objectContaining({
         data: expect.objectContaining({ action: "recorded" }),
         kind: "ok",
       }),
     );
+    expect(() =>
+      assertConformsToExportedReturns(recordRegisterSessionDeposit, result),
+    ).not.toThrow();
 
     expect(ctx.tables.get("paymentAllocation")).toEqual([
       expect.objectContaining({

--- a/packages/athena-webapp/convex/cashControls/deposits.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.ts
@@ -373,7 +373,9 @@ function buildRegisterSessionSummary(args: {
           status: args.approvalRequest.status,
         }
       : null,
-    localSyncStatus: buildRegisterSessionLocalSyncStatus(syncConflicts),
+    localSyncStatus: buildRegisterSessionLocalSyncStatus(syncConflicts, {
+      staffNamesById: args.staffNamesById,
+    }),
     totalDeposited: args.totalDeposited,
   };
 }
@@ -606,6 +608,10 @@ function collectStaffProfileIds(args: {
   approvalRequests: CashControlApprovalRequest[];
   deposits: CashControlDepositAllocation[];
   registerSessions: CashControlRegisterSession[];
+  syncConflictsBySessionId?: Map<
+    Id<"registerSession">,
+    CashControlSyncConflict[]
+  >;
   timeline?: Array<Pick<Doc<"operationalEvent">, "actorStaffProfileId">>;
   transactions?: CashControlTransaction[];
 }) {
@@ -642,6 +648,14 @@ function collectStaffProfileIds(args: {
   for (const transaction of args.transactions ?? []) {
     if (transaction.staffProfileId) {
       staffProfileIds.add(transaction.staffProfileId);
+    }
+  }
+
+  for (const syncConflicts of args.syncConflictsBySessionId?.values() ?? []) {
+    for (const conflict of syncConflicts) {
+      if (conflict.sale?.staffProfileId) {
+        staffProfileIds.add(conflict.sale.staffProfileId);
+      }
     }
   }
 
@@ -703,6 +717,7 @@ export const getDashboardSnapshot = query({
         approvalRequests: relevantApprovalRequests,
         deposits,
         registerSessions: dashboardRegisterSessionsWithTraceIds,
+        syncConflictsBySessionId,
       }),
     );
     const terminalNamesById = await listTerminalNames(
@@ -777,6 +792,7 @@ export const getRegisterSessionSnapshot = query({
         approvalRequests,
         deposits,
         registerSessions: [registerSessionWithTraceId],
+        syncConflictsBySessionId,
         timeline,
         transactions,
       }),

--- a/packages/athena-webapp/convex/lib/returnValidatorContract.ts
+++ b/packages/athena-webapp/convex/lib/returnValidatorContract.ts
@@ -57,11 +57,11 @@ const MIN_INT64 = -(1n << 63n);
 const MAX_INT64 = (1n << 63n) - 1n;
 
 export function assertConformsToExportedReturns(
-  definition: ConvexFunctionWithReturns,
+  definition: unknown,
   value: unknown,
 ) {
   const issues = collectReturnValidatorIssues(
-    parseExportedReturnValidator(definition),
+    parseExportedReturnValidator(definition as ConvexFunctionWithReturns),
     value,
   );
 
@@ -90,12 +90,22 @@ function validateValue(
     case "any":
       return isConvexValue(value)
         ? []
-        : [issue(path, `expected Convex value, received ${describeValue(value)}`)];
+        : [
+            issue(
+              path,
+              `expected Convex value, received ${describeValue(value)}`,
+            ),
+          ];
     case "bigint":
     case "int64":
       return isInt64(value)
         ? []
-        : [issue(path, `expected int64 bigint, received ${describeValue(value)}`)];
+        : [
+            issue(
+              path,
+              `expected int64 bigint, received ${describeValue(value)}`,
+            ),
+          ];
     case "boolean":
       return typeof value === "boolean"
         ? []

--- a/packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts
@@ -28,6 +28,26 @@ export type RegisterSessionSyncReviewKind =
   | "staff_access"
   | "unknown";
 
+export type RegisterSessionSyncSaleSummary = {
+  cashAmount?: number | null;
+  itemCount?: number | null;
+  items?: Array<{
+    name: string;
+    quantity?: number | null;
+    sku?: string | null;
+    total?: number | null;
+  }>;
+  localReceiptNumber?: string | null;
+  localTransactionId?: string | null;
+  occurredAt?: number | null;
+  paymentMethods?: string[];
+  receiptNumber?: string | null;
+  staffName?: string | null;
+  staffProfileId?: Id<"staffProfile"> | null;
+  total?: number | null;
+  totalPaid?: number | null;
+};
+
 export type RegisterSessionSyncConflict = {
   _id: string;
   conflictType?: string;
@@ -36,6 +56,7 @@ export type RegisterSessionSyncConflict = {
   localEventId: string;
   localRegisterSessionId?: string;
   sequence: number;
+  sale?: RegisterSessionSyncSaleSummary | null;
   sourceEventNotes?: string | null;
   status: string;
   storeId?: Id<"store">;
@@ -57,6 +78,7 @@ export type RegisterSessionLocalSyncStatus = {
     sequence?: number | null;
     status?: string | null;
     summary?: string | null;
+    sale?: RegisterSessionSyncSaleSummary | null;
     type?: string | null;
     variance?: number | null;
   }>;
@@ -182,8 +204,100 @@ function stringDetail(
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
+function recordDetail(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function arrayDetail(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value)
+    ? value
+        .map(recordDetail)
+        .filter((item): item is Record<string, unknown> => Boolean(item))
+    : [];
+}
+
+function summarizeSaleItems(payload: Record<string, unknown>) {
+  const retailItems = arrayDetail(payload.items).map((item) => {
+    const quantity = numberDetail(item, "quantity");
+    const unitPrice = numberDetail(item, "unitPrice");
+    return {
+      name:
+        stringDetail(item, "productName") ??
+        stringDetail(item, "name") ??
+        "Sale item",
+      quantity,
+      sku: stringDetail(item, "productSku"),
+      total:
+        quantity !== null && unitPrice !== null
+          ? Math.round(quantity * unitPrice * 100) / 100
+          : null,
+    };
+  });
+  const serviceItems = arrayDetail(payload.serviceLines).map((line) => ({
+    name:
+      stringDetail(line, "serviceCatalogName") ??
+      stringDetail(line, "name") ??
+      "Service line",
+    quantity: numberDetail(line, "quantity"),
+    sku: null,
+    total: numberDetail(line, "totalPrice"),
+  }));
+
+  return [...retailItems, ...serviceItems];
+}
+
+function buildSyncSaleSummary(
+  syncEvent?: Doc<"posLocalSyncEvent"> | null,
+): RegisterSessionSyncSaleSummary | null {
+  if (!syncEvent || syncEvent.eventType !== "sale_completed") {
+    return null;
+  }
+
+  const payload = syncEvent.payload ?? {};
+  const totals = recordDetail(payload.totals);
+  const payments = arrayDetail(payload.payments);
+  const items = summarizeSaleItems(payload);
+  const paymentMethods = Array.from(
+    new Set(
+      payments
+        .map((payment) => stringDetail(payment, "method"))
+        .filter((method): method is string => Boolean(method)),
+    ),
+  );
+  const totalPaid = payments.reduce(
+    (sum, payment) => sum + Math.max(0, numberDetail(payment, "amount") ?? 0),
+    0,
+  );
+  const cashAmount = payments
+    .filter((payment) => stringDetail(payment, "method") === "cash")
+    .reduce(
+      (sum, payment) => sum + Math.max(0, numberDetail(payment, "amount") ?? 0),
+      0,
+    );
+
+  return {
+    cashAmount: cashAmount > 0 ? cashAmount : null,
+    itemCount: items.reduce(
+      (sum, item) => sum + Math.max(0, item.quantity ?? 0),
+      0,
+    ),
+    items,
+    localReceiptNumber: stringDetail(payload, "localReceiptNumber"),
+    localTransactionId: stringDetail(payload, "localTransactionId"),
+    occurredAt: syncEvent.occurredAt,
+    paymentMethods,
+    receiptNumber: stringDetail(payload, "receiptNumber"),
+    staffProfileId: syncEvent.staffProfileId,
+    total: totals ? numberDetail(totals, "total") : null,
+    totalPaid,
+  };
+}
+
 export function buildRegisterSessionLocalSyncStatus(
   conflicts: RegisterSessionSyncConflict[],
+  options: { staffNamesById?: Map<Id<"staffProfile">, string> } = {},
 ): RegisterSessionLocalSyncStatus | null {
   if (conflicts.length === 0) {
     return null;
@@ -194,7 +308,7 @@ export function buildRegisterSessionLocalSyncStatus(
     reconciliationItems: conflicts.map((conflict) => {
       const review = classifyRegisterSessionSyncReview(conflict);
 
-      return {
+      const reconciliationItem = {
         actionPolicy: review.actionPolicy,
         createdAt: conflict.createdAt,
         countedCash: numberDetail(conflict.details, "countedCash"),
@@ -210,6 +324,21 @@ export function buildRegisterSessionLocalSyncStatus(
         type: getSyncConflictReconciliationType(review),
         variance: numberDetail(conflict.details, "variance"),
       };
+
+      if (!conflict.sale) {
+        return reconciliationItem;
+      }
+
+      return {
+        ...reconciliationItem,
+        sale: {
+          ...conflict.sale,
+          staffName: conflict.sale.staffProfileId
+            ? (options.staffNamesById?.get(conflict.sale.staffProfileId) ??
+              null)
+            : null,
+        },
+      };
     }),
   };
 }
@@ -219,28 +348,29 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
   storeId: Id<"store">,
   options: { includeRejectedEvidence?: boolean } = {},
 ) {
-  const [needsReviewConflicts, resolvedConflicts, rejectedEvents] = await Promise.all([
-    ctx.db
-      .query("posLocalSyncConflict")
-      .withIndex("by_store_status", (q) =>
-        q.eq("storeId", storeId).eq("status", "needs_review"),
-      )
-      .take(SYNC_CONFLICT_LIMIT),
-    ctx.db
-      .query("posLocalSyncConflict")
-      .withIndex("by_store_status", (q) =>
-        q.eq("storeId", storeId).eq("status", "resolved"),
-      )
-      .take(SYNC_CONFLICT_LIMIT),
-    options.includeRejectedEvidence
-      ? ctx.db
-          .query("posLocalSyncEvent")
-          .withIndex("by_store_status", (q) =>
-            q.eq("storeId", storeId).eq("status", "rejected"),
-          )
-          .take(SYNC_CONFLICT_LIMIT)
-      : Promise.resolve([]),
-  ]);
+  const [needsReviewConflicts, resolvedConflicts, rejectedEvents] =
+    await Promise.all([
+      ctx.db
+        .query("posLocalSyncConflict")
+        .withIndex("by_store_status", (q) =>
+          q.eq("storeId", storeId).eq("status", "needs_review"),
+        )
+        .take(SYNC_CONFLICT_LIMIT),
+      ctx.db
+        .query("posLocalSyncConflict")
+        .withIndex("by_store_status", (q) =>
+          q.eq("storeId", storeId).eq("status", "resolved"),
+        )
+        .take(SYNC_CONFLICT_LIMIT),
+      options.includeRejectedEvidence
+        ? ctx.db
+            .query("posLocalSyncEvent")
+            .withIndex("by_store_status", (q) =>
+              q.eq("storeId", storeId).eq("status", "rejected"),
+            )
+            .take(SYNC_CONFLICT_LIMIT)
+        : Promise.resolve([]),
+    ]);
   const staleResolvedConflicts = await Promise.all(
     resolvedConflicts.map(async (conflict) => {
       const syncEvent = await ctx.db
@@ -281,12 +411,8 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
       (conflict): conflict is Doc<"posLocalSyncConflict"> => conflict !== null,
     ),
   ];
-  const conflictsWithSourceEventNotes = await Promise.all(
+  const conflictsWithSourceEventEvidence = await Promise.all(
     conflicts.map(async (conflict) => {
-      if (stringDetail(conflict.details, "notes")) {
-        return conflict;
-      }
-
       const { terminalId } = conflict;
       if (!terminalId) {
         return conflict;
@@ -301,12 +427,17 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
             .eq("localEventId", conflict.localEventId),
         )
         .unique();
-      const sourceEventNotes = stringDetail(syncEvent?.payload, "notes");
+      const sourceEventNotes =
+        stringDetail(conflict.details, "notes") ??
+        stringDetail(syncEvent?.payload, "notes");
+      const sale = buildSyncSaleSummary(syncEvent);
 
-      return sourceEventNotes ? { ...conflict, sourceEventNotes } : conflict;
+      return sourceEventNotes || sale
+        ? { ...conflict, sale, sourceEventNotes }
+        : conflict;
     }),
   );
-  conflicts.splice(0, conflicts.length, ...conflictsWithSourceEventNotes);
+  conflicts.splice(0, conflicts.length, ...conflictsWithSourceEventEvidence);
   const includedConflictKeys = new Set(
     conflicts.map((conflict) =>
       [conflict.terminalId, conflict.localEventId].join(":"),
@@ -326,6 +457,7 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
         details: {},
         localEventId: event.localEventId,
         localRegisterSessionId: event.localRegisterSessionId,
+        sale: buildSyncSaleSummary(event),
         sequence: event.sequence,
         status: event.status,
         storeId: event.storeId,
@@ -391,16 +523,13 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
     }),
   );
 
-  return entries.reduce(
-    (conflictsBySessionId, entry) => {
-      if (!entry) return conflictsBySessionId;
-      const [registerSessionId, conflict] = entry;
-      conflictsBySessionId.set(registerSessionId, [
-        ...(conflictsBySessionId.get(registerSessionId) ?? []),
-        conflict,
-      ]);
-      return conflictsBySessionId;
-    },
-    new Map<Id<"registerSession">, RegisterSessionSyncConflict[]>(),
-  );
+  return entries.reduce((conflictsBySessionId, entry) => {
+    if (!entry) return conflictsBySessionId;
+    const [registerSessionId, conflict] = entry;
+    conflictsBySessionId.set(registerSessionId, [
+      ...(conflictsBySessionId.get(registerSessionId) ?? []),
+      conflict,
+    ]);
+    return conflictsBySessionId;
+  }, new Map<Id<"registerSession">, RegisterSessionSyncConflict[]>());
 }

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -358,9 +358,9 @@ describe("RegisterSessionViewContent", () => {
       "tracking-[0.12em]",
     );
     expect(transactionDetails.getByText("Cash")).toHaveClass("text-sm");
-    expect(screen.getAllByText(/3 items - Esi Boateng/i).length).toBeGreaterThan(
-      0,
-    );
+    expect(
+      screen.getAllByText(/3 items - Esi Boateng/i).length,
+    ).toBeGreaterThan(0);
     expect(screen.getAllByText("Ama M.").length).toBeGreaterThan(0);
     expect(screen.getByText("Variance review required.")).toBeInTheDocument();
     expect(screen.getByText("Closeout workflow")).toBeInTheDocument();
@@ -477,11 +477,9 @@ describe("RegisterSessionViewContent", () => {
     expect(
       screen.getByText("1 review item needs manager review."),
     ).toBeInTheDocument();
+    expect(screen.getByText("Reconciliation review.")).toBeInTheDocument();
     expect(
-      screen.getByText("Types: Reconciliation review."),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("Reasons: Review synced register activity."),
+      screen.getByText("Review synced register activity."),
     ).toBeInTheDocument();
   });
 
@@ -530,7 +528,7 @@ describe("RegisterSessionViewContent", () => {
     expect(
       screen.getByText("1 review item rejected by the server."),
     ).toBeInTheDocument();
-    expect(screen.getByText("Local queue #10.")).toBeInTheDocument();
+    expect(screen.getByText("#10")).toBeInTheDocument();
     expect(
       screen.queryByText("Register was closed before this sale synced."),
     ).not.toBeInTheDocument();
@@ -669,11 +667,7 @@ describe("RegisterSessionViewContent", () => {
     expect(screen.getAllByText("Expected")).toHaveLength(2);
     expect(screen.getAllByText("Counted")).toHaveLength(3);
     expect(screen.getAllByText("Variance")).toHaveLength(3);
-    expect(
-      screen.getByText(
-        "Short drawer",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Short drawer")).toBeInTheDocument();
     expect(
       screen.queryByText(
         "Register closeout variance requires manager review before synced closeout can be applied.",
@@ -700,7 +694,7 @@ describe("RegisterSessionViewContent", () => {
       screen.queryByRole("button", { name: "Submit closeout" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Approve synced closeout" }),
+      screen.getByRole("button", { name: "Apply synced closeout" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Reject synced closeout" }),
@@ -767,11 +761,11 @@ describe("RegisterSessionViewContent", () => {
     );
 
     await user.click(
-      screen.getByRole("button", { name: "Approve synced closeout" }),
+      screen.getByRole("button", { name: "Apply synced closeout" }),
     );
     await user.click(
       screen.getByRole("button", {
-        name: "Confirm staff for Approve synced closeout",
+        name: "Confirm staff for Apply synced closeout",
       }),
     );
 
@@ -846,10 +840,10 @@ describe("RegisterSessionViewContent", () => {
       ),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Approve synced sales" }),
+      screen.queryByRole("button", { name: "Apply reviewed sale activity" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Approve synced closeout" }),
+      screen.queryByRole("button", { name: "Apply synced closeout" }),
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Reject synced closeout" }),
@@ -918,7 +912,9 @@ describe("RegisterSessionViewContent", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("combines synced register review items with safe event evidence", () => {
+  it("combines synced register review items with safe event evidence", async () => {
+    const user = userEvent.setup();
+
     const createdAt = new Date("2026-05-20T14:30:00.000Z").getTime();
 
     render(
@@ -938,15 +934,67 @@ describe("RegisterSessionViewContent", () => {
                   createdAt,
                   id: "sync_conflict_permission",
                   localEventId: "event-sale-completed-2",
+                  sale: {
+                    cashAmount: 2200000,
+                    itemCount: 2,
+                    items: [
+                      {
+                        name: "Lace front wig",
+                        quantity: 2,
+                        sku: "WIG-001",
+                        total: 1200000,
+                      },
+                      {
+                        name: "Wig care kit",
+                        quantity: 1,
+                        sku: "CARE-001",
+                        total: 1000000,
+                      },
+                    ],
+                    localReceiptNumber: "local-receipt-1",
+                    localTransactionId: "local-transaction-1",
+                    occurredAt: createdAt,
+                    paymentMethods: ["cash"],
+                    receiptNumber: "R-1001",
+                    staffName: "Skank H.",
+                    total: 2200000,
+                    totalPaid: 2200000,
+                  },
                   sequence: 12,
                   status: "needs_review",
                   summary: "Register was not open before this sale synced.",
                   type: "permission",
                 },
                 {
-                  createdAt,
+                  createdAt: createdAt + 60_000,
                   id: "sync_conflict_payment",
                   localEventId: "event-payment-1",
+                  sale: {
+                    cashAmount: 2200000,
+                    itemCount: 2,
+                    items: [
+                      {
+                        name: "Lace front wig",
+                        quantity: 2,
+                        sku: "WIG-001",
+                        total: 1200000,
+                      },
+                      {
+                        name: "Wig care kit",
+                        quantity: 1,
+                        sku: "CARE-001",
+                        total: 1000000,
+                      },
+                    ],
+                    localReceiptNumber: "local-receipt-1",
+                    localTransactionId: "local-transaction-1",
+                    occurredAt: createdAt,
+                    paymentMethods: ["cash"],
+                    receiptNumber: "R-1001",
+                    staffName: "Skank H.",
+                    total: 2200000,
+                    totalPaid: 2200000,
+                  },
                   sequence: 13,
                   status: "needs_review",
                   summary: "Payment allocation needs manager review.",
@@ -962,16 +1010,42 @@ describe("RegisterSessionViewContent", () => {
     expect(
       screen.getByText("2 review items need manager review."),
     ).toBeInTheDocument();
+    expect(screen.getByText("Review details")).toBeInTheDocument();
+    expect(screen.getAllByText("Items").length).toBeGreaterThan(0);
+    expect(screen.getByText("Reasons")).toBeInTheDocument();
+    expect(screen.getByText("Categories")).toBeInTheDocument();
+    expect(screen.getByText("Sync timeline")).toBeInTheDocument();
+    expect(screen.getByText("2 reports")).toBeInTheDocument();
+    expect(screen.getByText("First reported")).toBeInTheDocument();
+    expect(screen.getByText("Latest report")).toBeInTheDocument();
+    expect(screen.getByText("Upload order")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "Reasons: Register was not open before this sale synced; Payment allocation needs manager review.",
-      ),
-    ).toBeInTheDocument();
+      screen.getAllByText(
+        "Register was not open before this sale synced; Payment allocation needs manager review.",
+      ).length,
+    ).toBeGreaterThan(0);
     expect(
-      screen.getByText("Types: Permission review and Payment review."),
+      screen.getByText("Permission review and Payment review."),
     ).toBeInTheDocument();
-    expect(screen.getByText("Local queue #12 and #13.")).toBeInTheDocument();
-    expect(screen.getByText(/Reported .*2026/)).toBeInTheDocument();
+    expect(screen.getByText("#12 and #13")).toBeInTheDocument();
+    expect(screen.getAllByText(/2026/).length).toBeGreaterThan(0);
+    expect(screen.getByText("Sales under review")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Receipt #R-1001/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Cashier Skank H\./)).toBeInTheDocument();
+    expect(screen.getAllByText("GH₵22,000").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Cash").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Lace Front Wig")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Receipt #R-1001/i }));
+
+    expect(screen.getByText("Lace Front Wig")).toBeInTheDocument();
+    expect(screen.getByText("Wig Care Kit")).toBeInTheDocument();
+    expect(screen.getByText("WIG-001")).toBeInTheDocument();
+    expect(screen.getByText("Qty 2")).toBeInTheDocument();
+    expect(screen.getByText("Items total")).toBeInTheDocument();
+    expect(screen.queryByText("2 x GH₵12,000")).not.toBeInTheDocument();
     expect(screen.queryByText("Permission review")).not.toBeInTheDocument();
     expect(
       screen.queryByText("Register was not open before this sale synced."),
@@ -1014,10 +1088,10 @@ describe("RegisterSessionViewContent", () => {
       ),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Approve synced sales" }),
+      screen.queryByRole("button", { name: "Apply reviewed sale activity" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Reject synced activity" }),
+      screen.getByRole("button", { name: "Reject reviewed activity" }),
     ).toBeInTheDocument();
   });
 
@@ -1053,6 +1127,24 @@ describe("RegisterSessionViewContent", () => {
               reconciliationItems: [
                 {
                   id: "sync_conflict_1",
+                  sale: {
+                    cashAmount: 2200000,
+                    itemCount: 1,
+                    items: [
+                      {
+                        name: "Lace front wig",
+                        quantity: 1,
+                        sku: "WIG-001",
+                        total: 2200000,
+                      },
+                    ],
+                    occurredAt: Date.parse("2026-05-20T10:30:00Z"),
+                    paymentMethods: ["cash"],
+                    receiptNumber: "R-1001",
+                    staffName: "Skank H.",
+                    total: 2200000,
+                    totalPaid: 2200000,
+                  },
                   status: "needs_review",
                   summary: "Register was not open before this sale synced.",
                   type: "permission",
@@ -1065,11 +1157,11 @@ describe("RegisterSessionViewContent", () => {
     );
 
     await user.click(
-      screen.getByRole("button", { name: "Approve synced sales" }),
+      screen.getByRole("button", { name: "Apply reviewed sale activity" }),
     );
     await user.click(
       screen.getByRole("button", {
-        name: "Confirm staff for Approve synced sales",
+        name: "Confirm staff for Apply reviewed sale activity",
       }),
     );
 
@@ -1199,10 +1291,12 @@ describe("RegisterSessionViewContent", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: "Approve synced sales" }));
+    await user.click(
+      screen.getByRole("button", { name: "Apply reviewed activity" }),
+    );
     await user.click(
       screen.getByRole("button", {
-        name: "Confirm staff for Approve synced sales",
+        name: "Confirm staff for Apply reviewed activity",
       }),
     );
 
@@ -1257,11 +1351,11 @@ describe("RegisterSessionViewContent", () => {
     );
 
     await user.click(
-      screen.getByRole("button", { name: "Reject synced activity" }),
+      screen.getByRole("button", { name: "Reject reviewed activity" }),
     );
     await user.click(
       screen.getByRole("button", {
-        name: "Confirm staff for Reject synced activity",
+        name: "Confirm staff for Reject reviewed activity",
       }),
     );
 

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -67,6 +67,12 @@ import {
 import { Textarea } from "../ui/textarea";
 import { WorkflowTraceRouteLink } from "../traces/WorkflowTraceRouteLink";
 import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "../ui/accordion";
+import {
   buildPosSyncStatusPresentation,
   formatPosReconciliationType,
   isRegisterCloseoutReviewItem,
@@ -315,7 +321,9 @@ type CloseoutStaffAuthIntent =
   | {
       kind: "sync_review";
       decision: "approved" | "rejected";
+      approveLabel: string;
       registerSessionId: string;
+      rejectLabel: string;
       reviewConflictIds?: string[];
     };
 
@@ -404,6 +412,30 @@ function formatPaymentMethod(method?: string | null) {
   return capitalizeWords(method.replaceAll("_", " "));
 }
 
+function formatPaymentMethods(methods?: string[] | null) {
+  const labels = Array.from(
+    new Set(
+      (methods ?? [])
+        .map((method) => formatPaymentMethod(method))
+        .filter((method) => method !== "Unknown"),
+    ),
+  );
+
+  return formatCompactTextList(labels) ?? "Unknown";
+}
+
+function getPrimaryPaymentMethod(methods?: string[] | null) {
+  const normalizedMethods = Array.from(
+    new Set((methods ?? []).map((method) => method?.trim()).filter(Boolean)),
+  );
+
+  if (normalizedMethods.length === 0) {
+    return null;
+  }
+
+  return normalizedMethods[0] ?? null;
+}
+
 function formatRegisterName(registerNumber?: string | null) {
   const trimmedRegisterNumber = registerNumber?.trim();
   return trimmedRegisterNumber ? trimmedRegisterNumber : "Unnamed register";
@@ -458,6 +490,53 @@ function getPaymentMethodIcon({
   }
 }
 
+function getSyncReviewActionCopy({
+  hasCloseoutReview,
+  hasOnlyRejectedReviewItems,
+  hasSaleReview,
+}: {
+  hasCloseoutReview: boolean;
+  hasOnlyRejectedReviewItems: boolean;
+  hasSaleReview: boolean;
+}) {
+  if (hasOnlyRejectedReviewItems) {
+    return {
+      approveAuthDescription:
+        "Authenticate to override and sync rejected local activity",
+      approveLabel: "Override and sync events",
+      rejectAuthDescription: "Authenticate to reject reviewed synced activity",
+      rejectLabel: "Reject reviewed activity",
+    };
+  }
+
+  if (hasCloseoutReview) {
+    return {
+      approveAuthDescription: "Authenticate to apply the synced closeout",
+      approveLabel: "Apply synced closeout",
+      rejectAuthDescription: "Authenticate to reject the synced closeout",
+      rejectLabel: "Reject synced closeout",
+    };
+  }
+
+  if (hasSaleReview) {
+    return {
+      approveAuthDescription:
+        "Authenticate to apply reviewed sale activity to this drawer",
+      approveLabel: "Apply reviewed sale activity",
+      rejectAuthDescription:
+        "Authenticate to reject reviewed sale activity from this review",
+      rejectLabel: "Reject reviewed sale activity",
+    };
+  }
+
+  return {
+    approveAuthDescription: "Authenticate to apply reviewed synced activity",
+    approveLabel: "Apply reviewed activity",
+    rejectAuthDescription: "Authenticate to reject reviewed synced activity",
+    rejectLabel: "Reject reviewed activity",
+  };
+}
+
 function getSyncBadgeClass(tone: PosSyncStatusPresentation["tone"]) {
   switch (tone) {
     case "success":
@@ -505,20 +584,27 @@ function formatReviewQueueSummary(items: PosReconciliationItem[]) {
     .filter((value): value is string => Boolean(value));
   const sequenceList = formatCompactTextList(sequences);
 
-  return sequenceList ? `Local queue ${sequenceList}.` : null;
+  return sequenceList ? sequenceList : null;
 }
 
-function formatReviewReportedSummary(items: PosReconciliationItem[]) {
-  const reportedTimes = Array.from(
-    new Set(
-      items
-        .map((item) => formatReviewItemTimestamp(item.createdAt))
-        .filter((value): value is string => Boolean(value)),
-    ),
-  );
-  const reportedList = formatCompactTextList(reportedTimes);
+function getReviewReportedEntries(items: PosReconciliationItem[]) {
+  const reportedEntries = items
+    .map((item) =>
+      typeof item.createdAt === "number"
+        ? {
+            timestamp: item.createdAt,
+            value: formatReviewItemTimestamp(item.createdAt),
+          }
+        : null,
+    )
+    .filter((entry): entry is { timestamp: number; value: string } =>
+      Boolean(entry?.value),
+    )
+    .sort((left, right) => left.timestamp - right.timestamp);
 
-  return reportedList ? `Reported ${reportedList}.` : null;
+  return Array.from(
+    new Map(reportedEntries.map((entry) => [entry.timestamp, entry])).values(),
+  );
 }
 
 function formatReviewTypeSummary(items: PosReconciliationItem[]) {
@@ -531,7 +617,7 @@ function formatReviewTypeSummary(items: PosReconciliationItem[]) {
   );
   const typeList = formatCompactTextList(reviewTypes);
 
-  return typeList ? `Types: ${typeList}.` : null;
+  return typeList ? `${typeList}.` : null;
 }
 
 function formatReviewReasonSummary(items: PosReconciliationItem[]) {
@@ -551,7 +637,398 @@ function formatReviewReasonSummary(items: PosReconciliationItem[]) {
     .map((reason) => reason.replace(/[.!?]+$/, ""))
     .join("; ");
 
-  return `Reasons: ${reasonList}.`;
+  return `${reasonList}.`;
+}
+
+function SyncReviewDetailGrid({
+  details,
+  title = "Review details",
+}: {
+  details: Array<{ label: string; value?: string | null }>;
+  title?: string;
+}) {
+  const visibleDetails = details.filter((detail) => detail.value?.trim());
+
+  if (visibleDetails.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-layout-xs">
+      <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+        {title}
+      </p>
+      <dl className="grid gap-layout-xs sm:grid-cols-2">
+        {visibleDetails.map((detail) => (
+          <div
+            className="rounded-md border border-border/70 bg-background/80 px-layout-sm py-layout-xs"
+            key={detail.label}
+          >
+            <dt className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+              {detail.label}
+            </dt>
+            <dd className="mt-1 text-sm leading-5 text-foreground">
+              {detail.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function SyncReviewTimeline({
+  items,
+  uploadOrder,
+}: {
+  items: PosReconciliationItem[];
+  uploadOrder?: string | null;
+}) {
+  const reportedEntries = getReviewReportedEntries(items);
+  const firstReported = reportedEntries[0]?.value ?? null;
+  const latestReported = reportedEntries.at(-1)?.value ?? null;
+  const hasMultipleReports = reportedEntries.length > 1;
+
+  if (!firstReported && !uploadOrder?.trim()) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-layout-xs">
+      <div className="flex flex-wrap items-baseline justify-between gap-x-layout-sm gap-y-1">
+        <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+          Sync timeline
+        </p>
+        {reportedEntries.length > 0 ? (
+          <p className="text-xs leading-5 text-muted-foreground">
+            {reportedEntries.length === 1
+              ? "1 report"
+              : `${reportedEntries.length} reports`}
+          </p>
+        ) : null}
+      </div>
+      <dl className="grid gap-layout-xs rounded-md border border-border/70 bg-background/80 px-layout-sm py-layout-xs text-xs">
+        {firstReported ? (
+          <div className="flex items-start justify-between gap-layout-sm">
+            <dt className="text-muted-foreground">
+              {hasMultipleReports ? "First reported" : "Reported"}
+            </dt>
+            <dd className="text-right leading-5 text-foreground">
+              {firstReported}
+            </dd>
+          </div>
+        ) : null}
+        {hasMultipleReports && latestReported ? (
+          <div className="flex items-start justify-between gap-layout-sm">
+            <dt className="text-muted-foreground">Latest report</dt>
+            <dd className="text-right leading-5 text-foreground">
+              {latestReported}
+            </dd>
+          </div>
+        ) : null}
+        {uploadOrder?.trim() ? (
+          <div className="flex items-start justify-between gap-layout-sm">
+            <dt className="text-muted-foreground">Upload order</dt>
+            <dd className="text-right leading-5 text-foreground">
+              {uploadOrder}
+            </dd>
+          </div>
+        ) : null}
+      </dl>
+    </div>
+  );
+}
+
+type SyncReviewSaleSummary = NonNullable<PosReconciliationItem["sale"]> & {
+  reasons: string[];
+  sequences: number[];
+};
+
+function getSaleReviewKey(item: PosReconciliationItem) {
+  const sale = item.sale;
+
+  return (
+    sale?.localTransactionId?.trim() ||
+    sale?.receiptNumber?.trim() ||
+    sale?.localReceiptNumber?.trim() ||
+    item.localEventId?.trim() ||
+    item.id
+  );
+}
+
+function getSyncReviewSaleSummaries(items: PosReconciliationItem[]) {
+  const salesByKey = new Map<string, SyncReviewSaleSummary>();
+
+  for (const item of items) {
+    if (!item.sale) continue;
+
+    const key = getSaleReviewKey(item);
+    if (!key) continue;
+
+    const existing = salesByKey.get(key);
+    const summary = item.summary?.trim();
+    const nextSale: SyncReviewSaleSummary = existing ?? {
+      ...item.sale,
+      reasons: [],
+      sequences: [],
+    };
+
+    if (summary && !nextSale.reasons.includes(summary)) {
+      nextSale.reasons.push(summary);
+    }
+
+    if (
+      typeof item.sequence === "number" &&
+      !nextSale.sequences.includes(item.sequence)
+    ) {
+      nextSale.sequences.push(item.sequence);
+    }
+
+    salesByKey.set(key, {
+      ...nextSale,
+      sequences: nextSale.sequences.sort((left, right) => left - right),
+    });
+  }
+
+  return Array.from(salesByKey.values());
+}
+
+function formatSaleItemCount(
+  sale: Pick<SyncReviewSaleSummary, "itemCount" | "items">,
+) {
+  const itemCount =
+    typeof sale.itemCount === "number" && sale.itemCount > 0
+      ? sale.itemCount
+      : (sale.items?.length ?? 0);
+
+  if (itemCount === 0) {
+    return "Items not recorded";
+  }
+
+  return itemCount === 1 ? "1 item" : `${itemCount} items`;
+}
+
+function formatSaleItemName(name: string) {
+  return capitalizeWords(name.trim());
+}
+
+function getSaleItemsTotal(sale: Pick<SyncReviewSaleSummary, "items">) {
+  const itemsTotal = sale.items?.reduce(
+    (sum, item) => sum + (typeof item.total === "number" ? item.total : 0),
+    0,
+  );
+
+  return itemsTotal && itemsTotal > 0 ? itemsTotal : null;
+}
+
+function SalesUnderReviewList({
+  currency,
+  sales,
+}: {
+  currency: string;
+  sales: SyncReviewSaleSummary[];
+}) {
+  if (sales.length === 0) {
+    return null;
+  }
+
+  const totalSalesAmount = sales.reduce(
+    (sum, sale) =>
+      sum + (typeof sale.total === "number" ? Math.max(0, sale.total) : 0),
+    0,
+  );
+  const totalCashImpact = sales.reduce(
+    (sum, sale) =>
+      sum +
+      (typeof sale.cashAmount === "number" ? Math.max(0, sale.cashAmount) : 0),
+    0,
+  );
+
+  return (
+    <div className="space-y-layout-xs md:col-span-2">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+            Sales under review
+          </p>
+          <p className="text-xs leading-5 text-muted-foreground">
+            These synced sale details will affect this closed drawer if applied.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-x-layout-sm gap-y-1 text-xs text-muted-foreground">
+          <span>{sales.length === 1 ? "1 sale" : `${sales.length} sales`}</span>
+          {totalSalesAmount > 0 ? (
+            <span>Total {formatCurrency(currency, totalSalesAmount)}</span>
+          ) : null}
+          {totalCashImpact > 0 ? (
+            <span>Cash impact {formatCurrency(currency, totalCashImpact)}</span>
+          ) : null}
+        </div>
+      </div>
+      <Accordion className="grid gap-layout-xs" collapsible type="single">
+        {sales.map((sale, index) => {
+          const receiptNumber =
+            sale.receiptNumber?.trim() ||
+            sale.localReceiptNumber?.trim() ||
+            sale.localTransactionId?.trim() ||
+            `Sale ${index + 1}`;
+          const completedAt =
+            typeof sale.occurredAt === "number"
+              ? formatTimestamp(sale.occurredAt)
+              : null;
+          const sequenceList = formatCompactTextList(
+            sale.sequences.map((sequence) => `#${sequence}`),
+          );
+          const primaryPaymentMethod = getPrimaryPaymentMethod(
+            sale.paymentMethods,
+          );
+          const hasMultiplePaymentMethods =
+            (sale.paymentMethods?.length ?? 0) > 1;
+          const PaymentIcon = getPaymentMethodIcon({
+            hasMultiplePaymentMethods,
+            paymentMethod: primaryPaymentMethod,
+          });
+          const itemsTotal = getSaleItemsTotal(sale);
+
+          return (
+            <AccordionItem
+              className="overflow-hidden rounded-md border border-border/70 bg-background/85"
+              key={`${receiptNumber}-${index}`}
+              value={`sale-${index}`}
+            >
+              <AccordionTrigger className="gap-layout-sm px-layout-sm py-layout-sm text-left hover:no-underline">
+                <div className="grid min-w-0 flex-1 gap-layout-sm sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+                  <div className="min-w-0 space-y-1">
+                    <p className="truncate text-sm font-medium text-foreground">
+                      Receipt #{receiptNumber}
+                    </p>
+                    <p className="truncate text-xs leading-5 text-muted-foreground">
+                      {[
+                        sale.staffName ? `Cashier ${sale.staffName}` : null,
+                        completedAt,
+                        sequenceList ? `Upload ${sequenceList}` : null,
+                      ]
+                        .filter(Boolean)
+                        .join(" · ")}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-x-layout-sm gap-y-1 text-xs leading-5 text-muted-foreground sm:justify-end">
+                    <span className="inline-flex items-center gap-1.5 text-foreground">
+                      <PaymentIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                      {hasMultiplePaymentMethods
+                        ? "Multiple"
+                        : formatPaymentMethod(primaryPaymentMethod)}
+                    </span>
+                    <span className="font-numeric tabular-nums text-foreground">
+                      {formatCurrency(currency, sale.total)}
+                    </span>
+                    <span>{formatSaleItemCount(sale)}</span>
+                  </div>
+                </div>
+              </AccordionTrigger>
+              <AccordionContent className="border-t border-border/70 px-layout-sm pb-layout-sm pt-layout-sm">
+                <div className="grid gap-layout-sm lg:grid-cols-[minmax(0,1fr)_minmax(14rem,0.7fr)]">
+                  <div className="space-y-layout-xs">
+                    <p className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                      Items
+                    </p>
+                    {sale.items?.length ? (
+                      <div className="divide-y divide-border/70 rounded-md border border-border/70 bg-muted/10">
+                        {sale.items.map((item, itemIndex) => (
+                          <div
+                            className="grid gap-1 px-layout-sm py-layout-xs text-xs sm:grid-cols-[minmax(0,1fr)_auto]"
+                            key={`${item.name}-${itemIndex}`}
+                          >
+                            <div className="min-w-0">
+                              <p className="truncate font-medium text-foreground">
+                                {formatSaleItemName(item.name)}
+                              </p>
+                              {item.sku ? (
+                                <p className="text-muted-foreground">
+                                  {item.sku}
+                                </p>
+                              ) : null}
+                            </div>
+                            <div className="text-left sm:text-right">
+                              {typeof item.quantity === "number" ? (
+                                <p className="text-muted-foreground">
+                                  Qty {item.quantity}
+                                </p>
+                              ) : null}
+                              {typeof item.total === "number" ? (
+                                <p className="font-numeric tabular-nums text-foreground">
+                                  {formatCurrency(currency, item.total)}
+                                </p>
+                              ) : null}
+                            </div>
+                          </div>
+                        ))}
+                        {itemsTotal ? (
+                          <div className="flex items-center justify-between gap-layout-sm px-layout-sm py-layout-xs text-xs">
+                            <span className="text-muted-foreground">
+                              Items total
+                            </span>
+                            <span className="font-numeric tabular-nums text-foreground">
+                              {formatCurrency(currency, itemsTotal)}
+                            </span>
+                          </div>
+                        ) : null}
+                      </div>
+                    ) : (
+                      <p className="text-xs leading-5 text-muted-foreground">
+                        Item details were not included with this synced sale.
+                      </p>
+                    )}
+                  </div>
+                  <div className="space-y-layout-xs">
+                    <p className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                      Sale impact
+                    </p>
+                    <dl className="grid gap-layout-xs rounded-md border border-border/70 bg-muted/10 px-layout-sm py-layout-xs text-xs">
+                      <div className="flex items-center justify-between gap-layout-sm">
+                        <dt className="text-muted-foreground">Payment</dt>
+                        <dd className="inline-flex items-center gap-1.5 text-right text-foreground">
+                          <PaymentIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                          {formatPaymentMethods(sale.paymentMethods)}
+                        </dd>
+                      </div>
+                      <div className="flex items-center justify-between gap-layout-sm">
+                        <dt className="text-muted-foreground">Cash impact</dt>
+                        <dd className="font-numeric tabular-nums text-foreground">
+                          {typeof sale.cashAmount === "number" &&
+                          sale.cashAmount > 0
+                            ? formatCurrency(currency, sale.cashAmount)
+                            : "None recorded"}
+                        </dd>
+                      </div>
+                      <div className="flex items-center justify-between gap-layout-sm">
+                        <dt className="text-muted-foreground">Items</dt>
+                        <dd className="text-foreground">
+                          {formatSaleItemCount(sale)}
+                        </dd>
+                      </div>
+                    </dl>
+                    <p className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                      Review reason
+                    </p>
+                    <div className="rounded-md border border-border/70 bg-muted/10 px-layout-sm py-layout-xs">
+                      <p className="text-xs leading-5 text-muted-foreground">
+                        {sale.reasons.length > 0
+                          ? `${sale.reasons
+                              .map((reason) => reason.replace(/[.!?]+$/, ""))
+                              .join("; ")}.`
+                          : "This sale needs manager review before it is applied."}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          );
+        })}
+      </Accordion>
+    </div>
+  );
 }
 
 function formatReviewItemActivity(item: PosReconciliationItem) {
@@ -635,12 +1112,11 @@ function getAutomaticStaffAccessSyncReviewSignature(
   );
   if (
     unresolvedItems.length === 0 ||
-    unresolvedItems.some(
-      (item) =>
-        item.reviewKind
-          ? item.reviewKind !== "staff_access"
-          : item.type !== "permission" ||
-            item.summary?.trim() !== STAFF_ACCESS_SYNC_REVIEW_SUMMARY,
+    unresolvedItems.some((item) =>
+      item.reviewKind
+        ? item.reviewKind !== "staff_access"
+        : item.type !== "permission" ||
+          item.summary?.trim() !== STAFF_ACCESS_SYNC_REVIEW_SUMMARY,
     )
   ) {
     return null;
@@ -717,12 +1193,14 @@ function RegisterSessionSyncNotice({
   const reconciliationItems = syncStatus.reconciliationItems.filter(
     isVisibleRegisterSyncReviewItem,
   );
-  if (syncStatus.status === "needs_review" && reconciliationItems.length === 0) {
+  if (
+    syncStatus.status === "needs_review" &&
+    reconciliationItems.length === 0
+  ) {
     return null;
   }
 
-  const hasOnlyRejectedReviewItems =
-    hasOnlyRejectedSyncReviewItems(syncStatus);
+  const hasOnlyRejectedReviewItems = hasOnlyRejectedSyncReviewItems(syncStatus);
   const hasClosedRegisterSyncedCloseout = reconciliationItems.some(
     isClosedRegisterSyncedCloseoutReviewItem,
   );
@@ -733,22 +1211,16 @@ function RegisterSessionSyncNotice({
     ? "Synced closeout cannot be applied"
     : hasOnlyRejectedReviewItems
       ? "Manager override available"
-    : syncStatus.status === "locally_closed_pending_sync"
-      ? "Pending reconciliation"
-      : hasCloseoutReview
-        ? "Closeout needs review"
-        : syncStatus.label;
+      : syncStatus.status === "locally_closed_pending_sync"
+        ? "Pending reconciliation"
+        : hasCloseoutReview
+          ? "Closeout needs review"
+          : syncStatus.label;
   const noticeDescription = hasClosedRegisterSyncedCloseout
     ? "This register is already closed. Reject the duplicate synced activity to clear the review."
     : hasOnlyRejectedReviewItems
       ? "Rejected local activity can be synced from Cash Controls. A manager can override and apply these events without the cashier present."
-    : syncStatus.description;
-  const approveLabel = hasCloseoutReview
-    ? "Approve synced closeout"
-    : "Approve synced sales";
-  const rejectLabel = hasCloseoutReview
-    ? "Reject synced closeout"
-    : "Reject synced activity";
+      : syncStatus.description;
   const closeoutReviewItem = hasCloseoutReview
     ? reconciliationItems.find(isRegisterCloseoutReviewItem)
     : null;
@@ -769,19 +1241,18 @@ function RegisterSessionSyncNotice({
   const hasUnsupportedReviewItems =
     shouldCombineReviewItems &&
     !hasOnlyRejectedReviewItems &&
-    reconciliationItems.some((item) => !isApprovableRegisterSyncReviewItem(item));
+    reconciliationItems.some(
+      (item) => !isApprovableRegisterSyncReviewItem(item),
+    );
   const canApplySyncReview = canApproveSyncReview && !hasUnsupportedReviewItems;
   const rejectedSyncQueueSummary = hasOnlyRejectedReviewItems
     ? formatReviewQueueSummary(reconciliationItems)
     : null;
-  const rejectedSyncReportedSummary = hasOnlyRejectedReviewItems
-    ? formatReviewReportedSummary(reconciliationItems)
-    : null;
+  const rejectedSyncSaleSummaries = hasOnlyRejectedReviewItems
+    ? getSyncReviewSaleSummaries(reconciliationItems)
+    : [];
   const reviewQueueSummary = shouldCombineReviewItems
     ? formatReviewQueueSummary(reconciliationItems)
-    : null;
-  const reviewReportedSummary = shouldCombineReviewItems
-    ? formatReviewReportedSummary(reconciliationItems)
     : null;
   const reviewTypeSummary = shouldCombineReviewItems
     ? formatReviewTypeSummary(reconciliationItems)
@@ -789,6 +1260,36 @@ function RegisterSessionSyncNotice({
   const reviewReasonSummary = shouldCombineReviewItems
     ? formatReviewReasonSummary(reconciliationItems)
     : null;
+  const syncReviewSaleSummaries = shouldCombineReviewItems
+    ? getSyncReviewSaleSummaries(reconciliationItems)
+    : [];
+  const actionCopy = getSyncReviewActionCopy({
+    hasCloseoutReview,
+    hasOnlyRejectedReviewItems,
+    hasSaleReview:
+      syncReviewSaleSummaries.length > 0 ||
+      rejectedSyncSaleSummaries.length > 0,
+  });
+  const rejectedSyncEvidenceDetails = hasOnlyRejectedReviewItems
+    ? [
+        {
+          label: "Items",
+          value: `${formatReviewItemCount(reconciliationItems.length)} rejected by the server.`,
+        },
+      ]
+    : [];
+  const combinedSyncEvidenceDetails = shouldCombineReviewItems
+    ? [
+        {
+          label: "Items",
+          value: `${formatReviewItemCount(reconciliationItems.length)} ${
+            reconciliationItems.length === 1 ? "needs" : "need"
+          } manager review.`,
+        },
+        { label: "Reasons", value: reviewReasonSummary },
+        { label: "Categories", value: reviewTypeSummary },
+      ]
+    : [];
 
   return (
     <section
@@ -820,7 +1321,7 @@ function RegisterSessionSyncNotice({
           </p>
           {hasOnlyRejectedReviewItems ? (
             <div className="pt-layout-xs">
-              <div className="grid gap-layout-sm rounded-md border border-danger/15 bg-background/70 p-layout-sm md:grid-cols-[minmax(0,1fr)_minmax(14rem,0.75fr)]">
+              <div className="grid gap-layout-md rounded-md border border-danger/15 bg-background/70 p-layout-sm md:grid-cols-[minmax(0,0.9fr)_minmax(18rem,1.1fr)]">
                 <div className="space-y-1">
                   <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
                     Next step
@@ -830,26 +1331,26 @@ function RegisterSessionSyncNotice({
                     drawer and records the override for audit.
                   </p>
                 </div>
-                <div className="space-y-1 border-t border-border pt-layout-sm text-xs text-muted-foreground md:border-l md:border-t-0 md:pl-layout-sm md:pt-0">
-                  <p className="font-medium uppercase tracking-[0.16em] text-muted-foreground">
-                    Evidence
-                  </p>
-                  <p>
-                    {formatReviewItemCount(reconciliationItems.length)} rejected
-                    by the server.
-                  </p>
-                  {rejectedSyncQueueSummary ? (
-                    <p>{rejectedSyncQueueSummary}</p>
-                  ) : null}
-                  {rejectedSyncReportedSummary ? (
-                    <p>{rejectedSyncReportedSummary}</p>
-                  ) : null}
+                <div className="border-t border-border pt-layout-sm md:border-l md:border-t-0 md:pl-layout-sm md:pt-0">
+                  <div className="space-y-layout-sm">
+                    <SyncReviewDetailGrid
+                      details={rejectedSyncEvidenceDetails}
+                    />
+                    <SyncReviewTimeline
+                      items={reconciliationItems}
+                      uploadOrder={rejectedSyncQueueSummary}
+                    />
+                  </div>
                 </div>
+                <SalesUnderReviewList
+                  currency={currency}
+                  sales={rejectedSyncSaleSummaries}
+                />
               </div>
             </div>
           ) : shouldCombineReviewItems ? (
             <div className="pt-layout-xs">
-              <div className="grid gap-layout-sm rounded-md border border-danger/15 bg-background/70 p-layout-sm md:grid-cols-[minmax(0,1fr)_minmax(16rem,0.85fr)]">
+              <div className="grid gap-layout-md rounded-md border border-danger/15 bg-background/70 p-layout-sm md:grid-cols-[minmax(0,0.9fr)_minmax(18rem,1.1fr)]">
                 <div className="space-y-1">
                   <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
                     Next step
@@ -858,22 +1359,21 @@ function RegisterSessionSyncNotice({
                     {getCombinedReviewNextStep(reconciliationItems)}
                   </p>
                 </div>
-                <div className="space-y-1 border-t border-border pt-layout-sm text-xs text-muted-foreground md:border-l md:border-t-0 md:pl-layout-sm md:pt-0">
-                  <p className="font-medium uppercase tracking-[0.16em] text-muted-foreground">
-                    Evidence
-                  </p>
-                  <p>
-                    {formatReviewItemCount(reconciliationItems.length)}{" "}
-                    {reconciliationItems.length === 1 ? "needs" : "need"}{" "}
-                    manager review.
-                  </p>
-                  {reviewReasonSummary ? <p>{reviewReasonSummary}</p> : null}
-                  {reviewTypeSummary ? <p>{reviewTypeSummary}</p> : null}
-                  {reviewQueueSummary ? <p>{reviewQueueSummary}</p> : null}
-                  {reviewReportedSummary ? (
-                    <p>{reviewReportedSummary}</p>
-                  ) : null}
+                <div className="border-t border-border pt-layout-sm md:border-l md:border-t-0 md:pl-layout-sm md:pt-0">
+                  <div className="space-y-layout-sm">
+                    <SyncReviewDetailGrid
+                      details={combinedSyncEvidenceDetails}
+                    />
+                    <SyncReviewTimeline
+                      items={reconciliationItems}
+                      uploadOrder={reviewQueueSummary}
+                    />
+                  </div>
                 </div>
+                <SalesUnderReviewList
+                  currency={currency}
+                  sales={syncReviewSaleSummaries}
+                />
               </div>
             </div>
           ) : syncStatus.status === "needs_review" &&
@@ -918,7 +1418,10 @@ function RegisterSessionSyncNotice({
                                   Expected
                                 </dt>
                                 <dd className="mt-1 font-numeric tabular-nums text-foreground">
-                                  {formatCurrency(currency, closeoutExpectedCash)}
+                                  {formatCurrency(
+                                    currency,
+                                    closeoutExpectedCash,
+                                  )}
                                 </dd>
                               </div>
                             ) : null}
@@ -928,7 +1431,10 @@ function RegisterSessionSyncNotice({
                                   Counted
                                 </dt>
                                 <dd className="mt-1 font-numeric tabular-nums text-foreground">
-                                  {formatCurrency(currency, closeoutCountedCash)}
+                                  {formatCurrency(
+                                    currency,
+                                    closeoutCountedCash,
+                                  )}
                                 </dd>
                               </div>
                             ) : null}
@@ -1075,7 +1581,7 @@ function RegisterSessionSyncNotice({
                   type="button"
                   variant="workflow"
                 >
-                  {approveLabel}
+                  {actionCopy.approveLabel}
                 </LoadingButton>
               ) : null}
               <Button
@@ -1086,7 +1592,7 @@ function RegisterSessionSyncNotice({
                 type="button"
                 variant="outline"
               >
-                {rejectLabel}
+                {actionCopy.rejectLabel}
               </Button>
             </>
           ) : null}
@@ -1312,7 +1818,9 @@ function RegisterSessionDepositCard({
           <dt className="font-medium uppercase tracking-[0.14em]">By</dt>
           <dd className="min-w-0 truncate text-right text-foreground">
             {deposit.recordedByStaffName
-              ? formatStaffDisplayName({ fullName: deposit.recordedByStaffName })
+              ? formatStaffDisplayName({
+                  fullName: deposit.recordedByStaffName,
+                })
               : "N/A"}
           </dd>
         </div>
@@ -2080,10 +2588,12 @@ export function RegisterSessionViewContent({
     typeof pendingCloseoutReviewItem?.variance === "number"
       ? pendingCloseoutReviewItem.variance
       : registerSession?.variance;
-  const isRejectedSyncOverride =
-    closeoutStaffAuthIntent?.kind === "sync_review" &&
-    closeoutStaffAuthIntent.decision === "approved" &&
-    hasOnlyRejectedSyncReviewItems(syncStatus);
+  const syncReviewActionCopy = getSyncReviewActionCopy({
+    hasCloseoutReview: isRegisterCloseoutSyncReview,
+    hasOnlyRejectedReviewItems: hasOnlyRejectedSyncReviewItems(syncStatus),
+    hasSaleReview:
+      getSyncReviewSaleSummaries(visibleSyncReviewItems).length > 0,
+  });
   const closeoutStaffAuthCopy =
     closeoutStaffAuthIntent?.kind === "review"
       ? {
@@ -2102,24 +2612,12 @@ export function RegisterSessionViewContent({
             title: "Manager sign-in required",
             description:
               closeoutStaffAuthIntent.decision === "approved"
-                ? isRejectedSyncOverride
-                  ? "Authenticate to override and sync rejected local activity"
-                  : isRegisterCloseoutSyncReview
-                  ? "Authenticate to approve and apply the synced closeout"
-                  : "Authenticate to approve and apply reviewed synced sales"
-                : isRegisterCloseoutSyncReview
-                  ? "Authenticate to reject the synced closeout"
-                  : "Authenticate to reject reviewed synced activity",
+                ? syncReviewActionCopy.approveAuthDescription
+                : syncReviewActionCopy.rejectAuthDescription,
             submitLabel:
               closeoutStaffAuthIntent.decision === "approved"
-                ? isRejectedSyncOverride
-                  ? "Override and sync events"
-                  : isRegisterCloseoutSyncReview
-                  ? "Approve synced closeout"
-                  : "Approve synced sales"
-                : isRegisterCloseoutSyncReview
-                  ? "Reject synced closeout"
-                  : "Reject synced activity",
+                ? closeoutStaffAuthIntent.approveLabel
+                : closeoutStaffAuthIntent.rejectLabel,
           }
         : {
             title: "Closeout sign-in required",
@@ -2135,11 +2633,20 @@ export function RegisterSessionViewContent({
       return;
     }
 
+    const actionCopy = getSyncReviewActionCopy({
+      hasCloseoutReview: isRegisterCloseoutSyncReview,
+      hasOnlyRejectedReviewItems: hasOnlyRejectedSyncReviewItems(syncStatus),
+      hasSaleReview:
+        getSyncReviewSaleSummaries(visibleSyncReviewItems).length > 0,
+    });
+
     setSyncReviewErrorMessage("");
     setCloseoutStaffAuthIntent({
       kind: "sync_review",
       decision,
+      approveLabel: actionCopy.approveLabel,
       registerSessionId: registerSession._id,
+      rejectLabel: actionCopy.rejectLabel,
       reviewConflictIds:
         isRegisterCloseoutSyncReview && pendingCloseoutReviewItem?.id
           ? [pendingCloseoutReviewItem.id]
@@ -3014,214 +3521,217 @@ export function RegisterSessionViewContent({
                     </div>
                   ) : (
                     <>
-                    <div className="order-2 space-y-layout-sm md:hidden">
-                      {previewTransactions.map((transaction) => {
-                        const canOpenTransaction = Boolean(
-                          orgUrlSlug && storeUrlSlug,
-                        );
-                        const transactionRoute = canOpenTransaction
-                          ? {
-                              params: {
-                                orgUrlSlug: orgUrlSlug!,
-                                storeUrlSlug: storeUrlSlug!,
-                                transactionId: transaction._id,
-                              },
-                              search: { o: getOrigin() },
-                              to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId" as const,
-                            }
-                          : null;
-                        const openTransaction = () => {
-                          if (!transactionRoute) {
-                            return;
-                          }
-
-                          navigate(transactionRoute);
-                        };
-
-                        return (
-                          <RegisterSessionTransactionCard
-                            canOpenTransaction={canOpenTransaction}
-                            currency={currency}
-                            key={transaction._id}
-                            onOpen={openTransaction}
-                            transaction={transaction}
-                          />
-                        );
-                      })}
-                    </div>
-                    <div className="order-2 hidden overflow-hidden rounded-lg border border-border bg-surface-raised md:block">
-                      <Table>
-                        <TableHeader>
-                          <TableRow className="border-b border-border hover:bg-transparent">
-                            <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                              Transaction
-                            </TableHead>
-                            <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                              Total
-                            </TableHead>
-                            <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                              Payment
-                            </TableHead>
-                            <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                              Cashier
-                            </TableHead>
-                            <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                              Completed
-                            </TableHead>
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          {previewTransactions.map((transaction) => {
-                            const PaymentIcon = getPaymentMethodIcon({
-                              hasMultiplePaymentMethods:
-                                transaction.hasMultiplePaymentMethods,
-                              paymentMethod: transaction.paymentMethod,
-                            });
-                            const transactionLabel = `#${transaction.transactionNumber}`;
-                            const isVoidedTransaction =
-                              transaction.status === "void" ||
-                              typeof transaction.voidedAt === "number";
-                            const canOpenTransaction = Boolean(
-                              orgUrlSlug && storeUrlSlug,
-                            );
-                            const transactionRoute = canOpenTransaction
-                              ? {
-                                  params: {
-                                    orgUrlSlug: orgUrlSlug!,
-                                    storeUrlSlug: storeUrlSlug!,
-                                    transactionId: transaction._id,
-                                  },
-                                  search: { o: getOrigin() },
-                                  to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId" as const,
-                                }
-                              : null;
-
-                            const openTransaction = () => {
-                              if (!transactionRoute) {
-                                return;
+                      <div className="order-2 space-y-layout-sm md:hidden">
+                        {previewTransactions.map((transaction) => {
+                          const canOpenTransaction = Boolean(
+                            orgUrlSlug && storeUrlSlug,
+                          );
+                          const transactionRoute = canOpenTransaction
+                            ? {
+                                params: {
+                                  orgUrlSlug: orgUrlSlug!,
+                                  storeUrlSlug: storeUrlSlug!,
+                                  transactionId: transaction._id,
+                                },
+                                search: { o: getOrigin() },
+                                to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId" as const,
                               }
+                            : null;
+                          const openTransaction = () => {
+                            if (!transactionRoute) {
+                              return;
+                            }
 
-                              navigate(transactionRoute);
-                            };
+                            navigate(transactionRoute);
+                          };
 
-                            return (
-                              <TableRow
-                                aria-label={
-                                  canOpenTransaction
-                                    ? `Open transaction ${transactionLabel}`
-                                    : undefined
-                                }
-                                className={
-                                  canOpenTransaction
-                                    ? "group border-b border-border/70 cursor-pointer transition-colors hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                                    : "border-b border-border/70 transition-colors"
-                                }
-                                key={transaction._id}
-                                onClick={
-                                  canOpenTransaction
-                                    ? openTransaction
-                                    : undefined
-                                }
-                                onKeyDown={
-                                  canOpenTransaction
-                                    ? (event) => {
-                                        if (
-                                          event.key !== "Enter" &&
-                                          event.key !== " "
-                                        ) {
-                                          return;
-                                        }
-
-                                        event.preventDefault();
-                                        openTransaction();
-                                      }
-                                    : undefined
-                                }
-                                role={canOpenTransaction ? "link" : undefined}
-                                tabIndex={canOpenTransaction ? 0 : undefined}
-                              >
-                                <TableCell>
-                                  <div className="flex flex-col gap-1">
-                                    <span className="inline-flex w-fit items-center gap-1 font-medium text-foreground group-hover:text-primary">
-                                      {transactionLabel}
-                                      {isVoidedTransaction ? (
-                                        <span className="rounded-sm border border-destructive/30 bg-destructive/10 px-1.5 py-0.5 text-xs font-medium text-destructive">
-                                          Voided
-                                        </span>
-                                      ) : null}
-                                      {canOpenTransaction ? (
-                                        <ArrowUpRight className="h-3.5 w-3.5" />
-                                      ) : null}
-                                    </span>
-                                    <span className="text-xs text-muted-foreground">
-                                      {transaction.itemCount}{" "}
-                                      {transaction.itemCount === 1
-                                        ? "item"
-                                        : "items"}
-                                      {transaction.customerName
-                                        ? ` - ${transaction.customerName}`
-                                        : ""}
-                                    </span>
-                                  </div>
-                                </TableCell>
-                                <TableCell className="font-numeric tabular-nums text-foreground">
-                                  {formatCurrency(currency, transaction.total)}
-                                </TableCell>
-                                <TableCell>
-                                  <span className="inline-flex items-center gap-2 text-sm text-muted-foreground">
-                                    <PaymentIcon className="h-4 w-4" />
-                                    {transaction.hasMultiplePaymentMethods
-                                      ? "Multiple"
-                                      : formatPaymentMethod(
-                                          transaction.paymentMethod,
-                                        )}
-                                  </span>
-                                </TableCell>
-                                <TableCell className="text-sm text-muted-foreground">
-                                  {transaction.cashierName
-                                    ? formatStaffDisplayName({
-                                        fullName: transaction.cashierName,
-                                      })
-                                    : "N/A"}
-                                </TableCell>
-                                <TableCell className="text-sm text-muted-foreground">
-                                  {formatTimestamp(transaction.completedAt)}
-                                </TableCell>
-                              </TableRow>
-                            );
-                          })}
-                        </TableBody>
-                      </Table>
-                    </div>
-                    {hasAdditionalTransactions &&
-                    registerSession &&
-                    orgUrlSlug &&
-                    storeUrlSlug ? (
-                      <div className="order-2 flex flex-col gap-layout-sm rounded-lg border border-border/70 bg-surface-raised px-4 py-3 sm:flex-row sm:items-center sm:justify-between md:rounded-t-none md:border-t-0">
-                        <p className="text-sm text-muted-foreground">
-                          Showing latest {previewTransactions.length} of{" "}
-                          {transactions.length} linked sales.
-                        </p>
-                        <Button
-                          asChild
-                          className="w-full sm:w-auto"
-                          size="sm"
-                          variant="outline"
-                        >
-                          <Link
-                            params={{ orgUrlSlug, storeUrlSlug }}
-                            search={{
-                              o: getOrigin(),
-                              registerSessionId: registerSession._id,
-                            }}
-                            to="/$orgUrlSlug/store/$storeUrlSlug/pos/transactions"
-                          >
-                            View all linked transactions
-                            <ArrowUpRight className="h-3.5 w-3.5" />
-                          </Link>
-                        </Button>
+                          return (
+                            <RegisterSessionTransactionCard
+                              canOpenTransaction={canOpenTransaction}
+                              currency={currency}
+                              key={transaction._id}
+                              onOpen={openTransaction}
+                              transaction={transaction}
+                            />
+                          );
+                        })}
                       </div>
-                    ) : null}
+                      <div className="order-2 hidden overflow-hidden rounded-lg border border-border bg-surface-raised md:block">
+                        <Table>
+                          <TableHeader>
+                            <TableRow className="border-b border-border hover:bg-transparent">
+                              <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                Transaction
+                              </TableHead>
+                              <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                Total
+                              </TableHead>
+                              <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                Payment
+                              </TableHead>
+                              <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                Cashier
+                              </TableHead>
+                              <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                Completed
+                              </TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {previewTransactions.map((transaction) => {
+                              const PaymentIcon = getPaymentMethodIcon({
+                                hasMultiplePaymentMethods:
+                                  transaction.hasMultiplePaymentMethods,
+                                paymentMethod: transaction.paymentMethod,
+                              });
+                              const transactionLabel = `#${transaction.transactionNumber}`;
+                              const isVoidedTransaction =
+                                transaction.status === "void" ||
+                                typeof transaction.voidedAt === "number";
+                              const canOpenTransaction = Boolean(
+                                orgUrlSlug && storeUrlSlug,
+                              );
+                              const transactionRoute = canOpenTransaction
+                                ? {
+                                    params: {
+                                      orgUrlSlug: orgUrlSlug!,
+                                      storeUrlSlug: storeUrlSlug!,
+                                      transactionId: transaction._id,
+                                    },
+                                    search: { o: getOrigin() },
+                                    to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId" as const,
+                                  }
+                                : null;
+
+                              const openTransaction = () => {
+                                if (!transactionRoute) {
+                                  return;
+                                }
+
+                                navigate(transactionRoute);
+                              };
+
+                              return (
+                                <TableRow
+                                  aria-label={
+                                    canOpenTransaction
+                                      ? `Open transaction ${transactionLabel}`
+                                      : undefined
+                                  }
+                                  className={
+                                    canOpenTransaction
+                                      ? "group border-b border-border/70 cursor-pointer transition-colors hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                      : "border-b border-border/70 transition-colors"
+                                  }
+                                  key={transaction._id}
+                                  onClick={
+                                    canOpenTransaction
+                                      ? openTransaction
+                                      : undefined
+                                  }
+                                  onKeyDown={
+                                    canOpenTransaction
+                                      ? (event) => {
+                                          if (
+                                            event.key !== "Enter" &&
+                                            event.key !== " "
+                                          ) {
+                                            return;
+                                          }
+
+                                          event.preventDefault();
+                                          openTransaction();
+                                        }
+                                      : undefined
+                                  }
+                                  role={canOpenTransaction ? "link" : undefined}
+                                  tabIndex={canOpenTransaction ? 0 : undefined}
+                                >
+                                  <TableCell>
+                                    <div className="flex flex-col gap-1">
+                                      <span className="inline-flex w-fit items-center gap-1 font-medium text-foreground group-hover:text-primary">
+                                        {transactionLabel}
+                                        {isVoidedTransaction ? (
+                                          <span className="rounded-sm border border-destructive/30 bg-destructive/10 px-1.5 py-0.5 text-xs font-medium text-destructive">
+                                            Voided
+                                          </span>
+                                        ) : null}
+                                        {canOpenTransaction ? (
+                                          <ArrowUpRight className="h-3.5 w-3.5" />
+                                        ) : null}
+                                      </span>
+                                      <span className="text-xs text-muted-foreground">
+                                        {transaction.itemCount}{" "}
+                                        {transaction.itemCount === 1
+                                          ? "item"
+                                          : "items"}
+                                        {transaction.customerName
+                                          ? ` - ${transaction.customerName}`
+                                          : ""}
+                                      </span>
+                                    </div>
+                                  </TableCell>
+                                  <TableCell className="font-numeric tabular-nums text-foreground">
+                                    {formatCurrency(
+                                      currency,
+                                      transaction.total,
+                                    )}
+                                  </TableCell>
+                                  <TableCell>
+                                    <span className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+                                      <PaymentIcon className="h-4 w-4" />
+                                      {transaction.hasMultiplePaymentMethods
+                                        ? "Multiple"
+                                        : formatPaymentMethod(
+                                            transaction.paymentMethod,
+                                          )}
+                                    </span>
+                                  </TableCell>
+                                  <TableCell className="text-sm text-muted-foreground">
+                                    {transaction.cashierName
+                                      ? formatStaffDisplayName({
+                                          fullName: transaction.cashierName,
+                                        })
+                                      : "N/A"}
+                                  </TableCell>
+                                  <TableCell className="text-sm text-muted-foreground">
+                                    {formatTimestamp(transaction.completedAt)}
+                                  </TableCell>
+                                </TableRow>
+                              );
+                            })}
+                          </TableBody>
+                        </Table>
+                      </div>
+                      {hasAdditionalTransactions &&
+                      registerSession &&
+                      orgUrlSlug &&
+                      storeUrlSlug ? (
+                        <div className="order-2 flex flex-col gap-layout-sm rounded-lg border border-border/70 bg-surface-raised px-4 py-3 sm:flex-row sm:items-center sm:justify-between md:rounded-t-none md:border-t-0">
+                          <p className="text-sm text-muted-foreground">
+                            Showing latest {previewTransactions.length} of{" "}
+                            {transactions.length} linked sales.
+                          </p>
+                          <Button
+                            asChild
+                            className="w-full sm:w-auto"
+                            size="sm"
+                            variant="outline"
+                          >
+                            <Link
+                              params={{ orgUrlSlug, storeUrlSlug }}
+                              search={{
+                                o: getOrigin(),
+                                registerSessionId: registerSession._id,
+                              }}
+                              to="/$orgUrlSlug/store/$storeUrlSlug/pos/transactions"
+                            >
+                              View all linked transactions
+                              <ArrowUpRight className="h-3.5 w-3.5" />
+                            </Link>
+                          </Button>
+                        </div>
+                      ) : null}
                     </>
                   )}
                 </div>
@@ -3249,62 +3759,64 @@ export function RegisterSessionViewContent({
                   />
                 ) : (
                   <>
-                  <div className="space-y-layout-sm md:hidden">
-                    {registerSessionSnapshot.deposits.map((deposit) => (
-                      <RegisterSessionDepositCard
-                        currency={currency}
-                        deposit={deposit}
-                        key={deposit._id}
-                      />
-                    ))}
-                  </div>
-                  <div className="hidden overflow-hidden rounded-lg border border-border bg-surface-raised md:block">
-                    <Table>
-                      <TableHeader>
-                        <TableRow className="border-b border-border hover:bg-transparent">
-                          <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                            Amount
-                          </TableHead>
-                          <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                            Recorded
-                          </TableHead>
-                          <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                            Reference
-                          </TableHead>
-                          <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                            By
-                          </TableHead>
-                          <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                            Notes
-                          </TableHead>
-                        </TableRow>
-                      </TableHeader>
-                      <TableBody>
-                        {registerSessionSnapshot.deposits.map((deposit) => (
-                          <TableRow
-                            className="border-b border-border/70 transition-colors hover:bg-muted/40"
-                            key={deposit._id}
-                          >
-                            <TableCell className="font-numeric tabular-nums text-foreground">
-                              {formatCurrency(currency, deposit.amount)}
-                            </TableCell>
-                            <TableCell className="text-muted-foreground">
-                              {formatTimestamp(deposit.recordedAt)}
-                            </TableCell>
-                            <TableCell>{deposit.reference ?? "N/A"}</TableCell>
-                            <TableCell>
-                              {deposit.recordedByStaffName
-                                ? formatStaffDisplayName({
-                                    fullName: deposit.recordedByStaffName,
-                                  })
-                                : "N/A"}
-                            </TableCell>
-                            <TableCell>{deposit.notes ?? "N/A"}</TableCell>
+                    <div className="space-y-layout-sm md:hidden">
+                      {registerSessionSnapshot.deposits.map((deposit) => (
+                        <RegisterSessionDepositCard
+                          currency={currency}
+                          deposit={deposit}
+                          key={deposit._id}
+                        />
+                      ))}
+                    </div>
+                    <div className="hidden overflow-hidden rounded-lg border border-border bg-surface-raised md:block">
+                      <Table>
+                        <TableHeader>
+                          <TableRow className="border-b border-border hover:bg-transparent">
+                            <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                              Amount
+                            </TableHead>
+                            <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                              Recorded
+                            </TableHead>
+                            <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                              Reference
+                            </TableHead>
+                            <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                              By
+                            </TableHead>
+                            <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                              Notes
+                            </TableHead>
                           </TableRow>
-                        ))}
-                      </TableBody>
-                    </Table>
-                  </div>
+                        </TableHeader>
+                        <TableBody>
+                          {registerSessionSnapshot.deposits.map((deposit) => (
+                            <TableRow
+                              className="border-b border-border/70 transition-colors hover:bg-muted/40"
+                              key={deposit._id}
+                            >
+                              <TableCell className="font-numeric tabular-nums text-foreground">
+                                {formatCurrency(currency, deposit.amount)}
+                              </TableCell>
+                              <TableCell className="text-muted-foreground">
+                                {formatTimestamp(deposit.recordedAt)}
+                              </TableCell>
+                              <TableCell>
+                                {deposit.reference ?? "N/A"}
+                              </TableCell>
+                              <TableCell>
+                                {deposit.recordedByStaffName
+                                  ? formatStaffDisplayName({
+                                      fullName: deposit.recordedByStaffName,
+                                    })
+                                  : "N/A"}
+                              </TableCell>
+                              <TableCell>{deposit.notes ?? "N/A"}</TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </div>
                   </>
                 )}
               </div>
@@ -3725,7 +4237,9 @@ export function RegisterSessionView() {
       return;
     }
 
-    if (automaticSyncReviewAttemptRef.current === automaticSyncReviewSignature) {
+    if (
+      automaticSyncReviewAttemptRef.current === automaticSyncReviewSignature
+    ) {
       return;
     }
     automaticSyncReviewAttemptRef.current = automaticSyncReviewSignature;

--- a/packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts
@@ -26,6 +26,25 @@ export type PosReconciliationItem = {
   sequence?: number | null;
   status?: string | null;
   summary?: string | null;
+  sale?: {
+    cashAmount?: number | null;
+    itemCount?: number | null;
+    items?: Array<{
+      name: string;
+      quantity?: number | null;
+      sku?: string | null;
+      total?: number | null;
+    }>;
+    localReceiptNumber?: string | null;
+    localTransactionId?: string | null;
+    occurredAt?: number | null;
+    paymentMethods?: string[];
+    receiptNumber?: string | null;
+    staffName?: string | null;
+    staffProfileId?: string | null;
+    total?: number | null;
+    totalPaid?: number | null;
+  } | null;
   type?: string | null;
   variance?: number | null;
 };


### PR DESCRIPTION
## Summary
- Enrich register-session sync review with sale receipt, cashier, tender, item, upload-order, and cash-impact evidence
- Refine the Cash Controls review IA with collapsed sale rows, reconciled item totals, clearer timeline details, and action-specific CTA copy
- Add return-validator contract proof and a reusable solution note for sale sync review evidence

## Validation
- bun run pr:athena
- bunx vitest run convex/cashControls/deposits.test.ts convex/lib/returnValidatorContract.test.ts --maxWorkers=1
- bunx vitest run convex/pos/infrastructure/repositories/registerSessionRepository.test.ts convex/cashControls/deposits.test.ts src/components/cash-controls/RegisterSessionView.test.tsx --maxWorkers=1

Browser validation intentionally left to the reviewer per request.