### PR TITLE
Refine Daily Operations store pulse presentation

### DIFF
--- a/docs/solutions/architecture/athena-store-pulse-daily-operations-reuse-2026-06-22.md
+++ b/docs/solutions/architecture/athena-store-pulse-daily-operations-reuse-2026-06-22.md
@@ -60,6 +60,22 @@ above the store-day timeline when it uses a rail-specific summary: status,
 count chips, three evidence rows, overflow text, and one full-width CTA back to
 Opening Handoff.
 
+When the same Store Pulse component appears on Daily Operations, keep the
+overview surface quieter than the POS hub:
+
+- Pin Daily Operations to the selected store-day `today` window and hide the
+  POS hub window tabs so store-day reporting stays deterministic.
+- Hide the repeated Store Pulse summary cards and section label when Daily
+  Operations already has equivalent top-level operations metrics.
+- Keep the sales trend, top items, and payment mix because they answer distinct
+  operator questions that the top metrics do not.
+- Show total item movement as a compact "Total items sold" header stat in the
+  Top items panel, with the value as a number only.
+- Treat payment mix percentages as a share of payment transaction counts, not
+  a share of payment tender totals. A day with two Mobile Money payments, one
+  cash payment, and one card payment should show 50% / 25% / 25%, even if the
+  tender amounts are uneven.
+
 ## Prevention
 
 - When sharing a POS visualization with another operations surface, extract the
@@ -68,6 +84,9 @@ Opening Handoff.
   Daily Operations pulse windows derive from client wall-clock state.
 - Keep role redaction in the snapshot contract. If a surface is financially
   restricted, the query should omit detailed pulse data.
+- Keep payment mix display tests anchored to the intended denominator. Tender
+  totals and transaction counts answer different questions, and both can look
+  plausible in small samples.
 - Add tests at all three layers: POS wrapper compatibility, Daily Operations
   rendering/window search behavior, and backend store pulse window/redaction
   behavior.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7789 nodes · 9080 edges · 2028 communities detected
+- 7787 nodes · 9078 edges · 2028 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2182,20 +2182,20 @@ Cohesion: 0.2
 Nodes (28): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftCreatedMessage(), buildCycleCountDraftSavedMessage(), buildCycleCountDraftSubmissionKey(), buildCycleCountDraftSubmittedMessage(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx() (+20 more)
 
 ### Community 29 - "Community 29"
-Cohesion: 0.13
-Nodes (19): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate(), getLocalOperatingDateRange() (+11 more)
-
-### Community 30 - "Community 30"
 Cohesion: 0.14
 Nodes (23): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+15 more)
 
-### Community 31 - "Community 31"
+### Community 30 - "Community 30"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
-### Community 32 - "Community 32"
+### Community 31 - "Community 31"
 Cohesion: 0.2
 Nodes (27): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), isExpenseLocalSyncEvent(), isSyncablePosLocalEvent() (+19 more)
+
+### Community 32 - "Community 32"
+Cohesion: 0.14
+Nodes (19): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate(), getLocalOperatingDateRange() (+11 more)
 
 ### Community 33 - "Community 33"
 Cohesion: 0.15
@@ -2594,28 +2594,28 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 132 - "Community 132"
-Cohesion: 0.36
-Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 133 - "Community 133"
 Cohesion: 0.36
-Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
+Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
 ### Community 134 - "Community 134"
+Cohesion: 0.36
+Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
+
+### Community 135 - "Community 135"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
-
-### Community 137 - "Community 137"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 138 - "Community 138"
 Cohesion: 0.31
@@ -2766,24 +2766,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 175 - "Community 175"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 176 - "Community 176"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 178 - "Community 178"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
 ### Community 179 - "Community 179"
 Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 180 - "Community 180"
 Cohesion: 0.22

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2100
-- Graph nodes: 7789
-- Graph edges: 9080
+- Graph nodes: 7787
+- Graph edges: 9078
 - Communities: 2028
 
 ## Graph Hotspots

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -4,7 +4,6 @@ import {
   screen,
   within,
 } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import React, {
   type AnchorHTMLAttributes,
   type ReactNode,
@@ -1142,8 +1141,20 @@ describe("DailyOperationsViewContent", () => {
     expect(within(storePulse).getByText("Sales trend")).toBeInTheDocument();
     expect(within(storePulse).getByTestId("store-pulse-chart")).toBeInTheDocument();
     expect(within(storePulse).getByText("Braiding Hair")).toBeInTheDocument();
+    expect(
+      within(storePulse).getByLabelText("Total items sold: 3"),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText("Store-day timeline")).toBeInTheDocument();
-    expect(within(storePulse).getByRole("tab", { name: "This week" })).toBeInTheDocument();
+    expect(within(storePulse).queryByRole("tablist")).not.toBeInTheDocument();
+    expect(within(storePulse).queryByText("Average sale")).not.toBeInTheDocument();
+    expect(within(storePulse).queryByText("Items sold")).not.toBeInTheDocument();
+    expect(screen.queryByText("Store pulse")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("POS sales activity for the selected reporting window."),
+    ).not.toBeInTheDocument();
+    expect(
+      within(storePulse).getByText("Today's completed POS sales."),
+    ).toBeInTheDocument();
   });
 
   it("shows a bounded empty state when store pulse is omitted", () => {
@@ -1814,7 +1825,7 @@ describe("DailyOperationsView", () => {
     );
   });
 
-  it("queries the daily operations snapshot for the selected store pulse window", () => {
+  it("ignores store pulse search state and queries the today store pulse window", () => {
     mockedHooks.useSearch.mockReturnValue({
       storePulseWindow: "this_month",
     });
@@ -1824,14 +1835,12 @@ describe("DailyOperationsView", () => {
     expect(mockedHooks.useQuery).toHaveBeenCalledWith(
       mockedApi.getDailyOperationsSnapshot,
       expect.objectContaining({
-        storePulseWindow: "this_month",
+        storePulseWindow: "today",
       }),
     );
   });
 
-  it("updates store pulse search state from the store pulse tabs", async () => {
-    const user = userEvent.setup();
-
+  it("does not render store pulse window tabs on daily operations", () => {
     mockedHooks.useSearch.mockReturnValue({
       storePulseWindow: "this_week",
     });
@@ -1842,53 +1851,12 @@ describe("DailyOperationsView", () => {
 
     render(<DailyOperationsView />);
 
-    await user.click(screen.getByRole("tab", { name: "All time" }));
+    const storePulse = screen.getByRole("region", { name: "Store pulse" });
 
-    expect(mockedHooks.navigate).toHaveBeenCalledWith({
-      search: expect.any(Function),
-    });
-
-    const searchUpdater = mockedHooks.navigate.mock.calls.at(-1)?.[0]
-      .search as (current: Record<string, unknown>) => Record<string, unknown>;
-
-    expect(searchUpdater({ operatingDate: "2026-05-08" })).toEqual({
-      operatingDate: "2026-05-08",
-      storePulseWindow: "all_time",
-    });
-  });
-
-  it("removes store pulse search state when the Today tab is selected", async () => {
-    const user = userEvent.setup();
-
-    mockedHooks.useSearch.mockReturnValue({
-      storePulseWindow: "this_month",
-    });
-    mockedHooks.useQuery.mockReturnValue({
-      ...operatingSnapshot,
-      storePulse: buildStorePulseSummary(),
-    });
-
-    render(<DailyOperationsView />);
-
-    await user.click(screen.getByRole("tab", { name: "Today" }));
-
-    expect(mockedHooks.navigate).toHaveBeenCalledWith({
-      search: expect.any(Function),
-    });
-
-    const searchUpdater = mockedHooks.navigate.mock.calls.at(-1)?.[0]
-      .search as (current: Record<string, unknown>) => Record<string, unknown>;
-
+    expect(within(storePulse).queryByRole("tablist")).not.toBeInTheDocument();
     expect(
-      searchUpdater({
-        operatingDate: "2026-05-08",
-        storePulseWindow: "this_month",
-        weekEndOperatingDate: "2026-05-09",
-      }),
-    ).toEqual({
-      operatingDate: "2026-05-08",
-      weekEndOperatingDate: "2026-05-09",
-    });
+      within(storePulse).getByText("Today's completed POS sales."),
+    ).toBeInTheDocument();
   });
 
   it("skips the protected query when access is not ready", () => {

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -282,7 +282,6 @@ type DailyOperationsViewContentProps = {
   isLoadingAccess: boolean;
   isLoadingSnapshot: boolean;
   onOperatingDateChange?: (date: Date) => void;
-  onStorePulseWindowChange?: (window: StorePulseWindow) => void;
   orgUrlSlug: string;
   snapshot?: DailyOperationsSnapshot;
   storePulseWindow: StorePulseWindow;
@@ -497,20 +496,6 @@ function getWeekEndOperatingDateFromSearch(weekEndOperatingDate?: unknown) {
   }
 
   return getSaturdayWeekEndOperatingDate(getLocalOperatingDate());
-}
-
-function getStorePulseWindowFromSearch(
-  storePulseWindow?: unknown,
-): StorePulseWindow {
-  if (
-    storePulseWindow === "this_week" ||
-    storePulseWindow === "this_month" ||
-    storePulseWindow === "all_time"
-  ) {
-    return storePulseWindow;
-  }
-
-  return "today";
 }
 
 function shouldShowPrimaryAction(snapshot: DailyOperationsSnapshot) {
@@ -1373,32 +1358,22 @@ function HistoricalWorkflowPanel({
 function DailyOperationsStorePulsePanel({
   currency,
   hasFullAdminAccess,
-  onStorePulseWindowChange,
   snapshot,
-  storePulseWindow,
 }: {
   currency: string;
   hasFullAdminAccess: boolean;
-  onStorePulseWindowChange?: (window: StorePulseWindow) => void;
   snapshot: DailyOperationsSnapshot;
-  storePulseWindow: StorePulseWindow;
 }) {
   return (
     <section className="space-y-layout-md">
-      <div>
-        <h3 className="text-base font-medium text-foreground">Store pulse</h3>
-        <p className="mt-1 text-sm text-muted-foreground">
-          POS sales activity for the selected reporting window.
-        </p>
-      </div>
       {snapshot.storePulse ? (
         <StorePulseSummaryView
           canViewFinancialDetails={hasFullAdminAccess}
           currencyFormatter={currencyFormatter(currency)}
-          onPulseWindowChange={(nextWindow) => {
-            onStorePulseWindowChange?.(nextWindow);
-          }}
-          pulseWindow={storePulseWindow}
+          onPulseWindowChange={() => undefined}
+          pulseWindow="today"
+          showPulseWindowFilter={false}
+          showSummaryMetrics={false}
           summary={snapshot.storePulse}
         />
       ) : (
@@ -1748,7 +1723,6 @@ export function DailyOperationsViewContent({
   isLoadingAccess,
   isLoadingSnapshot,
   onOperatingDateChange,
-  onStorePulseWindowChange,
   orgUrlSlug,
   snapshot,
   storePulseWindow,
@@ -2071,9 +2045,7 @@ export function DailyOperationsViewContent({
                   <DailyOperationsStorePulsePanel
                     currency={snapshot.currency ?? currency}
                     hasFullAdminAccess={hasFullAdminAccess}
-                    onStorePulseWindowChange={onStorePulseWindowChange}
                     snapshot={snapshot}
-                    storePulseWindow={storePulseWindow}
                   />
                   {isHistoricalDate ? (
                     <HistoricalWorkflowPanel
@@ -2247,7 +2219,6 @@ function DailyOperationsConnectedView({
   const navigate = useNavigate();
   const search = useSearch({ strict: false }) as {
     operatingDate?: unknown;
-    storePulseWindow?: unknown;
     weekEndOperatingDate?: unknown;
   };
   const operatingDateRange = useMemo(
@@ -2258,10 +2229,7 @@ function DailyOperationsConnectedView({
     () => getWeekEndOperatingDateFromSearch(search.weekEndOperatingDate),
     [search.weekEndOperatingDate],
   );
-  const storePulseWindow = useMemo(
-    () => getStorePulseWindowFromSearch(search.storePulseWindow),
-    [search.storePulseWindow],
-  );
+  const storePulseWindow: StorePulseWindow = "today";
   const snapshot = useExpectedDailyOperationsQuery(
     getDailyOperationsSnapshot,
     canQueryProtectedData
@@ -2292,22 +2260,6 @@ function DailyOperationsConnectedView({
     });
   };
 
-  const handleStorePulseWindowChange = (nextWindow: StorePulseWindow) => {
-    void navigate({
-      search: ((current: Record<string, unknown>) => {
-        const nextSearch = { ...current };
-
-        if (nextWindow === "today") {
-          delete nextSearch.storePulseWindow;
-        } else {
-          nextSearch.storePulseWindow = nextWindow;
-        }
-
-        return nextSearch;
-      }) as never,
-    });
-  };
-
   return (
     <DailyOperationsViewContent
       currency={activeStore?.currency ?? "GHS"}
@@ -2317,7 +2269,6 @@ function DailyOperationsConnectedView({
       isLoadingAccess={isLoadingAccess}
       isLoadingSnapshot={snapshot === undefined}
       onOperatingDateChange={handleOperatingDateChange}
-      onStorePulseWindowChange={handleStorePulseWindowChange}
       orgUrlSlug={params?.orgUrlSlug ?? ""}
       snapshot={snapshot}
       storePulseWindow={storePulseWindow}

--- a/packages/athena-webapp/src/components/pos/sales-pulse/POSSalesPulseView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/sales-pulse/POSSalesPulseView.test.tsx
@@ -35,6 +35,22 @@ vi.mock("@/components/ui/chart", () => ({
 }));
 
 function buildTodaySummary({
+  paymentMix = [
+    {
+      count: 1,
+      label: "Cash",
+      method: "cash",
+      share: 60,
+      total: 7_500,
+    },
+    {
+      count: 1,
+      label: "Card",
+      method: "card",
+      share: 40,
+      total: 5_000,
+    },
+  ],
   topItems = [
     {
       name: "Braiding hair",
@@ -70,22 +86,7 @@ function buildTodaySummary({
       },
       historyDays: 14,
       isLimited: false,
-      paymentMix: [
-        {
-          count: 1,
-          label: "Cash",
-          method: "cash",
-          share: 60,
-          total: 7_500,
-        },
-        {
-          count: 1,
-          label: "Card",
-          method: "card",
-          share: 40,
-          total: 5_000,
-        },
-      ],
+      paymentMix,
       topItems,
       trend: [
         {
@@ -167,10 +168,10 @@ describe("POSStorePulseSection", () => {
     expect(screen.queryByText("Busiest hour")).not.toBeInTheDocument();
     expect(screen.getByText("How customers paid")).toBeInTheDocument();
     expect(screen.getByText("Cash")).toBeInTheDocument();
-    expect(screen.getByText("60%")).toBeInTheDocument();
+    expect(screen.getAllByText("50%").length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText("Card")).toBeInTheDocument();
-    expect(screen.getByText("40%")).toBeInTheDocument();
     expect(screen.getByText("Braiding Hair")).toBeInTheDocument();
+    expect(screen.getByLabelText("Total items sold: 3")).toBeInTheDocument();
     expect(screen.getByText("2 units sold")).toBeInTheDocument();
     expect(screen.getByTestId("store-pulse-chart")).toBeInTheDocument();
     expect(screen.getByTestId("store-pulse-area")).toBeInTheDocument();
@@ -210,6 +211,41 @@ describe("POSStorePulseSection", () => {
     await user.click(screen.getByRole("tab", { name: "This month" }));
 
     expect(onPulseWindowChange).toHaveBeenCalledWith("this_month");
+  });
+
+  it("shows payment mix shares from transaction counts", () => {
+    renderStorePulse({
+      todaySummary: buildTodaySummary({
+        paymentMix: [
+          {
+            count: 2,
+            label: "Mobile money",
+            method: "mobile_money",
+            share: 65,
+            total: 2_450,
+          },
+          {
+            count: 1,
+            label: "Cash",
+            method: "cash",
+            share: 25,
+            total: 935,
+          },
+          {
+            count: 1,
+            label: "Card",
+            method: "card",
+            share: 11,
+            total: 400,
+          },
+        ],
+      }),
+    });
+
+    expect(screen.getByText("50%")).toBeInTheDocument();
+    expect(screen.getAllByText("25%")).toHaveLength(2);
+    expect(screen.queryByText("65%")).not.toBeInTheDocument();
+    expect(screen.queryByText("11%")).not.toBeInTheDocument();
   });
 
   it("uses a no-comparison helper for all time", () => {

--- a/packages/athena-webapp/src/components/store-pulse/StorePulseSummaryView.tsx
+++ b/packages/athena-webapp/src/components/store-pulse/StorePulseSummaryView.tsx
@@ -17,6 +17,7 @@ import {
 import { toDisplayAmount } from "~/convex/lib/currency";
 import { FinancialValue } from "../common/FinancialValue";
 import { ListPagination } from "../common/ListPagination";
+import { formatOperationsMetricComparison } from "../operations/operationsMetricFormatting";
 import {
   PageWorkspaceGrid,
   PageWorkspaceMain,
@@ -160,13 +161,12 @@ function formatComparisonHelper({
   priorValue?: number;
   priorWindowLabel: string;
 }) {
-  if (!priorValue) return `No ${priorWindowLabel}`;
-  if (!deltaPercent) return `Even vs ${priorWindowLabel}`;
-
-  const absoluteDelta = Math.abs(deltaPercent);
-  const direction = deltaPercent > 0 ? "up" : "down";
-
-  return `${absoluteDelta}% ${direction} vs ${priorWindowLabel}`;
+  return formatOperationsMetricComparison({
+    deltaPercent,
+    missingComparisonLabel: `No ${priorWindowLabel}`,
+    priorValue,
+    priorWindowLabel,
+  });
 }
 
 function StorePulseMetric({
@@ -259,6 +259,12 @@ function getPaymentMethodIcon(payment: {
   if (key.includes("card")) return CreditCardIcon;
 
   return WalletCards;
+}
+
+function formatPaymentSharePercent(share: number) {
+  const roundedShare = Math.round(share * 10) / 10;
+
+  return `${Number.isInteger(roundedShare) ? roundedShare : roundedShare.toFixed(1)}%`;
 }
 
 function formatCompactChartValue({
@@ -479,13 +485,25 @@ function TopItemsPanel({
     pageStartIndex,
     pageStartIndex + topItemsPageSize,
   );
+  const totalItemsSold = snapshot.comparison.currentItemsSold;
 
   return (
     <section className="space-y-layout-md">
-      <div>
-        <h3 className="text-base font-medium text-foreground">Top items</h3>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Highest-volume items in the current history window.
+      <div className="flex flex-col gap-layout-xs sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 className="text-base font-medium text-foreground">Top items</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Highest-volume items in the current history window.
+          </p>
+        </div>
+        <p
+          aria-label={`Total items sold: ${totalItemsSold}`}
+          className="inline-flex items-baseline gap-1.5 text-sm text-muted-foreground sm:justify-end sm:text-right"
+        >
+          <span>Total items sold</span>
+          <span className="font-numeric font-medium tabular-nums text-foreground">
+            {totalItemsSold}
+          </span>
         </p>
       </div>
       <div
@@ -565,6 +583,11 @@ function PaymentMethodsPanel({
 }: {
   snapshot: StorePulseOperatorSnapshot;
 }) {
+  const totalPaymentTransactions = snapshot.paymentMix.reduce(
+    (total, payment) => total + payment.count,
+    0,
+  );
+
   return (
     <section aria-label="Payment methods" className="space-y-layout-md">
       <div>
@@ -580,6 +603,10 @@ function PaymentMethodsPanel({
           {snapshot.paymentMix.length ? (
             snapshot.paymentMix.map((payment) => {
               const PaymentIcon = getPaymentMethodIcon(payment);
+              const paymentShare =
+                totalPaymentTransactions > 0
+                  ? (payment.count / totalPaymentTransactions) * 100
+                  : 0;
 
               return (
                 <div
@@ -595,13 +622,13 @@ function PaymentMethodsPanel({
                       <span className="truncate">{payment.label}</span>
                     </span>
                     <span className="font-numeric tabular-nums text-muted-foreground">
-                      {payment.share}%
+                      {formatPaymentSharePercent(paymentShare)}
                     </span>
                   </div>
                   <div className="h-1.5 overflow-hidden rounded-full bg-action-workflow-soft">
                     <div
                       className="h-full rounded-full bg-action-workflow"
-                      style={{ width: `${Math.max(4, payment.share)}%` }}
+                      style={{ width: `${Math.max(4, paymentShare)}%` }}
                     />
                   </div>
                   <p className="text-xs text-muted-foreground">
@@ -710,8 +737,10 @@ function StorePulseDetailSkeleton({
 
 function StorePulseSkeleton({
   showFinancialSalesCards,
+  showSummaryMetrics,
 }: {
   showFinancialSalesCards: boolean;
+  showSummaryMetrics: boolean;
 }) {
   const visibleLoadingMetrics = showFinancialSalesCards
     ? loadingMetrics
@@ -723,16 +752,18 @@ function StorePulseSkeleton({
       className="min-w-0 space-y-layout-xl md:space-y-layout-2xl"
     >
       <section className="space-y-layout-2xl">
-        <div className="grid gap-layout-sm sm:grid-cols-2 xl:grid-cols-4">
-          {visibleLoadingMetrics.map((metric) => (
-            <StorePulseMetric
-              helper={metric.helper}
-              key={metric.label}
-              label={metric.label}
-              value="-"
-            />
-          ))}
-        </div>
+        {showSummaryMetrics ? (
+          <div className="grid gap-layout-sm sm:grid-cols-2 xl:grid-cols-4">
+            {visibleLoadingMetrics.map((metric) => (
+              <StorePulseMetric
+                helper={metric.helper}
+                key={metric.label}
+                label={metric.label}
+                value="-"
+              />
+            ))}
+          </div>
+        ) : null}
 
         {showFinancialSalesCards ? <StorePulseChartSkeleton /> : null}
       </section>
@@ -765,12 +796,16 @@ export function StorePulseSummaryView({
   currencyFormatter,
   onPulseWindowChange,
   pulseWindow,
+  showPulseWindowFilter = true,
+  showSummaryMetrics = true,
   summary,
 }: {
   canViewFinancialDetails: boolean;
   currencyFormatter: Intl.NumberFormat;
   onPulseWindowChange: (pulseWindow: StorePulseWindow) => void;
   pulseWindow: StorePulseWindow;
+  showPulseWindowFilter?: boolean;
+  showSummaryMetrics?: boolean;
   summary: StorePulseSummary | undefined;
 }) {
   const snapshot = summary?.operatorSnapshot;
@@ -786,7 +821,7 @@ export function StorePulseSummaryView({
       aria-label="Store pulse"
       className="space-y-layout-xl md:space-y-layout-2xl"
     >
-      {canViewFinancialDetails ? (
+      {canViewFinancialDetails && showPulseWindowFilter ? (
         <div className="flex justify-end">
           <Tabs
             onValueChange={(nextValue) => {
@@ -824,89 +859,93 @@ export function StorePulseSummaryView({
       {!snapshot ? (
         <StorePulseSkeleton
           showFinancialSalesCards={canViewFinancialDetails}
+          showSummaryMetrics={showSummaryMetrics}
         />
       ) : (
         <div className="min-w-0 space-y-layout-xl md:space-y-layout-2xl">
           <section className="space-y-layout-2xl">
-            <div className="grid gap-layout-sm sm:grid-cols-2 xl:grid-cols-4">
-              {canViewFinancialDetails ? (
-                <>
-                  <StorePulseMetric
-                    helper={
-                      copy.comparisonHelper
+            {showSummaryMetrics ? (
+              <div className="grid gap-layout-sm sm:grid-cols-2 xl:grid-cols-4">
+                {canViewFinancialDetails ? (
+                  <>
+                    <StorePulseMetric
+                      helper={
+                        copy.comparisonHelper
+                          ? formatComparisonHelper({
+                              deltaPercent: comparison?.salesDeltaPercent,
+                              priorValue: comparison?.yesterdaySales,
+                              priorWindowLabel: copy.comparisonHelper,
+                            })
+                          : "-"
+                      }
+                      label="Sales"
+                      value={
+                        <FinancialValue
+                          canView={canViewFinancialDetails}
+                          label="Sales"
+                        >
+                          {currencyFormatter.format(toDisplayAmount(totalSales))}
+                        </FinancialValue>
+                      }
+                    />
+                    <StorePulseMetric
+                      helper={
+                        copy.comparisonHelper
+                          ? formatComparisonHelper({
+                              deltaPercent:
+                                comparison?.averageTransactionDeltaPercent,
+                              priorValue:
+                                comparison?.yesterdayAverageTransaction,
+                              priorWindowLabel: copy.comparisonHelper,
+                            })
+                          : "-"
+                      }
+                      label="Average sale"
+                      value={
+                        <FinancialValue
+                          canView={canViewFinancialDetails}
+                          label="Average sale"
+                        >
+                          {currencyFormatter.format(
+                            toDisplayAmount(averageTransaction),
+                          )}
+                        </FinancialValue>
+                      }
+                    />
+                  </>
+                ) : null}
+                <StorePulseMetric
+                  helper={
+                    canViewFinancialDetails
+                      ? copy.comparisonHelper
                         ? formatComparisonHelper({
-                            deltaPercent: comparison?.salesDeltaPercent,
-                            priorValue: comparison?.yesterdaySales,
+                            deltaPercent: comparison?.transactionDeltaPercent,
+                            priorValue: comparison?.yesterdayTransactions,
                             priorWindowLabel: copy.comparisonHelper,
                           })
                         : "-"
-                    }
-                    label="Sales"
-                    value={
-                      <FinancialValue
-                        canView={canViewFinancialDetails}
-                        label="Sales"
-                      >
-                        {currencyFormatter.format(toDisplayAmount(totalSales))}
-                      </FinancialValue>
-                    }
-                  />
-                  <StorePulseMetric
-                    helper={
-                      copy.comparisonHelper
+                      : undefined
+                  }
+                  label="Transactions"
+                  value={totalTransactions}
+                />
+                <StorePulseMetric
+                  helper={
+                    canViewFinancialDetails
+                      ? copy.comparisonHelper
                         ? formatComparisonHelper({
-                            deltaPercent:
-                              comparison?.averageTransactionDeltaPercent,
-                            priorValue: comparison?.yesterdayAverageTransaction,
+                            deltaPercent: comparison?.itemsSoldDeltaPercent,
+                            priorValue: comparison?.yesterdayItemsSold,
                             priorWindowLabel: copy.comparisonHelper,
                           })
                         : "-"
-                    }
-                    label="Average sale"
-                    value={
-                      <FinancialValue
-                        canView={canViewFinancialDetails}
-                        label="Average sale"
-                      >
-                        {currencyFormatter.format(
-                          toDisplayAmount(averageTransaction),
-                        )}
-                      </FinancialValue>
-                    }
-                  />
-                </>
-              ) : null}
-              <StorePulseMetric
-                helper={
-                  canViewFinancialDetails
-                    ? copy.comparisonHelper
-                      ? formatComparisonHelper({
-                          deltaPercent: comparison?.transactionDeltaPercent,
-                          priorValue: comparison?.yesterdayTransactions,
-                          priorWindowLabel: copy.comparisonHelper,
-                        })
-                      : "-"
-                    : undefined
-                }
-                label="Transactions"
-                value={totalTransactions}
-              />
-              <StorePulseMetric
-                helper={
-                  canViewFinancialDetails
-                    ? copy.comparisonHelper
-                      ? formatComparisonHelper({
-                          deltaPercent: comparison?.itemsSoldDeltaPercent,
-                          priorValue: comparison?.yesterdayItemsSold,
-                          priorWindowLabel: copy.comparisonHelper,
-                        })
-                      : "-"
-                    : undefined
-                }
-                label="Items sold"
-                value={totalItemsSold}
-              />
-            </div>
+                      : undefined
+                  }
+                  label="Items sold"
+                  value={totalItemsSold}
+                />
+              </div>
+            ) : null}
 
             {canViewFinancialDetails ? (
               <StorePulseTimeline


### PR DESCRIPTION
## Summary
- simplify the Daily Operations Store Pulse surface by pinning it to the store-day Today window and hiding repeated summary chrome
- add a compact total-items-sold header stat to Top items
- render payment mix percentages from transaction-count share instead of tender totals

## Validation
- bun run test src/components/pos/sales-pulse/POSSalesPulseView.test.tsx src/components/operations/DailyOperationsView.test.tsx
- bun run --filter '@athena/webapp' lint:frontend:changed
- bun run pr:athena