### PR TITLE
Align workspace metric cards

### DIFF
--- a/docs/solutions/architecture/athena-workspace-metric-card-alignment-2026-06-21.md
+++ b/docs/solutions/architecture/athena-workspace-metric-card-alignment-2026-06-21.md
@@ -1,0 +1,77 @@
+---
+title: Athena Workspace Metric Cards Should Share One Component Contract
+date: 2026-06-21
+category: architecture
+module: athena-webapp
+problem_type: presentation_component_drift
+component: operations
+symptoms:
+  - "Stock Adjustments and Procurement used bespoke compact metric tiles while Daily Operations used shared metric cards"
+  - "Clickable filter metrics had separate markup from read-only summary metrics"
+  - "Workspace rails presented KPI counts with row lists or icon cards that did not match the store-ops metric language"
+root_cause: workspace_metric_presentation_split_across_local_markup
+resolution_type: component_consolidation
+severity: low
+tags:
+  - store-ops
+  - metrics
+  - design-system
+  - procurement
+  - stock-adjustments
+---
+
+# Athena Workspace Metric Cards Should Share One Component Contract
+
+## Problem
+
+Athena store-ops workspaces gradually accumulated multiple metric-card styles.
+Daily Operations used `OperationsSummaryMetric`, while Stock Adjustments,
+Procurement, and Operations Queue rendered local metric tiles, row lists, or
+icon-led count cards. The cards carried the same operator job - quick scan of a
+label, value, and optional helper - but differed in typography, spacing, border
+treatment, and interaction markup.
+
+The split was especially visible when an operator moved between Daily
+Operations, Stock Adjustments, and Procurement. It also made clickable metrics
+harder to keep consistent: the Stock Adjustments `Reserved` card acted as a
+filter but had a separate button layout from the read-only metric cards.
+
+## Solution
+
+Use `OperationsSummaryMetric` as the shared metric contract for store-ops
+workspace KPIs:
+
+```tsx
+<OperationsSummaryMetric
+  label="Reserved"
+  value={formatInventoryNumber(inventoryState.unavailableUnits)}
+  onClick={handleUnavailableMetricClick}
+  ariaPressed={isUnavailableScopeSelectionActive}
+  disabled={inventoryState.unavailableUnits === 0}
+/>
+```
+
+Keep the shared card responsible for:
+
+- Default Daily Operations card scale, typography, border, and shadow.
+- Optional helper copy for secondary context.
+- Optional link affordances.
+- Optional button behavior for metric-as-filter interactions.
+
+Workspace-specific code should provide the data, labels, helper copy, and
+handlers. It should not recreate the card shell unless the surface is not a
+KPI metric.
+
+## Prevention
+
+- Before adding a new workspace KPI card, check whether `OperationsSummaryMetric`
+  can express it with `label`, `value`, `helper`, `link`, or `onClick`.
+- Preserve interactive semantics inside the shared metric component instead of
+  wrapping custom card markup in local buttons.
+- Use local cards for bounded forms, queue items, detail panels, and true
+  sub-decisions. Use `OperationsSummaryMetric` for operator-scan KPI totals.
+- When aligning one workspace, grep sibling store-ops surfaces for local
+  metric tile markup so the pattern does not remain split across adjacent
+  workflows.
+- Update focused rendering tests when consolidating markup so they assert
+  operator-visible labels and values, not the previous local DOM structure.

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
@@ -4,7 +4,6 @@ import { useMutation, useQuery } from "convex/react";
 import {
   ArrowUpRight,
   ClipboardCheck,
-  Clock3,
   Lock,
   LockOpen,
 } from "lucide-react";
@@ -55,6 +54,7 @@ import {
   OperationReviewItemCard,
   type OperationReviewMetadataEntry,
 } from "./OperationReviewItemCard";
+import { OperationsSummaryMetric } from "./OperationsSummaryMetric";
 
 const operationsApi = api.operations;
 const stockOpsApi = api.stockOps;
@@ -724,21 +724,11 @@ export function OperationsQueueViewContent({
             ) : (
               <PageWorkspaceGrid className="xl:grid-cols-[minmax(15rem,0.32fr)_minmax(0,1fr)]">
                 <PageWorkspaceRail className="gap-layout-md">
-                  <div className="rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface">
-                    <div className="flex items-start gap-layout-sm">
-                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
-                        <ClipboardCheck className="h-4 w-4" />
-                      </div>
-                      <div>
-                        <p className="text-sm text-muted-foreground">
-                          Waiting for progress
-                        </p>
-                        <p className="mt-1 font-numeric text-3xl font-semibold tabular-nums text-foreground">
-                          {workItems.length}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
+                  <OperationsSummaryMetric
+                    helper="Open work items"
+                    label="Waiting for progress"
+                    value={workItems.length}
+                  />
                 </PageWorkspaceRail>
 
                 <PageWorkspaceMain
@@ -794,21 +784,11 @@ export function OperationsQueueViewContent({
             ) : (
               <PageWorkspaceGrid className="xl:grid-cols-[minmax(15rem,0.32fr)_minmax(0,1fr)]">
                 <PageWorkspaceRail className="gap-layout-md">
-                  <div className="rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface">
-                    <div className="flex items-start gap-layout-sm">
-                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-warning/15 text-warning-foreground">
-                        <Clock3 className="h-4 w-4" />
-                      </div>
-                      <div>
-                        <p className="text-sm text-muted-foreground">
-                          Waiting for review
-                        </p>
-                        <p className="mt-1 font-numeric text-3xl font-semibold tabular-nums text-foreground">
-                          {approvalRequests.length}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
+                  <OperationsSummaryMetric
+                    helper="Pending approvals"
+                    label="Waiting for review"
+                    value={approvalRequests.length}
+                  />
 
                   {approvalDecisionUnlockRequired ? (
                     <div className="rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface">

--- a/packages/athena-webapp/src/components/operations/OperationsSummaryMetric.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsSummaryMetric.tsx
@@ -26,36 +26,34 @@ function buildParams(
 }
 
 export function OperationsSummaryMetric({
+  ariaPressed,
   className,
+  disabled,
   helper,
   helperClassName,
   label,
   labelClassName,
   link,
+  onClick,
   tone = "default",
   value,
   valueClassName,
 }: {
+  ariaPressed?: boolean;
   className?: string;
+  disabled?: boolean;
   helper?: ReactNode;
   helperClassName?: string;
   label: string;
   labelClassName?: string;
   link?: OperationsSummaryMetricLink;
+  onClick?: () => void;
   tone?: "default" | "quiet";
   value: ReactNode;
   valueClassName?: string;
 }) {
-  return (
-    <div
-      className={cn(
-        "rounded-lg border border-border bg-surface shadow-surface",
-        tone === "quiet"
-          ? "px-layout-md py-layout-md"
-          : "px-layout-md py-layout-sm",
-        className,
-      )}
-    >
+  const content = (
+    <>
       <div className="flex items-start justify-between gap-layout-sm">
         <p
           className={cn(
@@ -102,13 +100,41 @@ export function OperationsSummaryMetric({
       {helper ? (
         <p
           className={cn(
-            "mt-1 text-xs leading-5 text-muted-foreground",
+            "mt-1 whitespace-nowrap text-xs leading-5 text-muted-foreground [&>span]:flex-nowrap",
             helperClassName,
           )}
         >
           {helper}
         </p>
       ) : null}
+    </>
+  );
+  const rootClassName = cn(
+    "min-w-max rounded-lg border border-border bg-surface shadow-surface",
+    tone === "quiet" ? "px-layout-md py-layout-md" : "px-layout-md py-layout-sm",
+    onClick
+      ? "block w-full text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-default disabled:hover:bg-surface"
+      : null,
+    className,
+  );
+
+  if (onClick) {
+    return (
+      <button
+        aria-pressed={ariaPressed}
+        className={rootClassName}
+        disabled={disabled}
+        onClick={onClick}
+        type="button"
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <div className={rootClassName}>
+      {content}
     </div>
   );
 }

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
@@ -551,11 +551,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
     expect(screen.getByText("All saved counts")).toBeInTheDocument();
     expect(screen.getByText("Active category")).toBeInTheDocument();
     expect(screen.getByText("5")).toBeInTheDocument();
-    expect(screen.getByText("-9")).toBeInTheDocument();
-    expect(screen.getAllByText("SKUs").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Net").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Variance").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("4").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Net -9 · variance 4/i)).toBeInTheDocument();
   });
 
   it("submits the overall cycle count draft when the current category has no changes", async () => {

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
@@ -54,6 +54,7 @@ import {
   PageWorkspaceMain,
   PageWorkspaceRail,
 } from "../common/PageLevelHeader";
+import { OperationsSummaryMetric } from "./OperationsSummaryMetric";
 import {
   QuickAddProductDialog,
   type QuickAddAttachBarcodePayload,
@@ -2899,47 +2900,27 @@ export function StockAdjustmentWorkspaceContent({
       <PageWorkspaceGrid>
         <PageWorkspaceMain>
           <div className="flex flex-wrap items-start justify-between gap-layout-xl">
-            <div className="grid w-full max-w-2xl grid-cols-3 gap-layout-sm">
-              <div className="rounded-md border border-border bg-muted/30 px-3 py-2">
-                <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                  On hand
-                </p>
-                <p className="mt-1 text-sm font-medium tabular-nums text-foreground">
-                  {formatInventoryNumber(inventoryState.onHandUnits)}
-                </p>
-              </div>
-              <div className="rounded-md border border-border bg-muted/30 px-3 py-2">
-                <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                  Available
-                </p>
-                <p className="mt-1 text-sm font-medium tabular-nums text-foreground">
-                  {formatInventoryNumber(inventoryState.availableUnits)}
-                </p>
-              </div>
-              <div
-                className={`overflow-hidden rounded-md border ${
-                  inventoryState.unavailableUnits === 0
-                    ? "border-border bg-muted/30"
-                    : isUnavailableScopeSelectionActive
-                      ? "border-action-workflow-border bg-action-workflow-soft"
-                      : "border-border bg-muted/30 hover:bg-muted"
-                }`}
-              >
-                <button
-                  aria-pressed={isUnavailableScopeSelectionActive}
-                  className="block w-full px-3 py-2 text-left disabled:cursor-default"
-                  disabled={inventoryState.unavailableUnits === 0}
-                  onClick={handleUnavailableMetricClick}
-                  type="button"
-                >
-                  <span className="block text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                    Reserved
-                  </span>
-                  <span className="mt-1 block text-sm font-medium tabular-nums text-foreground">
-                    {formatInventoryNumber(inventoryState.unavailableUnits)}
-                  </span>
-                </button>
-              </div>
+            <div className="grid w-full max-w-3xl grid-cols-1 gap-layout-sm sm:grid-cols-3">
+              <OperationsSummaryMetric
+                label="On hand"
+                value={formatInventoryNumber(inventoryState.onHandUnits)}
+              />
+              <OperationsSummaryMetric
+                label="Available"
+                value={formatInventoryNumber(inventoryState.availableUnits)}
+              />
+              <OperationsSummaryMetric
+                ariaPressed={isUnavailableScopeSelectionActive}
+                className={
+                  isUnavailableScopeSelectionActive
+                    ? "border-action-workflow-border bg-action-workflow-soft"
+                    : undefined
+                }
+                disabled={inventoryState.unavailableUnits === 0}
+                label="Reserved"
+                onClick={handleUnavailableMetricClick}
+                value={formatInventoryNumber(inventoryState.unavailableUnits)}
+              />
             </div>
 
             <Tabs
@@ -3262,73 +3243,25 @@ export function StockAdjustmentWorkspaceContent({
                   <p className="text-xs font-medium text-muted-foreground">
                     Count metrics
                   </p>
-                  <div className="grid gap-2">
-                    <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
-                      <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                        All saved counts
-                      </p>
-                      <dl className="mt-2 space-y-2">
-                        <div className="flex items-baseline justify-between gap-3">
-                          <dt className="text-[11px] text-muted-foreground">
-                            SKUs
-                          </dt>
-                          <dd className="font-display text-2xl font-semibold tabular-nums tracking-tight text-foreground">
-                            {overallSummary.lineItemCount}
-                          </dd>
-                        </div>
-                        <div className="flex items-baseline justify-between gap-3">
-                          <dt className="text-[11px] text-muted-foreground">
-                            Net
-                          </dt>
-                          <dd className="font-display text-2xl font-semibold tabular-nums tracking-tight text-foreground">
-                            {overallSummary.netQuantityDelta > 0
-                              ? `+${overallSummary.netQuantityDelta}`
-                              : overallSummary.netQuantityDelta}
-                          </dd>
-                        </div>
-                        <div className="flex items-baseline justify-between gap-3">
-                          <dt className="text-[11px] text-muted-foreground">
-                            Variance
-                          </dt>
-                          <dd className="font-display text-2xl font-semibold tabular-nums tracking-tight text-foreground">
-                            {overallSummary.largestAbsoluteDelta}
-                          </dd>
-                        </div>
-                      </dl>
-                    </div>
-                    <div className="rounded-md border border-border px-3 py-3">
-                      <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                        Active category
-                      </p>
-                      <dl className="mt-2 space-y-2">
-                        <div className="flex items-baseline justify-between gap-3">
-                          <dt className="text-[11px] text-muted-foreground">
-                            SKUs
-                          </dt>
-                          <dd className="font-display text-2xl font-semibold tabular-nums tracking-tight text-foreground">
-                            {summary.lineItemCount}
-                          </dd>
-                        </div>
-                        <div className="flex items-baseline justify-between gap-3">
-                          <dt className="text-[11px] text-muted-foreground">
-                            Net
-                          </dt>
-                          <dd className="font-display text-2xl font-semibold tabular-nums tracking-tight text-foreground">
-                            {summary.netQuantityDelta > 0
-                              ? `+${summary.netQuantityDelta}`
-                              : summary.netQuantityDelta}
-                          </dd>
-                        </div>
-                        <div className="flex items-baseline justify-between gap-3">
-                          <dt className="text-[11px] text-muted-foreground">
-                            Variance
-                          </dt>
-                          <dd className="font-display text-2xl font-semibold tabular-nums tracking-tight text-foreground">
-                            {summary.largestAbsoluteDelta}
-                          </dd>
-                        </div>
-                      </dl>
-                    </div>
+                  <div className="grid gap-layout-sm">
+                    <OperationsSummaryMetric
+                      helper={`Net ${
+                        overallSummary.netQuantityDelta > 0
+                          ? `+${overallSummary.netQuantityDelta}`
+                          : overallSummary.netQuantityDelta
+                      } · variance ${overallSummary.largestAbsoluteDelta}`}
+                      label="All saved counts"
+                      value={overallSummary.lineItemCount}
+                    />
+                    <OperationsSummaryMetric
+                      helper={`Net ${
+                        summary.netQuantityDelta > 0
+                          ? `+${summary.netQuantityDelta}`
+                          : summary.netQuantityDelta
+                      } · variance ${summary.largestAbsoluteDelta}`}
+                      label="Active category"
+                      value={summary.lineItemCount}
+                    />
                   </div>
                 </div>
               ) : (
@@ -3336,39 +3269,15 @@ export function StockAdjustmentWorkspaceContent({
                   <p className="text-xs font-medium text-muted-foreground">
                     Adjustment metrics
                   </p>
-                  <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
-                    <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                      Manual batch
-                    </p>
-                    <div className="mt-2 grid grid-cols-3 gap-2">
-                      <div>
-                        <p className="font-display text-3xl font-semibold tabular-nums tracking-tight text-foreground">
-                          {summary.lineItemCount}
-                        </p>
-                        <p className="mt-1 text-[11px] text-muted-foreground">
-                          SKUs
-                        </p>
-                      </div>
-                      <div>
-                        <p className="font-display text-3xl font-semibold tabular-nums tracking-tight text-foreground">
-                          {summary.netQuantityDelta > 0
-                            ? `+${summary.netQuantityDelta}`
-                            : summary.netQuantityDelta}
-                        </p>
-                        <p className="mt-1 text-[11px] text-muted-foreground">
-                          Net
-                        </p>
-                      </div>
-                      <div>
-                        <p className="font-display text-3xl font-semibold tabular-nums tracking-tight text-foreground">
-                          {summary.largestAbsoluteDelta}
-                        </p>
-                        <p className="mt-1 text-[11px] text-muted-foreground">
-                          Variance
-                        </p>
-                      </div>
-                    </div>
-                  </div>
+                  <OperationsSummaryMetric
+                    helper={`Net ${
+                      summary.netQuantityDelta > 0
+                        ? `+${summary.netQuantityDelta}`
+                        : summary.netQuantityDelta
+                    } · variance ${summary.largestAbsoluteDelta}`}
+                    label="Manual batch"
+                    value={summary.lineItemCount}
+                  />
                 </div>
               )}
               <div

--- a/packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx
+++ b/packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx
@@ -1077,8 +1077,12 @@ describe("ProcurementViewContent", () => {
       ).getByText("PO-DRAFT"),
     ).toHaveClass("text-sm", "text-foreground/80");
     expect(screen.getByText("1 line · 4 units")).toBeInTheDocument();
+    const activeVendorsMetric = screen
+      .getByText("Active vendors")
+      .closest(".rounded-lg") as HTMLElement;
+
     expect(
-      within(screen.getByText("Active vendors").parentElement!).getByText("2"),
+      within(activeVendorsMetric).getByText("2"),
     ).toBeInTheDocument();
     expect(screen.getByText("Open purchase orders")).toBeInTheDocument();
     expect(

--- a/packages/athena-webapp/src/components/procurement/ProcurementView.tsx
+++ b/packages/athena-webapp/src/components/procurement/ProcurementView.tsx
@@ -29,6 +29,7 @@ import {
   SkuDetailPanel,
   type InventorySnapshotItem,
 } from "../operations/StockAdjustmentWorkspace";
+import { OperationsSummaryMetric } from "../operations/OperationsSummaryMetric";
 import { SkuSearchFilterBar } from "../stock-ops/SkuSearchFilterBar";
 import { ReceivingView } from "./ReceivingView";
 import { WorkflowTraceRouteLink } from "../traces/WorkflowTraceRouteLink";
@@ -1175,24 +1176,18 @@ export function ProcurementViewContent({
                   }
                 />
 
-                <div className="grid overflow-hidden rounded-md border border-border bg-muted/20 sm:grid-cols-4">
+                <div className="grid grid-cols-1 gap-layout-sm sm:grid-cols-2 xl:grid-cols-4">
                   {[
                     ["Needs action", summary.needsAction],
                     ["Planned", summary.planned],
                     ["Inbound", summary.inbound],
                     ["Exceptions", summary.exceptions],
                   ].map(([label, value]) => (
-                    <div
-                      className="border-border px-layout-md py-layout-sm sm:border-l sm:first:border-l-0"
+                    <OperationsSummaryMetric
                       key={label}
-                    >
-                      <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                        {label}
-                      </p>
-                      <p className="mt-1 text-lg font-semibold tabular-nums text-foreground">
-                        {value}
-                      </p>
-                    </div>
+                      label={String(label)}
+                      value={value}
+                    />
                   ))}
                 </div>
               </section>
@@ -1919,7 +1914,7 @@ export function ProcurementViewContent({
                 title="Planning signal"
               />
 
-              <div className="divide-y divide-border/70 rounded-lg border border-border bg-background">
+              <div className="grid gap-layout-sm">
                 {[
                   ["Needs action", summary.needsAction],
                   ["Planned", summary.planned],
@@ -1929,15 +1924,11 @@ export function ProcurementViewContent({
                   ["Active vendors", vendorOptions.length],
                   ["Active purchase orders", summary.activePurchaseOrders],
                 ].map(([label, value]) => (
-                  <div
-                    className="flex items-center justify-between gap-layout-md px-4 py-3 text-sm"
+                  <OperationsSummaryMetric
                     key={label}
-                  >
-                    <span className="text-muted-foreground">{label}</span>
-                    <span className="font-semibold tabular-nums text-foreground">
-                      {value}
-                    </span>
-                  </div>
+                    label={String(label)}
+                    value={value}
+                  />
                 ))}
               </div>
             </section>


### PR DESCRIPTION
## Summary
- Shared the Daily Operations metric card component across Stock Adjustments, Procurement, and Operations Queue metrics.
- Preserved metric filter interactions through the shared component while keeping helper text single-line and unclipped.
- Added a solution note for Athena workspace metric-card alignment and refreshed Graphify.

## Validation
- bun run pr:athena
- bun run test src/components/operations/StockAdjustmentWorkspace.test.tsx src/components/procurement/ProcurementView.test.tsx src/components/operations/OperationsQueueView.test.tsx (packages/athena-webapp)
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json --pretty false
- bun run lint:frontend:changed
