### PR TITLE
Fix terminal app update source state

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7212 nodes · 8321 edges · 1915 communities detected
+- 7214 nodes · 8325 edges · 1915 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1989,12 +1989,12 @@ Cohesion: 0.09
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.07
-Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
+Cohesion: 0.06
+Nodes (21): assertPosLocalStoreOk(), buildRuntimeAppUpdateInput(), clearAcceptedTerminalIntegrityState(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus() (+13 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.06
-Nodes (19): assertPosLocalStoreOk(), buildRuntimeAppUpdateInput(), clearAcceptedTerminalIntegrityState(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus() (+11 more)
+Cohesion: 0.07
+Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.1
@@ -2429,44 +2429,44 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 119 - "Community 119"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 120 - "Community 120"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 121 - "Community 121"
+### Community 120 - "Community 120"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 122 - "Community 122"
+### Community 121 - "Community 121"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 123 - "Community 123"
+### Community 122 - "Community 122"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 124 - "Community 124"
+### Community 123 - "Community 123"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 125 - "Community 125"
+### Community 124 - "Community 124"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 126 - "Community 126"
+### Community 125 - "Community 125"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 127 - "Community 127"
+### Community 126 - "Community 126"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 128 - "Community 128"
+### Community 127 - "Community 127"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
+
+### Community 128 - "Community 128"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 129 - "Community 129"
 Cohesion: 0.18
@@ -2869,16 +2869,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 229 - "Community 229"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 230 - "Community 230"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 231 - "Community 231"
+### Community 230 - "Community 230"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 231 - "Community 231"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 232 - "Community 232"
 Cohesion: 0.43

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1987
-- Graph nodes: 7212
-- Graph edges: 8321
+- Graph nodes: 7214
+- Graph edges: 8325
 - Communities: 1915
 
 ## Graph Hotspots

--- a/packages/athena-webapp/src/components/app-update/UpdateReadyBanner.test.tsx
+++ b/packages/athena-webapp/src/components/app-update/UpdateReadyBanner.test.tsx
@@ -123,8 +123,8 @@ describe("UpdateReadyBanner", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "mark ready" }));
-    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
-    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
 
     expect(screen.getByLabelText("Update ready")).toBeInTheDocument();
     expect(reload).toHaveBeenCalledTimes(1);
@@ -175,7 +175,7 @@ describe("UpdateReadyBanner", () => {
       screen.getByText("Finish this sale before refreshing."),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Refresh" }),
+      screen.queryByRole("button", { name: "Update" }),
     ).not.toBeInTheDocument();
   });
 
@@ -194,12 +194,14 @@ describe("UpdateReadyBanner", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "mark ready" }));
 
+    expect(screen.getByText("Update ready.")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "Update ready. Some files were not cached for offline use.",
-      ),
+      screen.queryByText("Some files were not cached for offline use."),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Update cache details" }),
     ).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
     expect(reload).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/athena-webapp/src/components/app-update/UpdateReadyBanner.tsx
+++ b/packages/athena-webapp/src/components/app-update/UpdateReadyBanner.tsx
@@ -1,8 +1,14 @@
 import { useEffect } from "react";
-import { RefreshCw } from "lucide-react";
+import { Download, Info } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
   usePreferredUpdateCommunicationVariant,
   useUpdateCoordinator,
@@ -10,7 +16,7 @@ import {
 import { cn } from "@/lib/utils";
 
 const updateReadyToastId = "athena-update-ready-toast";
-const refreshButtonClassName =
+const updateButtonClassName =
   "min-h-10 shrink-0 px-layout-md text-action-commit hover:bg-action-commit-soft hover:text-action-commit";
 
 export function UpdateReadyBanner() {
@@ -26,8 +32,8 @@ export function UpdateReadyBanner() {
   const hasBlocker = Boolean(blocker);
   const canApply = snapshot.canApply;
   const isApplying = snapshot.status === "applying";
-  const primaryCopy = getUpdateReadyBannerCopy(snapshot);
-  const showRefreshAction = !hasBlocker && (canApply || isApplying);
+  const bannerContent = getUpdateReadyBannerContent(snapshot);
+  const showUpdateAction = !hasBlocker && (canApply || isApplying);
   const shouldShowToast =
     hasUpdate && communicationVariant === "toast";
 
@@ -37,7 +43,7 @@ export function UpdateReadyBanner() {
       return;
     }
 
-    toast.message(primaryCopy, {
+    toast.message(bannerContent.message, {
       id: updateReadyToastId,
       closeButton: false,
       dismissible: false,
@@ -48,9 +54,9 @@ export function UpdateReadyBanner() {
         toast: "justify-between",
         content: "min-w-0 flex-1",
       },
-      action: showRefreshAction ? (
+      action: showUpdateAction ? (
         <Button
-          className={cn(refreshButtonClassName, "ml-auto")}
+          className={cn(updateButtonClassName, "ml-auto")}
           disabled={!canApply || isApplying}
           onClick={() => {
             if (canApply && !isApplying) {
@@ -61,22 +67,22 @@ export function UpdateReadyBanner() {
           type="button"
           variant="ghost"
         >
-          <RefreshCw
+          <Download
             aria-hidden="true"
             className={cn(isApplying && "animate-spin")}
           />
-          Refresh
+          Update
         </Button>
       ) : undefined,
     });
   }, [
     applyUpdate,
+    bannerContent.message,
     canApply,
     hasBlocker,
     isApplying,
-    primaryCopy,
     shouldShowToast,
-    showRefreshAction,
+    showUpdateAction,
   ]);
 
   if (!hasUpdate || communicationVariant !== "banner") {
@@ -91,24 +97,42 @@ export function UpdateReadyBanner() {
     >
       <div className="mx-auto flex max-w-7xl flex-col items-center justify-center gap-layout-lg text-center sm:flex-row sm:text-left">
         <div className="min-w-0">
-          <p className="truncate text-sm font-medium text-foreground">
-            {primaryCopy}
-          </p>
+          <div className="flex min-w-0 items-center justify-center gap-layout-xs truncate text-sm font-medium text-foreground sm:justify-start">
+            <span className="truncate">{bannerContent.message}</span>
+            {bannerContent.tooltip ? (
+              <TooltipProvider delayDuration={150}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      aria-label="Update cache details"
+                      className="inline-flex size-5 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      type="button"
+                    >
+                      <Info aria-hidden="true" className="size-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-64 text-xs leading-5">
+                    {bannerContent.tooltip}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : null}
+          </div>
         </div>
-        {showRefreshAction ? (
+        {showUpdateAction ? (
           <Button
-            className={refreshButtonClassName}
+            className={updateButtonClassName}
             disabled={!canApply || isApplying}
             onClick={() => applyUpdate()}
             size="sm"
             type="button"
             variant="ghost"
           >
-            <RefreshCw
+            <Download
               aria-hidden="true"
               className={cn(isApplying && "animate-spin")}
             />
-            Refresh
+            Update
           </Button>
         ) : null}
       </div>
@@ -116,35 +140,44 @@ export function UpdateReadyBanner() {
   );
 }
 
-function getUpdateReadyBannerCopy(
+function getUpdateReadyBannerContent(
   snapshot: ReturnType<typeof useUpdateCoordinator>["snapshot"],
 ) {
   if (snapshot.selectedBlocker) {
-    return snapshot.selectedBlocker.guidance;
+    return { message: snapshot.selectedBlocker.guidance };
   }
   if (snapshot.status === "applying") {
-    return "Refreshing Athena now.";
+    return { message: "Updating Athena now." };
   }
   if (snapshot.status === "ready-unstaged") {
     switch (snapshot.staging?.reason) {
       case "asset-staging-failed":
       case "service-worker-error":
-        return "Update ready. Some files were not cached for offline use.";
+        return {
+          message: "Update ready.",
+          tooltip: "Some files were not cached for offline use.",
+        };
       case "service-worker-timeout":
-        return "Update ready. Offline file caching is still catching up.";
+        return {
+          message: "Update ready. Offline file caching is still catching up.",
+        };
       case "service-worker-unavailable":
-        return "Update ready. App shell cache is not connected.";
+        return { message: "Update ready. App shell cache is not connected." };
       case "cache-storage-unavailable":
       case "no-entry-html":
       case "no-static-assets":
-        return "Update ready. Offline cache preparation is unavailable.";
+        return {
+          message: "Update ready. Offline cache preparation is unavailable.",
+        };
       default:
-        return "Update ready. Offline cache preparation is incomplete.";
+        return {
+          message: "Update ready. Offline cache preparation is incomplete.",
+        };
     }
   }
   if (snapshot.canApply) {
-    return "Update ready";
+    return { message: "Update ready" };
   }
 
-  return "Update detected. Preparing refresh.";
+  return { message: "Update detected. Preparing refresh." };
 }

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -86,6 +86,7 @@ function deferred<T>() {
 describe("usePosLocalSyncRuntimeStatus", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.unstubAllEnvs();
     mocks.reportTerminalRuntimeStatus.mockResolvedValue({
       kind: "ok",
       data: {},
@@ -2884,6 +2885,79 @@ describe("usePosLocalSyncRuntimeStatus", () => {
           }),
         }),
       ),
+    );
+  });
+
+  it("publishes current app update state when pending build is already running", async () => {
+    vi.stubEnv("VITE_ATHENA_WEBAPP_BUILD_SHA", "build-next");
+    vi.stubEnv("VITE_ATHENA_WEBAPP_VERSION", "quick-dolphin-prowls");
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+    };
+    const appUpdateCoordinator = {
+      applyUpdate: vi.fn(() => false),
+      getSnapshot: vi.fn(() => ({
+        blockers: [],
+        canApply: false,
+        currentBuildId: "build-current",
+        pendingBuildId: "build-next",
+        staging: {
+          reason: "service-worker-unavailable" as const,
+          status: "unstaged" as const,
+        },
+        status: "ready-unstaged" as const,
+      })),
+    };
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        appUpdateCoordinator,
+        mode: "status-only",
+        source: "register",
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.reportTerminalRuntimeStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: expect.objectContaining({
+            appUpdate: expect.objectContaining({
+              canApply: false,
+              currentBuildId: "build-next",
+              detectorStatus: "ok",
+              stagingStatus: "unknown",
+              status: "current",
+            }),
+            buildSha: "build-next",
+          }),
+        }),
+      ),
+    );
+    expect(
+      mocks.reportTerminalRuntimeStatus.mock.calls[0]?.[0].status.appUpdate,
+    ).not.toEqual(
+      expect.objectContaining({
+        pendingBuildId: "build-next",
+        status: "update_ready_unstaged",
+      }),
     );
   });
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -4,7 +4,10 @@ import type { FunctionArgs } from "convex/server";
 
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
-import { getInitialRuntimeBuildMetadata } from "@/lib/runtimeBuildMetadata";
+import {
+  getInitialRuntimeBuildMetadata,
+  type AthenaWebappRuntimeBuildMetadata,
+} from "@/lib/runtimeBuildMetadata";
 import { isLocalPinVerifierMetadata } from "@/lib/security/localPinVerifier";
 import {
   createIndexedDbPosLocalStorageAdapter,
@@ -801,8 +804,9 @@ export function usePosLocalSyncRuntimeStatus(input: {
       buildRuntimeAppUpdateInput({
         appUpdateCoordinator,
         commandCorrelation: appUpdateCommandCorrelation,
+        runtimeBuildMetadata,
       }),
-    [appUpdateCommandCorrelation, appUpdateCoordinator],
+    [appUpdateCommandCorrelation, appUpdateCoordinator, runtimeBuildMetadata],
   );
 
   const runtimeStatusInput = useMemo(
@@ -1998,14 +2002,29 @@ function hasPendingSyncableExpenseEvents(
 function buildRuntimeAppUpdateInput({
   appUpdateCoordinator,
   commandCorrelation,
+  runtimeBuildMetadata,
 }: {
   appUpdateCoordinator?: PosAppUpdateCoordinatorAdapter | null;
   commandCorrelation?: AppUpdateCommandCorrelation | null;
+  runtimeBuildMetadata: AthenaWebappRuntimeBuildMetadata;
 }): PosTerminalRuntimeAppUpdateInput | null {
   if (!appUpdateCoordinator) return null;
 
   try {
     const snapshot = appUpdateCoordinator.getSnapshot();
+    if (isPendingSnapshotAlreadyRunning(snapshot, runtimeBuildMetadata)) {
+      return {
+        canApply: false,
+        commandExecutionId: commandCorrelation?.commandExecutionId,
+        commandId: commandCorrelation?.commandId,
+        commandIssuedAt: commandCorrelation?.commandIssuedAt,
+        currentBuildId: snapshot.pendingBuildId,
+        detectorStatus: "ok",
+        stagingStatus: "unknown",
+        status: "current",
+      };
+    }
+
     return {
       canApply: snapshot.canApply,
       commandExecutionId: commandCorrelation?.commandExecutionId,
@@ -2040,6 +2059,34 @@ function buildRuntimeAppUpdateInput({
       status: "detector_failed",
     };
   }
+}
+
+function isPendingSnapshotAlreadyRunning(
+  snapshot: ReturnType<PosAppUpdateCoordinatorAdapter["getSnapshot"]>,
+  runtimeBuildMetadata: AthenaWebappRuntimeBuildMetadata,
+) {
+  if (
+    snapshot.status !== "ready" &&
+    snapshot.status !== "ready-unstaged" &&
+    snapshot.status !== "blocked"
+  ) {
+    return false;
+  }
+
+  const pendingBuildId = normalizeBuildIdentity(snapshot.pendingBuildId);
+  if (!pendingBuildId) {
+    return false;
+  }
+
+  return (
+    normalizeBuildIdentity(runtimeBuildMetadata.buildSha) === pendingBuildId ||
+    normalizeBuildIdentity(runtimeBuildMetadata.appVersion) === pendingBuildId
+  );
+}
+
+function normalizeBuildIdentity(value?: string | null) {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
 }
 
 function toRuntimeAppUpdateStatus(


### PR DESCRIPTION
## Summary
- publish app update as current when the coordinator pending build is already the running runtime build
- keep the update banner cache-warning detail behind an info tooltip
- rename the update banner CTA to Update and use a download/update icon

## Validation
- bun run --filter '@athena/webapp' test src/components/app-update/UpdateReadyBanner.test.tsx src/lib/app-update/updateCoordinator.test.ts src/lib/app-update/updateAssetStaging.test.ts src/utils/versionChecker.test.ts src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts src/components/pos/terminals/terminalHealthPresentation.test.ts src/components/pos/terminals/POSTerminalDetailView.test.tsx
- bun run pr:athena