### PR TITLE
Stabilize homepage storefront merchandising

### DIFF
--- a/docs/solutions/logic-errors/athena-homepage-snapshot-contract-2026-06-22.md
+++ b/docs/solutions/logic-errors/athena-homepage-snapshot-contract-2026-06-22.md
@@ -9,6 +9,8 @@ symptoms:
   - "Storefront homepage sections depended on multiple loosely shaped admin records"
   - "Admin homepage banner queries could crash when generated Convex functions were stale"
   - "Highlighted shop-look content could duplicate instead of behaving like a singleton"
+  - "Admin placement order could disagree with storefront order when legacy rows lacked ranks"
+  - "Broken product images could leak browser alt text into homepage merchandising slots"
 root_cause: homepage_data_was_split_between_admin_mutations_public_bootstrap_and_storefront_mapping
 resolution_type: typed_snapshot_contract_plus_admin_integrity_guards
 severity: medium
@@ -53,6 +55,16 @@ Use one typed public homepage snapshot as the storefront contract:
   mutation layer and present only that singleton in the snapshot.
 - Separate public active banner reads from admin draft reads so storefront
   bootstrap never depends on admin-only state.
+- Put homepage placement ranking and storefront-visibility predicates in shared
+  code that both Convex presenters and React surfaces import. Admin ordering,
+  backend inserts, and storefront display should not reimplement rank semantics.
+- Present snapshot ranks as contiguous display positions after sorting. Stored
+  explicit ranks remain useful for admin edits and appends, but public DTO ranks
+  must preserve final order even when production has a mix of ranked and legacy
+  unranked rows.
+- Render storefront and admin product-image fallbacks through the same UI-owned
+  placeholder behavior. Do not let a missing or failed product image show broken
+  image chrome or raw alt text in a merchandising section.
 
 The admin side should use shared product/SKU search for homepage add flows.
 That keeps product identity, category filters, and SKU details consistent with
@@ -64,6 +76,13 @@ and comparison.
 - Add snapshot contract tests whenever homepage DTO fields change. Cover
   visibility filtering, minor-unit values, category/subcategory hydration, and
   shop-look singleton behavior.
+- Add rank migration tests with explicit non-zero ranks plus legacy unranked
+  rows; then sort the returned snapshot in the storefront test path to prove the
+  order cannot flip after client normalization.
+- When product/category taxonomy is derived from ids instead of denormalized
+  names, test both visible labels and search/filter behavior with queries that
+  appear only in the derived taxonomy metadata.
+- Render-test image fallback branches, not only URL-selection helpers.
 - Test HTTP bootstrap routes separately from Convex presenter queries so cookie
   behavior and missing-store behavior do not regress silently.
 - Keep admin homepage mutations behind full-admin guards; public homepage
@@ -77,6 +96,8 @@ and comparison.
 
 - `bun run --filter "@athena/webapp" test convex/storeFront/homepageSnapshot.test.ts convex/http/domains/customerChannel/routes/homepageSnapshot.test.ts convex/http/domains/core/routes/bannerMessage.test.ts convex/inventory/bannerMessage.test.ts convex/inventory/bestSeller.test.ts convex/inventory/featuredItem.test.ts src/components/homepage/HomepageProductPickerDialog.test.tsx`
 - `bun run --filter "@athena/storefront-webapp" test src/api/homepageSnapshot.test.ts src/components/HomePage.test.tsx src/routes/-homePageLoader.test.ts src/components/home/homePageContent.test.ts`
+- `bun run --filter "@athena/webapp" test shared/homepageRanking.test.ts shared/storefrontVisibility.test.ts src/components/homepage/HomepagePlacementProductImage.test.ts`
+- `bun run --filter "@athena/storefront-webapp" test src/components/ProductCard.test.tsx src/components/home/HomeHero.test.tsx`
 - `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
 - `bunx tsc -p packages/storefront-webapp/tsconfig.json --noEmit`
 - `bun run --filter "@athena/storefront-webapp" build`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2090 files · ~0 words
+- 2097 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7761 nodes · 9064 edges · 2018 communities detected
+- 7781 nodes · 9074 edges · 2025 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2028,6 +2028,13 @@
 - [[_COMMUNITY_Community 2015|Community 2015]]
 - [[_COMMUNITY_Community 2016|Community 2016]]
 - [[_COMMUNITY_Community 2017|Community 2017]]
+- [[_COMMUNITY_Community 2018|Community 2018]]
+- [[_COMMUNITY_Community 2019|Community 2019]]
+- [[_COMMUNITY_Community 2020|Community 2020]]
+- [[_COMMUNITY_Community 2021|Community 2021]]
+- [[_COMMUNITY_Community 2022|Community 2022]]
+- [[_COMMUNITY_Community 2023|Community 2023]]
+- [[_COMMUNITY_Community 2024|Community 2024]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2116,12 +2123,12 @@ Cohesion: 0.13
 Nodes (35): buildFinalTrustedQuantitiesByRowNumber(), buildProvisionalSkuPatch(), buildSkuInsert(), buildSkuPatch(), finalizeProvisionalImportRowsForAppliedImport(), findExistingSku(), findOrCreateCategory(), findOrCreateProduct() (+27 more)
 
 ### Community 15 - "Community 15"
-Cohesion: 0.11
-Nodes (30): buildPosOperatorSnapshot(), buildRecentDayBuckets(), buildSummaryTrendBucket(), buildTransactionDateBuckets(), calculateDeltaPercent(), findLatestOpenOperatingDay(), formatHourLabel(), formatPaymentMethodLabel() (+22 more)
-
-### Community 16 - "Community 16"
 Cohesion: 0.12
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
+
+### Community 16 - "Community 16"
+Cohesion: 0.11
+Nodes (30): buildPosOperatorSnapshot(), buildRecentDayBuckets(), buildSummaryTrendBucket(), buildTransactionDateBuckets(), calculateDeltaPercent(), findLatestOpenOperatingDay(), formatHourLabel(), formatPaymentMethodLabel() (+22 more)
 
 ### Community 17 - "Community 17"
 Cohesion: 0.14
@@ -2244,56 +2251,56 @@ Cohesion: 0.19
 Nodes (22): buildEventMessage(), buildNextEvidence(), buildNextSaleEvidence(), buildReviewPriority(), buildWorkItemPriority(), createOrReusePendingCheckoutItem(), createProvisionalCatalogAnchors(), findMatchingPendingCheckoutItem() (+14 more)
 
 ### Community 47 - "Community 47"
-Cohesion: 0.19
-Nodes (21): buildHomepageSnapshotV1(), hydrateCategory(), hydrateFeaturedItem(), hydrateProduct(), hydrateSubcategory(), hydrateTargetProducts(), isCustomerVisibleCategory(), isCustomerVisibleProduct() (+13 more)
-
-### Community 48 - "Community 48"
 Cohesion: 0.17
 Nodes (19): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady(), mapSyncStatus() (+11 more)
 
-### Community 49 - "Community 49"
+### Community 48 - "Community 48"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 50 - "Community 50"
+### Community 49 - "Community 49"
 Cohesion: 0.21
 Nodes (21): detectFormat(), extractJsonRows(), flattenJsonRows(), inferProductName(), isRecord(), looksLikeLabel(), normalizeKey(), normalizeLegacyRow() (+13 more)
 
-### Community 51 - "Community 51"
+### Community 50 - "Community 50"
 Cohesion: 0.25
 Nodes (21): asRecord(), errorFor(), getLocalExpenseSessionId(), getOrCreateSession(), isExpenseEvent(), itemSource(), itemSourceKey(), numberField() (+13 more)
 
-### Community 52 - "Community 52"
+### Community 51 - "Community 51"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 53 - "Community 53"
+### Community 52 - "Community 52"
 Cohesion: 0.16
 Nodes (19): automationErrorMessage(), automationIdempotencyKey(), eodDecision(), getLatestDailyOperationsAutomationStatusWithCtx(), getOpeningAutoStartPolicyForApi(), listConfiguredAutomationPolicies(), localDateForPolicy(), openingDecision() (+11 more)
 
-### Community 54 - "Community 54"
+### Community 53 - "Community 53"
 Cohesion: 0.17
 Nodes (17): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+9 more)
 
-### Community 55 - "Community 55"
+### Community 54 - "Community 54"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
-### Community 56 - "Community 56"
+### Community 55 - "Community 55"
 Cohesion: 0.13
 Nodes (12): getLatestRuntimeStatusForTerminal(), getTerminalByFingerprint(), getTerminalSyncEvidence(), isActionableRejectedSyncEvent(), isActionableTerminalReviewSyncEvent(), mapTerminalRecord(), mergeRuntimeStatusPatch(), omitUndefined() (+4 more)
 
-### Community 57 - "Community 57"
+### Community 56 - "Community 56"
 Cohesion: 0.21
 Nodes (18): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), formatRecoveryCode(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode() (+10 more)
 
-### Community 58 - "Community 58"
+### Community 57 - "Community 57"
 Cohesion: 0.1
 Nodes (4): handleChange(), isSkuReserved(), parseVariantInputValue(), shouldDisable()
 
-### Community 59 - "Community 59"
+### Community 58 - "Community 58"
 Cohesion: 0.1
 Nodes (4): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onStartRemoteAssist()
+
+### Community 59 - "Community 59"
+Cohesion: 0.2
+Nodes (18): buildHomepageSnapshotV1(), hydrateCategory(), hydrateFeaturedItem(), hydrateProduct(), hydrateSubcategory(), hydrateTargetProducts(), isCustomerVisibleProduct(), isCustomerVisibleSku() (+10 more)
 
 ### Community 60 - "Community 60"
 Cohesion: 0.15
@@ -3144,88 +3151,88 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 272 - "Community 272"
+Cohesion: 0.4
+Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
+
+### Community 273 - "Community 273"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.4
 Nodes (2): moveFeaturedItem(), saveOrder()
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 280 - "Community 280"
+### Community 281 - "Community 281"
 Cohesion: 0.4
 Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
-
-### Community 282 - "Community 282"
-Cohesion: 0.4
-Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 283 - "Community 283"
 Cohesion: 0.4
-Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
+Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 284 - "Community 284"
+Cohesion: 0.4
+Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
+
+### Community 285 - "Community 285"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 285 - "Community 285"
+### Community 286 - "Community 286"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 286 - "Community 286"
+### Community 287 - "Community 287"
 Cohesion: 0.47
 Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
 
-### Community 287 - "Community 287"
+### Community 288 - "Community 288"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 288 - "Community 288"
+### Community 289 - "Community 289"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 289 - "Community 289"
+### Community 290 - "Community 290"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 290 - "Community 290"
+### Community 291 - "Community 291"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 291 - "Community 291"
+### Community 292 - "Community 292"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 292 - "Community 292"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 293 - "Community 293"
 Cohesion: 0.33
@@ -3240,104 +3247,104 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 296 - "Community 296"
-Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
-
-### Community 297 - "Community 297"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 297 - "Community 297"
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 298 - "Community 298"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 299 - "Community 299"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 300 - "Community 300"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 301 - "Community 301"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 302 - "Community 302"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 300 - "Community 300"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 301 - "Community 301"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 302 - "Community 302"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
 ### Community 303 - "Community 303"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 304 - "Community 304"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 305 - "Community 305"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 306 - "Community 306"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 307 - "Community 307"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 308 - "Community 308"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 309 - "Community 309"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 310 - "Community 310"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 311 - "Community 311"
-Cohesion: 0.53
-Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 312 - "Community 312"
-Cohesion: 0.47
-Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 313 - "Community 313"
 Cohesion: 0.53
-Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
 ### Community 314 - "Community 314"
+Cohesion: 0.47
+Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+
+### Community 315 - "Community 315"
+Cohesion: 0.53
+Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+
+### Community 316 - "Community 316"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 315 - "Community 315"
+### Community 317 - "Community 317"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 316 - "Community 316"
+### Community 318 - "Community 318"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 317 - "Community 317"
+### Community 319 - "Community 319"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 318 - "Community 318"
-Cohesion: 0.6
-Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 319 - "Community 319"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 320 - "Community 320"
 Cohesion: 0.6
-Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
+Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 321 - "Community 321"
 Cohesion: 0.4
@@ -3345,111 +3352,111 @@ Nodes (0):
 
 ### Community 322 - "Community 322"
 Cohesion: 0.6
-Nodes (3): countFeaturedTargets(), isCustomerVisibleCategory(), validateFeaturedPlacement()
+Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
 ### Community 323 - "Community 323"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 324 - "Community 324"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+Cohesion: 0.5
+Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
 ### Community 325 - "Community 325"
-Cohesion: 0.7
-Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
-
-### Community 326 - "Community 326"
-Cohesion: 0.5
-Nodes (2): buildCtx(), createDb()
-
-### Community 327 - "Community 327"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 328 - "Community 328"
+### Community 326 - "Community 326"
 Cohesion: 0.6
-Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+
+### Community 327 - "Community 327"
+Cohesion: 0.7
+Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
+
+### Community 328 - "Community 328"
+Cohesion: 0.5
+Nodes (2): buildCtx(), createDb()
 
 ### Community 329 - "Community 329"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 330 - "Community 330"
+Cohesion: 0.6
+Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
+
+### Community 331 - "Community 331"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 331 - "Community 331"
+### Community 332 - "Community 332"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 333 - "Community 333"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 332 - "Community 332"
+### Community 334 - "Community 334"
 Cohesion: 0.6
 Nodes (3): isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult()
-
-### Community 333 - "Community 333"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 334 - "Community 334"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 335 - "Community 335"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 336 - "Community 336"
-Cohesion: 0.5
-Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
-
-### Community 337 - "Community 337"
-Cohesion: 0.6
-Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
-
-### Community 338 - "Community 338"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 337 - "Community 337"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 338 - "Community 338"
+Cohesion: 0.5
+Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
+
 ### Community 339 - "Community 339"
-Cohesion: 0.7
-Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
+Cohesion: 0.6
+Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
 ### Community 340 - "Community 340"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 341 - "Community 341"
+Cohesion: 0.7
+Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
+
+### Community 342 - "Community 342"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 343 - "Community 343"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 342 - "Community 342"
+### Community 344 - "Community 344"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 343 - "Community 343"
+### Community 345 - "Community 345"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 344 - "Community 344"
+### Community 346 - "Community 346"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
 
-### Community 345 - "Community 345"
+### Community 347 - "Community 347"
 Cohesion: 0.5
 Nodes (2): handleChange(), parseVariantAttributeValue()
 
-### Community 346 - "Community 346"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 347 - "Community 347"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 348 - "Community 348"
-Cohesion: 0.5
-Nodes (2): moveBestSeller(), saveOrder()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 349 - "Community 349"
 Cohesion: 0.4
@@ -3457,15 +3464,15 @@ Nodes (0):
 
 ### Community 350 - "Community 350"
 Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 351 - "Community 351"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 352 - "Community 352"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 353 - "Community 353"
 Cohesion: 0.4
@@ -3476,8 +3483,8 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 355 - "Community 355"
-Cohesion: 0.5
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 356 - "Community 356"
 Cohesion: 0.4
@@ -3485,15 +3492,15 @@ Nodes (0):
 
 ### Community 357 - "Community 357"
 Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 358 - "Community 358"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 359 - "Community 359"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 360 - "Community 360"
 Cohesion: 0.4
@@ -3516,48 +3523,48 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 365 - "Community 365"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 366 - "Community 366"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 367 - "Community 367"
-Cohesion: 0.8
-Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+Cohesion: 0.7
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 368 - "Community 368"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 369 - "Community 369"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
+Cohesion: 0.8
+Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
 ### Community 370 - "Community 370"
-Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
-
-### Community 371 - "Community 371"
-Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
-
-### Community 372 - "Community 372"
-Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
-
-### Community 373 - "Community 373"
-Cohesion: 0.4
-Nodes (1): MockImage
-
-### Community 374 - "Community 374"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 371 - "Community 371"
+Cohesion: 0.5
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
+
+### Community 372 - "Community 372"
+Cohesion: 0.5
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
+
+### Community 373 - "Community 373"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 374 - "Community 374"
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+
 ### Community 375 - "Community 375"
-Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
+Cohesion: 0.4
+Nodes (1): MockImage
 
 ### Community 376 - "Community 376"
 Cohesion: 0.4
@@ -3565,35 +3572,35 @@ Nodes (0):
 
 ### Community 377 - "Community 377"
 Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 378 - "Community 378"
-Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
-
-### Community 379 - "Community 379"
-Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
-
-### Community 380 - "Community 380"
-Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
-
-### Community 381 - "Community 381"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 379 - "Community 379"
+Cohesion: 0.6
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+
+### Community 380 - "Community 380"
+Cohesion: 0.6
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+
+### Community 381 - "Community 381"
+Cohesion: 0.6
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+
 ### Community 382 - "Community 382"
-Cohesion: 0.7
-Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
 ### Community 383 - "Community 383"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 384 - "Community 384"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 385 - "Community 385"
 Cohesion: 0.4
@@ -3604,124 +3611,124 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 387 - "Community 387"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 388 - "Community 388"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 389 - "Community 389"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 388 - "Community 388"
+### Community 390 - "Community 390"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 389 - "Community 389"
+### Community 391 - "Community 391"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 390 - "Community 390"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
-
-### Community 391 - "Community 391"
-Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 392 - "Community 392"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 393 - "Community 393"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 394 - "Community 394"
-Cohesion: 0.6
-Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 395 - "Community 395"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 396 - "Community 396"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+Cohesion: 0.6
+Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
 ### Community 397 - "Community 397"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 398 - "Community 398"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 399 - "Community 399"
-Cohesion: 0.6
-Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 400 - "Community 400"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 401 - "Community 401"
+Cohesion: 0.6
+Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
+
+### Community 402 - "Community 402"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 403 - "Community 403"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 402 - "Community 402"
+### Community 404 - "Community 404"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 403 - "Community 403"
+### Community 405 - "Community 405"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 404 - "Community 404"
+### Community 406 - "Community 406"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 405 - "Community 405"
+### Community 407 - "Community 407"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 406 - "Community 406"
+### Community 408 - "Community 408"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 407 - "Community 407"
+### Community 409 - "Community 409"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 408 - "Community 408"
+### Community 410 - "Community 410"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
 
-### Community 409 - "Community 409"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 410 - "Community 410"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 411 - "Community 411"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 412 - "Community 412"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 413 - "Community 413"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 414 - "Community 414"
-Cohesion: 0.67
-Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 415 - "Community 415"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 416 - "Community 416"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
 ### Community 417 - "Community 417"
 Cohesion: 0.5
@@ -3732,44 +3739,44 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 419 - "Community 419"
-Cohesion: 0.67
-Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 420 - "Community 420"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 421 - "Community 421"
-Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 422 - "Community 422"
 Cohesion: 0.67
-Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
+Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
 ### Community 423 - "Community 423"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
 ### Community 424 - "Community 424"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
 ### Community 425 - "Community 425"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
 ### Community 426 - "Community 426"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 427 - "Community 427"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 428 - "Community 428"
-Cohesion: 0.67
-Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 429 - "Community 429"
 Cohesion: 0.5
@@ -3777,131 +3784,131 @@ Nodes (0):
 
 ### Community 430 - "Community 430"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 431 - "Community 431"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
 ### Community 432 - "Community 432"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 433 - "Community 433"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 434 - "Community 434"
-Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 435 - "Community 435"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 436 - "Community 436"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 437 - "Community 437"
-Cohesion: 0.67
-Nodes (2): buildCtx(), buildQueryCtx()
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 438 - "Community 438"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 439 - "Community 439"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 440 - "Community 440"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildCtx(), buildQueryCtx()
 
 ### Community 441 - "Community 441"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 442 - "Community 442"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 443 - "Community 443"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 444 - "Community 444"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 445 - "Community 445"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 446 - "Community 446"
-Cohesion: 0.83
-Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 447 - "Community 447"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 448 - "Community 448"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 449 - "Community 449"
 Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
 ### Community 450 - "Community 450"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 451 - "Community 451"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 452 - "Community 452"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 453 - "Community 453"
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+
+### Community 454 - "Community 454"
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+
+### Community 455 - "Community 455"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 454 - "Community 454"
+### Community 456 - "Community 456"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 457 - "Community 457"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 458 - "Community 458"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
-### Community 455 - "Community 455"
+### Community 459 - "Community 459"
 Cohesion: 0.67
 Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
-### Community 456 - "Community 456"
+### Community 460 - "Community 460"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
-### Community 457 - "Community 457"
+### Community 461 - "Community 461"
 Cohesion: 0.67
 Nodes (2): getPosRouteScope(), Login()
-
-### Community 458 - "Community 458"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 459 - "Community 459"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 460 - "Community 460"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 461 - "Community 461"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 462 - "Community 462"
 Cohesion: 0.5
@@ -3920,8 +3927,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 466 - "Community 466"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 467 - "Community 467"
 Cohesion: 0.5
@@ -3936,8 +3943,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 470 - "Community 470"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 471 - "Community 471"
 Cohesion: 0.5
@@ -3952,8 +3959,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 474 - "Community 474"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 475 - "Community 475"
 Cohesion: 0.5
@@ -3964,16 +3971,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 477 - "Community 477"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 478 - "Community 478"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 479 - "Community 479"
-Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 480 - "Community 480"
 Cohesion: 0.5
@@ -3981,15 +3988,15 @@ Nodes (0):
 
 ### Community 481 - "Community 481"
 Cohesion: 0.67
-Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 482 - "Community 482"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 483 - "Community 483"
 Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
 ### Community 484 - "Community 484"
 Cohesion: 0.5
@@ -3997,15 +4004,15 @@ Nodes (0):
 
 ### Community 485 - "Community 485"
 Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
+Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
 ### Community 486 - "Community 486"
-Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
-
-### Community 487 - "Community 487"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 487 - "Community 487"
+Cohesion: 0.67
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 488 - "Community 488"
 Cohesion: 0.5
@@ -4013,75 +4020,75 @@ Nodes (0):
 
 ### Community 489 - "Community 489"
 Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 490 - "Community 490"
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+
+### Community 491 - "Community 491"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 491 - "Community 491"
-Cohesion: 0.83
-Nodes (3): completedEvent(), event(), item()
-
 ### Community 492 - "Community 492"
-Cohesion: 0.67
-Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 493 - "Community 493"
-Cohesion: 0.83
-Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
+Cohesion: 0.67
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
 ### Community 494 - "Community 494"
-Cohesion: 0.83
-Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 495 - "Community 495"
 Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+Nodes (3): completedEvent(), event(), item()
 
 ### Community 496 - "Community 496"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
 ### Community 497 - "Community 497"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
 ### Community 498 - "Community 498"
 Cohesion: 0.83
-Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
+Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
 ### Community 499 - "Community 499"
+Cohesion: 0.83
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+
+### Community 500 - "Community 500"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 500 - "Community 500"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
-
 ### Community 501 - "Community 501"
-Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 502 - "Community 502"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
 ### Community 503 - "Community 503"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 504 - "Community 504"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 505 - "Community 505"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 506 - "Community 506"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 507 - "Community 507"
 Cohesion: 0.5
@@ -4100,76 +4107,76 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 511 - "Community 511"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 512 - "Community 512"
-Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 513 - "Community 513"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 514 - "Community 514"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 515 - "Community 515"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+Cohesion: 0.67
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 516 - "Community 516"
 Cohesion: 0.67
-Nodes (2): write(), writePublicQueryWithReturns()
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
 ### Community 517 - "Community 517"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
 ### Community 518 - "Community 518"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 519 - "Community 519"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Cohesion: 0.83
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 520 - "Community 520"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): write(), writePublicQueryWithReturns()
 
 ### Community 521 - "Community 521"
 Cohesion: 0.83
-Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 522 - "Community 522"
-Cohesion: 0.67
-Nodes (2): collectHarnessTestTargets(), runHarnessTest()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 523 - "Community 523"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 524 - "Community 524"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
 ### Community 525 - "Community 525"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
 ### Community 526 - "Community 526"
 Cohesion: 0.67
-Nodes (0):
+Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
 ### Community 527 - "Community 527"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 528 - "Community 528"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 529 - "Community 529"
 Cohesion: 0.67
@@ -4184,8 +4191,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 532 - "Community 532"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 533 - "Community 533"
 Cohesion: 0.67
@@ -4232,28 +4239,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 544 - "Community 544"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 545 - "Community 545"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 546 - "Community 546"
-Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
-
-### Community 547 - "Community 547"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 547 - "Community 547"
+Cohesion: 1.0
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 548 - "Community 548"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 549 - "Community 549"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 550 - "Community 550"
 Cohesion: 0.67
@@ -4261,15 +4268,15 @@ Nodes (0):
 
 ### Community 551 - "Community 551"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 552 - "Community 552"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 553 - "Community 553"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 554 - "Community 554"
 Cohesion: 0.67
@@ -4280,8 +4287,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 556 - "Community 556"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 557 - "Community 557"
 Cohesion: 0.67
@@ -4296,8 +4303,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 560 - "Community 560"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 561 - "Community 561"
 Cohesion: 0.67
@@ -4308,16 +4315,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 563 - "Community 563"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 564 - "Community 564"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 565 - "Community 565"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 566 - "Community 566"
 Cohesion: 0.67
@@ -4328,40 +4335,40 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 568 - "Community 568"
+Cohesion: 1.0
+Nodes (2): listBagItems(), loadBagWithItems()
+
+### Community 569 - "Community 569"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 569 - "Community 569"
+### Community 570 - "Community 570"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 571 - "Community 571"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 572 - "Community 572"
 Cohesion: 1.0
 Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
-### Community 570 - "Community 570"
+### Community 573 - "Community 573"
 Cohesion: 1.0
 Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
-### Community 571 - "Community 571"
+### Community 574 - "Community 574"
 Cohesion: 1.0
 Nodes (2): addLookup(), buildServiceCaseTraceSeed()
-
-### Community 572 - "Community 572"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 573 - "Community 573"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 574 - "Community 574"
-Cohesion: 0.67
-Nodes (0):
 
 ### Community 575 - "Community 575"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 576 - "Community 576"
-Cohesion: 0.67
-Nodes (1): View()
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 577 - "Community 577"
 Cohesion: 0.67
@@ -4373,15 +4380,15 @@ Nodes (0):
 
 ### Community 579 - "Community 579"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 580 - "Community 580"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 581 - "Community 581"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 582 - "Community 582"
 Cohesion: 0.67
@@ -4392,8 +4399,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 584 - "Community 584"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 585 - "Community 585"
 Cohesion: 0.67
@@ -4404,36 +4411,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 587 - "Community 587"
-Cohesion: 1.0
-Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 588 - "Community 588"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 589 - "Community 589"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 590 - "Community 590"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
 ### Community 591 - "Community 591"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 592 - "Community 592"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 593 - "Community 593"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
-
-### Community 594 - "Community 594"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 594 - "Community 594"
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 595 - "Community 595"
 Cohesion: 0.67
@@ -4441,15 +4448,15 @@ Nodes (0):
 
 ### Community 596 - "Community 596"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 597 - "Community 597"
 Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 598 - "Community 598"
-Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 599 - "Community 599"
 Cohesion: 0.67
@@ -4460,12 +4467,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 601 - "Community 601"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 602 - "Community 602"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 603 - "Community 603"
 Cohesion: 0.67
@@ -4488,8 +4495,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 608 - "Community 608"
-Cohesion: 1.0
-Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 609 - "Community 609"
 Cohesion: 0.67
@@ -4504,8 +4511,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 612 - "Community 612"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
 
 ### Community 613 - "Community 613"
 Cohesion: 0.67
@@ -4513,87 +4520,87 @@ Nodes (0):
 
 ### Community 614 - "Community 614"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 615 - "Community 615"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 616 - "Community 616"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (0):
 
 ### Community 617 - "Community 617"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (0):
 
 ### Community 618 - "Community 618"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 619 - "Community 619"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 620 - "Community 620"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): AppSkeleton()
 
 ### Community 621 - "Community 621"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): DashboardSkeleton()
 
 ### Community 622 - "Community 622"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): TableSkeleton()
 
 ### Community 623 - "Community 623"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 624 - "Community 624"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): NotFound()
 
 ### Community 625 - "Community 625"
-Cohesion: 0.67
-Nodes (1): onChange()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 626 - "Community 626"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): AppContextMenu()
 
 ### Community 627 - "Community 627"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): Badge()
 
 ### Community 628 - "Community 628"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): LoadingButton()
 
 ### Community 629 - "Community 629"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): onChange()
 
 ### Community 630 - "Community 630"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): AlertModal()
 
 ### Community 631 - "Community 631"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): OverlayModal()
 
 ### Community 632 - "Community 632"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Skeleton()
 
 ### Community 633 - "Community 633"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 634 - "Community 634"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 635 - "Community 635"
 Cohesion: 0.67
@@ -4617,7 +4624,7 @@ Nodes (0):
 
 ### Community 640 - "Community 640"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 641 - "Community 641"
 Cohesion: 0.67
@@ -4633,7 +4640,7 @@ Nodes (0):
 
 ### Community 644 - "Community 644"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 645 - "Community 645"
 Cohesion: 0.67
@@ -4648,44 +4655,44 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 648 - "Community 648"
-Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 649 - "Community 649"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 650 - "Community 650"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 651 - "Community 651"
-Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
-
-### Community 652 - "Community 652"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 653 - "Community 653"
+### Community 652 - "Community 652"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): getApprovalGuidance(), presentCommandToast()
+
+### Community 653 - "Community 653"
+Cohesion: 0.67
+Nodes (1): isInMaintenanceMode()
 
 ### Community 654 - "Community 654"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 655 - "Community 655"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 656 - "Community 656"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 657 - "Community 657"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 657 - "Community 657"
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 658 - "Community 658"
 Cohesion: 0.67
@@ -4696,8 +4703,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 660 - "Community 660"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 661 - "Community 661"
 Cohesion: 0.67
@@ -4712,12 +4719,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 664 - "Community 664"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 665 - "Community 665"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 666 - "Community 666"
 Cohesion: 0.67
@@ -4729,71 +4736,71 @@ Nodes (0):
 
 ### Community 668 - "Community 668"
 Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 669 - "Community 669"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 670 - "Community 670"
 Cohesion: 0.67
-Nodes (1): hashPassword()
+Nodes (0):
 
 ### Community 671 - "Community 671"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 672 - "Community 672"
-Cohesion: 0.67
-Nodes (1): manualChunks()
+Cohesion: 1.0
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 673 - "Community 673"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 674 - "Community 674"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 675 - "Community 675"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 676 - "Community 676"
-Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Cohesion: 0.67
+Nodes (1): manualChunks()
 
 ### Community 677 - "Community 677"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 678 - "Community 678"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 679 - "Community 679"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 680 - "Community 680"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 681 - "Community 681"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 682 - "Community 682"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 683 - "Community 683"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 684 - "Community 684"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 685 - "Community 685"
 Cohesion: 0.67
@@ -4809,7 +4816,7 @@ Nodes (0):
 
 ### Community 688 - "Community 688"
 Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 689 - "Community 689"
 Cohesion: 0.67
@@ -4824,8 +4831,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 692 - "Community 692"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 693 - "Community 693"
 Cohesion: 0.67
@@ -4880,56 +4887,56 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 706 - "Community 706"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 707 - "Community 707"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 708 - "Community 708"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 709 - "Community 709"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 710 - "Community 710"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
 ### Community 711 - "Community 711"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 712 - "Community 712"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
-### Community 712 - "Community 712"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 713 - "Community 713"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 714 - "Community 714"
 Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 715 - "Community 715"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 716 - "Community 716"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 717 - "Community 717"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 718 - "Community 718"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 719 - "Community 719"
 Cohesion: 1.0
@@ -6049,7 +6056,7 @@ Nodes (0):
 
 ### Community 998 - "Community 998"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 999 - "Community 999"
 Cohesion: 1.0
@@ -6065,7 +6072,7 @@ Nodes (0):
 
 ### Community 1002 - "Community 1002"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1003 - "Community 1003"
 Cohesion: 1.0
@@ -10127,374 +10134,402 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2018 - "Community 2018"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2019 - "Community 2019"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2020 - "Community 2020"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2021 - "Community 2021"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2022 - "Community 2022"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2023 - "Community 2023"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2024 - "Community 2024"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 715`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 719`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 720`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 721`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 722`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 723`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 724`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 725`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 726`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 727`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 728`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 729`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 730`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 731`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 732`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 733`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 734`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 735`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 736`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 737`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 738`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 739`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 740`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 741`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `createMutationCtx()`, `catalogImport.test.ts`
+- **Thin community `Community 742`** (2 nodes): `createMutationCtx()`, `catalogImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 743`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 744`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 745`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 746`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 747`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 748`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 749`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 750`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 751`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 752`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 753`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 754`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 755`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 756`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 757`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 758`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 759`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 760`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 761`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 762`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 763`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 764`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 765`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 766`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 767`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 768`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 769`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 770`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 771`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `resolveTerminalCloudRepair.ts`, `resolveTerminalCloudRepair()`
+- **Thin community `Community 772`** (2 nodes): `resolveTerminalCloudRepair.ts`, `resolveTerminalCloudRepair()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 773`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 774`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 775`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 776`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 777`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 778`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 779`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 780`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 781`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 782`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 783`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 784`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 785`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 786`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 787`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 788`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 789`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 790`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 791`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 792`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 793`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 794`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 795`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 796`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 797`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 798`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 799`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 800`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 801`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 802`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 803`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 804`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 805`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 806`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 807`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 808`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 809`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 810`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 811`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 812`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 813`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 814`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 815`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 816`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 817`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 818`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 819`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 820`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 821`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 822`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 823`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 824`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 825`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 826`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 827`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 828`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 829`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 830`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 831`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 832`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 833`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 834`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 835`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 836`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 837`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 838`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 839`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 840`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 841`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 842`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 843`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 844`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 845`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 846`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 847`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 848`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 849`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 850`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 851`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 852`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 853`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 854`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 855`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 856`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 857`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 858`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 859`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 860`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 861`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 862`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 863`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `PickerHarness()`, `HomepageProductPickerDialog.test.tsx`
+- **Thin community `Community 864`** (2 nodes): `PickerHarness()`, `HomepageProductPickerDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 865`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 866`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 867`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 868`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 869`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 870`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 871`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 872`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 873`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 874`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 875`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 876`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 877`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 878`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 879`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 880`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 881`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 882`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 883`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 884`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 885`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 886`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
+- **Thin community `Community 887`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 888`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 889`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 890`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 891`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 892`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 893`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 894`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 895`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 896`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 897`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 898`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 899`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
+- **Thin community `Community 900`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 901`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -10530,1335 +10565,1327 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 902`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 903`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 904`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 905`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 906`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 907`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 908`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 909`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 910`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 911`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
+- **Thin community `Community 912`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 913`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 914`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 915`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 916`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 917`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 918`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 919`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 920`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 921`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 922`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 923`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 924`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 925`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 926`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 927`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 928`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 929`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 930`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 931`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 932`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 933`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 934`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 935`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 936`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 937`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 938`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 939`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 940`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 941`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 942`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 943`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 944`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 945`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `Calendar()`, `calendar.tsx`
+- **Thin community `Community 946`** (2 nodes): `Calendar()`, `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 947`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 948`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 949`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 950`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 951`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 952`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 953`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 954`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 955`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 956`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 957`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 958`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 959`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 960`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 961`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 962`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 963`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 964`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 965`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 966`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 967`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 968`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 969`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 970`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 971`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 972`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 973`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 974`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 975`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 976`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 977`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 978`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 979`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 980`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 981`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 982`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 983`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 984`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 985`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 986`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 987`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 988`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 989`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 990`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 991`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 992`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 993`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 994`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 995`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 996`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 997`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 998`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 999`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1000`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1001`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1002`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1003`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1004`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1005`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1006`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1007`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1008`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 1009`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1010`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1011`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1012`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1013`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1014`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1015`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1016`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1017`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1018`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1019`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1020`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
+- **Thin community `Community 1021`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1022`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1023`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1024`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1025`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
+- **Thin community `Community 1026`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1027`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1028`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1029`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1030`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1031`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1032`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1033`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1034`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1035`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1036`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1037`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1038`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1039`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1040`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1041`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1042`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1043`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1044`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1045`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1046`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1047`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1048`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1049`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 1050`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 1051`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1052`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1053`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1054`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1055`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1056`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1057`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1058`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1059`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1060`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1061`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1062`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1063`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1064`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1065`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1066`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1067`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1068`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1069`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1070`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1071`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1072`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1073`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1074`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1075`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1076`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1077`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1078`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1079`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1080`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1081`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1082`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1083`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1084`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1085`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1086`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1087`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1088`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1089`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1090`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1091`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1092`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1093`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1094`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1095`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1096`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1097`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1098`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1099`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1100`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1101`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1102`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1103`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1104`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1105`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1106`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1107`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1108`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1109`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1110`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1111`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1112`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1113`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1114`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1115`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1116`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1117`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1118`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1119`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1120`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1121`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1122`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1123`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1124`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1125`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1126`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1127`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1128`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1129`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1130`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1131`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1132`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1133`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1134`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1135`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1136`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1137`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1138`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1139`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1140`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1141`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1142`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1143`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1144`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1145`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1146`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1147`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1148`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1149`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1150`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1151`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1152`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1153`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1154`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1155`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1156`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1157`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1158`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1159`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1160`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1161`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1162`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1163`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1164`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1165`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1166`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1167`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1168`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1169`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1170`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1171`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1172`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1173`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1174`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1175`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1176`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1177`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1178`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1179`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1180`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1181`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1182`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1183`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1184`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1185`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1186`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1187`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1188`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1189`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `runGit()`, `pr-athena-delivery-run.test.ts`
+- **Thin community `Community 1190`** (2 nodes): `runGit()`, `pr-athena-delivery-run.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1191`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1192`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `api.js`
+- **Thin community `Community 1193`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1194`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1195`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `server.js`
+- **Thin community `Community 1196`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `app.ts`
+- **Thin community `Community 1197`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1198`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1199`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1200`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1201`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `auth.ts`
+- **Thin community `Community 1202`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1203`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1204`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1205`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `countries.ts`
+- **Thin community `Community 1206`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `email.ts`
+- **Thin community `Community 1207`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1208`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `payment.ts`
+- **Thin community `Community 1209`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `contextEvents.test.ts`
+- **Thin community `Community 1210`** (1 nodes): `contextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1211`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `types.ts`
+- **Thin community `Community 1212`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1213`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `crons.ts`
+- **Thin community `Community 1214`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1215`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `internal.ts`
+- **Thin community `Community 1216`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1217`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1218`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1219`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1220`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1221`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1222`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1223`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1224`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1225`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1226`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1227`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `env.ts`
+- **Thin community `Community 1228`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1229`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `auth.ts`
+- **Thin community `Community 1230`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1231`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `colors.ts`
+- **Thin community `Community 1232`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `index.ts`
+- **Thin community `Community 1233`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1234`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `products.ts`
+- **Thin community `Community 1235`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1236`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `stores.ts`
+- **Thin community `Community 1237`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1238`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `bag.ts`
+- **Thin community `Community 1239`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `guest.ts`
+- **Thin community `Community 1240`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1241`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `index.ts`
+- **Thin community `Community 1242`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `me.ts`
+- **Thin community `Community 1243`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `offers.ts`
+- **Thin community `Community 1244`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1245`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1246`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1247`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1248`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1249`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1250`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1251`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1252`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1253`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `user.ts`
+- **Thin community `Community 1254`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1255`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `index.ts`
+- **Thin community `Community 1256`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1257`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `http.ts`
+- **Thin community `Community 1258`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `access.ts`
+- **Thin community `Community 1259`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1260`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1261`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1262`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `index.ts`
+- **Thin community `Community 1263`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1264`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `types.ts`
+- **Thin community `Community 1265`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1266`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `categories.ts`
+- **Thin community `Community 1267`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `colors.ts`
+- **Thin community `Community 1268`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1269`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1270`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1271`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1272`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `pos.ts`
+- **Thin community `Community 1273`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1274`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1275`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1276`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1277`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1278`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1279`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1280`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1281`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1282`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1283`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1284`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1285`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1286`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1287`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1288`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1289`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `types.ts`
+- **Thin community `Community 1290`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1291`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1292`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1293`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1294`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1295`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1296`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `dto.ts`
+- **Thin community `Community 1297`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1298`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1299`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1300`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `types.ts`
+- **Thin community `Community 1301`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `types.ts`
+- **Thin community `Community 1302`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `types.ts`
+- **Thin community `Community 1303`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1304`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1305`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `customers.ts`
+- **Thin community `Community 1306`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `register.ts`
+- **Thin community `Community 1307`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `sync.ts`
+- **Thin community `Community 1308`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1309`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1310`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1311`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `schema.ts`
+- **Thin community `Community 1312`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `automation.ts`
+- **Thin community `Community 1313`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1314`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1315`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `index.ts`
+- **Thin community `Community 1316`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1317`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1318`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1319`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1320`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1321`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1322`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `category.ts`
+- **Thin community `Community 1323`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `color.ts`
+- **Thin community `Community 1324`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1325`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1326`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `index.ts`
+- **Thin community `Community 1327`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1328`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1329`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1330`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1331`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `organization.ts`
+- **Thin community `Community 1332`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1333`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `product.ts`
+- **Thin community `Community 1334`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1335`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1336`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `store.ts`
+- **Thin community `Community 1337`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1338`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `index.ts`
+- **Thin community `Community 1339`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1340`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1341`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1342`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1343`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1344`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1345`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1346`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `index.ts`
+- **Thin community `Community 1347`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1348`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1349`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1350`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1351`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1352`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1353`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1354`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1355`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1356`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1357`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1358`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `customer.ts`
+- **Thin community `Community 1359`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1360`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1361`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1362`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1363`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `index.ts`
+- **Thin community `Community 1364`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1365`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1366`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1367`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1368`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1369`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1370`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1371`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1372`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1373`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1374`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1375`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1376`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1377`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1378`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1379`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1380`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1381`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1382`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1383`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `index.ts`
+- **Thin community `Community 1384`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1385`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1386`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `index.ts`
+- **Thin community `Community 1387`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1388`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1389`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1390`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1391`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1392`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1393`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `index.ts`
+- **Thin community `Community 1394`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1395`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1396`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1397`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1398`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1399`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1400`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `bag.ts`
+- **Thin community `Community 1401`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1402`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1403`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1404`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `guest.ts`
+- **Thin community `Community 1405`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `index.ts`
+- **Thin community `Community 1406`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `offer.ts`
+- **Thin community `Community 1407`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1408`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1409`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `review.ts`
+- **Thin community `Community 1410`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1411`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1412`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1413`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1414`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1415`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1416`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1417`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1418`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1419`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `bag.ts`
+- **Thin community `Community 1420`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1421`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `customer.ts`
+- **Thin community `Community 1422`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `guest.ts`
+- **Thin community `Community 1423`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1424`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1425`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1426`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1427`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1428`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1429`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1430`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `users.ts`
+- **Thin community `Community 1431`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `payment.ts`
+- **Thin community `Community 1432`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1433`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1434`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1435`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1436`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1437`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1438`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1439`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `index.ts`
+- **Thin community `Community 1440`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1441`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1442`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1443`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1444`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `auth.ts`
+- **Thin community `Community 1445`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1446`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1447`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1448`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1449`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1450`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1451`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `index.ts`
+- **Thin community `Community 1452`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1453`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1454`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1455`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1456`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1457`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1458`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1459`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1460`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1461`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1462`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1463`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1464`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1465`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1466`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1467`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1468`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1469`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `constants.ts`
+- **Thin community `Community 1470`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1471`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1472`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1473`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `types.ts`
+- **Thin community `Community 1474`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1475`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1476`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1477`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1478`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1479`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1480`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1481`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1482`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1483`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1484`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1485`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1486`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1487`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1488`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1489`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1490`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1491`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1492`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1493`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1494`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `constants.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `data-table-faceted-filter.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `data-table-pagination.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `data-table.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `data.ts`
+- **Thin community `Community 1495`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1496`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1497`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1498`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1499`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1500`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1501`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1502`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1503`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1504`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `constants.ts`
+- **Thin community `Community 1505`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1506`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1507`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1508`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `data.ts`
+- **Thin community `Community 1509`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1510`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1511`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1512`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1513`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1514`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1515`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1516`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1517`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1518`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1519`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1520`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1521`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `constants.ts`
+- **Thin community `Community 1522`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1523`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1524`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1525`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1526`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1527`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1528`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1529`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1530`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1531`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1532`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1533`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1534`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1535`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1536`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1537`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1538`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1539`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1540`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1541`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1542`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1543`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1544`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1545`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1546`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1547`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1548`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1549`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1550`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1551`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1552`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1553`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1554`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1555`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `constants.ts`
+- **Thin community `Community 1556`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1557`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1558`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1559`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `data.ts`
+- **Thin community `Community 1560`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1561`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1562`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1563`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -11866,13 +11893,13 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1565`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1566`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1567`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `data.ts`
+- **Thin community `Community 1568`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1569`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1570`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -11886,889 +11913,903 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1575`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1576`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1577`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1578`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1579`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1580`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1581`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1582`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1583`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1584`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1585`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1586`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1587`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1588`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1589`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1590`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1591`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1592`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1593`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1594`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1595`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1596`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1597`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1598`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1599`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1600`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1601`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1602`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1603`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `types.ts`
+- **Thin community `Community 1604`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1605`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1606`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1607`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1608`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1609`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1610`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1611`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1612`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1613`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1614`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1615`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1616`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1617`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1618`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1619`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1620`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1621`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `data.ts`
+- **Thin community `Community 1622`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1623`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1624`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1625`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1626`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1627`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1628`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1629`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1630`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1631`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1632`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1633`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1634`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `constants.ts`
+- **Thin community `Community 1635`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1636`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1637`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1638`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `data.ts`
+- **Thin community `Community 1639`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `types.ts`
+- **Thin community `Community 1640`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1641`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1642`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1643`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1644`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1645`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `index.ts`
+- **Thin community `Community 1646`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1647`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1648`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1649`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1650`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `index.tsx`
+- **Thin community `Community 1651`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1652`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1653`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1654`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1655`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1656`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1657`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1658`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1659`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `index.tsx`
+- **Thin community `Community 1660`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1661`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1662`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1663`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `button.tsx`
+- **Thin community `Community 1664`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1665`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `card.tsx`
+- **Thin community `Community 1666`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1667`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1668`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `command.tsx`
+- **Thin community `Community 1669`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1670`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1671`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1672`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `form.tsx`
+- **Thin community `Community 1673`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1674`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1675`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `input.tsx`
+- **Thin community `Community 1676`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1677`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1678`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1679`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1680`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1681`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1682`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `select.tsx`
+- **Thin community `Community 1683`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1684`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1685`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1686`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1687`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `table.tsx`
+- **Thin community `Community 1688`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1689`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1690`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1691`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1692`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1693`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1694`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1695`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1696`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `constants.ts`
+- **Thin community `Community 1697`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1698`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1699`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1700`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `data.ts`
+- **Thin community `Community 1701`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1702`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1703`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1704`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1705`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1706`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1707`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1708`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1709`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1710`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1711`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `index.ts`
+- **Thin community `Community 1712`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1713`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1714`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1715`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 1716`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1717`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1718`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1719`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1720`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1721`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1722`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1723`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1724`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 1725`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 1726`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `index.ts`
+- **Thin community `Community 1727`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 1728`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `index.ts`
+- **Thin community `Community 1729`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 1730`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 1731`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `aws.ts`
+- **Thin community `Community 1732`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `constants.ts`
+- **Thin community `Community 1733`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `countries.ts`
+- **Thin community `Community 1734`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1735`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1736`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1737`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1738`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1739`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1740`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1741`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `dto.ts`
+- **Thin community `Community 1742`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `ports.ts`
+- **Thin community `Community 1743`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `constants.ts`
+- **Thin community `Community 1744`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1745`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1746`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `index.ts`
+- **Thin community `Community 1747`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1748`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `types.ts`
+- **Thin community `Community 1749`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1750`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1751`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1752`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1753`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1754`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1755`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1756`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1757`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1758`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 1759`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 1760`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 1761`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 1762`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1763`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1764`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1765`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1766`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `index.ts`
+- **Thin community `Community 1767`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1768`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `category.ts`
+- **Thin community `Community 1769`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `product.ts`
+- **Thin community `Community 1770`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `store.ts`
+- **Thin community `Community 1771`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1772`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `user.ts`
+- **Thin community `Community 1773`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1774`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1775`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1776`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1777`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1778`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `main.tsx`
+- **Thin community `Community 1779`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 1780`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1781`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1782`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1783`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1784`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1785`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `index.tsx`
+- **Thin community `Community 1786`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `index.tsx`
+- **Thin community `Community 1787`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `index.tsx`
+- **Thin community `Community 1788`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1789`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1790`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1791`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1792`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1793`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1794`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1795`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1796`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1797`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `home.tsx`
+- **Thin community `Community 1798`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1799`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1800`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1801`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `index.tsx`
+- **Thin community `Community 1802`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `review.tsx`
+- **Thin community `Community 1803`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1804`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1805`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `index.tsx`
+- **Thin community `Community 1806`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1807`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1808`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1809`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `index.tsx`
+- **Thin community `Community 1810`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1811`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1812`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1813`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1814`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1815`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1816`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1817`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1818`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1819`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1820`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1821`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1822`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1823`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1824`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1825`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1826`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `index.tsx`
+- **Thin community `Community 1827`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1828`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `index.tsx`
+- **Thin community `Community 1829`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `new.tsx`
+- **Thin community `Community 1830`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `index.tsx`
+- **Thin community `Community 1831`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `new.tsx`
+- **Thin community `Community 1832`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1833`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1834`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `index.tsx`
+- **Thin community `Community 1835`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `new.tsx`
+- **Thin community `Community 1836`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `index.tsx`
+- **Thin community `Community 1837`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1838`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1839`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1840`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1841`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1842`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1843`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1844`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1845`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `index.tsx`
+- **Thin community `Community 1846`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1847`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1848`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1849`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1850`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1851`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1852`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1853`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 1854`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1855`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1856`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1857`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1858`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1859`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1860`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1861`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1862`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1863`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1864`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1865`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1866`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1867`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1868`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1869`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1870`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `setup.ts`
+- **Thin community `Community 1871`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1872`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `types.ts`
+- **Thin community `Community 1873`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1874`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1875`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1876`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1877`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1878`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1879`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1880`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `types.ts`
+- **Thin community `Community 1881`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1882`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1883`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1884`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1885`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1886`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1887`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1888`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1889`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1890`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `schema.ts`
+- **Thin community `Community 1891`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1892`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1893`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1894`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1895`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1896`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1897`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1898`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1899`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1900`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `types.ts`
+- **Thin community `Community 1901`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1902`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1903`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1904`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1905`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1906`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1907`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1908`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `constants.ts`
+- **Thin community `Community 1909`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1910`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `About.tsx`
+- **Thin community `Community 1911`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1912`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1913`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1914`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1915`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1916`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1917`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1918`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1919`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1920`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1921`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `types.ts`
+- **Thin community `Community 1922`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1923`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1924`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1925`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1926`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1927`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1928`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1929`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1930`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1931`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1932`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1933`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `button.tsx`
+- **Thin community `Community 1934`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `card.tsx`
+- **Thin community `Community 1935`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1936`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `command.tsx`
+- **Thin community `Community 1937`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1938`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1939`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1940`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `form.tsx`
+- **Thin community `Community 1941`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1942`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1943`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1944`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1945`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `input.tsx`
+- **Thin community `Community 1946`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `label.tsx`
+- **Thin community `Community 1947`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1948`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1949`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1950`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `index.ts`
+- **Thin community `Community 1951`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `types.ts`
+- **Thin community `Community 1952`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1953`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1954`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1955`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1956`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `select.tsx`
+- **Thin community `Community 1957`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1958`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1959`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `table.tsx`
+- **Thin community `Community 1960`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1961`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1962`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1963`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1964`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1965`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `config.ts`
+- **Thin community `Community 1966`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 1967`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1968`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1969`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1970`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1971`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `constants.ts`
+- **Thin community `Community 1972`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `countries.ts`
+- **Thin community `Community 1973`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1974`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1975`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1976`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1977`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `index.ts`
+- **Thin community `Community 1978`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `store.ts`
+- **Thin community `Community 1979`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `bag.ts`
+- **Thin community `Community 1980`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1981`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `category.ts`
+- **Thin community `Community 1982`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `organization.ts`
+- **Thin community `Community 1983`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `product.ts`
+- **Thin community `Community 1984`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `store.ts`
+- **Thin community `Community 1985`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1986`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `user.ts`
+- **Thin community `Community 1987`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `states.ts`
+- **Thin community `Community 1988`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 1989`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1990`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1991`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1992`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1993`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1994`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1995`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1996`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `index.tsx`
+- **Thin community `Community 1997`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1998`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `index.tsx`
+- **Thin community `Community 1999`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2000`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2001`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2002`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2003`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2004`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `index.tsx`
+- **Thin community `Community 2005`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2006`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2007`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2008`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2009`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2010`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `index.js`
+- **Thin community `Community 2011`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2012`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2013`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2014`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2015`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2016`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2017`** (1 nodes): `vitest.setup.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2018`** (1 nodes): `index.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2019`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2020`** (1 nodes): `athena-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2021`** (1 nodes): `storefront-runtime-api.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2022`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2023`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2024`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2090
-- Graph nodes: 7761
-- Graph edges: 9064
-- Communities: 2018
+- Code files discovered: 2097
+- Graph nodes: 7781
+- Graph edges: 9074
+- Communities: 2025
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (87 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,7 +19,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 8) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 8) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 52) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 51) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `storefrontContextEvents.ts` (17 edges, Community 73) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
 - `checkoutSession.ts` (14 edges, Community 85) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 

--- a/packages/athena-webapp/convex/inventory/bestSeller.test.ts
+++ b/packages/athena-webapp/convex/inventory/bestSeller.test.ts
@@ -103,6 +103,7 @@ describe("best-seller product visibility", () => {
         }),
         query: vi.fn(() => ({
           filter: vi.fn(() => ({
+            collect: vi.fn(async () => []),
             first: vi.fn(async () => null),
           })),
         })),
@@ -137,6 +138,7 @@ describe("best-seller product visibility", () => {
         }),
         query: vi.fn(() => ({
           filter: vi.fn(() => ({
+            collect: vi.fn(async () => []),
             first: vi.fn(async () => null),
           })),
         })),
@@ -175,6 +177,7 @@ describe("best-seller product visibility", () => {
         }),
         query: vi.fn(() => ({
           filter: vi.fn(() => ({
+            collect: vi.fn(async () => []),
             first: vi.fn(async () => null),
           })),
         })),
@@ -195,6 +198,52 @@ describe("best-seller product visibility", () => {
       failureMessage: "You do not have access to manage homepage content.",
       organizationId: "org-1",
       userId: "athena-user-1",
+    });
+  });
+
+  it("appends newly created best sellers after the current ranked list", async () => {
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string, id: string) => {
+          if (table === "store") {
+            return { _id: id, organizationId: "org-1" };
+          }
+          if (table === "product") {
+            return { _id: id, storeId: "store123" };
+          }
+          if (table === "productSku") {
+            return { _id: id, storeId: "store123", productId: "product-1" };
+          }
+          if (table === "bestSeller") {
+            return { _id: id, storeId: "store123", rank: 5 };
+          }
+          return null;
+        }),
+        query: vi.fn(() => ({
+          filter: vi.fn(() => ({
+            collect: vi.fn(async () => [
+              { _id: "best-seller-1", storeId: "store123", rank: 0 },
+              { _id: "best-seller-2", storeId: "store123", rank: 4 },
+              { _id: "best-seller-legacy", storeId: "store123" },
+            ]),
+            first: vi.fn(async () => null),
+          })),
+        })),
+        insert: vi.fn(async () => "best-seller-3"),
+      },
+    } as any;
+
+    await getHandler(create)(ctx, {
+      storeId: "store123",
+      productId: "product-1",
+      productSkuId: "sku-1",
+    });
+
+    expect(ctx.db.insert).toHaveBeenCalledWith("bestSeller", {
+      productId: "product-1",
+      productSkuId: "sku-1",
+      rank: 5,
+      storeId: "store123",
     });
   });
 });

--- a/packages/athena-webapp/convex/inventory/bestSeller.ts
+++ b/packages/athena-webapp/convex/inventory/bestSeller.ts
@@ -13,6 +13,7 @@ import {
   requireAuthenticatedAthenaUserWithCtx,
   requireOrganizationMemberRoleWithCtx,
 } from "../lib/athenaUserAuth";
+import { getNextHomepageRank } from "../../shared/homepageRanking";
 
 const entity = "bestSeller";
 
@@ -62,6 +63,17 @@ const validateBestSellerPlacement = async (
   }
 };
 
+const getNextBestSellerRank = async (
+  ctx: QueryCtx | MutationCtx,
+  storeId: Id<"store">,
+) => {
+  const rows = await ctx.db
+    .query(entity)
+    .filter((q) => q.eq(q.field("storeId"), storeId))
+    .collect();
+  return getNextHomepageRank(rows);
+};
+
 export const create = mutation({
   args: {
     productId: v.id("product"),
@@ -86,9 +98,12 @@ export const create = mutation({
       return;
     }
 
+    const rank = await getNextBestSellerRank(ctx, args.storeId);
+
     const id = await ctx.db.insert(entity, {
       productId: args.productId,
       productSkuId: args.productSkuId,
+      rank,
       storeId: args.storeId,
     });
 

--- a/packages/athena-webapp/convex/inventory/featuredItem.test.ts
+++ b/packages/athena-webapp/convex/inventory/featuredItem.test.ts
@@ -13,8 +13,12 @@ function getHandler(definition: unknown) {
   return (definition as { _handler: Function })._handler;
 }
 
-function makeCreateCtx(records: Record<string, unknown> = {}) {
+function makeCreateCtx(
+  records: Record<string, unknown> = {},
+  rankedRows: unknown[] = [],
+) {
   const first = vi.fn(async () => null);
+  const take = vi.fn(async () => rankedRows);
 
   return {
     db: {
@@ -22,6 +26,7 @@ function makeCreateCtx(records: Record<string, unknown> = {}) {
       query: vi.fn(() => ({
         filter: vi.fn(() => ({
           first,
+          take,
         })),
       })),
       insert: vi.fn(async () => "featured-created"),
@@ -117,6 +122,46 @@ describe("featured homepage placement writes", () => {
       failureMessage: "You do not have access to manage homepage content.",
       organizationId: "org-1",
       userId: "athena-user-1",
+    });
+  });
+
+  it("appends regular highlighted items after the current ranked list", async () => {
+    const ctx = makeCreateCtx(
+      {
+        "store-1": {
+          _id: "store-1",
+          organizationId: "org-1",
+        },
+        "product-1": {
+          _id: "product-1",
+          storeId: "store-1",
+        },
+        "featured-created": {
+          _id: "featured-created",
+          storeId: "store-1",
+          rank: 5,
+        },
+      },
+      [
+        { _id: "featured-1", storeId: "store-1", type: "regular", rank: 0 },
+        { _id: "featured-2", storeId: "store-1", type: "regular", rank: 4 },
+        { _id: "featured-legacy", storeId: "store-1", type: "regular" },
+      ],
+    );
+
+    await getHandler(create)(ctx, {
+      storeId: "store-1",
+      type: "regular",
+      productId: "product-1",
+    });
+
+    expect(ctx.db.insert).toHaveBeenCalledWith("featuredItem", {
+      productId: "product-1",
+      categoryId: undefined,
+      subcategoryId: undefined,
+      rank: 5,
+      storeId: "store-1",
+      type: "regular",
     });
   });
 

--- a/packages/athena-webapp/convex/inventory/featuredItem.ts
+++ b/packages/athena-webapp/convex/inventory/featuredItem.ts
@@ -11,11 +11,14 @@ import {
   requireAuthenticatedAthenaUserWithCtx,
   requireOrganizationMemberRoleWithCtx,
 } from "../lib/athenaUserAuth";
+import { getNextHomepageRank } from "../../shared/homepageRanking";
+import {
+  isStorefrontSelectableSubcategory,
+  isStorefrontVisibleCategory,
+  isStorefrontVisibleSubcategory,
+} from "../../shared/storefrontVisibility";
 
 const entity = "featuredItem";
-
-const RESERVED_STOREFRONT_CATEGORY_SLUGS = new Set(["pos-quick-add"]);
-const RESERVED_STOREFRONT_SUBCATEGORY_SLUGS = new Set(["uncategorized"]);
 
 async function requireHomepageStoreAdmin(
   ctx: QueryCtx | MutationCtx,
@@ -36,16 +39,6 @@ async function requireHomepageStoreAdmin(
 
   return store;
 }
-
-const isCustomerVisibleCategory = (
-  category: { showOnStorefront?: boolean; slug: string } | null,
-) => {
-  return Boolean(
-    category &&
-      category.showOnStorefront !== false &&
-      !RESERVED_STOREFRONT_CATEGORY_SLUGS.has(category.slug),
-  );
-};
 
 const countFeaturedTargets = (args: {
   productId?: unknown;
@@ -82,7 +75,7 @@ const validateFeaturedPlacement = async (
     if (!category || category.storeId !== args.storeId) {
       throw new Error("Featured category must belong to the same store.");
     }
-    if (!isCustomerVisibleCategory(category)) {
+    if (!isStorefrontVisibleCategory(category)) {
       throw new Error("Featured category must be customer-visible.");
     }
     return;
@@ -93,7 +86,7 @@ const validateFeaturedPlacement = async (
     if (!subcategory || subcategory.storeId !== args.storeId) {
       throw new Error("Featured subcategory must belong to the same store.");
     }
-    if (RESERVED_STOREFRONT_SUBCATEGORY_SLUGS.has(subcategory.slug)) {
+    if (!isStorefrontVisibleSubcategory(subcategory)) {
       throw new Error("Featured subcategory must be customer-visible.");
     }
 
@@ -101,10 +94,26 @@ const validateFeaturedPlacement = async (
     if (!category || category.storeId !== args.storeId) {
       throw new Error("Featured subcategory parent must belong to the same store.");
     }
-    if (!isCustomerVisibleCategory(category)) {
+    if (!isStorefrontSelectableSubcategory(subcategory, category)) {
       throw new Error("Featured subcategory parent must be customer-visible.");
     }
   }
+};
+
+const getNextFeaturedItemRank = async (
+  ctx: QueryCtx | MutationCtx,
+  args: { storeId: Id<"store">; type?: string },
+) => {
+  const rows = await ctx.db
+    .query(entity)
+    .filter((q) =>
+      q.and(
+        q.eq(q.field("storeId"), args.storeId),
+        args.type ? q.eq(q.field("type"), args.type) : q.eq(1, 1),
+      ),
+    )
+    .take(100);
+  return getNextHomepageRank(rows);
 };
 
 export const create = mutation({
@@ -149,10 +158,16 @@ export const create = mutation({
       return;
     }
 
+    const rank = await getNextFeaturedItemRank(ctx, {
+      storeId: args.storeId,
+      type: args.type,
+    });
+
     const id = await ctx.db.insert(entity, {
       productId: args.productId,
       categoryId: args.categoryId,
       subcategoryId: args.subcategoryId,
+      rank,
       storeId: args.storeId,
       type: args.type,
     });

--- a/packages/athena-webapp/convex/storeFront/homepageSnapshot.test.ts
+++ b/packages/athena-webapp/convex/storeFront/homepageSnapshot.test.ts
@@ -326,10 +326,49 @@ describe("homepage snapshot presenter", () => {
     expect(snapshot.featuredItems[2].subcategory?.products.map((product) => product.productSlug)).toEqual([
       "subcategory-product",
     ]);
+    expect(snapshot.featuredItems[2].subcategory?.categorySlug).toBe(
+      "lace-fronts",
+    );
     expect(snapshot.shopLook?.id).toBe("shop-look");
     expect(JSON.stringify(snapshot)).not.toContain("omission");
     expect(JSON.stringify(snapshot)).not.toContain("_creationTime");
     expect(() => assertConformsToExportedReturns(get, snapshot)).not.toThrow();
+  });
+
+  it("sorts legacy unranked best sellers after ranked rows", () => {
+    const unranked = sku("unranked", 0);
+    delete (unranked as { rank?: number }).rank;
+
+    const snapshot = buildHomepageSnapshotV1({
+      store,
+      nowMs: 1_000,
+      bestSellers: [unranked, sku("ranked", 0)],
+      featuredItems: [],
+    });
+
+    expect(snapshot.bestSellers.map((item) => item.productSku.sku)).toEqual([
+      "SKU-ranked",
+      "SKU-unranked",
+    ]);
+    expect(snapshot.bestSellers.map((item) => item.rank)).toEqual([0, 1]);
+  });
+
+  it("presents contiguous ranks when explicit ranks are not zero-based", () => {
+    const unranked = sku("unranked", 0);
+    delete (unranked as { rank?: number }).rank;
+
+    const snapshot = buildHomepageSnapshotV1({
+      store,
+      nowMs: 1_000,
+      bestSellers: [unranked, sku("ranked", 5)],
+      featuredItems: [],
+    });
+
+    expect(snapshot.bestSellers.map((item) => item.productSku.sku)).toEqual([
+      "SKU-ranked",
+      "SKU-unranked",
+    ]);
+    expect(snapshot.bestSellers.map((item) => item.rank)).toEqual([0, 1]);
   });
 
   it("uses arrays and nulls for empty or ineligible public content", () => {

--- a/packages/athena-webapp/convex/storeFront/homepageSnapshot.ts
+++ b/packages/athena-webapp/convex/storeFront/homepageSnapshot.ts
@@ -6,15 +6,21 @@ import {
   presentPublicBannerMessage,
   publicBannerMessageValidator,
 } from "../inventory/bannerMessage";
+import {
+  compareHomepageRankedItems,
+  getPresentedHomepageRank,
+} from "../../shared/homepageRanking";
+import {
+  isStorefrontSelectableSubcategory,
+  isStorefrontVisibleCategory,
+  isStorefrontVisibleSubcategory,
+} from "../../shared/storefrontVisibility";
 
 export const HOMEPAGE_SNAPSHOT_CONTRACT_VERSION = "homepage_snapshot.v1" as const;
 export const BEST_SELLERS_LIMIT = 12;
 export const FEATURED_ITEMS_LIMIT = 12;
 export const FEATURED_ITEM_PRODUCTS_LIMIT = 5;
 export const HOMEPAGE_SNAPSHOT_SCAN_LIMIT = 100;
-
-const RESERVED_STOREFRONT_CATEGORY_SLUGS = new Set(["pos-quick-add"]);
-const RESERVED_STOREFRONT_SUBCATEGORY_SLUGS = new Set(["uncategorized"]);
 
 type AnyRecord = Record<string, any>;
 
@@ -46,6 +52,7 @@ const homepageCategoryValidator = v.object({
 const homepageSubcategoryValidator = v.object({
   subcategoryId: v.string(),
   categoryId: v.string(),
+  categorySlug: v.string(),
   name: v.string(),
   slug: v.string(),
   products: v.array(homepageProductSkuValidator),
@@ -107,37 +114,8 @@ const numberOrNull = (value: unknown): number | null => {
 
 const rowId = (row: AnyRecord) => String(row._id ?? row.id ?? "");
 
-const rowRank = (row: AnyRecord) => {
-  return typeof row.rank === "number" ? row.rank : 0;
-};
-
 const sortByRankThenId = <T extends AnyRecord>(rows: T[]): T[] => {
-  return [...rows].sort((a, b) => {
-    const rankDelta = rowRank(a) - rowRank(b);
-    if (rankDelta !== 0) {
-      return rankDelta;
-    }
-    return rowId(a).localeCompare(rowId(b));
-  });
-};
-
-const isCustomerVisibleCategory = (category: AnyRecord | null | undefined) => {
-  if (!category) {
-    return false;
-  }
-  if (category.showOnStorefront === false) {
-    return false;
-  }
-  return !RESERVED_STOREFRONT_CATEGORY_SLUGS.has(category.slug);
-};
-
-const isCustomerVisibleSubcategory = (
-  subcategory: AnyRecord | null | undefined,
-) => {
-  if (!subcategory) {
-    return false;
-  }
-  return !RESERVED_STOREFRONT_SUBCATEGORY_SLUGS.has(subcategory.slug);
+  return [...rows].sort(compareHomepageRankedItems);
 };
 
 const isCustomerVisibleProduct = (
@@ -178,8 +156,8 @@ const presentProductSku = (
   if (
     !isCustomerVisibleProduct(product, storeId) ||
     !isCustomerVisibleSku(sku, product, storeId) ||
-    !isCustomerVisibleCategory(category) ||
-    !isCustomerVisibleSubcategory(subcategory)
+    !isStorefrontVisibleCategory(category) ||
+    !isStorefrontVisibleSubcategory(subcategory)
   ) {
     return null;
   }
@@ -243,7 +221,7 @@ const presentCategory = (
   category: AnyRecord | null | undefined,
   storeId: string,
 ) => {
-  if (!isCustomerVisibleCategory(category) || category?.storeId !== storeId) {
+  if (!isStorefrontVisibleCategory(category) || category?.storeId !== storeId) {
     return null;
   }
 
@@ -269,9 +247,9 @@ const presentSubcategory = (
   storeId: string,
 ) => {
   if (
-    !isCustomerVisibleSubcategory(subcategory) ||
+    !isStorefrontVisibleSubcategory(subcategory) ||
     subcategory?.storeId !== storeId ||
-    !isCustomerVisibleCategory(subcategory?.category)
+    !isStorefrontSelectableSubcategory(subcategory, subcategory?.category)
   ) {
     return null;
   }
@@ -288,13 +266,18 @@ const presentSubcategory = (
   return {
     subcategoryId: String(subcategory._id),
     categoryId: String(subcategory.categoryId),
+    categorySlug: subcategory.category.slug,
     name: subcategory.name,
     slug: subcategory.slug,
     products,
   };
 };
 
-const presentFeaturedItem = (item: AnyRecord, storeId: string) => {
+const presentFeaturedItem = (
+  item: AnyRecord,
+  storeId: string,
+  fallbackRank: number,
+) => {
   const type: "regular" | "shop_look" =
     item.type === "shop_look" ? "shop_look" : "regular";
   const product = presentProduct(
@@ -307,7 +290,7 @@ const presentFeaturedItem = (item: AnyRecord, storeId: string) => {
   if (product) {
     return {
       id: rowId(item),
-      rank: rowRank(item),
+      rank: getPresentedHomepageRank(item, fallbackRank),
       type,
       targetKind: "product" as const,
       product,
@@ -320,7 +303,7 @@ const presentFeaturedItem = (item: AnyRecord, storeId: string) => {
   if (category) {
     return {
       id: rowId(item),
-      rank: rowRank(item),
+      rank: getPresentedHomepageRank(item, fallbackRank),
       type,
       targetKind: "category" as const,
       product: null,
@@ -333,7 +316,7 @@ const presentFeaturedItem = (item: AnyRecord, storeId: string) => {
   if (subcategory) {
     return {
       id: rowId(item),
-      rank: rowRank(item),
+      rank: getPresentedHomepageRank(item, fallbackRank),
       type,
       targetKind: "subcategory" as const,
       product: null,
@@ -362,7 +345,7 @@ export const buildHomepageSnapshotV1 = ({
   const config = normalizeStoreConfig(store.config);
 
   const bestSellerItems = sortByRankThenId(bestSellers ?? [])
-    .map((item) => {
+    .map((item, index) => {
       const productSku = presentProductSku(item.productSku, storeId);
       if (!productSku) {
         return null;
@@ -370,7 +353,7 @@ export const buildHomepageSnapshotV1 = ({
 
       return {
         id: rowId(item),
-        rank: rowRank(item),
+        rank: getPresentedHomepageRank(item, index),
         productSku,
       };
     })
@@ -378,7 +361,7 @@ export const buildHomepageSnapshotV1 = ({
     .slice(0, BEST_SELLERS_LIMIT);
 
   const presentedFeatured = sortByRankThenId(featuredItems ?? [])
-    .map((item) => presentFeaturedItem(item, storeId))
+    .map((item, index) => presentFeaturedItem(item, storeId, index))
     .filter((item): item is NonNullable<typeof item> => item !== null);
 
   const featuredRegular = presentedFeatured

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,14 +7,14 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 88 file(s); key children: __root.tsx, _authed, _authed.test.tsx, _authed.tsx, index.test.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 624 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 626 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 29 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 46 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.test.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 8 file(s); key children: AppShellFullscreenContext.tsx, ManagerElevationContext.test.tsx, ManagerElevationContext.tsx, OnlineOrderContext.tsx, PermissionsContext.tsx.
 - [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 201 file(s); key children: access, app-messages, app-update, aws.ts, behaviorUtils.ts.
-- [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 26 file(s); key children: approvalPolicy.ts, auth.ts, commandResult.test.ts, commandResult.ts, currencyFormatter.test.ts.
+- [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 30 file(s); key children: approvalPolicy.ts, auth.ts, commandResult.test.ts, commandResult.ts, currencyFormatter.test.ts.
 - [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 4 file(s); key children: formatNumber.ts, index.ts, versionChecker.test.ts, versionChecker.ts.
 
 ## Backend and test surfaces

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -198,9 +198,11 @@ This index enumerates the current automated test files and ties them back to the
 
 - [`shared/commandResult.test.ts`](../../shared/commandResult.test.ts)
 - [`shared/currencyFormatter.test.ts`](../../shared/currencyFormatter.test.ts)
+- [`shared/homepageRanking.test.ts`](../../shared/homepageRanking.test.ts)
 - [`shared/intelligence/contextTracking.test.ts`](../../shared/intelligence/contextTracking.test.ts)
 - [`shared/registerSessionStatus.test.ts`](../../shared/registerSessionStatus.test.ts)
 - [`shared/staffDisplayName.test.ts`](../../shared/staffDisplayName.test.ts)
+- [`shared/storefrontVisibility.test.ts`](../../shared/storefrontVisibility.test.ts)
 
 ## Section `src`
 
@@ -229,6 +231,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/components/cash-controls/formatReviewReason.test.ts`](../../src/components/cash-controls/formatReviewReason.test.ts)
 - [`src/components/common/PageHeader.test.tsx`](../../src/components/common/PageHeader.test.tsx)
 - [`src/components/common/PageLevelHeader.test.tsx`](../../src/components/common/PageLevelHeader.test.tsx)
+- [`src/components/homepage/HomepagePlacementProductImage.test.ts`](../../src/components/homepage/HomepagePlacementProductImage.test.ts)
 - [`src/components/homepage/HomepageProductPickerDialog.test.tsx`](../../src/components/homepage/HomepageProductPickerDialog.test.tsx)
 - [`src/components/join-team/index.test.tsx`](../../src/components/join-team/index.test.tsx)
 - [`src/components/operations/CommandApprovalDialog.test.tsx`](../../src/components/operations/CommandApprovalDialog.test.tsx)

--- a/packages/athena-webapp/shared/homepageRanking.test.ts
+++ b/packages/athena-webapp/shared/homepageRanking.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getNextHomepageRank,
+  getPresentedHomepageRank,
+  sortHomepageRankedItems,
+} from "./homepageRanking";
+
+describe("homepage ranking", () => {
+  it("sorts ranked rows first and legacy unranked rows last", () => {
+    expect(
+      sortHomepageRankedItems([
+        { _id: "legacy-a" },
+        { _id: "ranked-b", rank: 1 },
+        { _id: "ranked-a", rank: 0 },
+        { _id: "legacy-b" },
+      ]).map((item) => item._id),
+    ).toEqual(["ranked-a", "ranked-b", "legacy-a", "legacy-b"]);
+  });
+
+  it("appends new rows after the highest explicit rank", () => {
+    expect(
+      getNextHomepageRank([
+        { _id: "first", rank: 0 },
+        { _id: "legacy" },
+        { _id: "last", rank: 4 },
+      ]),
+    ).toBe(5);
+  });
+
+  it("uses collection length when no existing row has an explicit rank", () => {
+    expect(getNextHomepageRank([{ _id: "legacy-a" }, { _id: "legacy-b" }])).toBe(
+      2,
+    );
+  });
+
+  it("presents contiguous display ranks after sorting", () => {
+    expect(getPresentedHomepageRank({ _id: "ranked", rank: 3 }, 10)).toBe(10);
+    expect(getPresentedHomepageRank({ _id: "legacy" }, 10)).toBe(10);
+  });
+});

--- a/packages/athena-webapp/shared/homepageRanking.ts
+++ b/packages/athena-webapp/shared/homepageRanking.ts
@@ -1,0 +1,52 @@
+export type HomepageRankedItem = {
+  _id?: unknown;
+  id?: unknown;
+  rank?: number;
+};
+
+export const HOMEPAGE_UNRANKED_SORT_VALUE = Number.MAX_SAFE_INTEGER;
+
+export const getHomepageSortRank = (item: HomepageRankedItem) => {
+  return typeof item.rank === "number"
+    ? item.rank
+    : HOMEPAGE_UNRANKED_SORT_VALUE;
+};
+
+export const getPresentedHomepageRank = (
+  _item: HomepageRankedItem,
+  fallbackRank: number,
+) => {
+  return fallbackRank;
+};
+
+export const compareHomepageRankedItems = <T extends HomepageRankedItem>(
+  a: T,
+  b: T,
+) => {
+  const rankDelta = getHomepageSortRank(a) - getHomepageSortRank(b);
+  if (rankDelta !== 0) {
+    return rankDelta;
+  }
+
+  return String(a._id ?? a.id ?? "").localeCompare(
+    String(b._id ?? b.id ?? ""),
+  );
+};
+
+export const sortHomepageRankedItems = <T extends HomepageRankedItem>(
+  items: T[],
+) => [...items].sort(compareHomepageRankedItems);
+
+export const getNextHomepageRank = <T extends HomepageRankedItem>(
+  items: T[],
+) => {
+  const rankedRows = items.filter(
+    (item): item is T & { rank: number } => typeof item.rank === "number",
+  );
+
+  if (!rankedRows.length) {
+    return items.length;
+  }
+
+  return Math.max(...rankedRows.map((item) => item.rank)) + 1;
+};

--- a/packages/athena-webapp/shared/storefrontVisibility.test.ts
+++ b/packages/athena-webapp/shared/storefrontVisibility.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isStorefrontSelectableSubcategory,
+  isStorefrontVisibleCategory,
+  isStorefrontVisibleSubcategory,
+} from "./storefrontVisibility";
+
+describe("storefront visibility", () => {
+  it("keeps hidden and reserved categories out of storefront selections", () => {
+    expect(
+      isStorefrontVisibleCategory({
+        showOnStorefront: true,
+        slug: "hair-care",
+      }),
+    ).toBe(true);
+    expect(
+      isStorefrontVisibleCategory({
+        showOnStorefront: false,
+        slug: "hair-care",
+      }),
+    ).toBe(false);
+    expect(
+      isStorefrontVisibleCategory({
+        showOnStorefront: true,
+        slug: "pos-quick-add",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps reserved subcategories out of storefront selections", () => {
+    expect(isStorefrontVisibleSubcategory({ slug: "closures" })).toBe(true);
+    expect(isStorefrontVisibleSubcategory({ slug: "uncategorized" })).toBe(
+      false,
+    );
+  });
+
+  it("requires subcategory parent categories to be storefront-visible", () => {
+    expect(
+      isStorefrontSelectableSubcategory(
+        { slug: "closures" },
+        { showOnStorefront: true, slug: "hair" },
+      ),
+    ).toBe(true);
+    expect(
+      isStorefrontSelectableSubcategory(
+        { slug: "closures" },
+        { showOnStorefront: false, slug: "hair" },
+      ),
+    ).toBe(false);
+    expect(
+      isStorefrontSelectableSubcategory(
+        { slug: "uncategorized" },
+        { showOnStorefront: true, slug: "hair" },
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/athena-webapp/shared/storefrontVisibility.ts
+++ b/packages/athena-webapp/shared/storefrontVisibility.ts
@@ -1,0 +1,40 @@
+type StorefrontCategoryVisibility = {
+  showOnStorefront?: boolean;
+  slug?: string;
+};
+
+type StorefrontSubcategoryVisibility = {
+  slug?: string;
+};
+
+const RESERVED_STOREFRONT_CATEGORY_SLUGS = new Set(["pos-quick-add"]);
+const RESERVED_STOREFRONT_SUBCATEGORY_SLUGS = new Set(["uncategorized"]);
+
+export const isStorefrontVisibleCategory = (
+  category: StorefrontCategoryVisibility | null | undefined,
+) => {
+  return Boolean(
+    category &&
+      category.showOnStorefront !== false &&
+      !RESERVED_STOREFRONT_CATEGORY_SLUGS.has(category.slug ?? ""),
+  );
+};
+
+export const isStorefrontVisibleSubcategory = (
+  subcategory: StorefrontSubcategoryVisibility | null | undefined,
+) => {
+  return Boolean(
+    subcategory &&
+      !RESERVED_STOREFRONT_SUBCATEGORY_SLUGS.has(subcategory.slug ?? ""),
+  );
+};
+
+export const isStorefrontSelectableSubcategory = (
+  subcategory: StorefrontSubcategoryVisibility | null | undefined,
+  parentCategory: StorefrontCategoryVisibility | null | undefined,
+) => {
+  return (
+    isStorefrontVisibleSubcategory(subcategory) &&
+    isStorefrontVisibleCategory(parentCategory)
+  );
+};

--- a/packages/athena-webapp/src/components/homepage/BestSellers.tsx
+++ b/packages/athena-webapp/src/components/homepage/BestSellers.tsx
@@ -23,8 +23,10 @@ import { toast } from "sonner";
 import { getOrigin } from "~/src/lib/navigationUtils";
 import { getProductName } from "~/src/lib/productUtils";
 import { formatStoredCurrencyAmount } from "~/src/lib/pos/displayAmounts";
+import { sortHomepageRankedItems } from "~/shared/homepageRanking";
 import type { Id } from "~/convex/_generated/dataModel";
 import type { ProductSku } from "~/types";
+import { HomepagePlacementProductImage } from "./HomepagePlacementProductImage";
 
 type BestSellerItem = {
   _id: Id<"bestSeller">;
@@ -51,9 +53,7 @@ export const BestSellers = () => {
       return;
     }
 
-    setBestSellers(
-      [...bestSellersQuery].sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0)),
-    );
+    setBestSellers(sortHomepageRankedItems(bestSellersQuery));
   }, [bestSellersQuery]);
 
   const currency = activeStore?.currency || "USD";
@@ -192,10 +192,12 @@ export const BestSellers = () => {
                                 }}
                                 className="flex min-w-0 items-center gap-4"
                               >
-                                <img
-                                  src={bestSeller?.productSku?.images[0]}
-                                  alt={bestSeller?.productSku?.productName}
-                                  className="h-16 w-16 shrink-0 rounded-md object-cover"
+                                <HomepagePlacementProductImage
+                                  alt={
+                                    bestSeller?.productSku?.productName ||
+                                    itemLabel
+                                  }
+                                  sku={bestSeller?.productSku}
                                 />
                                 <div className="min-w-0 space-y-1">
                                   <p className="truncate text-sm">

--- a/packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx
+++ b/packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery } from "convex/react";
 import { api } from "~/convex/_generated/api";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
 import { HomepageProductPickerDialog } from "./HomepageProductPickerDialog";
-import type { Product, ProductSku } from "~/types";
+import type { Category, Product, ProductSku, Subcategory } from "~/types";
 
 export function BestSellersDialog({
   dialogOpen,
@@ -15,6 +15,16 @@ export function BestSellersDialog({
 
   const products = useQuery(
     api.inventory.products.getAll,
+    activeStore?._id ? { storeId: activeStore._id } : "skip"
+  );
+
+  const categories = useQuery(
+    api.inventory.categories.getAll,
+    activeStore?._id ? { storeId: activeStore._id } : "skip"
+  );
+
+  const subcategories = useQuery(
+    api.inventory.subcategories.getAll,
     activeStore?._id ? { storeId: activeStore._id } : "skip"
   );
 
@@ -36,6 +46,7 @@ export function BestSellersDialog({
 
   return (
     <HomepageProductPickerDialog
+      categories={categories as Category[] | undefined}
       currency={activeStore.currency}
       description="Select the exact SKU that should appear in the storefront best sellers list."
       onOpenChange={setDialogOpen}
@@ -44,6 +55,7 @@ export function BestSellersDialog({
       products={products as Product[] | undefined}
       searchId="homepage-best-seller-sku-search"
       selectLabel="Add SKU"
+      subcategories={subcategories as Subcategory[] | undefined}
       title="Add best seller"
     />
   );

--- a/packages/athena-webapp/src/components/homepage/FeaturedSection.tsx
+++ b/packages/athena-webapp/src/components/homepage/FeaturedSection.tsx
@@ -23,8 +23,10 @@ import { FeaturedSectionDialog } from "./FeaturedSectionDialog";
 import { getOrigin } from "~/src/lib/navigationUtils";
 import { formatStoredCurrencyAmount } from "~/src/lib/pos/displayAmounts";
 import { toast } from "sonner";
+import { sortHomepageRankedItems } from "~/shared/homepageRanking";
 import type { Id } from "~/convex/_generated/dataModel";
 import type { Category, Product, Subcategory } from "~/types";
+import { HomepagePlacementProductImage } from "./HomepagePlacementProductImage";
 
 type FeaturedHomepageItem = {
   _id: Id<"featuredItem">;
@@ -54,9 +56,7 @@ export const FeaturedSection = () => {
       return;
     }
 
-    setFeaturedItems(
-      [...featuredItemsQuery].sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0)),
-    );
+    setFeaturedItems(sortHomepageRankedItems(featuredItemsQuery));
   }, [featuredItemsQuery]);
 
   const removeHighlightedItem = useMutation(api.inventory.featuredItem.remove);
@@ -194,13 +194,9 @@ export const FeaturedSection = () => {
                                   search={{ o: getOrigin() }}
                                   className="flex min-w-0 items-center gap-4"
                                 >
-                                  <img
-                                    src={
-                                      product.skus[0]?.images[0] ||
-                                      "/placeholder.jpg"
-                                    }
+                                  <HomepagePlacementProductImage
                                     alt={product.name || "Product"}
-                                    className="h-16 w-16 aspect-square shrink-0 rounded-md object-cover"
+                                    product={product}
                                   />
                                   <div className="min-w-0 space-y-1">
                                     <p className="truncate text-sm">

--- a/packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx
+++ b/packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx
@@ -1,6 +1,11 @@
 import { useMutation, useQuery } from "convex/react";
+import { useMemo } from "react";
 import { api } from "~/convex/_generated/api";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
+import {
+  isStorefrontSelectableSubcategory,
+  isStorefrontVisibleCategory,
+} from "~/shared/storefrontVisibility";
 import { HomepageProductPickerDialog } from "./HomepageProductPickerDialog";
 import type { Category, Product, Subcategory } from "~/types";
 
@@ -29,6 +34,29 @@ export function FeaturedSectionDialog({
   );
 
   const addFeaturedItem = useMutation(api.inventory.featuredItem.create);
+
+  const storefrontVisibleCategories = useMemo(() => {
+    return (categories as Category[] | undefined)?.filter((category) =>
+      isStorefrontVisibleCategory(category),
+    );
+  }, [categories]);
+
+  const storefrontVisibleSubcategories = useMemo(() => {
+    const categoryById = new Map(
+      (categories as Category[] | undefined)?.map((category) => [
+        category._id,
+        category,
+      ]) ?? [],
+    );
+
+    return (subcategories as Subcategory[] | undefined)?.filter(
+      (subcategory) =>
+        isStorefrontSelectableSubcategory(
+          subcategory,
+          categoryById.get(subcategory.categoryId),
+        ),
+    );
+  }, [categories, subcategories]);
 
   const handleAddProduct = async (product: Product) => {
     if (!activeStore) return;
@@ -70,7 +98,7 @@ export function FeaturedSectionDialog({
 
   return (
     <HomepageProductPickerDialog
-      categories={categories as Category[] | undefined}
+      categories={storefrontVisibleCategories}
       currency={activeStore.currency}
       description="Select a product, category, or subcategory to feature below the homepage hero."
       onOpenChange={setDialogOpen}
@@ -82,7 +110,7 @@ export function FeaturedSectionDialog({
       searchId="homepage-highlighted-sku-search"
       selectLabel="Feature product"
       showCollections
-      subcategories={subcategories as Subcategory[] | undefined}
+      subcategories={storefrontVisibleSubcategories}
       title="Add highlighted content"
     />
   );

--- a/packages/athena-webapp/src/components/homepage/Home.tsx
+++ b/packages/athena-webapp/src/components/homepage/Home.tsx
@@ -8,23 +8,31 @@ import { BestSellers } from "./BestSellers";
 import { FeaturedSection } from "./FeaturedSection";
 import { api } from "~/convex/_generated/api";
 import { EmptyState } from "../states/empty/empty-state";
-import { PackagePlus, Store as StoreIcon } from "lucide-react";
+import {
+  ArrowDown,
+  CheckCircle2,
+  CircleAlert,
+  PackagePlus,
+  Store as StoreIcon,
+} from "lucide-react";
 import { ShopLookSection } from "./ShopLook";
 import { FadeIn } from "../common/FadeIn";
 import { HeroSectionTabs } from "./HeroSectionTabs";
 import { BannerMessageEditor } from "./BannerMessageEditor";
-import type { ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 import { Button } from "../ui/button";
 import { getOrigin } from "~/src/lib/navigationUtils";
 import { getStoreConfigV2 } from "~/src/lib/storeConfig";
 import type { Store as StoreDoc } from "~/types";
 
 function HomepageSettingsSection({
+  id,
   title,
   description,
   children,
   withTopBorder = false,
 }: {
+  id?: string;
   title: string;
   description: string;
   children: ReactNode;
@@ -32,16 +40,15 @@ function HomepageSettingsSection({
 }) {
   return (
     <section
+      id={id}
       className={[
-        "grid gap-layout-xl border-b border-border py-layout-2xl lg:grid-cols-[17rem_minmax(0,1fr)]",
+        "scroll-mt-layout-2xl grid gap-layout-xl border-b border-border py-layout-2xl lg:grid-cols-[17rem_minmax(0,1fr)]",
         withTopBorder ? "border-t" : "",
       ].join(" ")}
     >
       <div className="space-y-layout-sm">
         <h2 className="text-2xl font-medium text-foreground">{title}</h2>
-        <p className="text-sm leading-6 text-muted-foreground">
-          {description}
-        </p>
+        <p className="text-sm leading-6 text-muted-foreground">{description}</p>
       </div>
       <div className="min-w-0">{children}</div>
     </section>
@@ -52,13 +59,11 @@ function HomepageReadinessSummary({
   activeStore,
   bestSellersCount,
   highlightedCount,
-  isBannerActive,
   shopLookCount,
 }: {
   activeStore: StoreDoc;
   bestSellersCount: number;
   highlightedCount: number;
-  isBannerActive: boolean;
   shopLookCount: number;
 }) {
   const storeConfig = getStoreConfigV2(activeStore);
@@ -78,29 +83,52 @@ function HomepageReadinessSummary({
 
   const items = [
     {
-      label: "Hero",
-      value: heroIsReady ? "Ready" : "Needs media",
+      isReady: heroIsReady,
+      label: "Hero media",
+      sectionId: "homepage-hero-display",
+      value: heroIsReady ? "Ready" : "Add reel or image",
     },
     {
-      label: "Banner",
-      value: isBannerActive ? "Active" : "Inactive",
-    },
-    {
+      isReady: bestSellersCount > 0,
       label: "Best sellers",
+      sectionId: "homepage-best-sellers",
       value: `${bestSellersCount} selected`,
     },
     {
+      isReady: highlightedCount > 0,
       label: "Highlighted",
+      sectionId: "homepage-highlighted-content",
       value: `${highlightedCount} selected`,
     },
     {
+      isReady: shopLookIsReady,
       label: "Shop the Look",
+      sectionId: "homepage-shop-the-look",
       value: shopLookIsReady ? "Ready" : "Needs image and product",
     },
   ];
 
+  function handleReadinessJump(
+    event: MouseEvent<HTMLAnchorElement>,
+    sectionId: string,
+  ) {
+    const section = document.getElementById(sectionId);
+
+    if (!section) return;
+
+    event.preventDefault();
+
+    window.history.pushState(null, "", `#${sectionId}`);
+    section.scrollIntoView({
+      behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches
+        ? "auto"
+        : "smooth",
+      block: "start",
+    });
+  }
+
   return (
-    <section className="border-b border-border pb-layout-xl">
+    <section className="py-layout-md">
       <div className="grid gap-layout-lg lg:grid-cols-[17rem_minmax(0,1fr)]">
         <div className="space-y-layout-sm">
           <h2 className="text-2xl font-medium text-foreground">
@@ -110,19 +138,36 @@ function HomepageReadinessSummary({
             {readyCount} of 4 required homepage areas are ready for customers.
           </p>
         </div>
-        <div className="grid gap-layout-sm md:grid-cols-2 xl:grid-cols-5">
+        <div className="flex flex-wrap items-center gap-x-layout-lg gap-y-layout-sm">
           {items.map((item) => (
-            <div
+            <a
+              aria-label={`Jump to ${item.label}`}
+              href={`#${item.sectionId}`}
               key={item.label}
-              className="rounded-md border border-border bg-background p-layout-sm"
+              onClick={(event) => handleReadinessJump(event, item.sectionId)}
+              className="group flex min-w-[11rem] items-start gap-layout-xs rounded-md outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
-              <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                {item.label}
-              </p>
-              <p className="mt-layout-xs text-sm font-medium leading-5 text-foreground">
-                {item.value}
-              </p>
-            </div>
+              {item.isReady ? (
+                <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-success" />
+              ) : (
+                <CircleAlert className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground" />
+              )}
+              <div className="min-w-0">
+                <p className="text-sm font-medium leading-5 text-foreground">
+                  {item.label}
+                </p>
+                <p className="text-xs leading-5 text-muted-foreground">
+                  {item.value}
+                </p>
+                <span className="mt-layout-xs inline-flex items-center gap-1 text-xs font-medium leading-5 underline-offset-4 group-hover:underline">
+                  Go to section
+                  <ArrowDown
+                    aria-hidden="true"
+                    className="h-3 w-3 transition-transform group-hover:translate-y-0.5"
+                  />
+                </span>
+              </div>
+            </a>
           ))}
         </div>
       </div>
@@ -135,7 +180,7 @@ export default function Home() {
 
   const products = useQuery(
     api.inventory.products.getAll,
-    activeStore?._id ? { storeId: activeStore._id } : "skip"
+    activeStore?._id ? { storeId: activeStore._id } : "skip",
   );
 
   const bestSellers = useQuery(
@@ -150,11 +195,6 @@ export default function Home() {
     api.inventory.featuredItem.getAll,
     activeStore?._id ? { storeId: activeStore._id, type: "shop_look" } : "skip",
   );
-  const bannerMessage = useQuery(
-    api.inventory.bannerMessage.get,
-    activeStore?._id ? { storeId: activeStore._id } : "skip",
-  );
-
   if (!activeStore || products === undefined) return null;
 
   const hasProducts = products.length > 0;
@@ -179,14 +219,13 @@ export default function Home() {
               activeStore={activeStore}
               bestSellersCount={bestSellers?.length ?? 0}
               highlightedCount={highlightedItems?.length ?? 0}
-              isBannerActive={Boolean(bannerMessage?.active)}
               shopLookCount={shopLookItems?.length ?? 0}
             />
 
             <HomepageSettingsSection
+              id="homepage-hero-display"
               title="Hero display"
               description="Choose the lead media, text treatment, and active reel or image for the top of the storefront."
-              withTopBorder
             >
               <HeroSectionTabs />
             </HomepageSettingsSection>
@@ -199,6 +238,7 @@ export default function Home() {
             </HomepageSettingsSection>
 
             <HomepageSettingsSection
+              id="homepage-best-sellers"
               title="Best sellers"
               description="Order the products that should anchor the customer's first shopping path."
             >
@@ -206,6 +246,7 @@ export default function Home() {
             </HomepageSettingsSection>
 
             <HomepageSettingsSection
+              id="homepage-highlighted-content"
               title="Highlighted content"
               description="Select the product, category, or collection callout shown after the hero."
             >
@@ -213,6 +254,7 @@ export default function Home() {
             </HomepageSettingsSection>
 
             <HomepageSettingsSection
+              id="homepage-shop-the-look"
               title="Shop the look"
               description="Pair one visual story with the product customers should move toward next."
             >

--- a/packages/athena-webapp/src/components/homepage/HomepagePlacementProductImage.test.ts
+++ b/packages/athena-webapp/src/components/homepage/HomepagePlacementProductImage.test.ts
@@ -1,0 +1,52 @@
+import { createElement } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  getProductImageUrl,
+  HomepagePlacementProductImage,
+} from "./HomepagePlacementProductImage";
+import type { Product } from "~/types";
+
+describe("getProductImageUrl", () => {
+  it("uses the first available image across product SKUs", () => {
+    const product = {
+      skus: [
+        {
+          images: [],
+        },
+        {
+          images: ["https://example.com/bone-straight.webp"],
+        },
+      ],
+    } as unknown as Product;
+
+    expect(getProductImageUrl(product)).toBe(
+      "https://example.com/bone-straight.webp",
+    );
+  });
+
+  it("renders the placement placeholder when the image fails to load", () => {
+    const product = {
+      skus: [
+        {
+          images: ["https://example.com/broken.webp"],
+        },
+      ],
+    } as unknown as Product;
+
+    render(
+      createElement(HomepagePlacementProductImage, {
+        alt: "Bone Straight Wig",
+        product,
+      }),
+    );
+
+    fireEvent.error(screen.getByRole("img", { name: "Bone Straight Wig" }));
+
+    expect(
+      screen.getByRole("img", { name: "Bone Straight Wig" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByAltText("Bone Straight Wig")).not.toBeInTheDocument();
+  });
+});

--- a/packages/athena-webapp/src/components/homepage/HomepagePlacementProductImage.tsx
+++ b/packages/athena-webapp/src/components/homepage/HomepagePlacementProductImage.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import { ImageIcon } from "lucide-react";
+
+import type { Product, ProductSku } from "~/types";
+
+export function HomepagePlacementProductImage({
+  alt,
+  className = "h-16 w-16",
+  product,
+  sku,
+}: {
+  alt: string;
+  className?: string;
+  product?: Product | null;
+  sku?: ProductSku | null;
+}) {
+  const [failed, setFailed] = useState(false);
+  const imageUrl = sku ? getSkuImageUrl(sku) : getProductImageUrl(product);
+
+  if (!imageUrl || failed) {
+    return (
+      <div
+        aria-label={alt}
+        className={`${className} flex aspect-square shrink-0 items-center justify-center rounded-md border border-border bg-surface text-muted-foreground`}
+        role="img"
+      >
+        <ImageIcon className="h-5 w-5" />
+      </div>
+    );
+  }
+
+  return (
+    <img
+      alt={alt}
+      className={`${className} aspect-square shrink-0 rounded-md object-cover`}
+      onError={() => setFailed(true)}
+      src={imageUrl}
+    />
+  );
+}
+
+export function getProductImageUrl(product?: Product | null) {
+  return product?.skus
+    .flatMap((sku) => sku.images)
+    .find((image): image is string => typeof image === "string" && image !== "");
+}
+
+function getSkuImageUrl(sku?: ProductSku | null) {
+  return sku?.images.find(
+    (image): image is string => typeof image === "string" && image !== "",
+  );
+}

--- a/packages/athena-webapp/src/components/homepage/HomepageProductPickerDialog.test.tsx
+++ b/packages/athena-webapp/src/components/homepage/HomepageProductPickerDialog.test.tsx
@@ -3,12 +3,14 @@ import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { HomepageProductPickerDialog } from "./HomepageProductPickerDialog";
-import type { Product } from "~/types";
+import type { Category, Product, Subcategory } from "~/types";
 
 const products = [
   {
     _id: "product-1",
+    categoryId: "category-hair",
     name: "Lace Front Wig",
+    subcategoryId: "subcategory-closures",
     categoryName: "Hair",
     categorySlug: "hair",
     skus: [
@@ -24,7 +26,9 @@ const products = [
   },
   {
     _id: "product-2",
+    categoryId: "category-closures",
     name: "Closure Unit",
+    subcategoryId: "subcategory-closures",
     categoryName: "Closures",
     categorySlug: "closures",
     skus: [
@@ -39,6 +43,23 @@ const products = [
     ],
   },
 ] as unknown as Product[];
+
+const categories = [
+  {
+    _id: "category-hair",
+    name: "Hair",
+    slug: "hair",
+  },
+] as unknown as Category[];
+
+const subcategories = [
+  {
+    _id: "subcategory-closures",
+    categoryId: "category-hair",
+    name: "Closures",
+    slug: "closures",
+  },
+] as unknown as Subcategory[];
 
 function PickerHarness() {
   const [open, setOpen] = useState(true);
@@ -105,5 +126,94 @@ describe("HomepageProductPickerDialog", () => {
     expect(screen.getByText("Closure Unit")).toBeInTheDocument();
 
     consoleError.mockRestore();
+  });
+
+  it("resolves product taxonomy labels from category and subcategory ids", () => {
+    const productsWithoutDenormalizedTaxonomy = [
+      {
+        _id: "product-raw-taxonomy",
+        categoryId: "category-hair",
+        name: '8" Closure',
+        subcategoryId: "subcategory-closures",
+        skus: [
+          {
+            _id: "sku-raw-taxonomy",
+            productId: "product-raw-taxonomy",
+            productName: '8" Closure',
+            sku: "CLOSURE-8",
+            images: [],
+            price: 99_900,
+            quantityAvailable: 43,
+          },
+        ],
+      },
+      {
+        _id: "product-other-taxonomy",
+        categoryId: "category-books",
+        name: "Operating Manual",
+        subcategoryId: "subcategory-systems",
+        skus: [
+          {
+            _id: "sku-other-taxonomy",
+            productId: "product-other-taxonomy",
+            productName: "Operating Manual",
+            sku: "BOOK-1",
+            images: [],
+            price: 90_000,
+            quantityAvailable: 4,
+          },
+        ],
+      },
+    ] as unknown as Product[];
+    const categoriesForDerivedTaxonomy = [
+      ...categories,
+      {
+        _id: "category-books",
+        name: "Books",
+        slug: "books",
+      },
+    ] as unknown as Category[];
+    const subcategoriesForDerivedTaxonomy = [
+      ...subcategories,
+      {
+        _id: "subcategory-systems",
+        categoryId: "category-books",
+        name: "Systems",
+        slug: "systems",
+      },
+    ] as unknown as Subcategory[];
+
+    render(
+      <HomepageProductPickerDialog
+        categories={categoriesForDerivedTaxonomy}
+        currency="GHS"
+        description="Select a SKU"
+        onOpenChange={vi.fn()}
+        onSelectSku={vi.fn()}
+        open
+        products={productsWithoutDenormalizedTaxonomy}
+        searchId="homepage-picker-taxonomy-test"
+        selectLabel="Add SKU"
+        subcategories={subcategoriesForDerivedTaxonomy}
+        title="Add best seller"
+      />,
+    );
+
+    expect(screen.getByText('8" Closure')).toBeInTheDocument();
+    expect(screen.getByText("Hair / Closures")).toBeInTheDocument();
+    expect(screen.queryByText("Uncategorized")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Hair" }));
+
+    expect(screen.getByText('8" Closure')).toBeInTheDocument();
+    expect(screen.queryByText("Operating Manual")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Hair" }));
+    fireEvent.change(screen.getByPlaceholderText("Search product, SKU, or barcode"), {
+      target: { value: "systems" },
+    });
+
+    expect(screen.queryByText('8" Closure')).not.toBeInTheDocument();
+    expect(screen.getByText("Operating Manual")).toBeInTheDocument();
   });
 });

--- a/packages/athena-webapp/src/components/homepage/HomepageProductPickerDialog.tsx
+++ b/packages/athena-webapp/src/components/homepage/HomepageProductPickerDialog.tsx
@@ -89,6 +89,16 @@ export function HomepageProductPickerDialog({
   const previousOpenRef = useRef(open);
   const isSkuSelection = !!onSelectSku;
 
+  const categoryById = useMemo(() => {
+    return new Map(categories.map((category) => [category._id, category]));
+  }, [categories]);
+
+  const subcategoryById = useMemo(() => {
+    return new Map(
+      subcategories.map((subcategory) => [subcategory._id, subcategory]),
+    );
+  }, [subcategories]);
+
   const skuOptions = useMemo(() => {
     return (products ?? []).flatMap((product) =>
       product.skus.map((sku) => ({ product, sku })),
@@ -99,7 +109,8 @@ export function HomepageProductPickerDialog({
     const counts = new Map<string, { itemCount: number; label: string }>();
 
     for (const product of products ?? []) {
-      const key = product.categorySlug || product.categoryName;
+      const category = categoryById.get(product.categoryId);
+      const key = product.categorySlug || category?.slug || product.categoryName;
       if (!key) continue;
 
       const existing = counts.get(key);
@@ -107,37 +118,48 @@ export function HomepageProductPickerDialog({
         itemCount:
           (existing?.itemCount ?? 0) +
           (isSkuSelection ? product.skus.length : 1),
-        label: product.categoryName ?? key,
+        label: product.categoryName ?? category?.name ?? key,
       });
     }
 
     return [...counts.entries()]
       .map(([key, value]) => ({ key, ...value }))
       .sort((a, b) => a.label.localeCompare(b.label));
-  }, [isSkuSelection, products]);
+  }, [categoryById, isSkuSelection, products]);
 
   const normalizedQuery = normalizeSkuSearchQuery(query);
   const productOptions = useMemo(() => products ?? [], [products]);
   const filteredSkuOptions = skuOptions.filter(({ product, sku }) => {
+    const categoryFilterKey = getProductCategoryFilterKey(
+      product,
+      categoryById,
+    );
+
     if (!skuMatchesAvailabilityFilter(sku, availabilityFilter)) {
       return false;
     }
 
     if (
       categoryFilter !== ALL_CATEGORY_FILTER_KEY &&
-      product.categorySlug !== categoryFilter &&
-      product.categoryName !== categoryFilter
+      categoryFilterKey !== categoryFilter
     ) {
       return false;
     }
 
-    return matchesSkuSearchTerms(getHomepageSkuSearchTerms(product, sku), normalizedQuery);
+    return matchesSkuSearchTerms(
+      getHomepageSkuSearchTerms(product, sku, categoryById, subcategoryById),
+      normalizedQuery,
+    );
   });
   const filteredProductOptions = productOptions.filter((product) => {
+    const categoryFilterKey = getProductCategoryFilterKey(
+      product,
+      categoryById,
+    );
+
     if (
       categoryFilter !== ALL_CATEGORY_FILTER_KEY &&
-      product.categorySlug !== categoryFilter &&
-      product.categoryName !== categoryFilter
+      categoryFilterKey !== categoryFilter
     ) {
       return false;
     }
@@ -152,7 +174,7 @@ export function HomepageProductPickerDialog({
     }
 
     return matchesSkuSearchTerms(
-      getHomepageProductSearchTerms(product),
+      getHomepageProductSearchTerms(product, categoryById, subcategoryById),
       normalizedQuery,
     );
   });
@@ -230,7 +252,7 @@ export function HomepageProductPickerDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="flex max-h-[min(92dvh,860px)] w-[min(calc(100vw-2rem),72rem)] max-w-none flex-col gap-0 overflow-hidden border-border bg-surface-raised p-0 shadow-overlay">
+      <DialogContent className="flex h-[min(92dvh,860px)] w-[min(calc(100vw-2rem),72rem)] max-w-none flex-col gap-0 overflow-hidden border-border bg-surface-raised p-0 shadow-overlay">
         <DialogHeader className="border-b border-border px-layout-lg py-layout-md text-left">
           <DialogTitle className="font-display text-2xl font-medium tracking-normal">
             {title}
@@ -331,6 +353,11 @@ export function HomepageProductPickerDialog({
                       getProductAvailableUnits(product) <= 0;
                     const selectionKey = `product-${product._id}`;
                     const productStatusId = `${searchId}-${selectionKey}-status`;
+                    const taxonomyLabel = getProductTaxonomyLabel(
+                      product,
+                      categoryById,
+                      subcategoryById,
+                    );
 
                     return (
                       <button
@@ -362,7 +389,7 @@ export function HomepageProductPickerDialog({
                               {product.name}
                             </p>
                             <p className="truncate text-xs text-muted-foreground">
-                              {product.categoryName ?? "Uncategorized"}
+                              {taxonomyLabel}
                             </p>
                           </div>
                           <div className="flex flex-wrap gap-1.5 text-xs text-muted-foreground">
@@ -421,6 +448,11 @@ export function HomepageProductPickerDialog({
                     const skuIsUnavailable = getSkuAvailableUnits(sku) <= 0;
                     const selectionKey = `sku-${sku._id}`;
                     const skuStatusId = `${searchId}-${selectionKey}-status`;
+                    const taxonomyLabel = getProductTaxonomyLabel(
+                      product,
+                      categoryById,
+                      subcategoryById,
+                    );
 
                     return (
                       <button
@@ -454,7 +486,7 @@ export function HomepageProductPickerDialog({
                               {getProductName(sku) || product.name}
                             </p>
                             <p className="truncate text-xs text-muted-foreground">
-                              {product.categoryName ?? "Uncategorized"}
+                              {taxonomyLabel}
                             </p>
                           </div>
                           <div className="flex flex-wrap gap-1.5 text-xs text-muted-foreground">
@@ -634,13 +666,47 @@ function MetadataPill({ children }: { children: ReactNode }) {
   );
 }
 
-function getHomepageSkuSearchTerms(product: Product, sku: ProductSku) {
+function getProductCategoryFilterKey(
+  product: Product,
+  categoryById: Map<Category["_id"], Category>,
+) {
+  const category = categoryById.get(product.categoryId);
+
+  return product.categorySlug || category?.slug || product.categoryName;
+}
+
+function getProductTaxonomyLabel(
+  product: Product,
+  categoryById: Map<Category["_id"], Category>,
+  subcategoryById: Map<Subcategory["_id"], Subcategory>,
+) {
+  const category = categoryById.get(product.categoryId);
+  const subcategory = subcategoryById.get(product.subcategoryId);
+  const categoryLabel = product.categoryName ?? category?.name;
+  const subcategoryLabel = product.subcategoryName ?? subcategory?.name;
+
+  if (categoryLabel && subcategoryLabel) {
+    return `${categoryLabel} / ${subcategoryLabel}`;
+  }
+
+  return categoryLabel ?? subcategoryLabel ?? "Uncategorized";
+}
+
+function getHomepageSkuSearchTerms(
+  product: Product,
+  sku: ProductSku,
+  categoryById: Map<Category["_id"], Category>,
+  subcategoryById: Map<Subcategory["_id"], Subcategory>,
+) {
+  const category = categoryById.get(product.categoryId);
+  const subcategory = subcategoryById.get(product.subcategoryId);
+
   return [
     product.name,
-    product.categoryName,
-    product.subcategoryName,
-    product.categorySlug,
-    product.subcategorySlug,
+    product.categoryName ?? category?.name,
+    product.subcategoryName ?? subcategory?.name,
+    product.categorySlug ?? category?.slug,
+    product.subcategorySlug ?? subcategory?.slug,
     sku.sku,
     sku.barcode,
     sku.productCategory,
@@ -653,14 +719,23 @@ function getHomepageSkuSearchTerms(product: Product, sku: ProductSku) {
   ];
 }
 
-function getHomepageProductSearchTerms(product: Product) {
+function getHomepageProductSearchTerms(
+  product: Product,
+  categoryById: Map<Category["_id"], Category>,
+  subcategoryById: Map<Subcategory["_id"], Subcategory>,
+) {
+  const category = categoryById.get(product.categoryId);
+  const subcategory = subcategoryById.get(product.subcategoryId);
+
   return [
     product.name,
-    product.categoryName,
-    product.subcategoryName,
-    product.categorySlug,
-    product.subcategorySlug,
-    ...product.skus.flatMap((sku) => getHomepageSkuSearchTerms(product, sku)),
+    product.categoryName ?? category?.name,
+    product.subcategoryName ?? subcategory?.name,
+    product.categorySlug ?? category?.slug,
+    product.subcategorySlug ?? subcategory?.slug,
+    ...product.skus.flatMap((sku) =>
+      getHomepageSkuSearchTerms(product, sku, categoryById, subcategoryById),
+    ),
   ];
 }
 

--- a/packages/athena-webapp/src/components/homepage/ShopLook.tsx
+++ b/packages/athena-webapp/src/components/homepage/ShopLook.tsx
@@ -22,6 +22,7 @@ import { getStoreConfigV2 } from "~/src/lib/storeConfig";
 import { formatStoredCurrencyAmount } from "~/src/lib/pos/displayAmounts";
 import type { Id } from "~/convex/_generated/dataModel";
 import type { Product } from "~/types";
+import { HomepagePlacementProductImage } from "./HomepagePlacementProductImage";
 
 type ShopLookItem = {
   _id: Id<"featuredItem">;
@@ -142,13 +143,9 @@ export const ShopLookSection = () => {
                 search={{ o: getOrigin() }}
                 className="flex min-w-0 items-center gap-4"
               >
-                <img
-                  src={
-                    featuredItem.product.skus[0]?.images[0] ||
-                    "/placeholder.jpg"
-                  }
+                <HomepagePlacementProductImage
                   alt={featuredItem.product.name || "Product"}
-                  className="h-16 w-16 aspect-square shrink-0 rounded-md object-cover"
+                  product={featuredItem.product}
                 />
                 <div className="min-w-0 space-y-1">
                   <p className="truncate text-sm">

--- a/packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx
+++ b/packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx
@@ -3,7 +3,7 @@ import { api } from "~/convex/_generated/api";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
 import { Id } from "~/convex/_generated/dataModel";
 import { HomepageProductPickerDialog } from "./HomepageProductPickerDialog";
-import type { Product } from "~/types";
+import type { Category, Product, Subcategory } from "~/types";
 
 export function ShopLookDialog({
   action,
@@ -20,6 +20,16 @@ export function ShopLookDialog({
 
   const products = useQuery(
     api.inventory.products.getAll,
+    activeStore?._id ? { storeId: activeStore._id } : "skip"
+  );
+
+  const categories = useQuery(
+    api.inventory.categories.getAll,
+    activeStore?._id ? { storeId: activeStore._id } : "skip"
+  );
+
+  const subcategories = useQuery(
+    api.inventory.subcategories.getAll,
     activeStore?._id ? { storeId: activeStore._id } : "skip"
   );
 
@@ -47,6 +57,7 @@ export function ShopLookDialog({
 
   return (
     <HomepageProductPickerDialog
+      categories={categories as Category[] | undefined}
       currency={activeStore.currency}
       description="Select the product that should anchor the Shop the Look story."
       onOpenChange={setDialogOpen}
@@ -55,6 +66,7 @@ export function ShopLookDialog({
       products={products as Product[] | undefined}
       searchId="homepage-shop-look-sku-search"
       selectLabel={action === "edit" ? "Replace product" : "Add product"}
+      subcategories={subcategories as Subcategory[] | undefined}
       title={action === "edit" ? "Replace Shop the Look product" : "Add Shop the Look product"}
     />
   );

--- a/packages/storefront-webapp/docs/agent/key-folder-index.md
+++ b/packages/storefront-webapp/docs/agent/key-folder-index.md
@@ -7,7 +7,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack Router routes, layouts, and browser journey entrypoints. Currently 36 file(s); key children: -homePageLoader.test.ts, -homePageLoader.ts, __root.tsx, _layout, _layout.tsx.
-- [`src/components`](../../src/components) — Reusable storefront UI and feature-specific checkout/catalog components. Currently 190 file(s); key children: DefaultCatchBoundary.tsx, EntityPage.tsx, HomePage.test.tsx, HomePage.tsx, ProductActionBar.tsx.
+- [`src/components`](../../src/components) — Reusable storefront UI and feature-specific checkout/catalog components. Currently 191 file(s); key children: DefaultCatchBoundary.tsx, EntityPage.tsx, HomePage.test.tsx, HomePage.tsx, ProductActionBar.tsx.
 - [`src/hooks`](../../src/hooks) — Client hooks for bag, routing, observability, and auth interactions. Currently 29 file(s); key children: TRACKING_SCALABILITY.md, use-store-modal.tsx, useAuth.ts, useCheckout.ts, useDiscountCodeAlert.tsx.
 - [`src/contexts`](../../src/contexts) — Shared client providers for store, navigation, and observability state. Currently 5 file(s); key children: FormSubmissionProvider.tsx, NavigationBarProvider.tsx, StoreContext.tsx, StorefrontObservabilityProvider.test.tsx, StorefrontObservabilityProvider.tsx.
 - [`src/lib`](../../src/lib) — Shared utilities, query helpers, schemas, and domain logic. Currently 50 file(s); key children: STOREFRONT_OBSERVABILITY.md, constants.ts, countries.ts, currency.ts, feeUtils.test.ts.

--- a/packages/storefront-webapp/docs/agent/test-index.md
+++ b/packages/storefront-webapp/docs/agent/test-index.md
@@ -31,6 +31,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/components/checkout/schemas/webOrderSchema.test.ts`](../../src/components/checkout/schemas/webOrderSchema.test.ts)
 - [`src/components/checkout/utils.test.ts`](../../src/components/checkout/utils.test.ts)
 - [`src/components/home/BestSellersSection.test.tsx`](../../src/components/home/BestSellersSection.test.tsx)
+- [`src/components/home/HomeHero.test.tsx`](../../src/components/home/HomeHero.test.tsx)
 - [`src/components/home/homePageContent.test.ts`](../../src/components/home/homePageContent.test.ts)
 - [`src/components/product-page/ProductActions.test.tsx`](../../src/components/product-page/ProductActions.test.tsx)
 - [`src/components/product-page/ProductPage.test.tsx`](../../src/components/product-page/ProductPage.test.tsx)

--- a/packages/storefront-webapp/src/api/homepageSnapshot.ts
+++ b/packages/storefront-webapp/src/api/homepageSnapshot.ts
@@ -18,6 +18,7 @@ export type HomepageSnapshotSkuV1 = {
 
 export type HomepageSnapshotCollectionV1 = {
   categoryId?: string;
+  categorySlug?: string;
   subcategoryId?: string;
   name: string;
   slug: string;

--- a/packages/storefront-webapp/src/components/ProductCard.test.tsx
+++ b/packages/storefront-webapp/src/components/ProductCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ProductSkuCard } from "./ProductCard";
@@ -16,6 +16,10 @@ vi.mock("@/hooks/useProductDiscount", () => ({
     originalPrice: 0,
     discountedSkuId: undefined,
   }),
+}));
+
+vi.mock("@/contexts/StoreContext", () => ({
+  useStoreContext: () => ({ store: undefined }),
 }));
 
 describe("ProductSkuCard", () => {
@@ -58,5 +62,28 @@ describe("ProductSkuCard", () => {
     );
 
     expect(screen.getByText("GH₵65")).toBeInTheDocument();
+  });
+
+  it("shows the storefront placeholder when product imagery fails", () => {
+    render(
+      <ProductSkuCard
+        sku={{
+          _id: "sku_1",
+          productName: "Banana",
+          price: 2000,
+          quantityAvailable: 0,
+          images: ["https://images.example.com/missing-banana.webp"],
+        } as any}
+        currencyFormatter={currencyFormatter("GHS")}
+      />,
+    );
+
+    const image = screen.getByAltText("Banana image");
+    fireEvent.error(image);
+
+    expect(image).toHaveAttribute(
+      "src",
+      expect.stringContaining("placeholder"),
+    );
   });
 });

--- a/packages/storefront-webapp/src/components/ProductCard.tsx
+++ b/packages/storefront-webapp/src/components/ProductCard.tsx
@@ -5,6 +5,7 @@ import {
   useProductDiscounts,
 } from "@/hooks/useProductDiscount";
 import { formatStoredAmount } from "@/lib/currency";
+import ImageWithFallback from "./ui/image-with-fallback";
 
 type ProductCardSku = Pick<
   ProductSku,
@@ -55,7 +56,7 @@ export function ProductCard({
   return (
     <div className="flex flex-col space-y-4">
       <div className="overflow-hidden relative">
-        <img
+        <ImageWithFallback
           alt={`${product?.name} image`}
           className="aspect-square md:aspect-auto md:w-[300px] md:h-[400px] object-cover rounded"
           decoding="async"
@@ -137,7 +138,7 @@ export function ProductSkuCard({
   return (
     <div className="flex flex-col">
       <div className="mb-2 overflow-hidden relative">
-        <img
+        <ImageWithFallback
           alt={`${sku?.productName} image`}
           className="aspect-square md:aspect-auto md:w-[300px] md:h-[400px] object-cover rounded"
           decoding="async"

--- a/packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx
+++ b/packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx
@@ -11,6 +11,7 @@ import type { HomepageDisplayProduct } from "./homePageContent";
 
 type HomepageProduct = (Product & { skus: ProductSku[] }) | HomepageDisplayProduct;
 type FeaturedCollection = {
+  categorySlug?: string;
   name: string;
   products: HomepageProduct[];
   slug: string;
@@ -67,9 +68,9 @@ function FeaturedSection({
   const { formatter } = useStoreContext();
 
   if (data.subcategory) {
-    const { name, products, slug } = data.subcategory;
+    const { categorySlug, name, products, slug } = data.subcategory;
 
-    if (!products.length) return null;
+    if (!products.length || !categorySlug) return null;
 
     return (
       <div className="space-y-8">
@@ -85,11 +86,11 @@ function FeaturedSection({
             <Link
               to="/shop/$categorySlug/$subcategorySlug"
               params={{
-                categorySlug: "hair",
+                categorySlug,
                 subcategorySlug: slug,
               }}
               search={{
-                origin: "shop_hair",
+                origin: `shop_${categorySlug}`,
               }}
             >
               <Button className="p-0" variant={"link"}>

--- a/packages/storefront-webapp/src/components/home/HomeHero.test.tsx
+++ b/packages/storefront-webapp/src/components/home/HomeHero.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { HomeHero } from "./HomeHero";
+import { VideoPlayer } from "./VideoPlayer";
+
+vi.mock("@/contexts/StoreContext", () => ({
+  useStoreContext: () => ({ store: undefined }),
+}));
+
+vi.mock("../ui/ScrollDownButton", () => ({
+  ScrollDownButton: () => <button type="button">Scroll</button>,
+}));
+
+vi.mock("hls.js/light", () => ({
+  default: class HlsMock {
+    static Events = { MANIFEST_PARSED: "manifestParsed" };
+    static isSupported() {
+      return false;
+    }
+    loadSource() {}
+    attachMedia() {}
+    on() {}
+    destroy() {}
+  },
+}));
+
+describe("HomeHero", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps the hero silent while store media config is unresolved", () => {
+    render(<HomeHero />);
+
+    expect(screen.getByTestId("homepage-hero-media-pending")).toHaveClass(
+      "bg-background",
+    );
+    expect(screen.queryByText("Find your next look")).not.toBeInTheDocument();
+    expect(screen.queryByText("Shop hair")).not.toBeInTheDocument();
+  });
+
+  it("does not render browser fallback text inside the hero video", () => {
+    const { container } = render(
+      <VideoPlayer hlsUrl="https://cdn.example.com/hero.m3u8" />,
+    );
+
+    expect(container).not.toHaveTextContent(
+      "Your browser does not support the video tag.",
+    );
+    expect(container.querySelector("source")).toHaveAttribute(
+      "type",
+      "application/x-mpegURL",
+    );
+  });
+});

--- a/packages/storefront-webapp/src/components/home/HomeHero.tsx
+++ b/packages/storefront-webapp/src/components/home/HomeHero.tsx
@@ -38,10 +38,12 @@ export const HomeHero = ({ nextSectionRef }: HomeHeroProps) => {
   const shouldShowOverlay = storeConfig.media.homeHero.showOverlay === true;
 
   const shouldShowText = storeConfig.media.homeHero.showText === true;
-  const shouldShowFallback = !shouldShowImage && !shouldShowVideo;
+  const isStoreResolved = Boolean(store);
+  const shouldShowFallback =
+    isStoreResolved && !shouldShowImage && !shouldShowVideo;
 
   return (
-    <section className="relative w-full h-screen flex items-center justify-center text-white text-center">
+    <section className="relative w-full h-screen flex items-center justify-center bg-background text-white text-center">
       {/* Background Video - shown when heroDisplayType is "reel" or not set */}
       {shouldShowVideo && hlsUrl && (
         <Suspense fallback={null}>
@@ -105,6 +107,14 @@ export const HomeHero = ({ nextSectionRef }: HomeHeroProps) => {
             </Link>
           </motion.div>
         </div>
+      )}
+
+      {!isStoreResolved && (
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 bg-background"
+          data-testid="homepage-hero-media-pending"
+        />
       )}
 
       {/* Text Content - conditionally shown */}

--- a/packages/storefront-webapp/src/components/home/VideoPlayer.tsx
+++ b/packages/storefront-webapp/src/components/home/VideoPlayer.tsx
@@ -58,8 +58,7 @@ export const VideoPlayer = ({ hlsUrl }: VideoPlayerProps) => {
       loop
       muted
     >
-      <source src={hlsUrl} type="video/mp4" />
-      Your browser does not support the video tag.
+      <source src={hlsUrl} type="application/x-mpegURL" />
     </motion.video>
   );
 };

--- a/packages/storefront-webapp/src/components/home/homePageContent.test.ts
+++ b/packages/storefront-webapp/src/components/home/homePageContent.test.ts
@@ -28,6 +28,20 @@ describe("resolveHomepageContent", () => {
     expect(result.hasHomepageData).toBe(true);
   });
 
+  it("sorts legacy unranked best sellers after ranked rows", () => {
+    const rankedSku = { _id: "sku-ranked", sku: "R" } as any;
+    const unrankedSku = { _id: "sku-unranked", sku: "U" } as any;
+
+    const result = resolveHomepageContent({
+      bestSellers: [
+        { productSku: unrankedSku },
+        { rank: 1, productSku: rankedSku },
+      ],
+    });
+
+    expect(result.bestSellersProducts).toEqual([rankedSku, unrankedSku]);
+  });
+
   it("resolves snapshot sections without converting minor-unit prices", () => {
     const result = resolveHomepageContent({
       snapshot: {
@@ -139,6 +153,55 @@ describe("resolveHomepageContent", () => {
     ).toBe("closure-unit");
     expect(result.shopLookProduct?.productId).toBe("shop-look-product");
     expect(result.hasHomepageData).toBe(true);
+  });
+
+  it("preserves parent category slug for snapshot subcategory highlights", () => {
+    const result = resolveHomepageContent({
+      snapshot: {
+        contractVersion: "homepage_snapshot.v1",
+        generatedAtMs: 1,
+        store: {} as any,
+        hero: {} as any,
+        bannerMessage: null,
+        bestSellers: [],
+        featuredItems: [
+          {
+            id: "highlight-subcategory",
+            rank: 1,
+            type: "regular",
+            targetKind: "subcategory",
+            product: null,
+            category: null,
+            subcategory: {
+              categoryId: "category-home-care",
+              categorySlug: "home-care",
+              subcategoryId: "subcategory-dispensers",
+              name: "Dispensers",
+              slug: "dispensers",
+              products: [
+                {
+                  productId: "product-dispenser",
+                  productSlug: "soap-dispenser",
+                  productName: "Soap Dispenser",
+                  skuId: "sku-dispenser",
+                  sku: null,
+                  imageUrls: ["soap.jpg"],
+                  currency: "GHS",
+                  priceAmountMinor: 4500,
+                  netPriceAmountMinor: null,
+                },
+              ],
+            },
+          },
+        ],
+        shopLook: null,
+      },
+    });
+
+    expect(result.featuredSectionSorted[0]?.subcategory).toMatchObject({
+      categorySlug: "home-care",
+      slug: "dispensers",
+    });
   });
 
   it("treats null snapshot sections as ready empty homepage content", () => {

--- a/packages/storefront-webapp/src/components/home/homePageContent.ts
+++ b/packages/storefront-webapp/src/components/home/homePageContent.ts
@@ -1,4 +1,5 @@
 import { Product, ProductSku } from "@athena/webapp";
+import { sortHomepageRankedItems } from "@athena/webapp/shared/homepageRanking";
 import type {
   HomepageSnapshotHighlightedItemV1,
   HomepageSnapshotSkuV1,
@@ -36,11 +37,18 @@ type FeaturedItem = {
     slug: string;
   };
   subcategory?: {
+    categorySlug?: string;
     name: string;
     products: Array<Product | HomepageDisplayProduct>;
     slug: string;
   };
   productId?: string;
+};
+
+type BestSellerItem = {
+  _id?: string;
+  rank?: number;
+  productSku: ProductSku | HomepageDisplaySku;
 };
 
 function toDisplaySku(sku: HomepageSnapshotSkuV1): HomepageDisplaySku {
@@ -82,6 +90,7 @@ function toFeaturedItem(item: HomepageSnapshotHighlightedItemV1): FeaturedItem {
       : undefined,
     subcategory: item.subcategory
       ? {
+          categorySlug: item.subcategory.categorySlug,
           name: item.subcategory.name,
           slug: item.subcategory.slug,
           products: item.subcategory.products.map(toDisplayProduct),
@@ -99,10 +108,13 @@ export function resolveHomepageContent({
   bestSellers?: Array<{ rank?: number; productSku: ProductSku }>;
   featured?: FeaturedItem[];
 }) {
-  const snapshotBestSellers = snapshot?.bestSellers?.map((item) => ({
-    rank: item.rank,
-    productSku: toDisplaySku(item.productSku),
-  }));
+  const snapshotBestSellers: BestSellerItem[] | undefined =
+    snapshot?.bestSellers?.map((item) => ({
+      _id: item.id,
+      rank: item.rank,
+      productSku: toDisplaySku(item.productSku),
+    }));
+  const legacyBestSellers: BestSellerItem[] | undefined = bestSellers;
 
   const snapshotFeatured = snapshot
     ? [
@@ -111,16 +123,16 @@ export function resolveHomepageContent({
       ].map(toFeaturedItem)
     : undefined;
 
-  const bestSellersSorted = [...(snapshotBestSellers ?? bestSellers ?? [])].sort(
-    (a, b) => (a.rank ?? 0) - (b.rank ?? 0),
+  const bestSellersSorted = sortHomepageRankedItems(
+    snapshotBestSellers ?? legacyBestSellers ?? [],
   );
 
   const bestSellersProducts = bestSellersSorted.map(
     (bestSeller) => bestSeller.productSku,
   );
 
-  const featuredSorted = [...(snapshotFeatured ?? featured ?? [])].sort(
-    (a, b) => (a.rank ?? 0) - (b.rank ?? 0),
+  const featuredSorted = sortHomepageRankedItems(
+    snapshotFeatured ?? featured ?? [],
   );
 
   const featuredSectionSorted = featuredSorted.filter(


### PR DESCRIPTION
## Summary
- share homepage ranking and storefront-visibility logic across Convex/admin/storefront surfaces
- normalize homepage snapshot ranks for mixed ranked and legacy rows, preserve admin/storefront ordering, and filter hidden taxonomy selections
- improve admin homepage readiness navigation, picker taxonomy labels, product-image fallbacks, and storefront hero/image fallback behavior

## Validation
- bun run --filter "@athena/webapp" test shared/homepageRanking.test.ts shared/storefrontVisibility.test.ts convex/inventory/bestSeller.test.ts convex/inventory/featuredItem.test.ts convex/storeFront/homepageSnapshot.test.ts src/components/homepage/HomepageProductPickerDialog.test.tsx src/components/homepage/HomepagePlacementProductImage.test.ts
- bun run --filter "@athena/storefront-webapp" test src/components/home/homePageContent.test.ts src/components/home/HomeHero.test.tsx src/components/ProductCard.test.tsx
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- bunx tsc -p packages/storefront-webapp/tsconfig.json --noEmit
- bun run pr:athena

## Reviewer loop
- ce-correctness-reviewer: approved after rank migration fix
- ce-testing-reviewer: approved after fallback and derived-taxonomy coverage fixes
- ce-kieran-typescript-reviewer: approved after staging full helper/component payload
- ce-api-contract-reviewer: approved after staging full helper/component payload