### PR TITLE
Close POS sync review workspace gaps

### DIFF
--- a/docs/solutions/logic-errors/athena-pos-sync-review-workspace-boundaries-2026-06-19.md
+++ b/docs/solutions/logic-errors/athena-pos-sync-review-workspace-boundaries-2026-06-19.md
@@ -1,0 +1,95 @@
+---
+title: Athena POS Sync Review Workspace Boundaries
+date: 2026-06-19
+category: logic-errors
+module: athena-webapp
+problem_type: sync_review_workspace_boundary_drift
+component: pos-terminal-health
+symptoms:
+  - "Terminal health reports local review counts without enough item-level context"
+  - "Cash Controls can show review actions for inventory work that belongs in Operations"
+  - "Queued manager approvals can drift from the drawer state that made the request safe"
+  - "Operator-facing review copy can leak backend conflict summaries or internal ids"
+root_cause: review_state_was_counted_without_preserving_the_owning_workflow_and_operator_evidence
+resolution_type: bounded_runtime_evidence_and_scoped_review_actions
+severity: medium
+tags:
+  - pos
+  - local-sync
+  - terminal-health
+  - cash-controls
+  - operations
+  - product-copy
+---
+
+# Athena POS Sync Review Workspace Boundaries
+
+## Problem
+
+POS local sync review state can span several workspaces. A late synced sale can
+need Cash Controls review for duplicate register activity, Operations review for
+inventory shortfall, and terminal support review for local runtime settlement.
+If the same count or conflict is projected into every workspace without a clear
+owner, operators see extra actions, stale review rows, or links to the wrong
+workflow.
+
+The most visible failure is terminal health reporting a local review count while
+cloud conflict evidence only shows a subset. A count is not enough for support:
+the runtime check-in must either include bounded item-level review evidence or
+the UI must say that details were not included in the latest report.
+
+## Solution
+
+Keep each review decision attached to its owner and evidence contract:
+
+- Terminal runtime check-ins may publish a bounded, sanitized sample of local
+  review events: local event id, sequence, type, upload status, and local
+  session ids. Never include raw payloads, payments, customer data, staff proof
+  tokens, PIN material, sync secrets, or browser fingerprints.
+- Terminal detail should render the local review sample when present. If the
+  terminal reports a positive review count but omits details, say that the
+  latest check-in did not include item-level local review details.
+- Cash Controls review actions should resolve only the review item that matches
+  the current sale decision. Hide global apply/reject bars when review items do
+  not share the same action scope.
+- Projected inventory-review sales belong to Operations once an open
+  `synced_sale_inventory_review` work item owns the inventory decision. Cash
+  Controls should suppress that review only for open matching work items, and
+  receipt-only matching must be scoped to the same local register session.
+- Queued void approvals may outlive an active drawer, but approval replay should
+  only bypass the usable-drawer check for the transitional `closing` state. A
+  fully `closed` drawer still blocks the void.
+- Operator-facing review copy should be derived from review kind, action policy,
+  and known workflow state. Raw backend conflict summaries and internal ids are
+  evidence, not product copy.
+
+## Regression Targets
+
+- `src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts` should prove
+  local review samples are sanitized and can come from sync debug when event
+  state is stale.
+- `src/components/pos/terminals/POSTerminalDetailView.test.tsx` should prove the
+  no-details fallback appears when review counts arrive without review events.
+- `convex/pos/application/terminals.test.ts` should prove terminal health
+  annotates inventory conflicts from open Operations work items instead of
+  relying on pre-seeded view-model fields.
+- `convex/cashControls/deposits.test.ts` should prove inventory handoff review
+  suppression ignores closed work items and receipt-only matches from another
+  local drawer.
+- `convex/pos/application/completeTransaction.test.ts` should prove queued void
+  approvals are allowed for `closing` register sessions and blocked for `closed`
+  register sessions.
+- `src/components/cash-controls/RegisterSessionView.test.tsx` should cover
+  review action rows with normalized state/action copy, not raw conflict text.
+
+## Prevention
+
+- Treat local sync review as workflow-owned state, not a generic count.
+- Add negative tests whenever a review row is hidden because another workspace
+  owns the next decision.
+- Keep terminal-health support surfaces explanatory only; do not add hidden
+  approval authority there.
+- Prefer scoped row-level decisions over drawer-level actions whenever review
+  items have mixed action policies.
+- Normalize product copy at the UI or read-model boundary before it reaches
+  operators.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7214 nodes · 8325 edges · 1915 communities detected
+- 7228 nodes · 8353 edges · 1915 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1965,12 +1965,12 @@ Cohesion: 0.06
 Nodes (56): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildDailyCloseApprovalSubject(), buildDailyCloseCompletionApprovalRequirement() (+48 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.11
-Nodes (53): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), collectExistingSaleMappings(), collectSaleSkuQuantities(), conflictResult(), createConflict() (+45 more)
+Cohesion: 0.08
+Nodes (53): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildRegisterCloseoutTimelineMessage(), buildWeekMetricForDate(), buildWeekMetrics() (+45 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.08
-Nodes (51): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildWeekMetricForDate(), buildWeekMetrics(), compareDailyOperationsTimelineEvents() (+43 more)
+Cohesion: 0.11
+Nodes (53): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), collectExistingSaleMappings(), collectSaleSkuQuantities(), conflictResult(), createConflict() (+45 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.09
@@ -1993,12 +1993,12 @@ Cohesion: 0.06
 Nodes (21): assertPosLocalStoreOk(), buildRuntimeAppUpdateInput(), clearAcceptedTerminalIntegrityState(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus() (+13 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.07
-Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
+Cohesion: 0.09
+Nodes (34): annotateTerminalSyncEvidenceReviewTargets(), buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalRecoveryActions(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryManualReview(), buildTerminalRecoveryPreview() (+26 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.1
-Nodes (33): buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalRecoveryActions(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryManualReview(), buildTerminalRecoveryPreview(), dedupeTerminalActions() (+25 more)
+Cohesion: 0.07
+Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.07
@@ -2033,12 +2033,12 @@ Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
 ### Community 20 - "Community 20"
-Cohesion: 0.12
-Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
-
-### Community 21 - "Community 21"
 Cohesion: 0.08
 Nodes (11): formatCompactTextList(), formatPaymentMethods(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary(), formatReviewTypeSummary(), formatTimestamp() (+3 more)
+
+### Community 21 - "Community 21"
+Cohesion: 0.12
+Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
 ### Community 22 - "Community 22"
 Cohesion: 0.15
@@ -2161,96 +2161,96 @@ Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
 ### Community 52 - "Community 52"
+Cohesion: 0.16
+Nodes (15): findLatestOpenOperatingDay(), getTodaySummary(), getTransactionById(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile(), loadPendingItemAdjustmentApprovals() (+7 more)
+
+### Community 53 - "Community 53"
+Cohesion: 0.13
+Nodes (12): getLatestRuntimeStatusForTerminal(), getTerminalByFingerprint(), getTerminalSyncEvidence(), isActionableRejectedSyncEvent(), isActionableTerminalReviewSyncEvent(), mapTerminalRecord(), mergeRuntimeStatusPatch(), omitUndefined() (+4 more)
+
+### Community 54 - "Community 54"
 Cohesion: 0.21
 Nodes (18): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), formatRecoveryCode(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode() (+10 more)
 
-### Community 53 - "Community 53"
+### Community 55 - "Community 55"
 Cohesion: 0.1
 Nodes (4): handleChange(), isSkuReserved(), parseVariantInputValue(), shouldDisable()
 
-### Community 54 - "Community 54"
+### Community 56 - "Community 56"
 Cohesion: 0.1
 Nodes (4): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onStartRemoteAssist()
 
-### Community 55 - "Community 55"
-Cohesion: 0.13
-Nodes (11): getLatestRuntimeStatusForTerminal(), getTerminalByFingerprint(), getTerminalSyncEvidence(), isActionableRejectedSyncEvent(), isActionableTerminalReviewSyncEvent(), mapTerminalRecord(), omitUndefined(), resolveRegisterSessionActionTarget() (+3 more)
-
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.15
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.27
 Nodes (18): assertConformsToExportedReturns(), collectReturnValidatorIssues(), decodeSerializedFloat64(), decodeSerializedInt64(), decodeSerializedLiteralValue(), describeValue(), formatReturnValidatorIssues(), isConvexValue() (+10 more)
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.2
 Nodes (17): acknowledgeTerminalRecoveryCommand(), buildExecutionId(), claimTerminalRecoveryCommand(), containsSecretLikeField(), getRuntimeAppUpdateEvidence(), isActiveCommand(), isEquivalentCommand(), issueTerminalRecoveryCommand() (+9 more)
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.22
 Nodes (18): assertPrAthenaProofReady(), classifySnapshotError(), collectFilesUnder(), collectProofSnapshot(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof() (+10 more)
 
-### Community 63 - "Community 63"
-Cohesion: 0.18
-Nodes (11): getTransactionById(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile(), loadPendingItemAdjustmentApprovals(), normalizeAdjustmentLineItem(), normalizeAdjustmentMetadata() (+3 more)
-
 ### Community 64 - "Community 64"
+Cohesion: 0.14
+Nodes (6): asBoolean(), asNumber(), asRecord(), buildRegisterCloseoutVarianceTimelineMessage(), formatCloseoutVarianceAmount(), getCashControlsConfig()
+
+### Community 65 - "Community 65"
 Cohesion: 0.12
 Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.22
 Nodes (15): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+7 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.16
 Nodes (8): asCloudOperableSession(), countPendingSyncableLocalEventsForStaff(), hasSyncedSaleLocalEventsForStaff(), hasUploadedLocalEventsForStaff(), isCloudOperableSession(), isEmptyLocalSaleShell(), trimOptional(), useRegisterViewModel()
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.13
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.14
 Nodes (5): getBlockedPosTerminalShellCopy(), getPosHubRouteParams(), getRouteParamsForPattern(), getStoreWorkspaceRouteParams(), PosTerminalBlockedShell()
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
-
-### Community 74 - "Community 74"
-Cohesion: 0.15
-Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
 ### Community 75 - "Community 75"
 Cohesion: 0.27
@@ -2325,84 +2325,84 @@ Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
 ### Community 93 - "Community 93"
+Cohesion: 0.26
+Nodes (10): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), classifyRegisterSessionSyncReview(), hasInventoryReviewWorkItemForProjectedSale(), listOpenLocalSyncConflictsByRegisterSession(), numberDetail(), recordDetail() (+2 more)
+
+### Community 94 - "Community 94"
 Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.19
 Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.22
 Nodes (6): buildParticipantIdentity(), getDataPublishRouting(), getParticipantRole(), isAllowedSender(), LiveKitRemoteAssistClient, parseParticipantRole()
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.26
 Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.29
 Nodes (10): applyTheme(), emitThemeChange(), getStorage(), getStoredThemeMode(), getSystemTheme(), getThemeSnapshot(), initializeAthenaTheme(), isThemeMode() (+2 more)
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.2
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
-
-### Community 112 - "Community 112"
-Cohesion: 0.3
-Nodes (8): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), listOpenLocalSyncConflictsByRegisterSession(), numberDetail(), recordDetail(), stringDetail(), summarizeSaleItems()
 
 ### Community 113 - "Community 113"
 Cohesion: 0.2
@@ -2429,44 +2429,44 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 119 - "Community 119"
-Cohesion: 0.36
-Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 120 - "Community 120"
 Cohesion: 0.36
-Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
+Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
 ### Community 121 - "Community 121"
+Cohesion: 0.36
+Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
+
+### Community 122 - "Community 122"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
-
-### Community 128 - "Community 128"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 129 - "Community 129"
 Cohesion: 0.18
@@ -2546,19 +2546,19 @@ Nodes (5): clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), r
 
 ### Community 148 - "Community 148"
 Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 149 - "Community 149"
 Cohesion: 0.39
-Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 150 - "Community 150"
-Cohesion: 0.22
-Nodes (0):
+Cohesion: 0.39
+Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
 ### Community 151 - "Community 151"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Cohesion: 0.22
+Nodes (0):
 
 ### Community 152 - "Community 152"
 Cohesion: 0.5
@@ -2853,172 +2853,172 @@ Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
 ### Community 225 - "Community 225"
+Cohesion: 0.33
+Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
+
+### Community 226 - "Community 226"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.38
 Nodes (3): getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusSignature()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.33
 Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
-
-### Community 228 - "Community 228"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 229 - "Community 229"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 230 - "Community 230"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 231 - "Community 231"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
+### Community 231 - "Community 231"
+Cohesion: 0.29
+Nodes (0):
+
 ### Community 232 - "Community 232"
+Cohesion: 0.52
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 233 - "Community 233"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
+Cohesion: 0.47
+Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
+
+### Community 239 - "Community 239"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 238 - "Community 238"
+### Community 240 - "Community 240"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 239 - "Community 239"
+### Community 241 - "Community 241"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
-
-### Community 240 - "Community 240"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 241 - "Community 241"
-Cohesion: 0.4
-Nodes (2): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository()
 
 ### Community 242 - "Community 242"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 243 - "Community 243"
+Cohesion: 0.4
+Nodes (2): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository()
+
+### Community 244 - "Community 244"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 245 - "Community 245"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 244 - "Community 244"
+### Community 246 - "Community 246"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 245 - "Community 245"
+### Community 247 - "Community 247"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 246 - "Community 246"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 247 - "Community 247"
-Cohesion: 0.53
-Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
-
 ### Community 248 - "Community 248"
 Cohesion: 0.33
-Nodes (1): DataTableToolbar()
+Nodes (0):
 
 ### Community 249 - "Community 249"
 Cohesion: 0.53
-Nodes (2): SelectedProductsProvider(), useSelectedProducts()
+Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
 ### Community 250 - "Community 250"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): DataTableToolbar()
 
 ### Community 251 - "Community 251"
-Cohesion: 0.47
-Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
+Cohesion: 0.53
+Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
 ### Community 252 - "Community 252"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 253 - "Community 253"
-Cohesion: 0.4
-Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
+Cohesion: 0.47
+Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
 ### Community 254 - "Community 254"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 255 - "Community 255"
 Cohesion: 0.4
-Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
+Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
 ### Community 256 - "Community 256"
+Cohesion: 0.33
+Nodes (1): ResizeObserverStub
+
+### Community 257 - "Community 257"
+Cohesion: 0.4
+Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
+
+### Community 258 - "Community 258"
 Cohesion: 0.4
 Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
-### Community 257 - "Community 257"
+### Community 259 - "Community 259"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 258 - "Community 258"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 259 - "Community 259"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 260 - "Community 260"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 261 - "Community 261"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 262 - "Community 262"
+Cohesion: 0.33
+Nodes (1): ResizeObserverStub
+
+### Community 263 - "Community 263"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 264 - "Community 264"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 263 - "Community 263"
+### Community 265 - "Community 265"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 264 - "Community 264"
+### Community 266 - "Community 266"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 265 - "Community 265"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 266 - "Community 266"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 267 - "Community 267"
 Cohesion: 0.33
@@ -3033,104 +3033,104 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 270 - "Community 270"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 271 - "Community 271"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 272 - "Community 272"
-Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 273 - "Community 273"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 274 - "Community 274"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 275 - "Community 275"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 276 - "Community 276"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 277 - "Community 277"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 278 - "Community 278"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 276 - "Community 276"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 277 - "Community 277"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 278 - "Community 278"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
 ### Community 279 - "Community 279"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 280 - "Community 280"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 281 - "Community 281"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 282 - "Community 282"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 283 - "Community 283"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 284 - "Community 284"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 285 - "Community 285"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 285 - "Community 285"
+### Community 286 - "Community 286"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 286 - "Community 286"
+### Community 287 - "Community 287"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 287 - "Community 287"
+### Community 288 - "Community 288"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 288 - "Community 288"
+### Community 289 - "Community 289"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 289 - "Community 289"
+### Community 290 - "Community 290"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 290 - "Community 290"
+### Community 291 - "Community 291"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 291 - "Community 291"
+### Community 292 - "Community 292"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 292 - "Community 292"
+### Community 293 - "Community 293"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 293 - "Community 293"
+### Community 294 - "Community 294"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
-
-### Community 294 - "Community 294"
-Cohesion: 0.5
-Nodes (2): createAuthorizedRegisterDepositCtx(), createQueryCtx()
 
 ### Community 295 - "Community 295"
 Cohesion: 0.6
@@ -12172,8 +12172,8 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**
-  _Cohesion score 0.11 - nodes in this community are weakly interconnected._
-- **Should `Community 4` be split into smaller, more focused modules?**
   _Cohesion score 0.08 - nodes in this community are weakly interconnected._
+- **Should `Community 4` be split into smaller, more focused modules?**
+  _Cohesion score 0.11 - nodes in this community are weakly interconnected._
 - **Should `Community 5` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,16 +8,16 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1987
-- Graph nodes: 7214
-- Graph edges: 8325
+- Graph nodes: 7228
+- Graph edges: 8353
 - Communities: 1915
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (88 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `harness-inferential-review.ts` (85 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `dailyClose.ts` (65 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `projectLocalEvents.ts` (55 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `dailyOperations.ts` (54 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `dailyOperations.ts` (55 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `projectLocalEvents.ts` (55 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 - `terminalHealthPresentation.ts` (53 edges, Community 6) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `posLocalStore.ts` (48 edges, Community 7) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -19,8 +19,8 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 ## Graph Hotspots
 - `DailyCloseView.tsx` (88 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (65 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `projectLocalEvents.ts` (55 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `dailyOperations.ts` (54 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `dailyOperations.ts` (55 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `projectLocalEvents.ts` (55 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 
 ## Navigation

--- a/packages/athena-webapp/convex/cashControls/closeouts.test.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.test.ts
@@ -6,8 +6,10 @@ import {
   correctRegisterSessionOpeningFloat,
   getCashControlsConfig,
   reopenRegisterSessionCloseout,
+  reviewRegisterSessionCloseout,
   submitRegisterSessionCloseout,
 } from "./closeouts";
+import { assertConformsToExportedReturns } from "../lib/returnValidatorContract";
 
 function getSource(relativePath: string) {
   return readFileSync(new URL(relativePath, import.meta.url), "utf8");
@@ -18,6 +20,33 @@ function getHandler(definition: unknown) {
 }
 
 describe("cash control closeouts", () => {
+  it("validates representative public closeout command results against exported return validators", () => {
+    const validationError = {
+      kind: "user_error" as const,
+      error: {
+        code: "validation_failed" as const,
+        message: "Counted cash cannot be negative.",
+      },
+    };
+
+    assertConformsToExportedReturns(
+      submitRegisterSessionCloseout,
+      validationError,
+    );
+    assertConformsToExportedReturns(
+      reopenRegisterSessionCloseout,
+      validationError,
+    );
+    assertConformsToExportedReturns(
+      correctRegisterSessionOpeningFloat,
+      validationError,
+    );
+    assertConformsToExportedReturns(
+      reviewRegisterSessionCloseout,
+      validationError,
+    );
+  });
+
   it("uses a sensible default approval threshold when store config is absent", () => {
     expect(getCashControlsConfig()).toEqual({
       requireManagerSignoffForAnyVariance: false,
@@ -166,6 +195,8 @@ describe("cash control closeouts", () => {
     expect(source).toContain("approvalMode: \"inline_manager_proof\"");
     expect(source).toContain("approvalRequired(approvalRequirement)");
     expect(source).toContain("REGISTER_VARIANCE_REVIEW_ACTION");
+    expect(source).toContain("buildRegisterCloseoutVarianceTimelineMessage");
+    expect(source).toContain("currency: store?.currency");
   });
 
   it("exposes opening float correction as a command-result mutation with audit rails", () => {

--- a/packages/athena-webapp/convex/cashControls/closeouts.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.ts
@@ -11,6 +11,8 @@ import { consumeApprovalProofWithCtx } from "../operations/approvalProofs";
 import { recordOperationalEventWithCtx } from "../operations/operationalEvents";
 import { recordRegisterSessionTraceBestEffort } from "../operations/registerSessionTracing";
 import { commandResultValidator } from "../lib/commandResultValidators";
+import { toDisplayAmount } from "../lib/currency";
+import { currencyFormatter } from "../utils";
 import {
   approvalRequired,
   ok,
@@ -34,6 +36,33 @@ const REGISTER_CLOSEOUT_REOPEN_ACTION =
   APPROVAL_ACTIONS.registerSessionCloseoutReopen;
 const REGISTER_CLOSEOUT_MODIFICATION_SUBMIT_ACTION =
   APPROVAL_ACTIONS.registerSessionCloseoutModificationSubmit;
+
+function formatCloseoutVarianceAmount(
+  currency: string | undefined,
+  amount: number,
+) {
+  const storeCurrency = currency?.trim() || "GHS";
+
+  try {
+    return currencyFormatter(storeCurrency).format(toDisplayAmount(amount));
+  } catch {
+    return currencyFormatter("GHS").format(toDisplayAmount(amount));
+  }
+}
+
+function buildRegisterCloseoutVarianceTimelineMessage(args: {
+  currency?: string;
+  registerNumber?: string;
+  variance: number;
+}) {
+  const registerLabel = args.registerNumber?.trim()
+    ? /^register\b/i.test(args.registerNumber)
+      ? args.registerNumber
+      : `Register ${args.registerNumber}`
+    : "Register session";
+
+  return `${registerLabel} closeout recorded with a cash variance of ${formatCloseoutVarianceAmount(args.currency, args.variance)}.`;
+}
 
 const userErrorValidator = v.object({
   code: v.union(
@@ -972,15 +1001,18 @@ export const submitRegisterSessionCloseout = mutation({
       await ctx.db.patch("registerSession", registerSession._id, {
         managerApprovalRequestId: approvalRequestId,
       });
+      const store = await ctx.db.get("store", args.storeId);
 
       await recordOperationalEventWithCtx(ctx, {
         actorStaffProfileId: closeoutSubmitActorStaffProfileId,
         actorUserId: args.actorUserId,
         approvalRequestId,
         eventType: "register_session_variance_review_requested",
-        message:
-          closeoutReview.reason ??
-          "Register closeout submitted for manager variance review.",
+        message: buildRegisterCloseoutVarianceTimelineMessage({
+          currency: store?.currency,
+          registerNumber: registerSession.registerNumber,
+          variance: closeoutReview.variance,
+        }),
         metadata: {
           actionKey: REGISTER_VARIANCE_REVIEW_ACTION_KEY,
           approvalMode: "async_approval",

--- a/packages/athena-webapp/convex/cashControls/deposits.test.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.test.ts
@@ -171,6 +171,95 @@ function createQueryCtx(seed: Record<string, Array<Record<string, unknown>>>) {
   };
 }
 
+function createProjectedInventoryReviewQueryCtx(input: {
+  workItemMetadata?: Record<string, unknown>;
+  workItemStatus?: string;
+}) {
+  return createQueryCtx({
+    operationalWorkItem: [
+      {
+        _id: "work_item_inventory",
+        approvalState: "not_required",
+        createdAt: 4,
+        metadata: {
+          localEventId: "event_inventory_sale",
+          localRegisterSessionId: "local-register-1",
+          localTransactionId: "local-transaction-1",
+          receiptNumber: "939540",
+          registerSessionId: "session_open",
+          ...(input.workItemMetadata ?? {}),
+        },
+        organizationId: "org_1",
+        priority: "high",
+        status: input.workItemStatus ?? "open",
+        storeId: "store_1",
+        title: "Review inventory for Ebin Skin Protector Enhanced",
+        type: "synced_sale_inventory_review",
+      },
+    ],
+    posLocalSyncConflict: [
+      {
+        _id: "sync_conflict_inventory",
+        storeId: "store_1",
+        terminalId: "terminal_1",
+        localRegisterSessionId: "local-register-1",
+        localEventId: "event_inventory_sale",
+        sequence: 3,
+        conflictType: "inventory",
+        status: "needs_review",
+        summary: "Inventory needs manager review for a synced offline sale.",
+        details: {
+          localTransactionId: "local-transaction-1",
+          productSkuId: "product_sku_1",
+          requestedQuantity: 2,
+          quantityAvailable: 1,
+          quantityAvailableAfterHolds: 1,
+        },
+        createdAt: 1,
+      },
+    ],
+    posLocalSyncEvent: [
+      {
+        _id: "sync_event_inventory_sale",
+        storeId: "store_1",
+        terminalId: "terminal_1",
+        localRegisterSessionId: "local-register-1",
+        localEventId: "event_inventory_sale",
+        sequence: 3,
+        eventType: "sale_completed",
+        occurredAt: 2,
+        staffProfileId: "staff_1",
+        payload: {
+          localTransactionId: "local-transaction-1",
+          receiptNumber: "939540",
+        },
+        projectedAt: 4,
+        status: "conflicted",
+        submittedAt: 3,
+      },
+    ],
+    posLocalSyncMapping: [
+      {
+        _id: "sync_mapping_1",
+        storeId: "store_1",
+        terminalId: "terminal_1",
+        localRegisterSessionId: "local-register-1",
+        localIdKind: "registerSession",
+        localId: "local-register-1",
+        cloudTable: "registerSession",
+        cloudId: "session_open",
+      },
+    ],
+    registerSession: [
+      {
+        _id: "session_open",
+        storeId: "store_1",
+        terminalId: "terminal_1",
+      },
+    ],
+  });
+}
+
 function createAuthorizedRegisterDepositCtx(
   overrides: Record<string, Array<Record<string, unknown>>> = {},
 ) {
@@ -1111,6 +1200,350 @@ describe("cash control deposits", () => {
         type: "synced_sale_inventory_review",
       }),
     ]);
+  });
+
+  it("resolves selected sale review rows without clearing sibling review rows", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      operationalEvent: [],
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_inventory",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_inventory_sale",
+          sequence: 3,
+          conflictType: "inventory",
+          status: "needs_review",
+          summary: "Inventory needs manager review for a synced offline sale.",
+          details: {
+            localTransactionId: "local-transaction-1",
+            productSkuId: "product_sku_1",
+            requestedQuantity: 2,
+            availableInventoryCount: 1,
+            quantityAvailable: 1,
+            quantityAvailableAfterHolds: 1,
+          },
+          createdAt: 1,
+        },
+        {
+          _id: "sync_conflict_duplicate",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_inventory_sale",
+          sequence: 3,
+          conflictType: "duplicate_local_id",
+          status: "needs_review",
+          summary:
+            "Local POS session id was reused by a different synced sale.",
+          details: {
+            localId: "local-pos-session-1",
+            localIdKind: "posSession",
+            localTransactionId: "local-transaction-1",
+            originalTransactionId: "transaction_original",
+          },
+          createdAt: 2,
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_inventory_sale",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_inventory_sale",
+          sequence: 3,
+          eventType: "sale_completed",
+          occurredAt: 2,
+          staffProfileId: "staff_1",
+          payload: {
+            localPosSessionId: "local-pos-session-1",
+            localTransactionId: "local-transaction-1",
+            localReceiptNumber: "939540",
+            receiptNumber: "939540",
+            registerNumber: "1",
+            totals: {
+              subtotal: 116000,
+              tax: 0,
+              total: 116000,
+            },
+            items: [
+              {
+                localTransactionItemId: "local-item-1",
+                productId: "product_1",
+                productSkuId: "product_sku_1",
+                productName: "Ebin Skin Protector Enhanced",
+                productSku: "KK38-3NA-5QK",
+                quantity: 2,
+                unitPrice: 58000,
+              },
+            ],
+            payments: [
+              {
+                localPaymentId: "local-payment-1",
+                method: "mobile_money",
+                amount: 116000,
+                timestamp: 3,
+              },
+            ],
+          },
+          status: "conflicted",
+          submittedAt: 4,
+          acceptedAt: 4,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "sync_mapping_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "registerSession",
+          cloudId: "session_open",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_open",
+          expectedCash: 231000,
+          openedAt: 1,
+          openingFloat: 15500,
+          organizationId: "org_1",
+          registerNumber: "1",
+          status: "closed",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+        },
+      ],
+      posTerminal: [
+        {
+          _id: "terminal_1",
+          registerNumber: "1",
+          registeredByUserId: "athena_user_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      product: [
+        {
+          _id: "product_1",
+          storeId: "store_1",
+        },
+      ],
+      productSku: [
+        {
+          _id: "product_sku_1",
+          images: [],
+          inventoryCount: 1,
+          price: 58000,
+          productId: "product_1",
+          quantityAvailable: 1,
+          sku: "KK38-3NA-5QK",
+          storeId: "store_1",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "manager_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "staff_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      staffRoleAssignment: [
+        {
+          _id: "role_1",
+          organizationId: "org_1",
+          role: "manager",
+          staffProfileId: "manager_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "role_2",
+          organizationId: "org_1",
+          role: "cashier",
+          staffProfileId: "staff_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+    });
+
+    const rejectDuplicate = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        decision: "rejected",
+        registerSessionId: "session_open" as Id<"registerSession">,
+        reviewConflictIds: ["sync_conflict_duplicate"],
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(rejectDuplicate).toEqual(
+      ok({
+        action: "rejected",
+        projectedCount: 0,
+        registerSession: expect.objectContaining({ _id: "session_open" }),
+        resolvedCount: 1,
+      }),
+    );
+    expect(ctx.tables.get("posLocalSyncEvent")).toEqual([
+      expect.objectContaining({
+        _id: "sync_event_inventory_sale",
+        status: "conflicted",
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncConflict")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          _id: "sync_conflict_duplicate",
+          resolvedByStaffProfileId: "manager_1",
+          status: "resolved",
+        }),
+        expect.objectContaining({
+          _id: "sync_conflict_inventory",
+          status: "needs_review",
+        }),
+      ]),
+    );
+    await expect(
+      listOpenLocalSyncConflictsByRegisterSession(
+        ctx as never,
+        "store_1" as Id<"store">,
+        { includeRejectedEvidence: true },
+      ),
+    ).resolves.toEqual(
+      new Map([
+        [
+          "session_open",
+          [
+            expect.objectContaining({
+              _id: "sync_conflict_inventory",
+              status: "needs_review",
+            }),
+          ],
+        ],
+      ]),
+    );
+
+    const applyInventory = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        reviewConflictIds: ["sync_conflict_inventory"],
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(applyInventory).toEqual(
+      ok({
+        action: "resolved",
+        projectedCount: 1,
+        registerSession: expect.objectContaining({ _id: "session_open" }),
+        resolvedCount: 1,
+      }),
+    );
+    expect(ctx.tables.get("posLocalSyncConflict")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          _id: "sync_conflict_duplicate",
+          status: "resolved",
+        }),
+        expect.objectContaining({
+          _id: "sync_conflict_inventory",
+          resolvedByStaffProfileId: "manager_1",
+          status: "resolved",
+        }),
+      ]),
+    );
+    expect(ctx.tables.get("posLocalSyncEvent")).toEqual([
+      expect.objectContaining({
+        _id: "sync_event_inventory_sale",
+        projectedAt: expect.any(Number),
+        status: "projected",
+      }),
+    ]);
+    expect(ctx.tables.get("operationalWorkItem")).toEqual([
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          receiptNumber: "939540",
+          sourceType: "posTransaction",
+        }),
+        title: "Review inventory for Ebin Skin Protector Enhanced",
+        type: "synced_sale_inventory_review",
+      }),
+    ]);
+  });
+
+  it("does not keep projected inventory handoff sales in cash-controls review", async () => {
+    const ctx = createProjectedInventoryReviewQueryCtx({});
+
+    await expect(
+      listOpenLocalSyncConflictsByRegisterSession(
+        ctx as never,
+        "store_1" as Id<"store">,
+        { includeRejectedEvidence: true },
+      ),
+    ).resolves.toEqual(new Map());
+  });
+
+  it("keeps projected inventory sales in cash-controls review when inventory work is closed", async () => {
+    const ctx = createProjectedInventoryReviewQueryCtx({
+      workItemStatus: "resolved",
+    });
+
+    await expect(
+      listOpenLocalSyncConflictsByRegisterSession(
+        ctx as never,
+        "store_1" as Id<"store">,
+        { includeRejectedEvidence: true },
+      ),
+    ).resolves.toEqual(
+      new Map([
+        [
+          "session_open",
+          [expect.objectContaining({ _id: "sync_conflict_inventory" })],
+        ],
+      ]),
+    );
+  });
+
+  it("keeps projected inventory sales in cash-controls review when receipt-only metadata belongs to another local drawer", async () => {
+    const ctx = createProjectedInventoryReviewQueryCtx({
+      workItemMetadata: {
+        localEventId: "other-event",
+        localRegisterSessionId: "other-local-register",
+        localTransactionId: "other-local-transaction",
+        receiptNumber: "939540",
+      },
+    });
+
+    await expect(
+      listOpenLocalSyncConflictsByRegisterSession(
+        ctx as never,
+        "store_1" as Id<"store">,
+        { includeRejectedEvidence: true },
+      ),
+    ).resolves.toEqual(
+      new Map([
+        [
+          "session_open",
+          [expect.objectContaining({ _id: "sync_conflict_inventory" })],
+        ],
+      ]),
+    );
   });
 
   it("applies proofless staff-access sync reviews after manager approval", async () => {
@@ -2682,6 +3115,7 @@ describe("cash control deposits", () => {
 
   it("clears duplicate synced closeout reviews after manager rejection", async () => {
     const ctx = createAuthorizedRegisterDepositCtx({
+      operationalEvent: [],
       posLocalSyncConflict: [
         {
           _id: "sync_conflict_closeout",
@@ -2694,8 +3128,12 @@ describe("cash control deposits", () => {
           status: "needs_review",
           summary: "Register session is not open for synced POS closeout.",
           details: {
+            countedCash: 45000,
+            expectedCash: 50000,
             localRegisterSessionId: "session_closed",
+            notes: "cash count issue",
             status: "closed",
+            variance: -5000,
           },
           createdAt: 1,
         },
@@ -2710,8 +3148,12 @@ describe("cash control deposits", () => {
           status: "needs_review",
           summary: "Register session is not open for synced POS closeout.",
           details: {
+            countedCash: 45000,
+            expectedCash: 50000,
             localRegisterSessionId: "session_closed",
+            notes: "cash count issue",
             status: "closed",
+            variance: -5000,
           },
           createdAt: 2,
         },
@@ -2728,7 +3170,8 @@ describe("cash control deposits", () => {
           occurredAt: 2,
           staffProfileId: "staff_1",
           payload: {
-            countedCash: 50000,
+            countedCash: 45000,
+            notes: "cash count issue",
           },
           status: "conflicted",
           submittedAt: 4,
@@ -2824,6 +3267,29 @@ describe("cash control deposits", () => {
         { includeRejectedEvidence: true },
       ),
     ).resolves.toEqual(new Map());
+    expect(ctx.tables.get("operationalEvent")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          actorStaffProfileId: "manager_1",
+          eventType: "register_session_sync_closeout_rejected",
+          localEventId: "event_closeout",
+          message: "Rejected synced closeout for Register 1.",
+          metadata: expect.objectContaining({
+            conflictId: "sync_conflict_closeout",
+            countedCash: 45000,
+            decision: "rejected",
+            expectedCash: 50000,
+            notes: "cash count issue",
+            sequence: 2,
+            syncOrigin: "local_sync",
+            variance: -5000,
+          }),
+          registerSessionId: "session_closed",
+          subjectId: "session_closed",
+          terminalId: "terminal_1",
+        }),
+      ]),
+    );
   });
 
   it("does not report success when a scoped review id is no longer present", async () => {

--- a/packages/athena-webapp/convex/cashControls/deposits.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.ts
@@ -1205,6 +1205,7 @@ export const resolveRegisterSessionSyncReview = mutation({
     }> = [];
     const localEventIds: string[] = [];
     const originalStatuses: string[] = [];
+    const rejectedCloseoutLocalEventIds = new Set<string>();
     const sequences: number[] = [];
     let managerOverrideCount = 0;
     let projectedCloseoutCount = 0;
@@ -1242,9 +1243,22 @@ export const resolveRegisterSessionSyncReview = mutation({
       sequences.push(syncEvent.sequence);
 
       if (decision === "rejected") {
+        const review = classifyRegisterSessionSyncReview(conflict);
+        const hasUnselectedOpenConflictForEvent =
+          requestedConflictIds.size > 0 &&
+          allConflicts.some(
+            (candidate) =>
+              candidate.localEventId === syncEvent.localEventId &&
+              candidate.terminalId === terminalId &&
+              candidate.conflictType !== conflict.conflictType &&
+              candidate.status === "needs_review" &&
+              !requestedConflictIds.has(candidate._id) &&
+              !requestedConflictIds.has(candidate.localEventId),
+          );
         if (
-          syncEvent.status === "conflicted" ||
-          syncEvent.status === "rejected"
+          !hasUnselectedOpenConflictForEvent &&
+          (syncEvent.status === "conflicted" ||
+            syncEvent.status === "rejected")
         ) {
           await localSyncRepository.patchEvent(syncEvent._id, {
             rejectionCode: "manager_rejected",
@@ -1255,6 +1269,46 @@ export const resolveRegisterSessionSyncReview = mutation({
         }
         if (hasConflictRecord) {
           resolvedConflictIds.add(conflict._id as Id<"posLocalSyncConflict">);
+        }
+        if (
+          syncEvent.eventType === "register_closed" &&
+          (review.reviewKind === "register_closeout_variance" ||
+            review.reviewKind === "duplicate_register_closeout") &&
+          !rejectedCloseoutLocalEventIds.has(syncEvent.localEventId)
+        ) {
+          const conflictDetails = conflict.details ?? {};
+          rejectedCloseoutLocalEventIds.add(syncEvent.localEventId);
+          await recordOperationalEventWithCtx(ctx, {
+            ...(args.actorStaffProfileId
+              ? { actorStaffProfileId: args.actorStaffProfileId }
+              : {}),
+            actorUserId: athenaUser._id,
+            eventType: "register_session_sync_closeout_rejected",
+            localEventId: syncEvent.localEventId,
+            message: registerSession.registerNumber
+              ? `Rejected synced closeout for Register ${registerSession.registerNumber}.`
+              : "Rejected synced register closeout.",
+            metadata: {
+              conflictId: conflict._id,
+              conflictType: conflict.conflictType,
+              countedCash: conflictDetails.countedCash,
+              decision: "rejected",
+              expectedCash: conflictDetails.expectedCash,
+              localEventId: syncEvent.localEventId,
+              notes: conflictDetails.notes ?? syncEvent.payload?.notes,
+              originalStatus: syncEvent.status,
+              sequence: syncEvent.sequence,
+              syncOrigin: "local_sync",
+              variance: conflictDetails.variance,
+            },
+            organizationId: store.organizationId,
+            registerSessionId: args.registerSessionId,
+            storeId: args.storeId,
+            subjectId: args.registerSessionId,
+            subjectLabel: registerSession.registerNumber,
+            subjectType: "register_session",
+            terminalId,
+          });
         }
         continue;
       }
@@ -1430,7 +1484,19 @@ export const resolveRegisterSessionSyncReview = mutation({
           .take(100);
 
         for (const conflict of matchingConflicts) {
-          if (conflict.status === "needs_review") {
+          const matchesSelectedConflictType = conflicts.some(
+            (selectedConflict) =>
+              selectedConflict.localEventId === conflict.localEventId &&
+              selectedConflict.terminalId === conflict.terminalId &&
+              selectedConflict.conflictType === conflict.conflictType,
+          );
+          if (
+            conflict.status === "needs_review" &&
+            (requestedConflictIds.size === 0 ||
+              requestedConflictIds.has(conflict._id) ||
+              requestedConflictIds.has(conflict.localEventId) ||
+              matchesSelectedConflictType)
+          ) {
             resolvedConflictIds.add(conflict._id);
           }
         }

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -1283,6 +1283,45 @@ describe("daily operations overview read model", () => {
     });
   });
 
+  it("formats fallback register closeout variance records for the timeline", async () => {
+    const snapshot = await buildDailyOperationsSnapshotWithCtx(
+      buildCtx({
+        dailyClose: [priorClose],
+        dailyOpening: [startedOpening],
+        registerSession: [
+          {
+            _id: "register-1",
+            closeoutRecords: [
+              {
+                actorStaffProfileId: "staff-1",
+                countedCash: 124_500,
+                expectedCash: 144_000,
+                occurredAt: Date.UTC(2026, 4, 8, 20, 45),
+                type: "closed",
+                variance: -19_500,
+              },
+            ],
+            expectedCash: 144_000,
+            openedAt: Date.UTC(2026, 4, 8, 8),
+            openingFloat: 100,
+            organizationId: "org-1",
+            registerNumber: "1",
+            status: "closed",
+            storeId: "store-1",
+          },
+        ],
+        store: [store],
+      }),
+      { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.timeline[0]).toMatchObject({
+      id: "register_closeout:register-1:closed:1778273100000",
+      message: "Register 1 closeout recorded with a cash variance of GH₵-195.",
+      type: "register_session_closed",
+    });
+  });
+
   it("labels and links generic register session close operational events", async () => {
     const snapshot = await buildDailyOperationsSnapshotWithCtx(
       buildCtx({
@@ -1336,6 +1375,58 @@ describe("daily operations overview read model", () => {
         type: "register_session",
       },
       type: "register_session_closed",
+    });
+  });
+
+  it("normalizes raw closeout variance approval events for the timeline", async () => {
+    const snapshot = await buildDailyOperationsSnapshotWithCtx(
+      buildCtx({
+        dailyClose: [priorClose],
+        dailyOpening: [startedOpening],
+        operationalEvent: [
+          {
+            _id: "event-variance-review-requested",
+            createdAt: Date.UTC(2026, 4, 8, 20, 45),
+            eventType: "register_session_variance_review_requested",
+            message: "Variance of -19500 exceeded the closeout approval threshold.",
+            metadata: {
+              countedCash: 124_500,
+              expectedCash: 144_000,
+              variance: -19_500,
+            },
+            registerSessionId: "register-1",
+            storeId: "store-1",
+            subjectId: "register-1",
+            subjectLabel: "1",
+            subjectType: "register_session",
+          },
+        ],
+        registerSession: [
+          {
+            _id: "register-1",
+            expectedCash: 144_000,
+            openedAt: Date.UTC(2026, 4, 8, 8),
+            registerNumber: "1",
+            status: "closing",
+            storeId: "store-1",
+          },
+        ],
+        store: [store],
+      }),
+      { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.timeline[0]).toMatchObject({
+      id: "event-variance-review-requested",
+      message: "Register 1 closeout recorded with a cash variance of GH₵-195.",
+      registerLink: {
+        label: "Register 1",
+        params: {
+          sessionId: "register-1",
+        },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId",
+      },
+      type: "register_session_variance_review_requested",
     });
   });
 
@@ -1455,6 +1546,59 @@ describe("daily operations overview read model", () => {
         type: "register_session",
       },
       type: "register_session_opening_float_corrected",
+    });
+  });
+
+  it("links void approval requests to the transaction and includes the requester", async () => {
+    const snapshot = await buildDailyOperationsSnapshotWithCtx(
+      buildCtx({
+        dailyClose: [priorClose],
+        dailyOpening: [startedOpening],
+        operationalEvent: [
+          {
+            _id: "event-void-requested",
+            actorStaffProfileId: "cashier-1",
+            createdAt: Date.UTC(2026, 4, 8, 15, 7),
+            eventType: "pos_transaction_void_approval_requested",
+            message: "Void requested for Transaction #851031.",
+            metadata: {
+              transactionNumber: "851031",
+            },
+            storeId: "store-1",
+            subjectId: "transaction-851031",
+            subjectLabel: "Transaction #851031",
+            subjectType: "pos_transaction",
+          },
+        ],
+        staffProfile: [
+          {
+            _id: "cashier-1",
+            fullName: "Joyce O.",
+            organizationId: "org-1",
+            storeId: "store-1",
+          },
+        ],
+        store: [store],
+      }),
+      { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.timeline[0]).toMatchObject({
+      id: "event-void-requested",
+      message: "Void requested by Joyce O. for Transaction #851031.",
+      subject: {
+        id: "transaction-851031",
+        label: "Transaction #851031",
+        type: "pos_transaction",
+      },
+      transactionLink: {
+        label: "#851031",
+        params: {
+          transactionId: "transaction-851031",
+        },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId",
+      },
+      type: "pos_transaction_void_approval_requested",
     });
   });
 

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -542,6 +542,7 @@ async function listTimelineEvents(
       ),
       Promise.resolve(
         buildRegisterCloseoutTimelineEvents({
+          currency: store?.currency ?? "GHS",
           endAt: args.endAt,
           operationalCloseoutKeys,
           registerSessions,
@@ -790,7 +791,7 @@ async function mapOperationalTimelineEvent(
         ? metadata.receiptNumber
         : undefined;
   const transactionLink =
-    event.subjectType === "posTransaction" && transactionNumber
+    isPosTransactionSubjectType(event.subjectType) && transactionNumber
       ? {
           label: `#${transactionNumber}`,
           params: {
@@ -848,9 +849,11 @@ async function mapOperationalTimelineEvent(
     message: normalizeTimelineEventMessage(event.message, {
       actorName: actorStaffProfile?.fullName,
       approvalSubjectLabel,
+      currency: args.currency,
       eventType: event.eventType,
       openingFloatLabel,
       registerLabel,
+      variance: numberFromRecord(metadata, "variance"),
     }),
     productLink,
     registerLink,
@@ -866,6 +869,10 @@ async function mapOperationalTimelineEvent(
 
 function isRegisterSessionSubjectType(subjectType: string) {
   return subjectType === "register_session" || subjectType === "registerSession";
+}
+
+function isPosTransactionSubjectType(subjectType: string) {
+  return subjectType === "pos_transaction" || subjectType === "posTransaction";
 }
 
 function isDailyOperationsTimelineAuditEvent(event: {
@@ -896,9 +903,11 @@ function normalizeTimelineEventMessage(
   context?: {
     actorName?: string;
     approvalSubjectLabel?: string;
+    currency?: string;
     eventType?: string;
     openingFloatLabel?: string;
     registerLabel?: string;
+    variance?: number;
   },
 ) {
   const approvalMessage = normalizeApprovalTimelineEventMessage(context);
@@ -917,6 +926,13 @@ function normalizeTimelineEventMessage(
       : `${registerLabel} opening float corrected.`;
   }
 
+  if (context?.eventType === "pos_transaction_void_approval_requested") {
+    const actorName = context.actorName?.trim();
+    return actorName
+      ? message.replace(/^Void requested for\b/i, `Void requested by ${actorName} for`)
+      : message;
+  }
+
   if (/^(?:Offline )?POS register opened\.$/i.test(message)) {
     const registerLabel = context?.registerLabel ?? "POS register";
     const actorName = context?.actorName?.trim();
@@ -932,6 +948,14 @@ function normalizeTimelineEventMessage(
 
   if (/^Register session closed with an exact cash match\.$/i.test(message)) {
     return `${context?.registerLabel ?? "Register session"} closed with an exact cash match.`;
+  }
+
+  if (
+    context?.eventType === "register_session_variance_review_requested" &&
+    typeof context.variance === "number" &&
+    context.variance !== 0
+  ) {
+    return `${context.registerLabel ?? "Register session"} closeout recorded with a cash variance of ${formatTimelineAmount(context.currency ?? "GHS", context.variance)}.`;
   }
 
   const varianceMatch = message.match(
@@ -1087,6 +1111,7 @@ async function listTimelineRegisterSessions(
 }
 
 function buildRegisterCloseoutTimelineEvents(args: {
+  currency: string;
   endAt: number;
   operationalCloseoutKeys: Set<string>;
   registerSessions: Array<Doc<"registerSession">>;
@@ -1119,6 +1144,7 @@ function buildRegisterCloseoutTimelineEvents(args: {
           createdAt: record.occurredAt,
           id: `register_closeout:${session._id}:${record.type}:${record.occurredAt}`,
           message: buildRegisterCloseoutTimelineMessage({
+            currency: args.currency,
             label,
             type: record.type,
             variance: record.variance,
@@ -1142,6 +1168,7 @@ function buildRegisterCloseoutTimelineEvents(args: {
 }
 
 function buildRegisterCloseoutTimelineMessage(args: {
+  currency: string;
   label: string;
   type: "closed" | "reopened";
   variance?: number;
@@ -1151,7 +1178,7 @@ function buildRegisterCloseoutTimelineMessage(args: {
   }
 
   if (args.variance && args.variance !== 0) {
-    return `${args.label} closeout recorded with a cash variance of ${args.variance}.`;
+    return `${args.label} closeout recorded with a cash variance of ${formatTimelineAmount(args.currency, args.variance)}.`;
   }
 
   return `${args.label} closeout recorded with an exact cash match.`;

--- a/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
@@ -1241,6 +1241,9 @@ async function transactionFallsInCompletedDailyClose(
 async function validateTransactionVoidPreconditions(
   ctx: MutationCtx,
   transaction: NonNullable<Awaited<ReturnType<typeof getPosTransactionById>>>,
+  options?: {
+    requireUsableRegisterSession?: boolean;
+  },
 ) {
   if (transaction.status === "void") {
     return userError({
@@ -1301,10 +1304,18 @@ async function validateTransactionVoidPreconditions(
   if (
     !registerSession ||
     registerSession.storeId !== transaction.storeId ||
-    !isUsableRegisterSession(registerSession) ||
     !registerSessionMatchesIdentity(registerSession, {
       terminalId: transaction.terminalId,
     })
+  ) {
+    return userError({
+      code: "precondition_failed",
+      message: "Drawer closed. Open the drawer before voiding this sale.",
+    });
+  }
+  if (
+    options?.requireUsableRegisterSession !== false &&
+    !isUsableRegisterSession(registerSession)
   ) {
     return userError({
       code: "precondition_failed",
@@ -1734,9 +1745,16 @@ export async function resolveTransactionVoidApprovalDecisionWithCtx(
     throw new Error(matchingApprovalRequest.error.message);
   }
 
+  const registerSession = await getRegisterSessionById(
+    ctx,
+    transaction.registerSessionId as Id<"registerSession">,
+  );
   const preconditions = await validateTransactionVoidPreconditions(
     ctx,
     transaction,
+    {
+      requireUsableRegisterSession: registerSession?.status !== "closing",
+    },
   );
   if (preconditions.kind !== "ok") {
     throw new Error(preconditions.error.message);

--- a/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
+++ b/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
@@ -852,6 +852,86 @@ describe("voidTransaction", () => {
     );
   });
 
+  it("applies a queued completed-sale void when the original drawer is closing", async () => {
+    vi.mocked(getRegisterSessionById).mockResolvedValue({
+      _id: "register-1",
+      status: "closing",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    } as never);
+    const ctx = createVoidCtx({
+      approvalRequests: [
+        {
+          _id: "approval-request-1",
+          posTransactionId: "txn-1",
+          requestType: "pos_transaction_void",
+          requestedByStaffProfileId: "staff-1",
+          requestedByUserId: "cashier-user-1",
+          status: "pending",
+          storeId: "store-1",
+          subjectId: "txn-1",
+          subjectType: "pos_transaction",
+        },
+      ],
+    });
+
+    await expect(
+      resolveTransactionVoidApprovalDecisionWithCtx(ctx as never, {
+        approvalProofId: "decision-proof-1" as Id<"approvalProof">,
+        approvalRequestId: "approval-request-1" as Id<"approvalRequest">,
+        decision: "approved",
+        decisionNotes: "Duplicate sale",
+        reviewedByStaffProfileId: "manager-1" as Id<"staffProfile">,
+        reviewedByUserId: "manager-user-1" as Id<"athenaUser">,
+      }),
+    ).resolves.toMatchObject({
+      approvalRequestId: "approval-request-1",
+      transactionId: "txn-1",
+    });
+    expect(recordRetailVoidPaymentAllocations).toHaveBeenCalled();
+    expect(patchPosTransaction).toHaveBeenCalledWith(
+      expect.anything(),
+      "txn-1",
+      expect.objectContaining({ status: "void" }),
+    );
+  });
+
+  it("blocks a queued completed-sale void when the original drawer is closed", async () => {
+    vi.mocked(getRegisterSessionById).mockResolvedValue({
+      _id: "register-1",
+      status: "closed",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    } as never);
+    const ctx = createVoidCtx({
+      approvalRequests: [
+        {
+          _id: "approval-request-1",
+          posTransactionId: "txn-1",
+          requestType: "pos_transaction_void",
+          requestedByStaffProfileId: "staff-1",
+          requestedByUserId: "cashier-user-1",
+          status: "pending",
+          storeId: "store-1",
+          subjectId: "txn-1",
+          subjectType: "pos_transaction",
+        },
+      ],
+    });
+
+    await expect(
+      resolveTransactionVoidApprovalDecisionWithCtx(ctx as never, {
+        approvalProofId: "decision-proof-1" as Id<"approvalProof">,
+        approvalRequestId: "approval-request-1" as Id<"approvalRequest">,
+        decision: "approved",
+        decisionNotes: "Duplicate sale",
+        reviewedByStaffProfileId: "manager-1" as Id<"staffProfile">,
+        reviewedByUserId: "manager-user-1" as Id<"athenaUser">,
+      }),
+    ).rejects.toThrow("Drawer closed. Open the drawer before voiding this sale.");
+    expectNoVoidBusinessSideEffects();
+  });
+
   it("does not apply void side effects when a queued void approval is rejected", async () => {
     const ctx = createVoidCtx({
       approvalRequests: [

--- a/packages/athena-webapp/convex/pos/application/getTransactions.test.ts
+++ b/packages/athena-webapp/convex/pos/application/getTransactions.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "../../_generated/dataModel";
 import {
   getCompletedTransactions,
+  getTodaySummary,
   getTransactionById,
 } from "./queries/getTransactions";
 import {
@@ -11,6 +12,7 @@ import {
   getPosTransactionById,
   getRegisterSessionById,
   listCompletedTransactions,
+  listCompletedTransactionsForDay,
   listTransactionItems,
 } from "../infrastructure/repositories/transactionRepository";
 
@@ -51,6 +53,13 @@ function mockCorrectionHistoryDb(overrides?: {
                 : tableName === "paymentAllocation"
                   ? (overrides?.paymentAllocations ?? [])
               : (overrides?.correctionHistory ?? []),
+          ),
+        take: vi
+          .fn()
+          .mockResolvedValue(
+            tableName === "approvalRequest"
+              ? (overrides?.approvalRequests ?? [])
+              : [],
           ),
       })),
     })),
@@ -240,6 +249,146 @@ describe("getCompletedTransactions", () => {
   });
 });
 
+describe("getTodaySummary", () => {
+  it("summarizes the latest open operating day instead of the server calendar day", async () => {
+    vi.setSystemTime(new Date("2026-06-20T00:49:30.000Z"));
+    vi.mocked(listCompletedTransactionsForDay).mockResolvedValue([
+      {
+        _id: "txn-1" as Id<"posTransaction">,
+        storeId: "store-1" as Id<"store">,
+        total: 20_500,
+      },
+      {
+        _id: "txn-2" as Id<"posTransaction">,
+        storeId: "store-1" as Id<"store">,
+        total: 6_500,
+      },
+    ] as never);
+    vi.mocked(listTransactionItems)
+      .mockResolvedValueOnce([{ quantity: 3 }, { quantity: 1 }] as never)
+      .mockResolvedValueOnce([{ quantity: 2 }] as never);
+    const query = vi.fn((tableName: string) => ({
+      withIndex: vi.fn(() => ({
+        collect: vi.fn().mockResolvedValue([]),
+        take: vi.fn().mockResolvedValue([]),
+        order: vi.fn(() => ({
+          take: vi.fn().mockResolvedValue(
+            tableName === "dailyOpening"
+              ? [
+                  {
+                    _id: "opening-2026-06-19",
+                    operatingDate: "2026-06-19",
+                    status: "started",
+                    storeId: "store-1",
+                  },
+                ]
+              : [],
+          ),
+        })),
+      })),
+    }));
+
+    const result = await getTodaySummary(
+      {
+        db: { query },
+      } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(listCompletedTransactionsForDay).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        endOfDay: Date.parse("2026-06-19T23:59:59.999Z"),
+        startOfDay: Date.parse("2026-06-19T00:00:00.000Z"),
+        storeId: "store-1",
+      },
+    );
+    expect(result).toEqual({
+      averageTransaction: 13_500,
+      date: "2026-06-19",
+      totalItemsSold: 6,
+      totalSales: 27_000,
+      totalTransactions: 2,
+    });
+  });
+
+  it("falls back to the server calendar day when the latest opening is already closed", async () => {
+    vi.setSystemTime(new Date("2026-06-20T00:49:30.000Z"));
+    vi.mocked(listCompletedTransactionsForDay).mockResolvedValue([] as never);
+    const query = vi.fn((tableName: string) => ({
+      withIndex: vi.fn(() => ({
+        collect: vi.fn().mockResolvedValue(
+          tableName === "dailyClose"
+            ? [
+                {
+                  _id: "close-2026-06-19",
+                  lifecycleStatus: "active",
+                  operatingDate: "2026-06-19",
+                  status: "completed",
+                  storeId: "store-1",
+                },
+              ]
+            : [],
+        ),
+        take: vi.fn().mockResolvedValue(
+          tableName === "dailyClose"
+            ? [
+                {
+                  _id: "close-2026-06-19",
+                  lifecycleStatus: "active",
+                  operatingDate: "2026-06-19",
+                  status: "completed",
+                  storeId: "store-1",
+                },
+              ]
+            : [],
+        ),
+        order: vi.fn(() => ({
+          take: vi.fn().mockResolvedValue(
+            tableName === "dailyOpening"
+              ? [
+                  {
+                    _id: "opening-2026-06-19",
+                    operatingDate: "2026-06-19",
+                    status: "started",
+                    storeId: "store-1",
+                  },
+                ]
+              : [],
+          ),
+        })),
+      })),
+    }));
+
+    const result = await getTodaySummary(
+      {
+        db: { query },
+      } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(listCompletedTransactionsForDay).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        endOfDay: Date.parse("2026-06-20T23:59:59.999Z"),
+        startOfDay: Date.parse("2026-06-20T00:00:00.000Z"),
+        storeId: "store-1",
+      },
+    );
+    expect(result).toEqual({
+      averageTransaction: 0,
+      date: "2026-06-20",
+      totalItemsSold: 0,
+      totalSales: 0,
+      totalTransactions: 0,
+    });
+  });
+});
+
 describe("getTransactionById", () => {
   it("ignores legacy transaction workflow trace ids when no session trace is available", async () => {
     vi.mocked(getPosTransactionById).mockResolvedValue({
@@ -311,6 +460,61 @@ describe("getTransactionById", () => {
       expect.objectContaining({
         transactionNumber: "POS-654321",
         hasTrace: false,
+      }),
+    );
+  });
+
+  it("surfaces a pending void approval request for completed transactions", async () => {
+    vi.mocked(getPosTransactionById).mockResolvedValue({
+      _id: "txn-pending-void" as Id<"posTransaction">,
+      storeId: "store-1" as Id<"store">,
+      transactionNumber: "POS-851031",
+      subtotal: 6000,
+      tax: 0,
+      total: 6000,
+      paymentMethod: "cash",
+      payments: [],
+      totalPaid: 6000,
+      status: "completed",
+      completedAt: 100,
+      customerId: undefined,
+      customerInfo: undefined,
+      notes: undefined,
+    } as never);
+    vi.mocked(getCashierById).mockResolvedValue(null as never);
+    vi.mocked(getPosSessionById).mockResolvedValue(null as never);
+    vi.mocked(listTransactionItems).mockResolvedValue([] as never);
+
+    const result = await getTransactionById(
+      {
+        db: mockCorrectionHistoryDb({
+          approvalRequests: [
+            {
+              _id: "approval-request-1",
+              createdAt: 200,
+              posTransactionId: "txn-pending-void",
+              requestType: "pos_transaction_void",
+              requestedByStaffProfileId: "staff-1",
+              status: "pending",
+              storeId: "store-1",
+              subjectId: "txn-pending-void",
+              subjectType: "pos_transaction",
+            },
+          ],
+        }),
+      } as never,
+      {
+        transactionId: "txn-pending-void" as Id<"posTransaction">,
+      },
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        pendingVoidApprovalRequest: {
+          _id: "approval-request-1",
+          createdAt: 200,
+          requestedByStaffProfileId: "staff-1",
+        },
       }),
     );
   });
@@ -457,7 +661,7 @@ describe("getTransactionById", () => {
                 })),
               })),
             });
-            return { collect };
+            return { collect, take: vi.fn().mockResolvedValue([]) };
           }),
         })),
       },

--- a/packages/athena-webapp/convex/pos/application/queries/getTransactions.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/getTransactions.ts
@@ -24,6 +24,8 @@ const ITEM_ADJUSTMENT_EVENT_TYPES = new Set([
   "pos_transaction_item_adjustment_applied",
   "pos_transaction_item_adjusted",
 ]);
+const TRANSACTION_VOID_REQUEST_TYPE = "pos_transaction_void";
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 type AdjustmentMetadata = {
   adjustedTotal?: number;
@@ -134,7 +136,6 @@ async function loadPendingItemAdjustmentApprovals(
     transactionId: Id<"posTransaction">;
   },
 ) {
-  // eslint-disable-next-line @convex-dev/no-collect-in-query -- Transaction detail needs all pending approvals for one transaction in the store.
   const approvalRequests = await ctx.db
     .query("approvalRequest")
     .withIndex("by_storeId_status_posTransactionId", (q) =>
@@ -143,7 +144,7 @@ async function loadPendingItemAdjustmentApprovals(
         .eq("status", "pending")
         .eq("posTransactionId", args.transactionId),
     )
-    .collect();
+    .take(10);
 
   return approvalRequests.filter(
     (request) =>
@@ -152,6 +153,39 @@ async function loadPendingItemAdjustmentApprovals(
         request.subjectId === String(args.transactionId)) ||
         request.metadata?.transactionId === args.transactionId),
   );
+}
+
+async function loadPendingVoidApprovalRequest(
+  ctx: QueryCtx,
+  args: {
+    storeId: Id<"store">;
+    transactionId: Id<"posTransaction">;
+  },
+) {
+  const pendingRequests = await ctx.db
+    .query("approvalRequest")
+    .withIndex("by_storeId_status_posTransactionId", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("status", "pending")
+        .eq("posTransactionId", args.transactionId),
+    )
+    .take(10);
+
+  const request = pendingRequests.find(
+    (candidate) =>
+      candidate.requestType === TRANSACTION_VOID_REQUEST_TYPE &&
+      candidate.subjectType === "pos_transaction" &&
+      candidate.subjectId === args.transactionId,
+  );
+
+  return request
+    ? {
+        _id: request._id,
+        createdAt: request.createdAt,
+        requestedByStaffProfileId: request.requestedByStaffProfileId,
+      }
+    : null;
 }
 
 async function listStaffNames(
@@ -410,6 +444,10 @@ export async function getTransactionById(
       storeId: transaction.storeId,
       transactionId: transaction._id,
     });
+  const pendingVoidApprovalRequest = await loadPendingVoidApprovalRequest(ctx, {
+    storeId: transaction.storeId,
+    transactionId: transaction._id,
+  });
   const receiptDeliveries = await listReceiptDeliveriesForTransaction(ctx, {
     storeId: transaction.storeId,
     transactionId: transaction._id,
@@ -524,6 +562,7 @@ export async function getTransactionById(
     voidApprovalProofId: transaction.voidApprovalProofId,
     voidApprovedByStaffProfileId: transaction.voidApprovedByStaffProfileId,
     voidOperationalEventId: transaction.voidOperationalEventId,
+    pendingVoidApprovalRequest,
     cashier: cashier
       ? {
           _id: cashier._id,
@@ -648,17 +687,14 @@ export async function getTodaySummary(
     storeId: Id<"store">;
   },
 ) {
-  const now = new Date();
-  const startOfDay = new Date(
-    now.getFullYear(),
-    now.getMonth(),
-    now.getDate(),
-  ).getTime();
-  const endOfDay = startOfDay + 24 * 60 * 60 * 1000 - 1;
+  const summaryWindow = await resolveCurrentPosSummaryWindow(ctx, {
+    now: Date.now(),
+    storeId: args.storeId,
+  });
   const todayTransactions = await listCompletedTransactionsForDay(ctx, {
     storeId: args.storeId,
-    startOfDay,
-    endOfDay,
+    startOfDay: summaryWindow.startOfDay,
+    endOfDay: summaryWindow.endOfDay,
   });
 
   const totalTransactions = todayTransactions.length;
@@ -679,6 +715,76 @@ export async function getTodaySummary(
     totalItemsSold,
     averageTransaction:
       totalTransactions > 0 ? totalSales / totalTransactions : 0,
-    date: now.toISOString().split("T")[0],
+    date: summaryWindow.operatingDate,
   };
+}
+
+async function resolveCurrentPosSummaryWindow(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    now: number;
+    storeId: Id<"store">;
+  },
+) {
+  const activeOpening = await findLatestOpenOperatingDay(ctx, {
+    storeId: args.storeId,
+  });
+  const operatingDate =
+    activeOpening?.operatingDate ??
+    new Date(args.now).toISOString().slice(0, 10);
+  const startOfDay = Date.parse(`${operatingDate}T00:00:00.000Z`);
+
+  if (!Number.isFinite(startOfDay)) {
+    const fallbackStart = Date.parse(
+      `${new Date(args.now).toISOString().slice(0, 10)}T00:00:00.000Z`,
+    );
+
+    return {
+      endOfDay: fallbackStart + DAY_MS - 1,
+      operatingDate: new Date(args.now).toISOString().slice(0, 10),
+      startOfDay: fallbackStart,
+    };
+  }
+
+  return {
+    endOfDay: startOfDay + DAY_MS - 1,
+    operatingDate,
+    startOfDay,
+  };
+}
+
+async function findLatestOpenOperatingDay(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    storeId: Id<"store">;
+  },
+) {
+  const startedOpenings = await ctx.db
+    .query("dailyOpening")
+    .withIndex("by_storeId_status_operatingDate", (q) =>
+      q.eq("storeId", args.storeId).eq("status", "started"),
+    )
+    .order("desc")
+    .take(10);
+
+  for (const opening of startedOpenings) {
+    const closes = await ctx.db
+      .query("dailyClose")
+      .withIndex("by_storeId_operatingDate", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("operatingDate", opening.operatingDate),
+      )
+      .take(10);
+    const hasCompletedActiveClose = closes.some(
+      (close) =>
+        close.status === "completed" && close.lifecycleStatus !== "reopened",
+    );
+
+    if (!hasCompletedActiveClose) {
+      return opening;
+    }
+  }
+
+  return null;
 }

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.ts
@@ -64,6 +64,7 @@ export type TerminalHealthAttentionReason = {
     | "cloud_conflict"
     | "cloud_held"
     | "cloud_rejected"
+    | "synced_sale_inventory_review"
     | "local_review"
     | "local_store_unavailable"
     | "sync_failed"
@@ -79,7 +80,7 @@ export type TerminalHealthAttentionActionTarget =
       type: "cash_control_register_session";
       registerSessionId: Id<"registerSession">;
     }
-  | { type: "open_work" }
+  | { label?: string; type: "open_work" }
   | { type: "pos_register" }
   | { type: "pos_settings" };
 
@@ -316,7 +317,7 @@ async function buildTerminalHealthSummary(
     now: number;
   },
 ): Promise<TerminalHealthSummary> {
-  const [runtimeStatus, syncEvidence, registerSessionLink] = await Promise.all([
+  const [runtimeStatus, rawSyncEvidence, registerSessionLink] = await Promise.all([
     getLatestRuntimeStatusForTerminal(ctx, {
       storeId: args.terminal.storeId,
       terminalId: args.terminal._id,
@@ -332,6 +333,10 @@ async function buildTerminalHealthSummary(
       terminalId: args.terminal._id,
     }),
   ]);
+  const syncEvidence = await annotateTerminalSyncEvidenceReviewTargets(ctx, {
+    storeId: args.terminal.storeId,
+    syncEvidence: rawSyncEvidence,
+  });
   const supportRuntimeStatus = await normalizeRuntimeStatusForSupport(ctx, {
     runtimeStatus,
     terminal: args.terminal,
@@ -498,6 +503,7 @@ async function buildTerminalRecoveryPreview(
   return {
     appUpdate: buildTerminalAppUpdatePreview({
       commandStatus,
+      now: args.now,
       runtimeAgeMs: args.runtimeAgeMs,
       runtimeFresh,
       runtimeStatus: args.runtimeStatus,
@@ -527,6 +533,7 @@ async function buildTerminalRecoveryPreview(
 
 function buildTerminalAppUpdatePreview(args: {
   commandStatus: TerminalRecoveryPreview["commandStatus"];
+  now: number;
   runtimeAgeMs: number | null;
   runtimeFresh: boolean;
   runtimeStatus: Doc<"posTerminalRuntimeStatus"> | null;
@@ -539,7 +546,13 @@ function buildTerminalAppUpdatePreview(args: {
     };
   }
 
-  if (!args.runtimeFresh || args.runtimeAgeMs === null) {
+  const observedAt = readNumber(evidence.observedAt);
+  const appUpdateEvidenceFresh =
+    observedAt === undefined || args.runtimeAgeMs === null
+      ? args.runtimeFresh
+      : Math.max(0, args.now - observedAt) <= 2 * 60 * 1000;
+
+  if (!args.runtimeFresh || args.runtimeAgeMs === null || !appUpdateEvidenceFresh) {
     return {
       commandCorrelated: isAppUpdateEvidenceCommandCorrelated(
         evidence,
@@ -547,7 +560,7 @@ function buildTerminalAppUpdatePreview(args: {
       ),
       currentBuildId: readString(evidence.currentBuildId ?? evidence.currentBuildSha),
       evidenceFresh: false,
-      observedAt: readNumber(evidence.observedAt),
+      observedAt,
       pendingBuildId: readString(evidence.pendingBuildId ?? evidence.latestBuildId),
       stagingAssetCount: readNumber(evidence.stagingAssetCount),
       stagingFailedAssetCount: readNumber(evidence.stagingFailedAssetCount),
@@ -568,7 +581,7 @@ function buildTerminalAppUpdatePreview(args: {
     ),
     currentBuildId: readString(evidence.currentBuildId ?? evidence.currentBuildSha),
     evidenceFresh: true,
-    observedAt: readNumber(evidence.observedAt),
+    observedAt,
     pendingBuildId: readString(evidence.pendingBuildId ?? evidence.latestBuildId),
     stagingAssetCount: readNumber(evidence.stagingAssetCount),
     stagingFailedAssetCount: readNumber(evidence.stagingFailedAssetCount),
@@ -1038,7 +1051,7 @@ async function resolveAttentionReasonActionTargets(
   },
 ): Promise<TerminalHealthAttentionReason[]> {
   const registerSessionIdByReasonType =
-    args.attentionReasons.some((reason) => reason.source === "cloud_sync")
+    args.attentionReasons.some(isRegisterSessionReviewReason)
       ? await resolveRegisterSessionTargets(ctx, args)
       : new Map<TerminalHealthAttentionReason["type"], Id<"registerSession"> | null>();
 
@@ -1062,7 +1075,7 @@ async function resolveRegisterSessionTargets(
 ) {
   const uniqueTypes = new Set(
     args.attentionReasons
-      .filter((reason) => reason.source === "cloud_sync")
+      .filter(isRegisterSessionReviewReason)
       .map((reason) => reason.type),
   );
   const entries = await Promise.all(
@@ -1084,6 +1097,15 @@ async function resolveRegisterSessionTargets(
   );
 
   return new Map(entries);
+}
+
+function isRegisterSessionReviewReason(reason: TerminalHealthAttentionReason) {
+  return (
+    reason.source === "cloud_sync" &&
+    (reason.type === "cloud_conflict" ||
+      reason.type === "cloud_held" ||
+      reason.type === "cloud_rejected")
+  );
 }
 
 function getReviewReasonLocalRegisterSessionId(
@@ -1126,6 +1148,8 @@ function getAttentionReasonActionTarget(
   },
 ): TerminalHealthAttentionActionTarget {
   switch (reason.type) {
+    case "synced_sale_inventory_review":
+      return { label: "Review inventory work", type: "open_work" };
     case "cloud_conflict":
     case "cloud_held":
     case "cloud_rejected":
@@ -1146,6 +1170,75 @@ function getAttentionReasonActionTarget(
     case "sync_unavailable":
       return { type: "pos_register" };
   }
+}
+
+async function annotateTerminalSyncEvidenceReviewTargets(
+  ctx: QueryCtx,
+  args: {
+    storeId: Id<"store">;
+    syncEvidence: TerminalSyncEvidence;
+  },
+): Promise<TerminalSyncEvidence> {
+  const unresolvedConflicts = args.syncEvidence.unresolvedConflicts ?? [];
+  const inventoryConflictLocalEventIds = new Set(
+    unresolvedConflicts
+      .filter((conflict) => conflict.conflictType === "inventory")
+      .map((conflict) => conflict.localEventId),
+  );
+  if (
+    inventoryConflictLocalEventIds.size === 0 ||
+    !ctx.db ||
+    typeof ctx.db.query !== "function"
+  ) {
+    return args.syncEvidence;
+  }
+
+  const workItems = await ctx.db
+    .query("operationalWorkItem")
+    .withIndex("by_storeId_type", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("type", "synced_sale_inventory_review"),
+    )
+    .take(200);
+  const openWorkItemByLocalEventId = new Map<
+    string,
+    Doc<"operationalWorkItem">
+  >();
+  for (const workItem of workItems) {
+    if (workItem.status !== "open") {
+      continue;
+    }
+    const localEventId = workItem.metadata?.localEventId;
+    if (
+      typeof localEventId === "string" &&
+      inventoryConflictLocalEventIds.has(localEventId)
+    ) {
+      openWorkItemByLocalEventId.set(localEventId, workItem);
+    }
+  }
+
+  if (openWorkItemByLocalEventId.size === 0) {
+    return args.syncEvidence;
+  }
+
+  return {
+    ...args.syncEvidence,
+    unresolvedConflicts: unresolvedConflicts.map((conflict) => {
+      const workItem = openWorkItemByLocalEventId.get(conflict.localEventId);
+      if (!workItem || conflict.conflictType !== "inventory") {
+        return conflict;
+      }
+      return {
+        ...conflict,
+        reviewTarget: {
+          type: "open_work" as const,
+          workItemId: workItem._id,
+          workItemType: "synced_sale_inventory_review" as const,
+        },
+      };
+    }),
+  };
 }
 
 function deriveTerminalHealth(input: {
@@ -1259,13 +1352,37 @@ function deriveTerminalHealthAttentionReasons(input: {
     });
   }
 
-  if (input.syncEvidence.conflictedCount > 0) {
+  const inventoryReviewCount =
+    input.syncEvidence.unresolvedConflicts?.filter(
+      (conflict) =>
+        conflict.conflictType === "inventory" &&
+        conflict.reviewTarget?.workItemType ===
+          "synced_sale_inventory_review",
+    ).length ?? 0;
+
+  if (inventoryReviewCount > 0) {
     reasons.push({
-      count: input.syncEvidence.conflictedCount,
+      count: inventoryReviewCount,
       latestEventSequence: latestEvent?.sequence,
       latestEventStatus: latestEvent?.status,
       source: "cloud_sync",
-      summary: `${input.syncEvidence.conflictedCount} cloud sync conflict${input.syncEvidence.conflictedCount === 1 ? " needs" : "s need"} review.`,
+      summary: `${inventoryReviewCount} inventory review item${inventoryReviewCount === 1 ? " needs" : "s need"} attention.`,
+      type: "synced_sale_inventory_review",
+    });
+  }
+
+  const conflictedCount = Math.max(
+    0,
+    input.syncEvidence.conflictedCount - inventoryReviewCount,
+  );
+
+  if (conflictedCount > 0) {
+    reasons.push({
+      count: conflictedCount,
+      latestEventSequence: latestEvent?.sequence,
+      latestEventStatus: latestEvent?.status,
+      source: "cloud_sync",
+      summary: `${conflictedCount} cloud sync conflict${conflictedCount === 1 ? " needs" : "s need"} review.`,
       type: "cloud_conflict",
     });
   }

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -2685,6 +2685,129 @@ describe("projectLocalSyncEvent", () => {
     );
   });
 
+  it("does not duplicate-conflict an already projected inventory review sale replay", async () => {
+    const repository = createProjectionRepository({
+      sku: {
+        _id: "sku-1",
+        storeId: "store-1",
+        productId: "product-1",
+        sku: "CAP-1",
+        price: 25,
+        quantityAvailable: 0,
+        inventoryCount: 0,
+        images: [],
+      },
+    });
+    repository.createdPosSessions.push({
+      _id: "pos-session-1",
+      completedAt: 20,
+      createdAt: 20,
+      expiresAt: 20,
+      inventoryHoldMode: "ledger",
+      payments: [
+        {
+          amount: 25,
+          method: "cash",
+          timestamp: 21,
+        },
+      ],
+      registerNumber: "1",
+      registerSessionId: "register-session-1",
+      sessionNumber: "local-session-1",
+      staffProfileId: "staff-1",
+      status: "completed",
+      storeId: "store-1",
+      subtotal: 25,
+      tax: 0,
+      terminalId: "terminal-1",
+      total: 25,
+      transactionId: "transaction-1",
+      updatedAt: 20,
+    });
+    repository.mappings.push(
+      {
+        _id: "mapping-existing-pos-session",
+        storeId: "store-1" as never,
+        terminalId: "terminal-1" as never,
+        localRegisterSessionId: "local-register-1",
+        localEventId: "event-sale-completed-1",
+        localIdKind: "posSession",
+        localId: "local-session-1",
+        cloudTable: "posSession",
+        cloudId: "pos-session-1",
+        createdAt: 1,
+      },
+      {
+        _id: "mapping-existing-transaction",
+        storeId: "store-1" as never,
+        terminalId: "terminal-1" as never,
+        localRegisterSessionId: "local-register-1",
+        localEventId: "event-sale-completed-1",
+        localIdKind: "transaction",
+        localId: "local-txn-1",
+        cloudTable: "posTransaction",
+        cloudId: "transaction-1",
+        createdAt: 1,
+      },
+      {
+        _id: "mapping-existing-receipt",
+        storeId: "store-1" as never,
+        terminalId: "terminal-1" as never,
+        localRegisterSessionId: "local-register-1",
+        localEventId: "event-sale-completed-1",
+        localIdKind: "receipt",
+        localId: "LR-001",
+        cloudTable: "posTransaction",
+        cloudId: "transaction-1",
+        createdAt: 1,
+      },
+    );
+    repository.createdConflicts.push({
+      _id: "conflict-reviewed-inventory",
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      localRegisterSessionId: "local-register-1",
+      localEventId: "event-sale-completed-1",
+      sequence: 2,
+      conflictType: "inventory",
+      status: "needs_review",
+      summary: "Inventory needs manager review for a synced offline sale.",
+      details: {
+        localTransactionId: "local-txn-1",
+        productSkuId: "sku-1",
+        quantityAvailable: 0,
+        requestedQuantity: 1,
+      },
+      createdAt: 1,
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent(),
+      syncEventId: "sync-event-1",
+      submittedByUserId: "athena-user-1" as never,
+      now: 100,
+      options: {
+        allowReviewedInventorySaleProjection: true,
+        reviewedConflictIds: ["conflict-reviewed-inventory"],
+      },
+    });
+
+    expect(result.status).toBe("projected");
+    expect(result.conflicts).toEqual([]);
+    expect(repository.createdConflicts).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          conflictType: "duplicate_local_id",
+          summary: "Local POS session id was reused by a different synced sale.",
+        }),
+      ]),
+    );
+    expect(repository.createdTransactions).toEqual([]);
+    expect(repository.createdServiceWorkItems).toHaveLength(1);
+  });
+
   it("aggregates duplicate SKU lines before validating and patching inventory", async () => {
     const repository = createProjectionRepository({
       sku: {
@@ -3836,6 +3959,27 @@ describe("projectLocalSyncEvent", () => {
         }),
         summary:
           "Register closeout variance requires manager review before synced closeout can be applied.",
+      }),
+    ]);
+    expect(repository.createdOperationalEvents).toEqual([
+      expect.objectContaining({
+        actorStaffProfileId: "staff-1",
+        createdAt: 30,
+        eventType: "register_session_sync_closeout_review_requested",
+        localEventId: "event-register-closed-1",
+        message:
+          "Register 1 closeout submitted with a cash variance of GH₵-0.1. Review before applying it.",
+        metadata: expect.objectContaining({
+          countedCash: 90,
+          expectedCash: 100,
+          localEventId: "event-register-closed-1",
+          notes: "Short drawer",
+          reviewConflictId: "conflict-1",
+          syncOrigin: "local_sync",
+          variance: -10,
+        }),
+        registerSessionId: "register-session-1",
+        terminalId: "terminal-1",
       }),
     ]);
   });

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -1406,17 +1406,31 @@ async function resolveSaleRegisterAndSession(
   }
 
   if (existingPosSession?.transactionId) {
-    const conflict = await createConflict(repository, args, {
-      conflictType: "duplicate_local_id",
-      summary: "Local POS session id was reused by a different synced sale.",
-      details: {
-        localIdKind: "posSession",
-        localId: payload.localPosSessionId,
-        localTransactionId: payload.localTransactionId,
-        originalTransactionId: existingPosSession.transactionId,
+    const existingTransactionMapping = await findMappingForTerminal(
+      repository,
+      args,
+      {
+        localIdKind: "transaction",
+        localId: payload.localTransactionId,
       },
-    });
-    return conflictResult(conflict);
+    );
+    const isSameSyncedSale =
+      existingTransactionMapping?.localEventId === args.event.localEventId &&
+      existingTransactionMapping.cloudId === existingPosSession.transactionId;
+
+    if (!isSameSyncedSale) {
+      const conflict = await createConflict(repository, args, {
+        conflictType: "duplicate_local_id",
+        summary: "Local POS session id was reused by a different synced sale.",
+        details: {
+          localIdKind: "posSession",
+          localId: payload.localPosSessionId,
+          localTransactionId: payload.localTransactionId,
+          originalTransactionId: existingPosSession.transactionId,
+        },
+      });
+      return conflictResult(conflict);
+    }
   }
 
   const terminalRegisterNumber = normalizeOptionalString(
@@ -3261,6 +3275,7 @@ async function projectRegisterClosed(
     roundMoney(variance) !== 0 &&
     args.options?.allowRegisterCloseoutVarianceProjection !== true
   ) {
+    const store = await repository.getStore(args.storeId);
     const conflict = await createConflict(repository, args, {
       conflictType: "permission",
       summary:
@@ -3271,6 +3286,31 @@ async function projectRegisterClosed(
         notes: payload.notes,
         variance,
       },
+    });
+    await repository.createOperationalEvent({
+      storeId: args.storeId,
+      organizationId: store?.organizationId,
+      eventType: "register_session_sync_closeout_review_requested",
+      subjectType: "register_session",
+      subjectId: registerSession._id,
+      message: registerSession.registerNumber
+        ? `Register ${registerSession.registerNumber} closeout submitted with a cash variance of ${formatSaleTotal(store?.currency, variance)}. Review before applying it.`
+        : `Register closeout submitted with a cash variance of ${formatSaleTotal(store?.currency, variance)}. Review before applying it.`,
+      metadata: {
+        countedCash,
+        expectedCash: registerSession.expectedCash,
+        localEventId: args.event.localEventId,
+        notes: payload.notes,
+        registerNumber: registerSession.registerNumber,
+        reviewConflictId: conflict._id,
+        syncOrigin: "local_sync",
+        variance,
+      },
+      createdAt: args.event.occurredAt,
+      actorStaffProfileId: args.event.staffProfileId,
+      registerSessionId: registerSession._id,
+      terminalId: args.terminalId,
+      localEventId: args.event.localEventId,
     });
     return { status: "conflicted", mappings: [], conflicts: [conflict] };
   }

--- a/packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts
@@ -3,6 +3,8 @@ import type { QueryCtx } from "../../../_generated/server";
 
 const SYNC_CONFLICT_LIMIT = 500;
 const MANAGER_REJECTED_SYNC_REVIEW_CODE = "manager_rejected";
+const SYNCED_SALE_INVENTORY_REVIEW_WORK_ITEM_TYPE =
+  "synced_sale_inventory_review";
 export const REGISTER_NOT_OPEN_SYNC_REVIEW_SUMMARY =
   "Register was not open before this sale synced.";
 export const STAFF_ACCESS_SYNC_REVIEW_SUMMARY =
@@ -231,6 +233,75 @@ function stringDetail(
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
+function syncConflictEventKey(
+  conflict: Pick<RegisterSessionSyncConflict, "localEventId" | "terminalId">,
+) {
+  return [conflict.terminalId, conflict.localEventId].join(":");
+}
+
+async function hasInventoryReviewWorkItemForProjectedSale(
+  ctx: Pick<QueryCtx, "db">,
+  storeId: Id<"store">,
+  conflict: Doc<"posLocalSyncConflict">,
+) {
+  if (
+    classifyRegisterSessionSyncReview(conflict).reviewKind !==
+    "inventory_review"
+  ) {
+    return false;
+  }
+
+  const syncEvent = await ctx.db
+    .query("posLocalSyncEvent")
+    .withIndex("by_store_terminal_localEvent", (q) =>
+      q
+        .eq("storeId", conflict.storeId)
+        .eq("terminalId", conflict.terminalId)
+        .eq("localEventId", conflict.localEventId),
+    )
+    .unique();
+  if (
+    syncEvent?.eventType !== "sale_completed" ||
+    typeof syncEvent.projectedAt !== "number"
+  ) {
+    return false;
+  }
+
+  const localTransactionId =
+    stringDetail(conflict.details, "localTransactionId") ??
+    stringDetail(syncEvent.payload, "localTransactionId");
+  const receiptNumber = stringDetail(syncEvent.payload, "receiptNumber");
+  const inventoryReviewWorkItems = await ctx.db
+    .query("operationalWorkItem")
+    .withIndex("by_storeId_type", (q) =>
+      q
+        .eq("storeId", storeId)
+        .eq("type", SYNCED_SALE_INVENTORY_REVIEW_WORK_ITEM_TYPE),
+    )
+    .take(SYNC_CONFLICT_LIMIT);
+
+  return inventoryReviewWorkItems.some((workItem) => {
+    if (workItem.status !== "open") {
+      return false;
+    }
+
+    const metadata = workItem.metadata ?? {};
+    const metadataLocalRegisterSessionId =
+      typeof metadata.localRegisterSessionId === "string"
+        ? metadata.localRegisterSessionId
+        : null;
+
+    return (
+      metadata.localEventId === conflict.localEventId ||
+      (localTransactionId !== null &&
+        metadata.localTransactionId === localTransactionId) ||
+      (receiptNumber !== null &&
+        metadata.receiptNumber === receiptNumber &&
+        metadataLocalRegisterSessionId === conflict.localRegisterSessionId)
+    );
+  });
+}
+
 function recordDetail(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -428,8 +499,34 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
             .take(SYNC_CONFLICT_LIMIT)
         : Promise.resolve([]),
     ]);
+  const projectedInventoryReviewResults = await Promise.all(
+    needsReviewConflicts.map(async (conflict) => ({
+      conflict,
+      hasInventoryWorkItem:
+        await hasInventoryReviewWorkItemForProjectedSale(ctx, storeId, conflict),
+    })),
+  );
+  const projectedInventoryReviewEventKeys = new Set(
+    projectedInventoryReviewResults
+      .filter((result) => result.hasInventoryWorkItem)
+      .map((result) => syncConflictEventKey(result.conflict)),
+  );
+  const activeNeedsReviewConflicts = projectedInventoryReviewResults
+    .filter((result) => !result.hasInventoryWorkItem)
+    .map((result) => result.conflict);
+  const openConflictEventKeys = new Set(
+    activeNeedsReviewConflicts.map(syncConflictEventKey),
+  );
   const staleResolvedConflicts = await Promise.all(
     resolvedConflicts.map(async (conflict) => {
+      const conflictEventKey = syncConflictEventKey(conflict);
+      if (
+        openConflictEventKeys.has(conflictEventKey) ||
+        projectedInventoryReviewEventKeys.has(conflictEventKey)
+      ) {
+        return null;
+      }
+
       const syncEvent = await ctx.db
         .query("posLocalSyncEvent")
         .withIndex("by_store_terminal_localEvent", (q) =>
@@ -463,7 +560,7 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
     }),
   );
   const conflicts: RegisterSessionSyncConflict[] = [
-    ...needsReviewConflicts,
+    ...activeNeedsReviewConflicts,
     ...staleResolvedConflicts.filter(
       (conflict): conflict is Doc<"posLocalSyncConflict"> => conflict !== null,
     ),

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts
@@ -807,6 +807,56 @@ describe("terminal command service", () => {
     expect(result.verifiedCommandIds).toEqual(["command-1"]);
   });
 
+  it("waits for post-apply runtime evidence before verifying app update commands", async () => {
+    const repository = buildRepository({
+      commands: [
+        buildCommand({
+          commandType: "update_app",
+          expectedEvidence: {
+            appUpdateCommandExecutionId: "execution-1",
+          },
+          status: "completed",
+          verificationStatus: "runtime_verification_ready",
+        }),
+      ],
+    });
+
+    const applying = await verifyTerminalRecoveryCommandsFromRuntime(repository, {
+      runtimeStatus: buildRuntimeStatus({
+        appUpdate: {
+          canApply: false,
+          commandExecutionId: "execution-1",
+          detectorStatus: "ok",
+          observedAt: now,
+          status: "applying",
+        },
+        receivedAt: now,
+      }),
+      storeId,
+      terminalId,
+      verifiedAt: now,
+    });
+    expect(applying.verifiedCommandIds).toEqual([]);
+
+    const current = await verifyTerminalRecoveryCommandsFromRuntime(repository, {
+      runtimeStatus: buildRuntimeStatus({
+        appUpdate: {
+          canApply: false,
+          commandExecutionId: "execution-1",
+          detectorStatus: "ok",
+          observedAt: now,
+          status: "current",
+        },
+        receivedAt: now,
+      }),
+      storeId,
+      terminalId,
+      verifiedAt: now,
+    });
+
+    expect(current.verifiedCommandIds).toEqual(["command-1"]);
+  });
+
   it("verifies cleared drawer authority when runtime omits the healthy drawer section", async () => {
     const repository = buildRepository({
       commands: [

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts
@@ -359,17 +359,18 @@ function runtimeMatchesExpectedEvidence(
   runtimeStatus: Doc<"posTerminalRuntimeStatus">,
   expectedEvidence: TerminalRecoveryExpectedEvidence,
 ) {
+  const appUpdateEvidence = getRuntimeAppUpdateEvidence(runtimeStatus);
   if (
     expectedEvidence.appUpdateStatus !== undefined &&
-    getRuntimeAppUpdateEvidence(runtimeStatus).status !==
-      expectedEvidence.appUpdateStatus
+    appUpdateEvidence.status !== expectedEvidence.appUpdateStatus
   ) {
     return false;
   }
   if (
     expectedEvidence.appUpdateCommandExecutionId !== undefined &&
-    getRuntimeAppUpdateEvidence(runtimeStatus).commandExecutionId !==
-      expectedEvidence.appUpdateCommandExecutionId
+    (appUpdateEvidence.commandExecutionId !==
+      expectedEvidence.appUpdateCommandExecutionId ||
+      appUpdateEvidence.status === "applying")
   ) {
     return false;
   }

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -845,6 +845,55 @@ describe("terminal health summaries", () => {
     });
   });
 
+  it("ages preserved app-update evidence independently from fresh runtime check-ins", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(getLatestRuntimeStatusForTerminal).mockResolvedValue(
+      buildPersistedRuntimeStatus({
+        appUpdate: {
+          canApply: true,
+          currentBuildId: "build-current",
+          detectorStatus: "ok",
+          observedAt: 100,
+          pendingBuildId: "build-next",
+          stagingStatus: "unstaged",
+          status: "update_ready_unstaged",
+        },
+        receivedAt: 130_000,
+        reportedAt: 130_000,
+      } as never),
+    );
+    vi.mocked(getTerminalSyncEvidence).mockResolvedValue({
+      latestEvent: null,
+      sampledEventCount: 0,
+      acceptedCount: 0,
+      projectedCount: 0,
+      conflictedCount: 0,
+      heldCount: 0,
+      rejectedCount: 0,
+      unresolvedConflictCount: 0,
+      unresolvedConflicts: [],
+    });
+
+    const result = await getTerminalHealthSummary(
+      { db: null as never } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        now: 130_010,
+      },
+    );
+
+    expect(result?.runtimeAgeMs).toBe(10);
+    expect(result?.recoveryPreview?.runtimeFresh).toBe(true);
+    expect(result?.recoveryPreview?.appUpdate).toEqual(
+      expect.objectContaining({
+        evidenceFresh: false,
+        observedAt: 100,
+        status: "stale",
+      }),
+    );
+  });
+
   it("loads sampled sync evidence for terminal detail", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
     vi.mocked(getLatestRuntimeStatusForTerminal).mockResolvedValue(
@@ -1186,6 +1235,96 @@ describe("terminal health summaries", () => {
           type: "cash_control_register_session",
         },
         type: "cloud_conflict",
+      }),
+    ]);
+  });
+
+  it("routes projected inventory review conflicts to operations work", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(getLatestRuntimeStatusForTerminal).mockResolvedValue(null);
+    vi.mocked(getTerminalSyncEvidence).mockResolvedValue({
+      latestEvent: {
+        localEventId: "event-sale-completed-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 26,
+        eventType: "sale_completed",
+        status: "conflicted",
+        occurredAt: 120,
+        submittedAt: 130,
+      },
+      latestReviewEvent: {
+        localEventId: "event-sale-completed-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 26,
+        eventType: "sale_completed",
+        status: "conflicted",
+      },
+      sampledEventCount: 1,
+      acceptedCount: 0,
+      projectedCount: 1,
+      conflictedCount: 1,
+      heldCount: 0,
+      rejectedCount: 0,
+      unresolvedConflictCount: 1,
+      unresolvedConflicts: [
+        {
+          _id: "conflict-1" as Id<"posLocalSyncConflict">,
+          conflictType: "inventory",
+          createdAt: 140,
+          localEventId: "event-sale-completed-1",
+          localRegisterSessionId: "local-register-1",
+          sequence: 26,
+          summary: "Inventory needs manager review for a synced offline sale.",
+        },
+      ],
+    });
+
+    const result = await getTerminalHealthSummary(
+      {
+        db: {
+          query: vi.fn((tableName: string) => ({
+            withIndex: vi.fn(() => {
+              const query = {
+                order: vi.fn(() => query),
+                take: vi.fn().mockResolvedValue(
+                  tableName === "operationalWorkItem"
+                    ? [
+                        {
+                          _id: "work-item-1" as Id<"operationalWorkItem">,
+                          metadata: {
+                            localEventId: "event-sale-completed-1",
+                          },
+                          status: "open",
+                          storeId: "store-1",
+                          type: "synced_sale_inventory_review",
+                        },
+                      ]
+                    : [],
+                ),
+              };
+              return query;
+            }),
+          })),
+        },
+      } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        now: 220,
+      },
+    );
+
+    expect(resolveTerminalRegisterSessionActionTarget).not.toHaveBeenCalled();
+    expect(result?.attentionReasons).toEqual([
+      expect.objectContaining({
+        actionTarget: {
+          label: "Review inventory work",
+          type: "open_work",
+        },
+        count: 1,
+        source: "cloud_sync",
+        summary: "1 inventory review item needs attention.",
+        type: "synced_sale_inventory_review",
       }),
     ]);
   });

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
@@ -70,6 +70,47 @@ describe("terminalRepository runtime status", () => {
     expect(ctx.db.insert).not.toHaveBeenCalled();
   });
 
+  it("preserves last-known app-update evidence when a newer runtime report omits it", async () => {
+    const appUpdate = {
+      canApply: true,
+      currentBuildId: "build-current",
+      detectorStatus: "ok",
+      observedAt: 200,
+      pendingBuildId: "build-next",
+      stagingStatus: "unstaged",
+      status: "update_ready_unstaged",
+    } as const;
+    const ctx = buildCtx({
+      posTerminalRuntimeStatus: [
+        buildRuntimeStatus({
+          appUpdate,
+          reportedAt: 200,
+          receivedAt: 210,
+        }),
+      ],
+    });
+    const input = {
+      ...buildRuntimeStatus(),
+      appUpdate: undefined,
+      reportedAt: 250,
+      receivedAt: 260,
+    };
+
+    const result = await upsertLatestRuntimeStatus(ctx as never, input);
+
+    expect(result).toBe("runtime-status-1");
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "posTerminalRuntimeStatus",
+      "runtime-status-1",
+      expect.objectContaining({
+        appUpdate,
+        reportedAt: 250,
+        receivedAt: 260,
+      }),
+    );
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
   it("ignores delayed older runtime status reports for the latest row", async () => {
     const ctx = buildCtx({
       posTerminalRuntimeStatus: [

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
@@ -110,11 +110,29 @@ export async function upsertLatestRuntimeStatus(
       return existing._id;
     }
 
-    await ctx.db.patch("posTerminalRuntimeStatus", existing._id, input);
+    await ctx.db.patch(
+      "posTerminalRuntimeStatus",
+      existing._id,
+      mergeRuntimeStatusPatch(existing, input),
+    );
     return existing._id;
   }
 
   return ctx.db.insert("posTerminalRuntimeStatus", omitUndefined(input));
+}
+
+function mergeRuntimeStatusPatch(
+  existing: Doc<"posTerminalRuntimeStatus">,
+  input: Omit<Doc<"posTerminalRuntimeStatus">, "_id" | "_creationTime">,
+) {
+  if (input.appUpdate !== undefined || existing.appUpdate === undefined) {
+    return input;
+  }
+
+  return {
+    ...input,
+    appUpdate: existing.appUpdate,
+  };
 }
 
 function omitUndefined<T extends Record<string, unknown>>(input: T) {
@@ -154,6 +172,11 @@ export type TerminalSyncEvidence = {
     createdAt: number;
     localEventId: string;
     localRegisterSessionId: string;
+    reviewTarget?: {
+      type: "open_work";
+      workItemId: Id<"operationalWorkItem">;
+      workItemType: "synced_sale_inventory_review";
+    };
     sequence: number;
     summary: string;
   }>;

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -1279,7 +1279,7 @@ describe("POS terminal public mutations", () => {
     assertConformsToExportedReturns(getTerminalHealthSummary as never, summary);
   });
 
-  it("validates representative terminal public command results against exported return validators", () => {
+  it("validates representative terminal public read and command results against exported return validators", () => {
     const terminal = buildPublicTerminal();
     const provisionedTerminal = {
       ...terminal,

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -250,6 +250,11 @@ const terminalSyncEvidenceReturnValidator = v.object({
     createdAt: v.number(),
     localEventId: v.string(),
     localRegisterSessionId: v.string(),
+    reviewTarget: v.optional(v.object({
+      type: v.literal("open_work"),
+      workItemId: v.id("operationalWorkItem"),
+      workItemType: v.literal("synced_sale_inventory_review"),
+    })),
     sequence: v.number(),
     summary: v.string(),
   }))),
@@ -265,6 +270,7 @@ const terminalHealthActionTargetReturnValidator = v.union(
   }),
   v.object({
     type: v.literal("open_work"),
+    label: v.optional(v.string()),
   }),
   v.object({
     type: v.literal("pos_register"),
@@ -299,6 +305,7 @@ const terminalHealthAttentionReasonReturnValidator = v.object({
     v.literal("cloud_conflict"),
     v.literal("cloud_held"),
     v.literal("cloud_rejected"),
+    v.literal("synced_sale_inventory_review"),
     v.literal("local_review"),
     v.literal("local_store_unavailable"),
     v.literal("sync_failed"),

--- a/packages/athena-webapp/convex/pos/public/transactions.test.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.test.ts
@@ -16,6 +16,7 @@ import {
   voidTransaction,
 } from "./transactions";
 import type { Id } from "../../_generated/dataModel";
+import { assertConformsToExportedReturns } from "../../lib/returnValidatorContract";
 import * as athenaUserAuth from "../../lib/athenaUserAuth";
 import * as correctionCommands from "../application/commands/correctTransaction";
 import * as itemAdjustmentCommands from "../application/commands/adjustTransactionItems";
@@ -74,6 +75,36 @@ beforeEach(() => {
 });
 
 describe("POS public transaction query validators", () => {
+  it("validates representative public transaction results against exported return validators", () => {
+    const validationError = {
+      kind: "user_error" as const,
+      error: {
+        code: "validation_failed" as const,
+        message: "Validation failed.",
+      },
+    };
+
+    assertConformsToExportedReturns(completeTransaction, validationError);
+    assertConformsToExportedReturns(getCompletedTransactions, []);
+    assertConformsToExportedReturns(getTransactionById, null);
+    assertConformsToExportedReturns(voidTransaction, validationError);
+    assertConformsToExportedReturns(createTransactionFromSession, validationError);
+    assertConformsToExportedReturns(correctTransactionCustomer, validationError);
+    assertConformsToExportedReturns(
+      correctTransactionPaymentMethod,
+      validationError,
+    );
+    assertConformsToExportedReturns(adjustTransactionItems, validationError);
+    assertConformsToExportedReturns(getRecentTransactionsWithCustomers, []);
+    assertConformsToExportedReturns(getTodaySummary, {
+      averageTransaction: 0,
+      date: "2026-06-19",
+      totalItemsSold: 0,
+      totalSales: 0,
+      totalTransactions: 0,
+    });
+  });
+
   it("allows payment correction to return inline approval requirements", () => {
     const validator = parseValidator(exportReturns(correctTransactionPaymentMethod));
 

--- a/packages/athena-webapp/convex/pos/public/transactions.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.ts
@@ -488,6 +488,14 @@ export const getTransactionById = query({
       voidApprovalProofId: v.optional(v.id("approvalProof")),
       voidApprovedByStaffProfileId: v.optional(v.id("staffProfile")),
       voidOperationalEventId: v.optional(v.id("operationalEvent")),
+      pendingVoidApprovalRequest: v.union(
+        v.null(),
+        v.object({
+          _id: v.id("approvalRequest"),
+          createdAt: v.number(),
+          requestedByStaffProfileId: v.optional(v.id("staffProfile")),
+        }),
+      ),
       cashier: v.union(
         v.null(),
         v.object({

--- a/packages/athena-webapp/src/components/app-update/UpdateReadyBanner.test.tsx
+++ b/packages/athena-webapp/src/components/app-update/UpdateReadyBanner.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -88,6 +89,7 @@ function renderWithUpdateProviders(
 
 describe("UpdateReadyBanner", () => {
   beforeEach(() => {
+    vi.stubGlobal("BroadcastChannel", undefined);
     toastMock.show.mockReset();
     toastMock.message.mockReset();
     toastMock.custom.mockReset();
@@ -124,9 +126,11 @@ describe("UpdateReadyBanner", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "mark ready" }));
     fireEvent.click(screen.getByRole("button", { name: "Update" }));
-    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+    const applyingButton = screen.getByRole("button", { name: "Update" });
+    fireEvent.click(applyingButton);
 
     expect(screen.getByLabelText("Update ready")).toBeInTheDocument();
+    expect(applyingButton.querySelector("svg")).not.toHaveClass("animate-spin");
     expect(reload).toHaveBeenCalledTimes(1);
     expect(toastMock.message).not.toHaveBeenCalled();
   });
@@ -179,7 +183,8 @@ describe("UpdateReadyBanner", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("warns about incomplete staging while allowing a manual refresh", () => {
+  it("warns about incomplete staging while allowing a manual refresh", async () => {
+    const user = userEvent.setup();
     const reload = vi.fn();
     renderWithUpdateProviders(
       <>
@@ -194,13 +199,23 @@ describe("UpdateReadyBanner", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "mark ready" }));
 
-    expect(screen.getByText("Update ready.")).toBeInTheDocument();
+    expect(screen.getByText("Update ready")).toBeInTheDocument();
     expect(
       screen.queryByText("Some files were not cached for offline use."),
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Update cache details" }),
-    ).toBeInTheDocument();
+    const detailsTrigger = screen.getByRole("button", {
+      name: "Update cache details",
+    });
+    expect(detailsTrigger).toBeInTheDocument();
+    await user.hover(detailsTrigger);
+    const tooltipContent = (
+      await screen.findAllByText("Some files were not cached for offline use.")
+    ).find((element) => element.classList.contains("w-72"));
+    expect(tooltipContent).toHaveClass(
+      "w-72",
+      "whitespace-normal",
+      "text-left",
+    );
     fireEvent.click(screen.getByRole("button", { name: "Update" }));
     expect(reload).toHaveBeenCalledTimes(1);
   });

--- a/packages/athena-webapp/src/components/app-update/UpdateReadyBanner.tsx
+++ b/packages/athena-webapp/src/components/app-update/UpdateReadyBanner.tsx
@@ -67,10 +67,7 @@ export function UpdateReadyBanner() {
           type="button"
           variant="ghost"
         >
-          <Download
-            aria-hidden="true"
-            className={cn(isApplying && "animate-spin")}
-          />
+          <Download aria-hidden="true" />
           Update
         </Button>
       ) : undefined,
@@ -111,7 +108,7 @@ export function UpdateReadyBanner() {
                       <Info aria-hidden="true" className="size-4" />
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent className="max-w-64 text-xs leading-5">
+                  <TooltipContent className="w-72 max-w-[calc(100vw-2rem)] whitespace-normal text-left text-xs leading-5">
                     {bannerContent.tooltip}
                   </TooltipContent>
                 </Tooltip>
@@ -128,10 +125,7 @@ export function UpdateReadyBanner() {
             type="button"
             variant="ghost"
           >
-            <Download
-              aria-hidden="true"
-              className={cn(isApplying && "animate-spin")}
-            />
+            <Download aria-hidden="true" />
             Update
           </Button>
         ) : null}
@@ -154,7 +148,7 @@ function getUpdateReadyBannerContent(
       case "asset-staging-failed":
       case "service-worker-error":
         return {
-          message: "Update ready.",
+          message: "Update ready",
           tooltip: "Some files were not cached for offline use.",
         };
       case "service-worker-timeout":

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -1198,7 +1198,7 @@ describe("RegisterSessionViewContent", () => {
     await user.click(screen.getByRole("button", { name: /Receipt #939540/i }));
 
     expect(screen.getByText("None recorded")).toBeInTheDocument();
-    expect(screen.getByText("Inventory review")).toBeInTheDocument();
+    expect(screen.getAllByText("Inventory review").length).toBeGreaterThan(0);
     expect(screen.getByText("Requested 2")).toBeInTheDocument();
     expect(screen.getByText("Available after holds 1")).toBeInTheDocument();
     expect(screen.getByText("Active holds 1")).toBeInTheDocument();
@@ -1250,6 +1250,146 @@ describe("RegisterSessionViewContent", () => {
       registerSessionId: "session-1",
       reviewConflictIds: ["sync_conflict_inventory"],
     });
+  });
+
+  it("shows only the duplicate rejection decision for duplicate synced sale reviews", async () => {
+    const user = userEvent.setup();
+    const onAuthenticateStaff = vi.fn().mockResolvedValue(
+      ok({
+        activeRoles: ["manager"],
+        staffProfile: { fullName: "Ato Kofi" },
+        staffProfileId: "manager-1",
+      }),
+    );
+    const onResolveSyncReview = vi
+      .fn()
+      .mockResolvedValue(
+        ok({ action: "rejected", projectedCount: 0, resolvedCount: 1 }),
+      );
+
+    render(
+      <RegisterSessionViewContent
+        currency="GHS"
+        isLoading={false}
+        onRecordDeposit={vi.fn()}
+        {...closeoutHandlers}
+        onAuthenticateStaff={onAuthenticateStaff}
+        onResolveSyncReview={onResolveSyncReview}
+        registerSessionSnapshot={{
+          ...baseSnapshot,
+          registerSession: {
+            ...baseSnapshot.registerSession,
+            localSyncStatus: {
+              status: "needs_review",
+              reconciliationItems: [
+                {
+                  actionPolicy: "apply_or_reject",
+                  id: "sync_conflict_inventory",
+                  inventoryReview: {
+                    availableInventoryCount: 1,
+                    productSkuId: "sku-hair-dryer",
+                    quantityAvailable: 1,
+                    quantityAvailableAfterHolds: 1,
+                    requestedQuantity: 2,
+                  },
+                  reviewKind: "inventory_review",
+                  sale: {
+                    itemCount: 8,
+                    items: [
+                      {
+                        name: "Promaxgold 3000w Hair Dryer",
+                        productSkuId: "sku-hair-dryer",
+                        quantity: 2,
+                        sku: "KK38-E2Z-E9V",
+                        total: 36000,
+                      },
+                    ],
+                    occurredAt: Date.parse("2026-06-19T10:52:00Z"),
+                    paymentMethods: ["mobile_money"],
+                    receiptNumber: "8707507",
+                    staffName: "Joyce O.",
+                    total: 18500,
+                    totalPaid: 18500,
+                  },
+                  sequence: 26,
+                  status: "needs_review",
+                  summary:
+                    "Inventory needs manager review for a synced offline sale.",
+                  type: "inventory",
+                },
+                {
+                  actionPolicy: "reject_only",
+                  id: "sync_conflict_duplicate",
+                  localEventId: "event-duplicate-sale",
+                  reviewKind: "unknown",
+                  sale: {
+                    itemCount: 8,
+                    items: [
+                      {
+                        name: "Promaxgold 3000w Hair Dryer",
+                        productSkuId: "sku-hair-dryer",
+                        quantity: 2,
+                        sku: "KK38-E2Z-E9V",
+                        total: 36000,
+                      },
+                    ],
+                    occurredAt: Date.parse("2026-06-19T10:52:00Z"),
+                    paymentMethods: ["mobile_money"],
+                    receiptNumber: "8707507",
+                    staffName: "Joyce O.",
+                    total: 18500,
+                    totalPaid: 18500,
+                  },
+                  sequence: 10,
+                  status: "needs_review",
+                  summary:
+                    "Local POS session id was reused by a different synced sale.",
+                  type: "duplicate_local_id",
+                },
+              ],
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("Review decisions")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Reject reviewed sale activity" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /Receipt #8707507/i }),
+    );
+
+    expect(screen.getByText("Review decisions")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Apply inventory review item" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Reject inventory review item" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Apply duplicate review item" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Reject duplicate review item" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm staff for Reject duplicate review item",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(onResolveSyncReview).toHaveBeenNthCalledWith(1, {
+        actorStaffProfileId: "manager-1",
+        decision: "rejected",
+        registerSessionId: "session-1",
+        reviewConflictIds: ["sync_conflict_duplicate"],
+      }),
+    );
   });
 
   it("approves synced register review items after manager sign-in", async () => {
@@ -2671,7 +2811,11 @@ describe("RegisterSessionViewContent", () => {
       screen.getByLabelText("Manager closeout notes"),
       "Deposit variance approved.",
     );
-    await user.click(screen.getByRole("button", { name: "Approve variance" }));
+    const approveVarianceButton = screen.getByRole("button", {
+      name: "Approve variance",
+    });
+    expect(approveVarianceButton).toHaveClass("bg-action-workflow");
+    await user.click(approveVarianceButton);
     await user.click(
       screen.getByRole("button", {
         name: "Confirm staff for Approve variance",

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -230,6 +230,12 @@ type ResolveSyncReviewArgs = {
   reviewConflictIds?: string[];
 };
 
+type ResolveSyncReviewDecisionOptions = {
+  approveLabel?: string;
+  rejectLabel?: string;
+  reviewConflictIds?: string[];
+};
+
 type ResolveSyncReviewResult = NormalizedCommandResult<{
   action?: "already_resolved" | "resolved" | "rejected";
   projectedCount?: number;
@@ -742,6 +748,7 @@ function SyncReviewTimeline({
 type SyncReviewSaleSummary = NonNullable<PosReconciliationItem["sale"]> & {
   inventoryReviews: NonNullable<PosReconciliationItem["inventoryReview"]>[];
   reasons: string[];
+  reviewItems: PosReconciliationItem[];
   sequences: number[];
 };
 
@@ -772,6 +779,7 @@ function getSyncReviewSaleSummaries(items: PosReconciliationItem[]) {
       ...item.sale,
       inventoryReviews: [],
       reasons: [],
+      reviewItems: [],
       sequences: [],
     };
 
@@ -798,6 +806,7 @@ function getSyncReviewSaleSummaries(items: PosReconciliationItem[]) {
 
     salesByKey.set(key, {
       ...nextSale,
+      reviewItems: [...nextSale.reviewItems, item],
       sequences: nextSale.sequences.sort((left, right) => left - right),
     });
   }
@@ -959,11 +968,18 @@ function InventoryReviewList({
 
 function SalesUnderReviewList({
   currency,
+  isResolving,
+  onReviewDecision,
   orgUrlSlug,
   sales,
   storeUrlSlug,
 }: {
   currency: string;
+  isResolving?: boolean;
+  onReviewDecision?: (
+    decision: "approved" | "rejected",
+    options?: ResolveSyncReviewDecisionOptions,
+  ) => void;
   orgUrlSlug?: string;
   sales: SyncReviewSaleSummary[];
   storeUrlSlug?: string;
@@ -1168,12 +1184,111 @@ function SalesUnderReviewList({
                     sale={sale}
                     storeUrlSlug={storeUrlSlug}
                   />
+                  {onReviewDecision && sale.reviewItems.length > 0 ? (
+                    <RegisterSyncReviewItemDecisionList
+                      isResolving={isResolving}
+                      items={sale.reviewItems}
+                      onReviewDecision={onReviewDecision}
+                    />
+                  ) : null}
                 </div>
               </AccordionContent>
             </AccordionItem>
           );
         })}
       </Accordion>
+    </div>
+  );
+}
+
+function RegisterSyncReviewItemDecisionList({
+  isResolving,
+  items,
+  onReviewDecision,
+}: {
+  isResolving?: boolean;
+  items: PosReconciliationItem[];
+  onReviewDecision: (
+    decision: "approved" | "rejected",
+    options?: ResolveSyncReviewDecisionOptions,
+  ) => void;
+}) {
+  const duplicateItems = items.filter(isDuplicateLocalIdRegisterSyncReviewItem);
+  const decisionItems =
+    duplicateItems.length > 0 ? duplicateItems : items;
+  const actionableItems = decisionItems.filter((item) => item.id);
+
+  if (actionableItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-layout-xs">
+      <div className="space-y-1">
+        <p className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+          Review decisions
+        </p>
+        <p className="text-xs leading-5 text-muted-foreground">
+          Resolve only the review item that matches this sale decision.
+        </p>
+      </div>
+      <div className="grid gap-layout-xs">
+        {actionableItems.map((item, index) => {
+          const labels = getRegisterSyncReviewItemActionLabels(item);
+          const reviewConflictIds = item.id ? [item.id] : undefined;
+
+          return (
+            <article
+              className="grid gap-layout-sm rounded-md border border-border/70 bg-background/80 p-layout-sm sm:grid-cols-[minmax(0,1fr)_auto]"
+              key={item.id ?? `${item.type ?? "review"}-${index}`}
+            >
+              <div className="min-w-0 space-y-1">
+                <p className="text-xs font-medium text-foreground">
+                  {formatPosReconciliationType(item.type, item)}
+                </p>
+                <p className="text-xs leading-5 text-muted-foreground">
+                  {getRegisterSyncReviewItemSummary(item)}
+                </p>
+              </div>
+              <div className="flex flex-col gap-layout-xs sm:flex-row sm:items-center">
+                {isApprovableRegisterSyncReviewItem(item) ? (
+                  <LoadingButton
+                    className="w-full sm:w-auto"
+                    disabled={isResolving}
+                    isLoading={Boolean(isResolving)}
+                    onClick={() =>
+                      onReviewDecision("approved", {
+                        approveLabel: labels.approveLabel,
+                        reviewConflictIds,
+                      })
+                    }
+                    size="sm"
+                    type="button"
+                    variant="workflow"
+                  >
+                    {labels.approveLabel}
+                  </LoadingButton>
+                ) : null}
+                <Button
+                  className="w-full border-destructive/30 bg-background text-destructive hover:bg-destructive/10 hover:text-destructive sm:w-auto"
+                  disabled={isResolving}
+                  onClick={() =>
+                    onReviewDecision("rejected", {
+                      rejectLabel: labels.rejectLabel,
+                      reviewConflictIds,
+                    })
+                  }
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  {labels.rejectLabel}
+                </Button>
+              </div>
+            </article>
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -1327,6 +1442,117 @@ function getCombinedReviewNextStep(items: PosReconciliationItem[]) {
   return "Manager sign-in reviews and applies the synced register activity to this drawer.";
 }
 
+function isInventoryRegisterSyncReviewItem(item: PosReconciliationItem) {
+  return (
+    item.reviewKind === "inventory_review" ||
+    item.type === "inventory" ||
+    item.type === "inventory_conflict"
+  );
+}
+
+function isDuplicateLocalIdRegisterSyncReviewItem(item: PosReconciliationItem) {
+  const summary = item.summary?.trim().toLowerCase() ?? "";
+
+  return (
+    item.type === "duplicate_local_id" ||
+    summary.includes("session id was reused") ||
+    summary.includes("duplicate")
+  );
+}
+
+function getRegisterSyncReviewItemActionLabels(item: PosReconciliationItem) {
+  if (isDuplicateLocalIdRegisterSyncReviewItem(item)) {
+    return {
+      approveLabel: "Apply duplicate review item",
+      rejectLabel: "Reject duplicate review item",
+    };
+  }
+
+  if (isInventoryRegisterSyncReviewItem(item)) {
+    return {
+      approveLabel: "Apply inventory review item",
+      rejectLabel: "Reject inventory review item",
+    };
+  }
+
+  return {
+    approveLabel: "Apply review item",
+    rejectLabel: "Reject review item",
+  };
+}
+
+function getRegisterSyncReviewItemSummary(item: PosReconciliationItem) {
+  if (isDuplicateLocalIdRegisterSyncReviewItem(item)) {
+    return "Local register activity already synced from another sale. Reject this item unless the sale needs to be reviewed again.";
+  }
+
+  if (isInventoryRegisterSyncReviewItem(item)) {
+    return "Inventory needs manager review before this synced sale can be applied.";
+  }
+
+  if (item.reviewKind === "register_closeout_variance") {
+    return "Closeout variance needs manager review before this synced closeout can be applied.";
+  }
+
+  if (item.reviewKind === "duplicate_register_closeout") {
+    return "This synced closeout has already been reviewed. Reject this item to clear it.";
+  }
+
+  if (
+    item.reviewKind === "service_customer_attribution" ||
+    item.summary?.trim() === SERVICE_CUSTOMER_ATTRIBUTION_SYNC_REVIEW_SUMMARY
+  ) {
+    return "Service customer attribution is missing. Reject this item, then recreate the service work with a customer if needed.";
+  }
+
+  if (
+    item.reviewKind === "staff_access" ||
+    item.summary?.trim() === STAFF_ACCESS_SYNC_REVIEW_SUMMARY
+  ) {
+    return "Staff access changed before this local register activity synced.";
+  }
+
+  if (
+    item.reviewKind === "register_not_open_sale" ||
+    item.summary?.trim() === REGISTER_NOT_OPEN_SYNC_REVIEW_SUMMARY
+  ) {
+    return "Drawer state needs manager review before this synced sale can be applied.";
+  }
+
+  return "Review synced register activity before it is applied.";
+}
+
+function getRegisterSyncReviewDecisionScope(item: PosReconciliationItem) {
+  if (isDuplicateLocalIdRegisterSyncReviewItem(item)) {
+    return "duplicate_local_id";
+  }
+
+  if (isInventoryRegisterSyncReviewItem(item)) {
+    return "inventory";
+  }
+
+  if (isRegisterCloseoutReviewItem(item)) {
+    return "register_closeout";
+  }
+
+  if (
+    item.reviewKind === "service_customer_attribution" ||
+    item.summary?.trim() === SERVICE_CUSTOMER_ATTRIBUTION_SYNC_REVIEW_SUMMARY
+  ) {
+    return "service_customer_attribution";
+  }
+
+  return `${item.actionPolicy ?? "default"}:${item.reviewKind ?? item.type ?? "unknown"}`;
+}
+
+function hasUniformRegisterSyncReviewDecisionScope(
+  items: PosReconciliationItem[],
+) {
+  const scopes = new Set(items.map(getRegisterSyncReviewDecisionScope));
+
+  return scopes.size <= 1;
+}
+
 function RegisterSessionSyncNotice({
   currency,
   errorMessage,
@@ -1339,7 +1565,10 @@ function RegisterSessionSyncNotice({
   currency: string;
   errorMessage?: string;
   isResolving?: boolean;
-  onReviewDecision?: (decision: "approved" | "rejected") => void;
+  onReviewDecision?: (
+    decision: "approved" | "rejected",
+    options?: ResolveSyncReviewDecisionOptions,
+  ) => void;
   orgUrlSlug?: string;
   storeUrlSlug?: string;
   syncStatus: PosSyncStatusPresentation;
@@ -1402,7 +1631,29 @@ function RegisterSessionSyncNotice({
     reconciliationItems.some(
       (item) => !isApprovableRegisterSyncReviewItem(item),
     );
+  const hasUniformBatchReviewDecision =
+    !shouldCombineReviewItems ||
+    hasUniformRegisterSyncReviewDecisionScope(reconciliationItems);
   const canApplySyncReview = canApproveSyncReview && !hasUnsupportedReviewItems;
+  const shouldShowRejectedReviewAction =
+    syncStatus.status === "needs_review" &&
+    hasOnlyRejectedReviewItems &&
+    Boolean(onReviewDecision);
+  const shouldShowRejectedReviewRetryLink =
+    syncStatus.status === "needs_review" &&
+    hasOnlyRejectedReviewItems &&
+    !onReviewDecision &&
+    Boolean(orgUrlSlug && storeUrlSlug);
+  const shouldShowNeedsReviewBatchActions =
+    syncStatus.status === "needs_review" &&
+    !hasOnlyRejectedReviewItems &&
+    Boolean(onReviewDecision) &&
+    hasUniformBatchReviewDecision;
+  const shouldShowSyncFooter =
+    shouldShowRejectedReviewAction ||
+    shouldShowRejectedReviewRetryLink ||
+    shouldShowNeedsReviewBatchActions ||
+    syncStatus.status !== "needs_review";
   const rejectedSyncQueueSummary = hasOnlyRejectedReviewItems
     ? formatReviewQueueSummary(reconciliationItems)
     : null;
@@ -1532,6 +1783,8 @@ function RegisterSessionSyncNotice({
                 </div>
                 <SalesUnderReviewList
                   currency={currency}
+                  isResolving={isResolving}
+                  onReviewDecision={onReviewDecision}
                   orgUrlSlug={orgUrlSlug}
                   sales={syncReviewSaleSummaries}
                   storeUrlSlug={storeUrlSlug}
@@ -1689,76 +1942,72 @@ function RegisterSessionSyncNotice({
             <p className="text-sm leading-6 text-destructive">{errorMessage}</p>
           ) : null}
         </div>
-        <div
-          className={cn(
-            "flex w-full flex-col gap-layout-sm border-t pt-layout-md sm:flex-row sm:flex-wrap sm:items-center",
-            hasCloseoutReview ? "border-amber-200/70" : "border-border/70",
-          )}
-        >
-          {syncStatus.status === "needs_review" &&
-          hasOnlyRejectedReviewItems &&
-          onReviewDecision ? (
-            <LoadingButton
-              className="w-full border-border bg-background text-foreground hover:bg-muted sm:w-auto"
-              disabled={isResolving}
-              isLoading={Boolean(isResolving)}
-              onClick={() => onReviewDecision("approved")}
-              size="sm"
-              type="button"
-              variant="outline"
-            >
-              Override and sync events
-            </LoadingButton>
-          ) : syncStatus.status === "needs_review" &&
-            hasOnlyRejectedReviewItems &&
-            orgUrlSlug &&
-            storeUrlSlug ? (
-            <Button
-              asChild
-              className="w-full border-border bg-background text-foreground hover:bg-muted sm:w-auto"
-              size="sm"
-              variant="outline"
-            >
-              <Link
-                params={{ orgUrlSlug, storeUrlSlug }}
-                search={{ o: getOrigin() }}
-                to="/$orgUrlSlug/store/$storeUrlSlug/pos/register"
-              >
-                <span>Open POS to retry sync</span>
-                <ArrowUpRight className="size-3.5" aria-hidden="true" />
-              </Link>
-            </Button>
-          ) : null}
-          {syncStatus.status === "needs_review" &&
-          !hasOnlyRejectedReviewItems &&
-          onReviewDecision ? (
-            <>
-              {canApplySyncReview ? (
-                <LoadingButton
-                  className="w-full sm:w-auto"
-                  disabled={isResolving}
-                  isLoading={Boolean(isResolving)}
-                  onClick={() => onReviewDecision("approved")}
-                  size="sm"
-                  type="button"
-                  variant="workflow"
-                >
-                  {actionCopy.approveLabel}
-                </LoadingButton>
-              ) : null}
-              <Button
-                className="w-full border-destructive/30 bg-background text-destructive hover:bg-destructive/10 hover:text-destructive sm:w-auto"
+        {shouldShowSyncFooter ? (
+          <div
+            className={cn(
+              "flex w-full flex-col gap-layout-sm border-t pt-layout-md sm:flex-row sm:flex-wrap sm:items-center",
+              hasCloseoutReview ? "border-amber-200/70" : "border-border/70",
+            )}
+          >
+            {shouldShowRejectedReviewAction ? (
+              <LoadingButton
+                className="w-full border-border bg-background text-foreground hover:bg-muted sm:w-auto"
                 disabled={isResolving}
-                onClick={() => onReviewDecision("rejected")}
+                isLoading={Boolean(isResolving)}
+                onClick={() => onReviewDecision?.("approved")}
                 size="sm"
                 type="button"
                 variant="outline"
               >
-                {actionCopy.rejectLabel}
+                Override and sync events
+              </LoadingButton>
+            ) : shouldShowRejectedReviewRetryLink &&
+              orgUrlSlug &&
+              storeUrlSlug ? (
+              <Button
+                asChild
+                className="w-full border-border bg-background text-foreground hover:bg-muted sm:w-auto"
+                size="sm"
+                variant="outline"
+              >
+                <Link
+                  params={{ orgUrlSlug, storeUrlSlug }}
+                  search={{ o: getOrigin() }}
+                  to="/$orgUrlSlug/store/$storeUrlSlug/pos/register"
+                >
+                  <span>Open POS to retry sync</span>
+                  <ArrowUpRight className="size-3.5" aria-hidden="true" />
+                </Link>
               </Button>
-            </>
-          ) : null}
-          {syncStatus.status !== "needs_review" ? (
+            ) : null}
+            {shouldShowNeedsReviewBatchActions ? (
+              <>
+                {canApplySyncReview ? (
+                  <LoadingButton
+                    className="w-full sm:w-auto"
+                    disabled={isResolving}
+                    isLoading={Boolean(isResolving)}
+                    onClick={() => onReviewDecision?.("approved")}
+                    size="sm"
+                    type="button"
+                    variant="workflow"
+                  >
+                    {actionCopy.approveLabel}
+                  </LoadingButton>
+                ) : null}
+                <Button
+                  className="w-full border-destructive/30 bg-background text-destructive hover:bg-destructive/10 hover:text-destructive sm:w-auto"
+                  disabled={isResolving}
+                  onClick={() => onReviewDecision?.("rejected")}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  {actionCopy.rejectLabel}
+                </Button>
+              </>
+            ) : null}
+            {syncStatus.status !== "needs_review" ? (
             <Badge
               className={getSyncBadgeClass(syncStatus.tone)}
               size="sm"
@@ -1768,8 +2017,9 @@ function RegisterSessionSyncNotice({
                 ? `${syncStatus.pendingEventCount} pending`
                 : syncStatus.label}
             </Badge>
-          ) : null}
-        </div>
+            ) : null}
+          </div>
+        ) : null}
       </div>
     </section>
   );
@@ -2790,7 +3040,10 @@ export function RegisterSessionViewContent({
     syncStatus.status === "needs_review" && Boolean(onResolveSyncReview);
   const headerTerminalName = registerSession?.terminalName?.trim();
 
-  function requestResolveSyncReview(decision: "approved" | "rejected") {
+  function requestResolveSyncReview(
+    decision: "approved" | "rejected",
+    options: ResolveSyncReviewDecisionOptions = {},
+  ) {
     if (!registerSession || !canResolveSyncReview) {
       return;
     }
@@ -2809,15 +3062,16 @@ export function RegisterSessionViewContent({
     setCloseoutStaffAuthIntent({
       kind: "sync_review",
       decision,
-      approveLabel: actionCopy.approveLabel,
+      approveLabel: options.approveLabel ?? actionCopy.approveLabel,
       registerSessionId: registerSession._id,
-      rejectLabel: actionCopy.rejectLabel,
+      rejectLabel: options.rejectLabel ?? actionCopy.rejectLabel,
       reviewConflictIds:
-        isRegisterCloseoutSyncReview && pendingCloseoutReviewItem?.id
+        options.reviewConflictIds ??
+        (isRegisterCloseoutSyncReview && pendingCloseoutReviewItem?.id
           ? [pendingCloseoutReviewItem.id]
           : visibleReviewConflictIds.length > 0
             ? visibleReviewConflictIds
-          : undefined,
+            : undefined),
     });
   }
   const sessionCode = registerSession
@@ -3002,6 +3256,7 @@ export function RegisterSessionViewContent({
             isLoading={pendingCloseoutAction === "approved"}
             onClick={() => void handleReviewCloseout("approved")}
             type="button"
+            variant="workflow"
           >
             Approve variance
           </LoadingButton>

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -452,6 +452,30 @@ const posSyncedSaleTimelineSnapshot: DailyOperationsSnapshot = {
   ],
 };
 
+const voidRequestedTimelineSnapshot: DailyOperationsSnapshot = {
+  ...operatingSnapshot,
+  timeline: [
+    {
+      createdAt: Date.UTC(2026, 4, 8, 15, 11),
+      id: "event-void-requested",
+      message: "Void requested by Joyce O. for Transaction #851031.",
+      subject: {
+        id: "transaction-851031",
+        label: "Transaction #851031",
+        type: "pos_transaction",
+      },
+      transactionLink: {
+        label: "#851031",
+        params: {
+          transactionId: "transaction-851031",
+        },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId",
+      },
+      type: "pos_transaction_void_approval_requested",
+    },
+  ],
+};
+
 const automationSnapshot: DailyOperationsSnapshot = {
   ...operatingSnapshot,
   automationStatuses: [
@@ -1392,6 +1416,28 @@ describe("DailyOperationsViewContent", () => {
         return (
           node?.textContent ===
           "Sale #946956 synced: 3 sale lines, GH₵1,039, cash."
+        );
+      }),
+    ).toBeInTheDocument();
+    expect(transactionLink.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("links void requested timeline transactions and keeps requester copy inline", () => {
+    renderContent(voidRequestedTimelineSnapshot);
+
+    const transactionLink = screen.getByRole("link", { name: "#851031" });
+
+    expect(transactionLink).toHaveAttribute(
+      "href",
+      expect.stringContaining(
+        "/wigclub/store/osu/pos/transactions/transaction-851031?o=",
+      ),
+    );
+    expect(
+      screen.getByText((content, node) => {
+        return (
+          node?.textContent ===
+          "Void requested by Joyce O. for Transaction #851031."
         );
       }),
     ).toBeInTheDocument();

--- a/packages/athena-webapp/src/components/pos/OrderSummary.test.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.test.tsx
@@ -772,6 +772,42 @@ describe("OrderSummary completed transaction summary", () => {
     expect(onVoidTransaction).toHaveBeenCalledTimes(1);
   });
 
+  it("disables the void action when a void request is pending", async () => {
+    const user = userEvent.setup();
+    const onVoidTransaction = vi.fn();
+
+    render(
+      <OrderSummary
+        cartItems={[]}
+        completedOrderNumber="192231"
+        completedTransactionData={{
+          paymentMethod: "cash",
+          completedAt: new Date("2026-05-25T14:27:00.000Z"),
+          cartItems: [],
+          customerInfo: undefined,
+          subtotal: 150000,
+          tax: 0,
+          total: 150000,
+          status: "completed",
+          payments: [
+            { id: "payment-1", method: "cash", amount: 150000, timestamp: 1 },
+          ],
+        }}
+        isTransactionCompleted
+        onVoidTransaction={onVoidTransaction}
+        pendingVoidApprovalRequestId="approval-request-1"
+      />,
+    );
+
+    const voidButton = screen.getByRole("button", {
+      name: "Void requested",
+    });
+
+    expect(voidButton).toBeDisabled();
+    await user.click(voidButton);
+    expect(onVoidTransaction).not.toHaveBeenCalled();
+  });
+
   it("reflects a draft amount equal to balance due as zero remaining", async () => {
     const user = userEvent.setup();
 

--- a/packages/athena-webapp/src/components/pos/OrderSummary.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.tsx
@@ -161,6 +161,7 @@ interface OrderSummaryProps {
   onCompleteTransaction?: () => Promise<boolean>;
   onStartNewTransaction?: () => void | Promise<void>;
   onVoidTransaction?: () => void | Promise<void>;
+  pendingVoidApprovalRequestId?: string | null;
   onPaymentFlowChange?: (isActive: boolean) => void;
   onPaymentEntryStart?: () => void;
   onCompletionBlockAction?: () => void;
@@ -205,6 +206,7 @@ export function OrderSummary({
   onCompleteTransaction,
   onStartNewTransaction,
   onVoidTransaction,
+  pendingVoidApprovalRequestId,
   onPaymentFlowChange,
   onPaymentEntryStart,
   onCompletionBlockAction,
@@ -285,10 +287,13 @@ export function OrderSummary({
   const showCompletedPaymentBreakdown =
     Boolean(completedTransactionData) && completedPaymentBreakdown.length > 1;
   const hasCompletedAdjustment = Boolean(completedAdjustmentSummary);
-  const canVoidCompletedTransaction =
-    Boolean(onVoidTransaction) &&
+  const hasPendingVoidApprovalRequest = Boolean(pendingVoidApprovalRequestId);
+  const showVoidCompletedTransaction =
+    (Boolean(onVoidTransaction) || hasPendingVoidApprovalRequest) &&
     !readOnly &&
     completedTransactionData?.status !== "voided";
+  const canVoidCompletedTransaction =
+    showVoidCompletedTransaction && !hasPendingVoidApprovalRequest;
   const completedSummaryTitle = hasCompletedAdjustment
     ? "Adjusted sale recorded"
     : "Sale recorded";
@@ -1047,7 +1052,7 @@ export function OrderSummary({
                 <div
                   className={cn(
                     "grid gap-3",
-                    canVoidCompletedTransaction
+                    showVoidCompletedTransaction
                       ? "md:grid-cols-3"
                       : "md:grid-cols-2",
                   )}
@@ -1070,14 +1075,29 @@ export function OrderSummary({
                       New sale
                     </Button>
                   )}
-                  {canVoidCompletedTransaction ? (
+                  {showVoidCompletedTransaction ? (
                     <Button
-                      onClick={onVoidTransaction}
+                      disabled={!canVoidCompletedTransaction}
+                      onClick={
+                        canVoidCompletedTransaction
+                          ? onVoidTransaction
+                          : undefined
+                      }
+                      title={
+                        hasPendingVoidApprovalRequest
+                          ? "A void request is pending approval."
+                          : undefined
+                      }
                       variant="outline"
-                      className="h-14 rounded-2xl border-destructive/30 bg-destructive/5 px-5 text-sm font-semibold text-destructive hover:border-destructive/40 hover:bg-destructive/10 hover:text-destructive"
+                      className={cn(
+                        "h-14 rounded-2xl border-destructive/30 bg-destructive/5 px-5 text-sm font-semibold text-destructive hover:border-destructive/40 hover:bg-destructive/10 hover:text-destructive",
+                        "disabled:border-border disabled:bg-muted/30 disabled:text-muted-foreground disabled:opacity-100",
+                      )}
                     >
                       <Ban className="h-4 w-4" />
-                      Void sale
+                      {hasPendingVoidApprovalRequest
+                        ? "Void requested"
+                        : "Void sale"}
                     </Button>
                   ) : null}
                 </div>

--- a/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
+++ b/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
@@ -289,7 +289,7 @@ export default function PointOfSaleView() {
             </div>
           </div>
 
-          {/* Today's Summary */}
+          {/* Store day summary */}
           <div>
             <h2 className="text-xl font-medium mb-6">Summary</h2>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -311,7 +311,9 @@ export default function PointOfSaleView() {
                           <span className="text-muted-foreground">--</span>
                         )}
                       </div>
-                      <p className="text-xs text-muted-foreground">Today</p>
+                      <p className="text-xs text-muted-foreground">
+                        Store day
+                      </p>
                     </CardContent>
                   </div>
                 </>
@@ -331,7 +333,7 @@ export default function PointOfSaleView() {
                       <span className="text-muted-foreground">--</span>
                     )}
                   </div>
-                  <p className="text-xs text-muted-foreground">Today</p>
+                  <p className="text-xs text-muted-foreground">Store day</p>
                 </CardContent>
               </div>
 
@@ -349,7 +351,7 @@ export default function PointOfSaleView() {
                       <span className="text-muted-foreground">--</span>
                     )}
                   </div>
-                  <p className="text-xs text-muted-foreground">Today</p>
+                  <p className="text-xs text-muted-foreground">Store day</p>
                 </CardContent>
               </div>
 
@@ -370,7 +372,7 @@ export default function PointOfSaleView() {
                       <span className="text-muted-foreground">--</span>
                     )}
                   </div>
-                  <p className="text-xs text-muted-foreground">Today</p>
+                  <p className="text-xs text-muted-foreground">Store day</p>
                 </CardContent>
               </div>
             )} */}

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -146,6 +146,21 @@ const detail: TerminalHealthDetail = {
   runtimeStatus: {
     _id: "status-1",
     _creationTime: 1,
+    activeRegisterSession: {
+      cloudRegisterSessionId: "register-session-1",
+      localRegisterSessionId: "local-register-session-1",
+      observedAt: Date.now() - 4 * 60_000,
+      openedAt: Date.now() - 60 * 60_000,
+      registerNumber: "1",
+      status: "closing",
+    },
+    appUpdate: {
+      canApply: false,
+      detectorStatus: "ok",
+      observedAt: Date.now() - 4 * 60_000,
+      stagingStatus: "unknown",
+      status: "current",
+    },
     appVersion: "gentle-lion-climbs (20260608193135)",
     buildSha: "b463caa2d36dabcdef",
     browserInfo: { online: false, platform: "MacIntel" },
@@ -314,6 +329,16 @@ describe("POSTerminalDetailViewContent", () => {
       "Latest version: gentle-lion-climbs (20260608193135) / b463caa2d36d.",
     );
     expect(screen.getByText("Readiness evidence")).toBeInTheDocument();
+    expect(screen.getByText("Runtime report")).toBeInTheDocument();
+    expect(screen.getByText("Latest terminal report")).toBeInTheDocument();
+    expect(screen.getByText("Active drawer")).toBeInTheDocument();
+    expect(screen.getByText("Register 1 Closing")).toBeInTheDocument();
+    expect(screen.getByText("Upload queue")).toBeInTheDocument();
+    expect(screen.getByText("2 uploadable / 3 pending")).toBeInTheDocument();
+    expect(screen.getByText("Local review")).toBeInTheDocument();
+    expect(screen.getByText("1 item")).toBeInTheDocument();
+    expect(screen.getAllByText("App update").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Current").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Availability").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Catalog").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Service catalog").length).toBeGreaterThan(0);
@@ -1432,6 +1457,43 @@ describe("POSTerminalDetailViewContent", () => {
     expect(onResolveRegisterSessionReview).not.toHaveBeenCalled();
   });
 
+  it("routes inventory review attention to open work with inventory copy", () => {
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [
+            {
+              actionTarget: {
+                label: "Review inventory work",
+                type: "open_work",
+              },
+              count: 1,
+              latestEventSequence: 26,
+              latestEventStatus: "conflicted",
+              source: "cloud_sync",
+              summary: "1 inventory review item needs attention.",
+              type: "synced_sale_inventory_review",
+            },
+          ],
+        }}
+        isLoading={false}
+        orgUrlSlug="wigclub"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    expect(
+      screen.getByText("1 inventory review item needs attention."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /review inventory work/i }),
+    ).toHaveAttribute("href", "/wigclub/store/osu/operations/open-work");
+    expect(
+      screen.queryByRole("link", { name: /review register session/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("resolves explicitly eligible register reviews inline from terminal health", async () => {
     const onResolveRegisterSessionReview = vi.fn().mockResolvedValue({
       data: { action: "resolved", resolvedCount: 1 },
@@ -1524,6 +1586,40 @@ describe("POSTerminalDetailViewContent", () => {
     expect(
       screen.getByText(
         "No unresolved cloud sync conflicts are currently reported. Local runtime review, pending sync, or stale check-ins may still need attention above.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("explains when local review counts arrive without item details", () => {
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          runtimeStatus: {
+            ...detail.runtimeStatus!,
+            sync: {
+              ...detail.runtimeStatus!.sync,
+              reviewEventCount: 33,
+              reviewEvents: [],
+              status: "needs_review",
+            },
+          },
+          syncEvidence: {
+            ...detail.syncEvidence,
+            unresolvedConflicts: [],
+            unresolvedConflictCount: 0,
+          },
+        }}
+        isLoading={false}
+      />,
+    );
+
+    expect(
+      screen.getByText("33 local review items were reported by this terminal."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The latest runtime check-in did not include item-level local review details.",
       ),
     ).toBeInTheDocument();
   });

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
@@ -436,6 +436,146 @@ function SnapshotReadinessGroup({
   );
 }
 
+function RuntimeReportGroup({
+  runtimeStatus,
+}: {
+  runtimeStatus: TerminalRuntimeStatus | null;
+}) {
+  const syncTone = getRuntimeSyncTone(runtimeStatus?.sync.status);
+  const appUpdateTone = getRuntimeAppUpdateTone(runtimeStatus?.appUpdate?.status);
+  const activeRegisterSession = runtimeStatus?.activeRegisterSession;
+
+  return (
+    <div className="space-y-layout-xs rounded-md border border-border/80 bg-surface px-layout-md py-layout-sm">
+      <div className="flex items-center justify-between gap-layout-sm">
+        <p className="text-xs font-medium uppercase text-muted-foreground">
+          Runtime report
+        </p>
+        <span className="text-xs text-muted-foreground">
+          {runtimeStatus ? "Latest terminal report" : "Not reported"}
+        </span>
+      </div>
+      <div className="divide-y divide-border/70">
+        <RailSignalRow
+          label="Reported"
+          value={formatTerminalTimestamp(runtimeStatus?.reportedAt)}
+        />
+        <RailSignalRow
+          label="Active drawer"
+          tone={activeRegisterSession ? "neutral" : "warning"}
+          value={
+            activeRegisterSession
+              ? formatActiveRegisterSession(activeRegisterSession)
+              : "Not reported"
+          }
+        />
+        <RailSignalRow
+          label="Sync"
+          tone={syncTone}
+          value={
+            runtimeStatus ? formatStatusLabel(runtimeStatus.sync.status) : "No report"
+          }
+        />
+        <RailSignalRow
+          label="Upload queue"
+          value={formatUploadQueue(runtimeStatus)}
+        />
+        <RailSignalRow
+          label="Local review"
+          tone={(runtimeStatus?.sync.reviewEventCount ?? 0) > 0 ? "warning" : "neutral"}
+          value={formatLocalReviewCount(runtimeStatus)}
+        />
+        <RailSignalRow
+          label="App update"
+          tone={appUpdateTone}
+          value={
+            runtimeStatus?.appUpdate
+              ? formatStatusLabel(runtimeStatus.appUpdate.status)
+              : "Not reported"
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+function getRuntimeSyncTone(status?: TerminalRuntimeStatus["sync"]["status"]) {
+  switch (status) {
+    case "idle":
+      return "success";
+    case "failed":
+    case "needs_review":
+    case "pending":
+    case "syncing":
+      return "warning";
+    default:
+      return "neutral";
+  }
+}
+
+function getRuntimeAppUpdateTone(
+  status?: TerminalRuntimeStatus["appUpdate"] extends infer AppUpdate
+    ? AppUpdate extends { status?: infer Status }
+      ? Status
+      : never
+    : never,
+) {
+  switch (status) {
+    case "current":
+      return "success";
+    case "applying":
+    case "blocked":
+    case "checking":
+    case "detector_failed":
+    case "detector-failed":
+    case "ready":
+    case "ready_unstaged":
+    case "staged":
+    case "update_ready":
+    case "update_ready_unstaged":
+      return "warning";
+    default:
+      return "neutral";
+  }
+}
+
+function formatActiveRegisterSession(
+  activeRegisterSession: NonNullable<
+    TerminalRuntimeStatus["activeRegisterSession"]
+  >,
+) {
+  const registerLabel = activeRegisterSession.registerNumber
+    ? `Register ${activeRegisterSession.registerNumber}`
+    : "Drawer";
+
+  return `${registerLabel} ${formatStatusLabel(activeRegisterSession.status)}`;
+}
+
+function formatUploadQueue(runtimeStatus: TerminalRuntimeStatus | null) {
+  if (!runtimeStatus) {
+    return "Not reported";
+  }
+
+  const uploadable = runtimeStatus.sync.uploadableEventCount;
+  const pending = runtimeStatus.sync.pendingEventCount;
+
+  if (uploadable === 0 && pending === 0) {
+    return "Clear";
+  }
+
+  return `${uploadable} uploadable / ${pending} pending`;
+}
+
+function formatLocalReviewCount(runtimeStatus: TerminalRuntimeStatus | null) {
+  if (!runtimeStatus) {
+    return "Not reported";
+  }
+
+  const reviewCount = runtimeStatus.sync.reviewEventCount;
+
+  return `${reviewCount} item${reviewCount === 1 ? "" : "s"}`;
+}
+
 function RailSection({
   children,
   icon,
@@ -522,6 +662,7 @@ function TerminalContextRail({
                   : "Not reported"
             }
           />
+          <RuntimeReportGroup runtimeStatus={runtimeStatus} />
           <SnapshotReadinessGroup runtimeStatus={runtimeStatus} />
         </RailSection>
       </div>
@@ -911,6 +1052,9 @@ function ConflictSection({
   syncEvidence: TerminalSyncEvidence;
 }) {
   const localReviewEvents = runtimeStatus?.sync.reviewEvents ?? [];
+  const runtimeReviewCount = runtimeStatus?.sync.reviewEventCount ?? 0;
+  const missingRuntimeReviewDetails =
+    runtimeReviewCount > 0 && localReviewEvents.length === 0;
   const unresolvedConflicts = syncEvidence.unresolvedConflicts ?? [];
   const reviewCount = getReviewEvidenceCount(syncEvidence);
 
@@ -981,6 +1125,20 @@ function ConflictSection({
                 </div>
               ))}
             </div>
+          </div>
+        ) : null}
+
+        {missingRuntimeReviewDetails ? (
+          <div className="rounded-md border border-warning/30 bg-warning/10 px-layout-md py-layout-sm">
+            <p className="text-sm font-medium text-foreground">
+              {runtimeReviewCount} local review{" "}
+              {runtimeReviewCount === 1 ? "item was" : "items were"} reported
+              by this terminal.
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              The latest runtime check-in did not include item-level local
+              review details.
+            </p>
           </div>
         ) : null}
       </div>
@@ -1143,7 +1301,7 @@ function AttentionReasonAction({
           search={{ o: getOrigin() }}
           to="/$orgUrlSlug/store/$storeUrlSlug/operations/open-work"
         >
-          Review open work
+          {target.label ?? "Review open work"}
           <ArrowRight aria-hidden="true" />
         </Link>
       </Button>

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
@@ -195,6 +195,11 @@ export type TerminalSyncConflict = {
   createdAt: number;
   localEventId: string;
   localRegisterSessionId: string;
+  reviewTarget?: {
+    type: "open_work";
+    workItemId: Id<"operationalWorkItem"> | string;
+    workItemType: "synced_sale_inventory_review";
+  };
   sequence: number;
   summary: string;
 };
@@ -225,7 +230,7 @@ export type TerminalHealthAttentionActionTarget =
       registerSessionId: Id<"registerSession"> | string;
       type: "cash_control_register_session";
     }
-  | { type: "open_work" }
+  | { label?: string; type: "open_work" }
   | { type: "pos_register" }
   | { type: "pos_settings" };
 
@@ -242,6 +247,7 @@ export type TerminalHealthAttentionReason = {
     | "cloud_conflict"
     | "cloud_held"
     | "cloud_rejected"
+    | "synced_sale_inventory_review"
     | "local_review"
     | "local_store_unavailable"
     | "sync_failed"

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
@@ -865,6 +865,112 @@ describe("TransactionView", () => {
     });
   });
 
+  it("disables completed sale voids while a void approval request is pending", async () => {
+    const user = userEvent.setup();
+    const voidMutation = vi.fn();
+    mockTransactionMutations(
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      voidMutation,
+    );
+    useParamsMock.mockReturnValue({ transactionId: "txn_void_pending" });
+    useQueryMock.mockReturnValue({
+      ...baseTransaction,
+      _id: "txn_void_pending",
+      pendingVoidApprovalRequest: {
+        _id: "approval-request-1",
+        createdAt: 100,
+        requestedByStaffProfileId: "staff_1",
+      },
+    });
+
+    render(<TransactionView />);
+
+    const voidButton = screen.getByRole("button", {
+      name: "Void requested",
+    });
+
+    expect(voidButton).toBeDisabled();
+    await user.click(voidButton);
+    expect(voidMutation).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("heading", { name: "Void completed sale" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("links full admins to approvals when a void request is pending", () => {
+    mockTransactionMutations(vi.fn(), vi.fn(), vi.fn());
+    useProtectedAdminPageStateMock.mockReturnValue({
+      activeStore: { _id: "store_1" },
+      hasFullAdminAccess: true,
+      isAuthenticated: true,
+    });
+    useParamsMock.mockReturnValue({
+      orgUrlSlug: "wigclub",
+      storeUrlSlug: "wigclub",
+      transactionId: "txn_void_pending",
+    });
+    useQueryMock.mockReturnValue({
+      ...baseTransaction,
+      _id: "txn_void_pending",
+      pendingVoidApprovalRequest: {
+        _id: "approval-request-1",
+        createdAt: 100,
+        requestedByStaffProfileId: "staff_1",
+      },
+    });
+
+    render(<TransactionView />);
+
+    expect(screen.getByText("Void approval pending")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Review this request in Approvals before the sale can be voided.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Review/ })).toHaveAttribute(
+      "href",
+      "/wigclub/store/wigclub/operations/approvals",
+    );
+  });
+
+  it("does not link non-admins to approvals when a void request is pending", () => {
+    mockTransactionMutations(vi.fn(), vi.fn(), vi.fn());
+    useProtectedAdminPageStateMock.mockReturnValue({
+      activeStore: { _id: "store_1" },
+      hasFullAdminAccess: false,
+      isAuthenticated: true,
+    });
+    useParamsMock.mockReturnValue({
+      orgUrlSlug: "wigclub",
+      storeUrlSlug: "wigclub",
+      transactionId: "txn_void_pending",
+    });
+    useQueryMock.mockReturnValue({
+      ...baseTransaction,
+      _id: "txn_void_pending",
+      pendingVoidApprovalRequest: {
+        _id: "approval-request-1",
+        createdAt: 100,
+        requestedByStaffProfileId: "staff_1",
+      },
+    });
+
+    render(<TransactionView />);
+
+    expect(
+      screen.queryByText("Void approval pending"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Review/ })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Void requested" }),
+    ).toBeDisabled();
+  });
+
   it("uses terminal staff proof when submitting completed sale voids without a reason", async () => {
     const user = userEvent.setup();
     const authMutation = vi.fn().mockResolvedValue({

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
@@ -380,7 +380,8 @@ export function TransactionView() {
     reason: string;
     result: TransactionVoidResultData;
   } | null>(null);
-  const { activeStore, isAuthenticated } = useProtectedAdminPageState();
+  const { activeStore, hasFullAdminAccess, isAuthenticated } =
+    useProtectedAdminPageState();
   const correctAuth = useMutation(
     api.operations.staffCredentials.authenticateStaffCredential,
   );
@@ -826,10 +827,28 @@ export function TransactionView() {
     showPaymentMethodDirectFlow && correctionError;
   const transactionRecord = transaction as typeof transaction & {
     canVoid?: boolean;
+    pendingVoidApprovalRequest?: {
+      _id: Id<"approvalRequest"> | string;
+      createdAt: number;
+      requestedByStaffProfileId?: Id<"staffProfile"> | string;
+    } | null;
     voidEligibility?: { eligible?: boolean } | null;
     voidReason?: string | null;
     voidedAt?: number | null;
   };
+  const pendingVoidApprovalRequestId =
+    transactionRecord.pendingVoidApprovalRequest?._id ?? null;
+  const hasPendingVoidApprovalRequest = Boolean(pendingVoidApprovalRequestId);
+  const voidApprovalLinkParams =
+    hasPendingVoidApprovalRequest &&
+    hasFullAdminAccess &&
+    params?.orgUrlSlug &&
+    params?.storeUrlSlug
+      ? {
+          orgUrlSlug: params.orgUrlSlug,
+          storeUrlSlug: params.storeUrlSlug,
+        }
+      : null;
   const transactionVoidedAt =
     localVoidState?.result.voidedAt ?? transactionRecord.voidedAt ?? null;
   const transactionVoidReason =
@@ -843,7 +862,10 @@ export function TransactionView() {
     transactionRecord.canVoid !== false &&
     transactionRecord.voidEligibility?.eligible !== false;
   const canVoidTransaction =
-    isCompletedTransaction && !isVoidedTransaction && readModelAllowsVoid;
+    isCompletedTransaction &&
+    !isVoidedTransaction &&
+    readModelAllowsVoid &&
+    !hasPendingVoidApprovalRequest;
   const transactionStatusLabel = isVoidedTransaction ? "Voided" : "Completed";
   const transactionStatusTime = getRelativeTime(
     transactionVoidedAt ?? transaction.completedAt,
@@ -1534,10 +1556,15 @@ export function TransactionView() {
                             Update
                           </Button>
                         ) : null}
-                        {canVoidTransaction ? (
+                        {canVoidTransaction || hasPendingVoidApprovalRequest ? (
                           <Button
                             className="w-full"
+                            disabled={hasPendingVoidApprovalRequest}
                             onClick={() => {
+                              if (hasPendingVoidApprovalRequest) {
+                                return;
+                              }
+
                               if (voidPanelOpen) {
                                 exitVoidWorkflow();
                                 return;
@@ -1552,8 +1579,43 @@ export function TransactionView() {
                               voidPanelOpen ? "destructive" : "outline"
                             }
                           >
-                            Void sale
+                            {hasPendingVoidApprovalRequest
+                              ? "Void requested"
+                              : "Void sale"}
                           </Button>
+                        ) : null}
+                        {voidApprovalLinkParams ? (
+                          <div className="rounded-[calc(var(--radius)*0.85)] border border-border bg-background p-3">
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="min-w-0 space-y-1">
+                                <p className="text-sm font-medium text-foreground">
+                                  Void approval pending
+                                </p>
+                                <p className="text-xs leading-5 text-muted-foreground">
+                                  Review this request in Approvals before the
+                                  sale can be voided.
+                                </p>
+                              </div>
+                              <Button
+                                asChild
+                                className="h-8 shrink-0 px-2 text-xs"
+                                size="sm"
+                                variant="ghost"
+                              >
+                                <Link
+                                  params={voidApprovalLinkParams}
+                                  search={{ o: getOrigin() }}
+                                  to="/$orgUrlSlug/store/$storeUrlSlug/operations/approvals"
+                                >
+                                  Review
+                                  <ArrowUpRight
+                                    aria-hidden="true"
+                                    className="h-3.5 w-3.5"
+                                  />
+                                </Link>
+                              </Button>
+                            </div>
+                          </div>
                         ) : null}
                       </div>
                     ) : null}
@@ -2403,6 +2465,7 @@ export function TransactionView() {
                 }
                 receiptNumberOverride={transaction.transactionNumber}
                 receiptMessaging={receiptMessaging}
+                pendingVoidApprovalRequestId={pendingVoidApprovalRequestId}
                 customerInfo={
                   transaction.customer
                     ? {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localSyncDrainCoordinator.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localSyncDrainCoordinator.ts
@@ -5,6 +5,7 @@ import {
 } from "./syncContract";
 import type { PosLocalSyncTrigger } from "./syncScheduler";
 import type { PosLocalEventRecord } from "./posLocalStore";
+import type { PosTerminalRuntimeDiagnosticsEvent } from "./terminalRuntimeStatus";
 
 export type PosLocalRuntimeSyncDebugSnapshot = {
   appSessionUnverifiedEventCount?: number;
@@ -19,6 +20,7 @@ export type PosLocalRuntimeSyncDebugSnapshot = {
   oldestPendingUploadSequence?: number;
   nextPendingUploadSequence?: number;
   pendingUploadEventCount?: number;
+  reviewEvents?: PosTerminalRuntimeDiagnosticsEvent[];
   reviewEventCount?: number;
 };
 
@@ -89,6 +91,7 @@ export function buildRuntimeSyncDebug(
     oldestPendingUploadSequence: oldestPendingEvent?.uploadSequence,
     nextPendingUploadSequence: nextPendingUploadableEvent?.uploadSequence,
     pendingUploadEventCount: pendingUploadableEvents.length,
+    reviewEvents: getReviewDiagnosticsEvents(reviewEvents),
     reviewEventCount: reviewEvents.length,
   };
 }
@@ -119,6 +122,38 @@ function compareUploadableEventOrder(
   }
 
   return left.sequence - right.sequence;
+}
+
+function getReviewDiagnosticsEvents(
+  events: PosLocalEventRecord[],
+): PosTerminalRuntimeDiagnosticsEvent[] {
+  return events
+    .slice()
+    .sort(compareUploadableEventOrder)
+    .slice(0, 10)
+    .map((event) => ({
+      createdAt: event.createdAt,
+      localEventId: event.localEventId,
+      ...(event.localPosSessionId
+        ? { localPosSessionId: event.localPosSessionId }
+        : {}),
+      ...(event.localRegisterSessionId
+        ? { localRegisterSessionId: event.localRegisterSessionId }
+        : {}),
+      ...(event.localTransactionId
+        ? { localTransactionId: event.localTransactionId }
+        : {}),
+      sequence: event.sequence,
+      ...(event.staffProfileId ? { staffProfileId: event.staffProfileId } : {}),
+      status: event.sync.status,
+      type: event.type,
+      ...(event.sync.uploaded !== undefined
+        ? { uploaded: event.sync.uploaded }
+        : {}),
+      ...(typeof event.uploadSequence === "number"
+        ? { uploadSequence: event.uploadSequence }
+        : {}),
+    }));
 }
 
 function isPendingUploadCandidate(event: PosLocalEventRecord) {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts
@@ -325,6 +325,40 @@ describe("terminalRuntimeStatus", () => {
     );
   });
 
+  it("keeps local review samples from sync debug when event state is stale", () => {
+    const status = buildPosTerminalRuntimeStatus({
+      clock: () => 2_000,
+      events: [],
+      source: "register",
+      syncDebug: {
+        localOnlyEventCount: 1,
+        pendingUploadEventCount: 0,
+        reviewEventCount: 1,
+        reviewEvents: [
+          {
+            createdAt: 1_000,
+            localEventId: "event-review",
+            localRegisterSessionId: "register-1",
+            sequence: 5,
+            status: "needs_review",
+            type: "transaction.completed",
+            uploaded: true,
+            uploadSequence: 2,
+          },
+        ],
+      },
+    });
+
+    expect(status.sync.reviewEventCount).toBe(1);
+    expect(status.sync.reviewEvents).toEqual([
+      expect.objectContaining({
+        localEventId: "event-review",
+        sequence: 5,
+        type: "transaction.completed",
+      }),
+    ]);
+  });
+
   it("reports app-shell readiness from the terminal runtime", () => {
     const status = buildPosTerminalRuntimeStatus({
       appShell: { ready: true },

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
@@ -87,6 +87,7 @@ export type PosTerminalRuntimeSyncDebugInput = {
   nextPendingUploadSequence?: number;
   oldestPendingEventAt?: number;
   pendingUploadEventCount?: number;
+  reviewEvents?: PosTerminalRuntimeDiagnosticsEvent[];
   reviewEventCount?: number;
   schedulerRunning?: boolean;
 };
@@ -288,6 +289,7 @@ export type PosTerminalRuntimeDiagnosticsEvent = {
   staffProfileId?: string;
   status: PosLocalEventRecord["sync"]["status"];
   type: PosLocalEventRecord["type"];
+  uploaded?: boolean;
   uploadSequence?: number;
 };
 
@@ -437,7 +439,8 @@ export function buildPosTerminalRuntimeStatus(
       localOnlyEventCount: sync.localOnlyEventCount,
       pendingEventCount: sync.pendingEventCount,
       reviewEventCount: sync.reviewEventCount,
-      reviewEvents: getReviewDiagnosticsEvents(input.events),
+      reviewEvents:
+        input.syncDebug?.reviewEvents ?? getReviewDiagnosticsEvents(input.events),
       status: sync.status,
       uploadableEventCount: sync.uploadableEventCount,
       lastSyncedSequence: sync.lastSyncedSequence,

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -146,6 +146,7 @@ export type PosLocalRuntimeSyncDebug = {
   oldestPendingUploadSequence?: number;
   nextPendingUploadSequence?: number;
   pendingUploadEventCount?: number;
+  reviewEvents?: PosTerminalRuntimeSyncDebugInput["reviewEvents"];
   reviewEventCount?: number;
   schedulerBackoffUntil?: number | null;
   schedulerRunning?: boolean;
@@ -784,6 +785,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
       nextPendingUploadSequence: debug.nextPendingUploadSequence,
       oldestPendingEventAt: debug.oldestPendingEventAt,
       pendingUploadEventCount: debug.pendingUploadEventCount,
+      reviewEvents: debug.reviewEvents,
       reviewEventCount: debug.reviewEventCount,
       schedulerRunning: debug.schedulerRunning,
     }),
@@ -795,6 +797,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
       debug.nextPendingUploadSequence,
       debug.oldestPendingEventAt,
       debug.pendingUploadEventCount,
+      debug.reviewEvents,
       debug.reviewEventCount,
       debug.schedulerRunning,
     ],


### PR DESCRIPTION
## Summary
- surface terminal local review detail/fallback evidence for support recovery
- keep POS sync review decisions scoped to the owning workspace and row-level item
- tighten void/closeout flows, approval links, timeline copy, and public return-contract coverage

## Validation
- reviewer loop reached unanimous approval
- bun run pr:athena
