### PR TITLE
fix: align POS pulse metrics to store-day windows

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7548 nodes · 8750 edges · 1977 communities detected
+- 7550 nodes · 8756 edges · 1977 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2079,16 +2079,16 @@ Cohesion: 0.12
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
 ### Community 16 - "Community 16"
+Cohesion: 0.11
+Nodes (30): buildPosOperatorSnapshot(), buildRecentDayBuckets(), buildSummaryTrendBucket(), buildTransactionDateBuckets(), calculateDeltaPercent(), findLatestOpenOperatingDay(), formatHourLabel(), formatPaymentMethodLabel() (+22 more)
+
+### Community 17 - "Community 17"
 Cohesion: 0.14
 Nodes (34): asRecord(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale() (+26 more)
 
-### Community 17 - "Community 17"
-Cohesion: 0.12
-Nodes (32): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+24 more)
-
 ### Community 18 - "Community 18"
 Cohesion: 0.12
-Nodes (28): buildPosOperatorSnapshot(), buildRecentDayBuckets(), buildSummaryTrendBucket(), buildTransactionDateBuckets(), calculateDeltaPercent(), findLatestOpenOperatingDay(), formatHourLabel(), formatPaymentMethodLabel() (+20 more)
+Nodes (32): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+24 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.16
@@ -2644,15 +2644,15 @@ Nodes (5): clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), r
 
 ### Community 157 - "Community 157"
 Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 158 - "Community 158"
 Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
+Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
 ### Community 159 - "Community 159"
 Cohesion: 0.39
-Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 160 - "Community 160"
 Cohesion: 0.39

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2049
-- Graph nodes: 7548
-- Graph edges: 8750
+- Graph nodes: 7550
+- Graph edges: 8756
 - Communities: 1977
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/pos/application/getTransactions.test.ts
+++ b/packages/athena-webapp/convex/pos/application/getTransactions.test.ts
@@ -327,6 +327,143 @@ describe("getTodaySummary", () => {
     });
   });
 
+  it("honors the active opening time range for today's POS pulse summary", async () => {
+    vi.setSystemTime(new Date("2026-06-21T18:00:00.000Z"));
+    vi.mocked(listCompletedTransactionsForRange).mockResolvedValueOnce([
+      {
+        _id: "txn-in-window" as Id<"posTransaction">,
+        completedAt: Date.parse("2026-06-21T12:00:00.000Z"),
+        payments: [{ amount: 82_150, method: "cash", timestamp: 1 }],
+        storeId: "store-1" as Id<"store">,
+        total: 82_150,
+      },
+      {
+        _id: "txn-after-midnight" as Id<"posTransaction">,
+        completedAt: Date.parse("2026-06-22T01:30:00.000Z"),
+        payments: [{ amount: 10_000, method: "cash", timestamp: 1 }],
+        storeId: "store-1" as Id<"store">,
+        total: 10_000,
+      },
+    ] as never);
+    vi.mocked(listCompletedTransactionsForRange).mockResolvedValueOnce([
+      {
+        _id: "txn-prior-window" as Id<"posTransaction">,
+        completedAt: Date.parse("2026-06-20T12:00:00.000Z"),
+        payments: [{ amount: 50_000, method: "cash", timestamp: 1 }],
+        storeId: "store-1" as Id<"store">,
+        total: 50_000,
+      },
+    ] as never);
+    vi.mocked(listCompletedTransactionsSince).mockResolvedValue([
+      {
+        _id: "txn-before-opening" as Id<"posTransaction">,
+        completedAt: Date.parse("2026-06-21T02:00:00.000Z"),
+        payments: [{ amount: 99_999, method: "cash", timestamp: 1 }],
+        storeId: "store-1" as Id<"store">,
+        total: 99_999,
+      },
+      {
+        _id: "txn-in-window" as Id<"posTransaction">,
+        completedAt: Date.parse("2026-06-21T12:00:00.000Z"),
+        payments: [{ amount: 82_150, method: "cash", timestamp: 1 }],
+        storeId: "store-1" as Id<"store">,
+        total: 82_150,
+      },
+      {
+        _id: "txn-after-midnight" as Id<"posTransaction">,
+        completedAt: Date.parse("2026-06-22T01:30:00.000Z"),
+        payments: [{ amount: 10_000, method: "cash", timestamp: 1 }],
+        storeId: "store-1" as Id<"store">,
+        total: 10_000,
+      },
+    ] as never);
+    vi.mocked(listTransactionItems)
+      .mockResolvedValueOnce([{ quantity: 3 }] as never)
+      .mockResolvedValueOnce([{ quantity: 1 }] as never)
+      .mockResolvedValueOnce([{ quantity: 2 }] as never)
+      .mockResolvedValueOnce([{ quantity: 3 }] as never)
+      .mockResolvedValueOnce([{ quantity: 1 }] as never);
+    const query = vi.fn((tableName: string) => ({
+      withIndex: vi.fn(() => ({
+        collect: vi.fn().mockResolvedValue([]),
+        take: vi.fn().mockResolvedValue([]),
+        order: vi.fn(() => ({
+          take: vi.fn().mockResolvedValue(
+            tableName === "dailyOpening"
+              ? [
+                  {
+                    _id: "opening-2026-06-21",
+                    endAt: Date.parse("2026-06-22T04:00:00.000Z"),
+                    operatingDate: "2026-06-21",
+                    startAt: Date.parse("2026-06-21T04:00:00.000Z"),
+                    status: "started",
+                    storeId: "store-1",
+                  },
+                ]
+              : [],
+          ),
+        })),
+      })),
+    }));
+
+    const result = await getTodaySummary(
+      {
+        db: { query },
+      } as never,
+      {
+        pulseWindow: "today",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(listCompletedTransactionsForRange).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      {
+        completedFrom: Date.parse("2026-06-21T04:00:00.000Z"),
+        completedTo: Date.parse("2026-06-22T03:59:59.999Z"),
+        storeId: "store-1",
+      },
+    );
+    expect(listCompletedTransactionsForRange).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      {
+        completedFrom: Date.parse("2026-06-20T04:00:00.000Z"),
+        completedTo: Date.parse("2026-06-21T03:59:59.999Z"),
+        storeId: "store-1",
+      },
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        averageTransaction: 46_075,
+        date: "2026-06-21",
+        totalItemsSold: 4,
+        totalSales: 92_150,
+        totalTransactions: 2,
+      }),
+    );
+    expect(result.operatorSnapshot.comparison).toMatchObject({
+      currentItemsSold: 4,
+      currentSales: 92_150,
+      currentTransactions: 2,
+      yesterdaySales: 50_000,
+      yesterdayTransactions: 1,
+    });
+    expect(result.operatorSnapshot.trend).toEqual([
+      expect.objectContaining({
+        date: "2026-06-20",
+        totalSales: 50_000,
+        transactionCount: 1,
+      }),
+      expect.objectContaining({
+        date: "2026-06-21",
+        totalSales: 92_150,
+        transactionCount: 2,
+      }),
+    ]);
+  });
+
   it("falls back to the server calendar day when the latest opening is already closed", async () => {
     vi.setSystemTime(new Date("2026-06-20T00:49:30.000Z"));
     vi.mocked(listCompletedTransactionsForDay).mockResolvedValue([] as never);
@@ -467,6 +604,120 @@ describe("getTodaySummary", () => {
       "2026-06-18",
       "2026-06-19",
       "2026-06-20",
+    ]);
+  });
+
+  it("buckets this week sales by store-day window instead of raw UTC date", async () => {
+    vi.setSystemTime(new Date("2026-06-21T18:00:00.000Z"));
+    vi.mocked(listCompletedTransactionsForRange).mockResolvedValueOnce([
+      {
+        _id: "txn-before-midnight" as Id<"posTransaction">,
+        completedAt: Date.parse("2026-06-21T12:00:00.000Z"),
+        payments: [{ amount: 82_150, method: "cash", timestamp: 1 }],
+        storeId: "store-1" as Id<"store">,
+        total: 82_150,
+      },
+      {
+        _id: "txn-after-midnight" as Id<"posTransaction">,
+        completedAt: Date.parse("2026-06-22T01:30:00.000Z"),
+        payments: [{ amount: 102_900, method: "cash", timestamp: 1 }],
+        storeId: "store-1" as Id<"store">,
+        total: 102_900,
+      },
+    ] as never);
+    vi.mocked(listCompletedTransactionsForRange).mockResolvedValueOnce(
+      [] as never,
+    );
+    vi.mocked(listCompletedTransactionsSince).mockResolvedValue([
+      {
+        _id: "txn-before-midnight" as Id<"posTransaction">,
+        completedAt: Date.parse("2026-06-21T12:00:00.000Z"),
+        payments: [{ amount: 82_150, method: "cash", timestamp: 1 }],
+        storeId: "store-1" as Id<"store">,
+        total: 82_150,
+      },
+      {
+        _id: "txn-after-midnight" as Id<"posTransaction">,
+        completedAt: Date.parse("2026-06-22T01:30:00.000Z"),
+        payments: [{ amount: 102_900, method: "cash", timestamp: 1 }],
+        storeId: "store-1" as Id<"store">,
+        total: 102_900,
+      },
+    ] as never);
+    vi.mocked(listTransactionItems)
+      .mockResolvedValueOnce([{ quantity: 15 }] as never)
+      .mockResolvedValueOnce([{ quantity: 23 }] as never)
+      .mockResolvedValueOnce([
+        {
+          productId: "product-1",
+          productName: "Wig cap",
+          productSku: "CAP",
+          productSkuId: "sku-1",
+          quantity: 15,
+          totalPrice: 82_150,
+        },
+      ] as never)
+      .mockResolvedValueOnce([
+        {
+          productId: "product-2",
+          productName: "Bundle",
+          productSku: "BUNDLE",
+          productSkuId: "sku-2",
+          quantity: 23,
+          totalPrice: 102_900,
+        },
+      ] as never);
+    const query = vi.fn((tableName: string) => ({
+      withIndex: vi.fn(() => ({
+        collect: vi.fn().mockResolvedValue([]),
+        take: vi.fn().mockResolvedValue([]),
+        order: vi.fn(() => ({
+          take: vi.fn().mockResolvedValue(
+            tableName === "dailyOpening"
+              ? [
+                  {
+                    _id: "opening-2026-06-21",
+                    endAt: Date.parse("2026-06-22T04:00:00.000Z"),
+                    operatingDate: "2026-06-21",
+                    startAt: Date.parse("2026-06-21T04:00:00.000Z"),
+                    status: "started",
+                    storeId: "store-1",
+                  },
+                ]
+              : [],
+          ),
+        })),
+      })),
+    }));
+
+    const result = await getTodaySummary(
+      {
+        db: { query },
+      } as never,
+      {
+        pulseWindow: "this_week",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result.totalSales).toBe(185_050);
+    expect(result.totalTransactions).toBe(2);
+    expect(result.totalItemsSold).toBe(38);
+    expect(
+      result.operatorSnapshot.trend.find((day) => day.date === "2026-06-21"),
+    ).toMatchObject({
+      totalItemsSold: 38,
+      totalSales: 185_050,
+      transactionCount: 2,
+    });
+    expect(result.operatorSnapshot.trend.map((day) => day.date)).toEqual([
+      "2026-06-15",
+      "2026-06-16",
+      "2026-06-17",
+      "2026-06-18",
+      "2026-06-19",
+      "2026-06-20",
+      "2026-06-21",
     ]);
   });
 

--- a/packages/athena-webapp/convex/pos/application/queries/getTransactions.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/getTransactions.ts
@@ -742,6 +742,8 @@ export async function getTodaySummary(
 
   if (args.pulseWindow) {
     return getPulseSummaryForWindow(ctx, {
+      currentDayEnd: summaryWindow.endOfDay,
+      currentDayStart: summaryWindow.startOfDay,
       currentOperatingDate: summaryWindow.operatingDate,
       pulseWindow: args.pulseWindow,
       storeId: args.storeId,
@@ -788,12 +790,16 @@ export async function getTodaySummary(
 async function getPulseSummaryForWindow(
   ctx: QueryCtx,
   args: {
+    currentDayEnd: number;
+    currentDayStart: number;
     currentOperatingDate: string;
     pulseWindow: PosPulseWindow;
     storeId: Id<"store">;
   },
 ) {
   const pulseWindow = resolvePosPulseWindow({
+    currentDayEnd: args.currentDayEnd,
+    currentDayStart: args.currentDayStart,
     currentOperatingDate: args.currentOperatingDate,
     pulseWindow: args.pulseWindow,
   });
@@ -835,8 +841,13 @@ async function getPulseSummaryForWindow(
           buildSummaryTrendBucket(
             pulseWindow.comparisonStart,
             comparisonSummary,
+            pulseWindow.comparisonOperatingDate,
           ),
-          buildSummaryTrendBucket(pulseWindow.rangeEnd, todaySummary),
+          buildSummaryTrendBucket(
+            pulseWindow.rangeStart,
+            todaySummary,
+            args.currentOperatingDate,
+          ),
         ]
       : operatorSnapshot.trend;
 
@@ -845,7 +856,10 @@ async function getPulseSummaryForWindow(
       todaySummary.totalTransactions > 0
         ? todaySummary.totalSales / todaySummary.totalTransactions
         : 0,
-    date: toIsoDate(pulseWindow.rangeEnd),
+    date:
+      args.pulseWindow === "today"
+        ? args.currentOperatingDate
+        : toIsoDate(pulseWindow.rangeEnd),
     operatorSnapshot: {
       ...operatorSnapshot,
       historyDays: Math.max(operatorSnapshot.historyDays, trend.length),
@@ -934,7 +948,10 @@ async function buildPosOperatorSnapshot(
   >();
 
   for (const transaction of transactions) {
-    const date = toIsoDate(transaction.completedAt);
+    const date =
+      args.historyBucketMode === "transaction_dates"
+        ? toIsoDate(transaction.completedAt)
+        : getFixedHistoryBucketDate(transaction.completedAt, historyStart);
     const dayBucket = dayBucketsByDate.get(date);
     if (dayBucket) {
       dayBucket.totalSales += transaction.total;
@@ -1106,11 +1123,19 @@ async function buildPosOperatorSnapshot(
 }
 
 function resolvePosPulseWindow(args: {
+  currentDayEnd: number;
+  currentDayStart: number;
   currentOperatingDate: string;
   pulseWindow: PosPulseWindow;
 }) {
-  const currentDayStart = parseOperatingDateStart(args.currentOperatingDate);
-  const currentDayEnd = currentDayStart + DAY_MS - 1;
+  const parsedCurrentDayStart = parseOperatingDateStart(args.currentOperatingDate);
+  const currentDayStart = Number.isFinite(args.currentDayStart)
+    ? args.currentDayStart
+    : parsedCurrentDayStart;
+  const currentDayEnd =
+    Number.isFinite(args.currentDayEnd) && args.currentDayEnd >= currentDayStart
+      ? args.currentDayEnd
+      : parsedCurrentDayStart + DAY_MS - 1;
 
   if (args.pulseWindow === "all_time") {
     return {
@@ -1122,9 +1147,12 @@ function resolvePosPulseWindow(args: {
   }
 
   if (args.pulseWindow === "today") {
+    const windowLength = currentDayEnd - currentDayStart + 1;
+
     return {
       comparisonEnd: currentDayStart - 1,
-      comparisonStart: currentDayStart - DAY_MS,
+      comparisonOperatingDate: toIsoDate(parsedCurrentDayStart - DAY_MS),
+      comparisonStart: currentDayStart - windowLength,
       dayCount: 1,
       rangeEnd: currentDayEnd,
       rangeStart: currentDayStart,
@@ -1248,8 +1276,9 @@ function buildRecentDayBuckets(startAt: number, dayCount: number) {
 function buildSummaryTrendBucket(
   dateAt: number,
   summary: PosPulseSummaryTotals,
+  operatingDate?: string,
 ): PosOperatorDayBucket {
-  const date = toIsoDate(dateAt);
+  const date = operatingDate ?? toIsoDate(dateAt);
 
   return {
     averageTransaction:
@@ -1295,6 +1324,15 @@ function buildTransactionDateBuckets(
     totalSales: 0,
     transactionCount: 0,
   }));
+}
+
+function getFixedHistoryBucketDate(timestamp: number, historyStart: number) {
+  const bucketIndex = Math.max(
+    0,
+    Math.floor((timestamp - historyStart) / DAY_MS),
+  );
+
+  return toIsoDate(historyStart + bucketIndex * DAY_MS);
 }
 
 function toIsoDate(timestamp: number) {
@@ -1361,9 +1399,20 @@ async function resolveCurrentPosSummaryWindow(
   const operatingDate =
     activeOpening?.operatingDate ??
     new Date(args.now).toISOString().slice(0, 10);
-  const startOfDay = Date.parse(`${operatingDate}T00:00:00.000Z`);
+  const fallbackStartOfDay = Date.parse(`${operatingDate}T00:00:00.000Z`);
+  const activeOpeningStartAt = activeOpening?.startAt;
+  const activeOpeningEndAt = activeOpening?.endAt;
+  const activeOpeningRange =
+    typeof activeOpeningStartAt === "number" &&
+    typeof activeOpeningEndAt === "number" &&
+    isValidPosSummaryWindowRange(activeOpeningStartAt, activeOpeningEndAt)
+      ? {
+          endOfDay: activeOpeningEndAt - 1,
+          startOfDay: activeOpeningStartAt,
+        }
+      : null;
 
-  if (!Number.isFinite(startOfDay)) {
+  if (!Number.isFinite(fallbackStartOfDay)) {
     const fallbackStart = Date.parse(
       `${new Date(args.now).toISOString().slice(0, 10)}T00:00:00.000Z`,
     );
@@ -1376,10 +1425,21 @@ async function resolveCurrentPosSummaryWindow(
   }
 
   return {
-    endOfDay: startOfDay + DAY_MS - 1,
+    endOfDay: activeOpeningRange?.endOfDay ?? fallbackStartOfDay + DAY_MS - 1,
     operatingDate,
-    startOfDay,
+    startOfDay: activeOpeningRange?.startOfDay ?? fallbackStartOfDay,
   };
+}
+
+function isValidPosSummaryWindowRange(startAt: unknown, endAt: unknown) {
+  return (
+    typeof startAt === "number" &&
+    typeof endAt === "number" &&
+    Number.isFinite(startAt) &&
+    Number.isFinite(endAt) &&
+    endAt > startAt &&
+    endAt - startAt <= 36 * 60 * 60 * 1000
+  );
 }
 
 async function findLatestOpenOperatingDay(

--- a/packages/athena-webapp/scripts/convex-lint-changed.sh
+++ b/packages/athena-webapp/scripts/convex-lint-changed.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-REPO_ROOT="$(git -C "$ROOT_DIR" rev-parse --show-toplevel)"
+REPO_ROOT="$(cd "$ROOT_DIR/../.." && pwd)"
 
 resolve_base_ref() {
   local candidate


### PR DESCRIPTION
## Summary
- Align POS pulse "Today" metrics to the active Daily Opening window instead of raw UTC-midnight day bounds.
- Bucket fixed-window sales trend data by store-day windows so after-midnight sales stay in the Sunday operating day.
- Harden the changed-Convex lint script so Git hook environment cannot resolve the monorepo root to the package directory.

## Validation
- `bun run --filter @athena/webapp lint:convex:changed`
- `bun run graphify:rebuild`
- pre-push `@athena/webapp:test` (380 files, 3704 tests)
- pre-push targeted POS/runtime suite (40 files, 1138 tests)
- pre-push `@athena/webapp:build`
- pre-push behavior harness: `athena-convex-storefront-composition`, `athena-convex-storefront-failure-visibility`, `athena-admin-shell-boot`
- pre-push harness inferential review

🤖 Generated with [Codex](https://openai.com/codex)
