### PR TITLE
Restore recovered plan artifacts

### DIFF
--- a/docs/plans/2026-06-13-002-feat-register-sale-review-detail-plan.html
+++ b/docs/plans/2026-06-13-002-feat-register-sale-review-detail-plan.html
@@ -1,0 +1,270 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Plan: Add Sale-Level Register Sync Review Details</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fa;
+      --panel: #ffffff;
+      --ink: #172033;
+      --muted: #5c667a;
+      --line: #d9dee8;
+      --accent: #295bdb;
+      --soft: #eef3ff;
+      --warn: #fff7ed;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 40px 24px 64px;
+    }
+    header {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 28px;
+      box-shadow: 0 10px 30px rgba(23, 32, 51, 0.06);
+    }
+    h1, h2, h3 { line-height: 1.2; }
+    h1 { margin: 0 0 12px; font-size: 30px; }
+    h2 { margin: 34px 0 12px; font-size: 20px; }
+    h3 { margin: 20px 0 8px; font-size: 16px; }
+    p { margin: 0 0 12px; }
+    a { color: var(--accent); }
+    code {
+      background: #f0f2f6;
+      border: 1px solid #e2e6ee;
+      border-radius: 5px;
+      padding: 1px 5px;
+      font-size: 0.92em;
+    }
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 18px;
+    }
+    .pill {
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 4px 10px;
+      color: var(--muted);
+      background: #fbfcff;
+      font-size: 13px;
+    }
+    nav {
+      margin-top: 20px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+    nav a {
+      text-decoration: none;
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      padding: 6px 10px;
+      background: var(--soft);
+      font-size: 13px;
+    }
+    section {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 24px;
+      margin-top: 18px;
+    }
+    ul { margin: 8px 0 0 20px; padding: 0; }
+    li { margin: 6px 0; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 12px;
+      font-size: 14px;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 10px;
+      vertical-align: top;
+      text-align: left;
+    }
+    th { background: #f4f6fb; }
+    .callout {
+      border-left: 4px solid var(--accent);
+      background: var(--soft);
+      padding: 12px 14px;
+      margin: 14px 0;
+      border-radius: 6px;
+    }
+    .warn {
+      border-left-color: #b45309;
+      background: var(--warn);
+    }
+    .unit {
+      border: 1px solid var(--line);
+      border-radius: 9px;
+      padding: 16px;
+      margin: 14px 0;
+      background: #fcfdff;
+    }
+    .unit h3 { margin-top: 0; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 14px;
+    }
+    .small { color: var(--muted); font-size: 13px; }
+    pre {
+      overflow-x: auto;
+      background: #111827;
+      color: #f9fafb;
+      padding: 16px;
+      border-radius: 8px;
+      font-size: 13px;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div class="meta">
+        <span class="pill">type: feat</span>
+        <span class="pill">status: active</span>
+        <span class="pill">date: 2026-06-13</span>
+        <span class="pill">source: 2026-06-13-002-feat-register-sale-review-detail-plan.md</span>
+      </div>
+      <h1>feat: Add Sale-Level Register Sync Review Details</h1>
+      <p>Add an in-flow sale-level detail panel to Cash Controls register-session sync review so a manager can understand the synced sale being rejected or reviewed without leaving the drawer workspace.</p>
+      <nav aria-label="Plan sections">
+        <a href="#requirements">Requirements</a>
+        <a href="#decisions">Key Decisions</a>
+        <a href="#units">Implementation Units</a>
+        <a href="#impact">Impact</a>
+        <a href="#risks">Risks</a>
+      </nav>
+    </header>
+
+    <section id="problem">
+      <h2>Problem Frame</h2>
+      <p>The register session correctly owns sync review decisions, but the current review banner explains the action more than the sale. Managers need sale reference, amount, payment, cashier, time, and consequence in the register session before taking action.</p>
+      <div class="callout">
+        <strong>Scope shape:</strong> inline sale-level review details inside the existing review banner. No new route, no item/payment drilldown, and no correction workflow in this first pass.
+      </div>
+    </section>
+
+    <section id="requirements">
+      <h2>Requirements</h2>
+      <ul>
+        <li>Managers stay on the Cash Controls register session while inspecting synced sale review context.</li>
+        <li>The review banner exposes sale reference, amount, item count, payment method, cashier, completed/offline time, queue number, status, and reported time when available.</li>
+        <li>Unsupported or reject-only states explain why the sale cannot be applied and what rejecting does.</li>
+        <li>Multiple review items render as compact sale-level rows with independent expansion.</li>
+        <li>Closeout review behavior remains value-first and unchanged.</li>
+        <li>Raw sync internals and sensitive proof or payment material stay out of the primary UI.</li>
+        <li>Fallback-only records continue to render useful reason/type/queue evidence.</li>
+      </ul>
+    </section>
+
+    <section id="decisions">
+      <h2>Key Technical Decisions</h2>
+      <ul>
+        <li>Extend the existing reconciliation item contract instead of adding a separate review-detail query.</li>
+        <li>Enrich sale context at projection/query boundaries from safe sync conflict details.</li>
+        <li>Render detail inline in the existing review banner so the register session remains the workspace.</li>
+        <li>Keep closeout review presentation separate from sale-level review detail.</li>
+        <li>Treat missing sale-level fields as normal and preserve fallback evidence.</li>
+      </ul>
+    </section>
+
+    <section id="design">
+      <h2>Intended Flow</h2>
+      <pre><code>Local sale sync conflict
+  -> safe sale summary in conflict details
+  -> register-session reconciliation item
+  -> register snapshot
+  -> compact synced sale row
+  -> inline sale detail expansion
+  -> existing approve/reject action area</code></pre>
+    </section>
+
+    <section id="units">
+      <h2>Implementation Units</h2>
+      <article class="unit">
+        <h3>U1. Extend Sale-Level Review Evidence Contract</h3>
+        <p>Add optional sale-summary fields to <code>PosReconciliationItem</code> and matching Convex/domain return types. Keep the contract additive so old review records render cleanly.</p>
+        <p class="small">Primary files: sync status presentation, register session sync review builder, POS domain types, RegisterSessionView tests.</p>
+      </article>
+      <article class="unit">
+        <h3>U2. Populate Safe Sale Context From Sync Projection Evidence</h3>
+        <p>Preserve safe sale context when sale sync conflicts are created and summarized: receipt/reference, total, item count, payment label, completed time, and staff/cashier context where safe.</p>
+        <p class="small">Primary files: local event projection, register session sync review builder, Cash Controls snapshot query, Convex tests.</p>
+      </article>
+      <article class="unit">
+        <h3>U3. Render Inline Sale-Level Review Details</h3>
+        <p>Render compact sale rows and inline expansion inside <code>RegisterSessionSyncNotice</code>, while preserving closeout review and existing manager sign-in flows.</p>
+        <p class="small">Primary files: RegisterSessionView, sync status presentation, component tests.</p>
+      </article>
+      <article class="unit">
+        <h3>U4. Validate Browser Flow, Copy, And Guardrails</h3>
+        <p>Verify the actual register-session page at desktop and mobile widths, check copy against Athena tone guidance, and update solution docs only if a reusable pattern emerges.</p>
+        <p class="small">Primary files: RegisterSessionView tests, deposits tests, optional docs/solutions note.</p>
+      </article>
+    </section>
+
+    <section id="impact">
+      <h2>System-Wide Impact</h2>
+      <div class="grid">
+        <div>
+          <h3>Interaction Graph</h3>
+          <p>Local sync projection creates conflict evidence, the register snapshot exposes reconciliation items, and Cash Controls renders the review packet before manager action.</p>
+        </div>
+        <div>
+          <h3>State Lifecycle</h3>
+          <p>Older conflict rows may lack sale-level fields; the UI must degrade to existing evidence without blocking review.</p>
+        </div>
+        <div>
+          <h3>Unchanged Invariants</h3>
+          <p>Projection settlement, manager authorization, linked transaction navigation, closeout review, and terminal recovery routing remain unchanged.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="risks">
+      <h2>Risks And Mitigations</h2>
+      <table>
+        <thead>
+          <tr><th>Risk</th><th>Mitigation</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Projection does not populate enough data.</td><td>Add projection and snapshot tests before UI-only assertions.</td></tr>
+          <tr><td>UI exposes raw sync internals or sensitive proof data.</td><td>Keep the contract display-safe and add negative tests.</td></tr>
+          <tr><td>Closeout review regresses.</td><td>Preserve closeout-specific tests and keep sale detail out of the closeout branch.</td></tr>
+          <tr><td>Multiple review items crowd the banner.</td><td>Use compact rows and independent expansion with actions after evidence.</td></tr>
+          <tr><td>Old review rows lack sale fields.</td><td>Treat fields as optional and preserve fallback evidence.</td></tr>
+          <tr><td>Completed/offline time is not present on older conflict rows.</td><td>Copy it at projection time or deliberately join the source sync event when building review status.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="verification">
+      <h2>Verification Strategy</h2>
+      <ul>
+        <li>Focused component coverage in <code>RegisterSessionView.test.tsx</code>.</li>
+        <li>Convex projection and snapshot coverage in sync and deposits tests.</li>
+        <li>Browser verification of the register-session review banner in flow.</li>
+        <li>Graphify rebuild after code changes during implementation.</li>
+      </ul>
+      <p class="small">Canonical markdown source: <code>docs/plans/2026-06-13-002-feat-register-sale-review-detail-plan.md</code></p>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-06-13-002-feat-register-sale-review-detail-plan.md
+++ b/docs/plans/2026-06-13-002-feat-register-sale-review-detail-plan.md
@@ -1,0 +1,330 @@
+---
+title: "feat: Add Sale-Level Register Sync Review Details"
+type: feat
+status: active
+date: 2026-06-13
+---
+
+# feat: Add Sale-Level Register Sync Review Details
+
+## Summary
+
+Add an in-flow sale-level detail panel to Cash Controls register-session sync review so a manager can understand the synced sale being rejected or reviewed without leaving the drawer workspace. The implementation should extend the existing reconciliation item contract, enrich it with sale-level context when available, and render compact expandable decision packets inside the current register review banner.
+
+---
+
+## Problem Frame
+
+The register session correctly owns sync review decisions, but the current review banner explains the action more than the sale. A manager can see that synced activity needs correction and can reject it, yet still has to infer which sale, amount, payment, cashier, and time are involved from nearby transaction tables, support traces, or terminal evidence.
+
+---
+
+## Requirements
+
+- R1. Managers stay on the Cash Controls register session while inspecting synced sale review context.
+- R2. The review banner exposes sale-level context when available: sale reference, amount, item count, payment method, cashier, completed/offline time, local queue number, sync status, and reported time.
+- R3. Unsupported or reject-only review states explain why the sale cannot be applied and what rejecting does, using calm operator-facing copy.
+- R4. Multiple review items render as compact sale-level rows with independent detail expansion, while the primary reject action remains scoped to the reviewed synced activity set.
+- R5. Closeout review behavior remains value-first and is not regressed by sale-level review details.
+- R6. Raw sync internals remain secondary support evidence; no sync secrets, staff proof material, PIN material, raw payloads, customer private data, or payment-sensitive data are exposed.
+- R7. Older reconciliation items without sale-level fields continue to render a useful fallback using the existing reason, type, queue, and reported-time evidence.
+
+---
+
+## Scope Boundaries
+
+- This plan does not add item-line detail, payment allocation detail, or sale editing inside Cash Controls.
+- This plan does not create a new route, modal-only workspace, or transaction reconstruction UI.
+- This plan does not change manager approval/rejection semantics for synced activity.
+- This plan does not automatically correct inventory, payment, service customer attribution, or permission conflicts.
+- This plan does not change POS terminal support routing or terminal recovery behavior.
+
+### Deferred to Follow-Up Work
+
+- Item-line and payment-line drilldown for reviewed synced sales.
+- A dedicated correction workflow for rejected sale facts after this review is cleared.
+- Cross-linking a review item to reconstructed transaction detail when a future projection can safely create a draft or audit-only transaction shell.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx` owns the register detail workspace, sync review banner, linked transaction preview, manager sign-in flow, and reject/approve action placement.
+- `packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts` defines `PosReconciliationItem`, normalizes sync review state, and maps backend types into operator-facing review labels.
+- `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts` builds `localSyncStatus.reconciliationItems` from `posLocalSyncConflict` rows and already copies closeout-specific review evidence from conflict details.
+- `packages/athena-webapp/convex/cashControls/deposits.ts` returns register session snapshots and linked transaction summaries, using staff/customer/payment maps to create operator-facing transaction context.
+- `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts` creates sync conflicts from sale projection failures and already has access to sale payload totals, receipt numbers, payments, staff, line count, and local event metadata at conflict time.
+- `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx` already covers register review banner behavior for combined review items, reject-only service attribution, rejected server activity, closeout review, and linked transactions.
+- `packages/athena-webapp/convex/cashControls/deposits.test.ts` already covers register session snapshot shape, linked transaction summaries, and sync review resolution behavior.
+
+### Institutional Learnings
+
+- `docs/solutions/logic-errors/athena-pos-register-review-and-adjusted-sale-projection-2026-05-21.md` says register sync events that need manager review should expose unresolved event count, readable event context, and manager action.
+- `docs/solutions/logic-errors/athena-cash-controls-closeout-review-ia-2026-06-08.md` says review items should be compact decision packets and that action placement should come after evidence.
+- `docs/solutions/logic-errors/athena-pos-local-sync-review-and-service-lines-2026-05-29.md` says server-rejected synced activity affecting a register session needs enough evidence for operators to recover it from Cash Controls.
+- `docs/product-copy-tone.md` requires calm, clear, restrained, operational copy and says correction surfaces should preserve trust without implying original sale facts disappeared.
+
+### External References
+
+- External research skipped. This is a repo-local Cash Controls/POS sync review interaction with established local patterns and no new third-party API or framework behavior.
+
+---
+
+## Key Technical Decisions
+
+- Extend the existing reconciliation item contract instead of introducing a separate review-detail query. The register snapshot already carries the review item list, and the UI needs this context in the review banner before action.
+- Enrich sale-level context at projection/query boundaries from already-known sync conflict details and linked transaction-style formatting, not from raw local payloads in the browser.
+- Render detail inline inside the existing review banner. The register session remains the workspace, and the manager can expand sale-level evidence without route changes.
+- Keep closeout review presentation separate. Closeout remains value-first with expected/count/variance/note, while sale review gets sale summary rows and sale-specific detail.
+- Treat missing sale-level fields as normal. Older or non-sale review records should fall back to the current evidence lines instead of showing empty labels.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should the first version show item/payment line detail? No. The signed-off scope is sale-level detail only.
+- Should the UI take the manager out of the register session? No. The detail must stay within the register-session flow.
+- Should this become a dedicated detail route? No. The first version should use inline expansion inside the existing review banner.
+
+### Deferred to Implementation
+
+- Exact sale-reference priority when both local receipt number and cloud transaction number are present. Implementation should choose the most operator-recognizable value using existing transaction display conventions.
+- Exact treatment for multi-payment sale summaries. Implementation should mirror linked transaction summary behavior: show a compact "Multiple" style label when no single primary method is safe to name.
+- Exact source for completed/offline time when existing conflict rows only carry conflict creation time. Implementation should copy it into safe conflict details at projection time or deliberately join the source `posLocalSyncEvent` when building register-session review status.
+- Whether any existing conflict rows in local development need fixture refresh to demonstrate sale-level values. The UI must still pass with fallback-only records.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  A["Local sale sync conflict"] --> B["Conflict details preserve safe sale summary"]
+  B --> C["Register session localSyncStatus reconciliation item"]
+  C --> D["Cash Controls register snapshot"]
+  D --> E["RegisterSessionSyncNotice"]
+  E --> F["Compact synced sale row"]
+  F --> G["Inline sale detail expansion"]
+  E --> H["Approve/reject action area"]
+```
+
+The important boundary is that sale summary values are safe operator evidence. They should be normalized before reaching the browser and rendered as sale facts, while raw event payloads and secret-bearing proof material stay out of the presentation contract.
+
+---
+
+## Implementation Units
+
+- U1. **Extend Sale-Level Review Evidence Contract**
+
+**Goal:** Add portable sale-level fields to the POS sync review/reconciliation item shape so register review UI can present sale context consistently.
+
+**Requirements:** R2, R6, R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts`
+- Modify: `packages/athena-webapp/convex/pos/domain/types.ts`
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`
+- Test: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+- Test: `packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.test.ts`
+
+**Approach:**
+- Extend `PosReconciliationItem` and the corresponding Convex/domain return types with optional sale-summary fields.
+- Keep the contract optional and additive so existing conflict rows continue to render.
+- Include only display-safe values: sale reference, local transaction/receipt reference, total, item count, primary or multiple payment summary, cashier display name when available, completed/offline timestamp, reported timestamp, local queue sequence, and status.
+- Preserve closeout-specific fields as-is; do not overload sale fields for closeout review.
+
+**Execution note:** Implement the contract test-first where practical: start with failing presentation and repository tests that show a sale review item can carry sale-level fields and that missing fields still render fallback evidence.
+
+**Patterns to follow:**
+- `PosReconciliationItem` optional-field normalization in `packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts`
+- Closeout review evidence copied by `buildRegisterSessionLocalSyncStatus` in `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts`
+- Linked transaction display model in `RegisterSessionView.tsx`
+
+**Test scenarios:**
+- Happy path: a reconciliation item with sale reference, total, item count, payment summary, cashier, completed timestamp, queue sequence, and status is accepted by the presentation contract and available to the register view.
+- Edge case: a reconciliation item with no sale-level fields still renders existing reason/type/queue/reported fallback evidence.
+- Error path: secret-like or raw proof fields are not part of the reconciliation item contract and do not appear in UI fixtures.
+- Integration: register session repository/snapshot output carries the new optional fields without breaking current closeout or rejected-review fixtures.
+
+**Verification:**
+- Register sync review items can represent sale-level context without requiring a separate query.
+- Existing review item tests continue to pass with fallback-only records.
+
+---
+
+- U2. **Populate Safe Sale Context From Sync Projection Evidence**
+
+**Goal:** Preserve safe sale-level context when a sale sync conflict is created or summarized, so Cash Controls can show the manager what sale is under review.
+
+**Requirements:** R2, R6, R7
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+- Test: `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+
+**Approach:**
+- When sale projection creates a conflict, include a safe sale summary in conflict details from the parsed local sale event: receipt/reference, total, item count, payment labels, completed timestamp, local transaction reference, and staff profile where already known.
+- When building register-session local sync status, map safe conflict details into the optional sale fields from U1.
+- Where a conflict can be matched to already-projected or linked transaction context, prefer the existing register-session snapshot display conventions for cashier and payment labels.
+- Do not store or expose raw local sale payloads, staff proof tokens, payment-sensitive payloads, or customer private details in the review item.
+
+**Execution note:** Add tests at the projection boundary before changing UI. The UI should not need to infer sale facts from local event IDs.
+
+**Patterns to follow:**
+- Conflict detail creation in `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Register snapshot transaction mapping in `packages/athena-webapp/convex/cashControls/deposits.ts`
+- Closeout context preservation in `buildRegisterSessionLocalSyncStatus`
+
+**Test scenarios:**
+- Happy path: a sale completion conflict includes sale total, item count, payment summary, receipt/reference, completed timestamp, and staff/cashier context where safe.
+- Edge case: multi-payment sale conflict stores a compact payment summary instead of exposing individual payment payload details.
+- Edge case: service sale missing customer attribution still includes sale-level context while preserving the reject-only state.
+- Error path: permission, inventory, and payment conflicts do not expose staff proof tokens, sync secrets, raw payment payloads, customer private data, or raw local payloads.
+- Integration: `getRegisterSessionSnapshot` returns sale-level review context alongside linked transactions and current register session data.
+
+**Verification:**
+- Backend tests prove sale-level evidence is generated from sync conflict context and survives through the register snapshot.
+- Rejection and approval command behavior remains unchanged.
+
+---
+
+- U3. **Render Inline Sale-Level Review Details In Register Session**
+
+**Goal:** Replace the summary-only non-closeout review block with compact sale rows and inline detail expansion inside the existing register-session review banner.
+
+**Requirements:** R1, R2, R3, R4, R5, R7
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts`
+- Test: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+
+**Approach:**
+- Keep `RegisterSessionSyncNotice` as the owner of the review banner and action placement.
+- Add a sale-level row component for non-closeout review items. The row should show a concise summary such as sale reference, total, item count, payment label, cashier, completed time, and queue sequence when available.
+- Add inline expansion for each row. Expanded detail should group content around manager questions: "Synced sale", "Why this needs review", "What rejecting does", and "Support evidence".
+- For multiple review items, render multiple compact rows with independent expansion. Keep the combined next-step copy and action buttons scoped to the whole reviewed set.
+- Preserve closeout review rendering and its expected/count/variance/note layout.
+- Put the reject or approve action after the evidence so the manager reads the decision packet before acting.
+
+**Execution note:** Use characterization-first coverage around existing closeout and combined-review banner behavior, then add sale-detail expectations.
+
+**Patterns to follow:**
+- Existing closeout review card structure in `RegisterSessionSyncNotice`
+- Linked transaction row/card display conventions in `RegisterSessionView.tsx`
+- Operator copy guidance in `docs/product-copy-tone.md`
+
+**Test scenarios:**
+- Happy path: a single unsupported sale review item renders a compact synced-sale row with reference, total, item count, payment, cashier, completed time, queue number, and a `View sale details` control.
+- Happy path: expanding the row shows grouped sale facts, plain-language reason, rejecting consequence, and support evidence without navigating away.
+- Edge case: multiple review items render multiple sale rows and keep the reject action scoped to the reviewed synced activity set.
+- Edge case: fallback-only records render reason/type/queue/reported evidence and do not show empty labels or raw null values.
+- Edge case: closeout review still renders expected/count/variance/note and does not show sale-detail UI.
+- Error path: service customer attribution review remains reject-only and explains that the sale must be recreated or corrected from the appropriate workflow.
+- Integration: manager sign-in and `Reject synced activity` flows still open the existing authentication path and call the same sync review resolution callback.
+
+**Verification:**
+- The register session page presents enough sale-level context to identify which sale is under review without leaving the drawer workspace.
+- Existing closeout, rejected override, and approval tests remain green.
+
+---
+
+- U4. **Validate Browser Flow, Copy, And Guardrails**
+
+**Goal:** Prove the finished feature works in the actual register-session surface and document any durable learning if the implementation reveals a reusable pattern.
+
+**Requirements:** R1, R3, R4, R5, R6, R7
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Modify: `docs/solutions/logic-errors/athena-cash-controls-closeout-review-ia-2026-06-08.md` or create a new `docs/solutions/logic-errors/*` note if implementation reveals a distinct reusable pattern
+- Test: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+- Test: `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+
+**Approach:**
+- Validate the page in a browser against a register session with sale-level review context and confirm no route change is needed for inspection.
+- Check desktop and mobile widths for the review banner so row expansion does not crowd the action area or linked transactions.
+- Review copy against `docs/product-copy-tone.md`: lead with sale state, explain next action, avoid raw backend language as the primary label, and keep rejection consequences factual.
+- Rebuild Graphify after code changes per repo instructions.
+- Add or refresh a solution note only if implementation changes the reusable sync-review evidence pattern beyond this one feature.
+
+**Execution note:** Browser verification should follow code/tests; it is not a substitute for component and Convex coverage.
+
+**Patterns to follow:**
+- Existing register-session browser verification paths from prior Cash Controls UI work.
+- Graphify maintenance rule in project instructions.
+
+**Test scenarios:**
+- Happy path: browser-visible register session shows review banner, sale summary row, expanded details, and unchanged linked transaction context.
+- Edge case: narrow viewport keeps the detail expansion readable and keeps reject action reachable after evidence.
+- Error path: no secret-like strings, raw local payloads, or staff proof fields appear in the browser-visible review banner.
+- Integration: focused frontend and Convex tests cover the same sale-review fixture used for browser validation.
+
+**Verification:**
+- Focused frontend and Convex tests pass.
+- Browser inspection confirms the manager can identify the sale and reject consequence in-flow.
+- `bun run graphify:rebuild` has updated `graphify-out/` after code changes.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Local sync projection creates conflict evidence, register session snapshot exposes reconciliation items, Cash Controls register session renders the review packet, and manager sign-in resolves or rejects the same sync review through the existing mutation.
+- **Error propagation:** Unsupported review states remain reject-only; backend command errors continue to flow through existing sync review error handling.
+- **State lifecycle risks:** Older conflict records may lack sale-level evidence. The UI must degrade to existing reason/type/queue evidence without blocking review.
+- **API surface parity:** The new optional sale fields must be reflected in Convex/domain types and frontend presentation types together.
+- **Integration coverage:** Unit tests alone are not enough; at least one browser check should verify the expanded review detail inside the actual register session layout.
+- **Unchanged invariants:** This plan does not change projection settlement, manager authorization, linked transaction navigation, closeout variance review, or terminal recovery routing.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Review item shape expands but projection does not populate enough data | Add projection and snapshot tests before UI-only assertions |
+| UI exposes raw sync internals or sensitive proof data | Keep the contract display-safe and add negative tests for secret-like fields |
+| Closeout review regresses while changing shared banner code | Preserve closeout-specific tests and keep sale detail out of closeout branch |
+| Multiple review items make the banner too dense | Use compact rows and independent expansion; keep the action area after evidence |
+| Old review rows lack sale fields | Treat fields as optional and preserve existing fallback evidence |
+
+---
+
+## Documentation / Operational Notes
+
+- Product copy should stay calm and operational: "Synced sale", "Why this needs review", "What rejecting does", and "Support evidence" are preferred framing.
+- The implementation may need a new or updated solution note if it establishes a reusable rule for safe sale-level sync review evidence.
+- No rollout flag is required unless implementation discovers that existing production conflict rows need a gradual presentation fallback.
+
+---
+
+## Sources & References
+
+- Related code: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`
+- Related code: `packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Related code: `packages/athena-webapp/convex/cashControls/deposits.ts`
+- Related tests: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+- Related tests: `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+- Related learning: `docs/solutions/logic-errors/athena-pos-register-review-and-adjusted-sale-projection-2026-05-21.md`
+- Related learning: `docs/solutions/logic-errors/athena-cash-controls-closeout-review-ia-2026-06-08.md`
+- Related learning: `docs/solutions/logic-errors/athena-pos-local-sync-review-and-service-lines-2026-05-29.md`
+- Copy guidance: `docs/product-copy-tone.md`

--- a/docs/plans/2026-06-16-001-refactor-register-viewmodel-boundaries-plan.html
+++ b/docs/plans/2026-06-16-001-refactor-register-viewmodel-boundaries-plan.html
@@ -1,0 +1,533 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>refactor: Modularize POS register view model boundaries</title>
+  <style>body{font-family:Inter,system-ui,sans-serif;line-height:1.55;margin:0;background:#f8fafc;color:#111827}main{max-width:920px;margin:0 auto;padding:48px 24px 72px}h1,h2,h3{line-height:1.2}h1{font-size:2rem}h2{margin-top:2rem;border-top:1px solid #e5e7eb;padding-top:1.25rem}li{margin:.35rem 0}code,pre{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}pre{background:#111827;color:#f9fafb;padding:16px;overflow:auto;border-radius:8px}</style>
+</head>
+<body>
+<main>
+<p>title: &quot;refactor: Modularize POS register view model boundaries&quot;</p>
+<p>type: refactor</p>
+<p>status: active</p>
+<p>date: 2026-06-16</p>
+<h1>refactor: Modularize POS register view model boundaries</h1>
+<h2>Summary</h2>
+<p>Split the POS register view-model internals into focused presentation and runtime hooks while preserving the existing `RegisterViewModel` facade consumed by `POSRegisterView`. The implementation should reduce `useRegisterViewModel.ts` from a monolithic orchestration hotspot into composable cashier-presence, local-runtime, drawer-lifecycle, sale-draft, checkout, and view-model assembly boundaries, with focused tests guarding each extracted behavior.</p>
+<h2>Problem Frame</h2>
+<p>`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts` is a Graphify hotspot and currently concentrates local POS runtime state, cashier restore, drawer lifecycle, service lines, optimistic cart updates, payment queues, checkout completion, sync presentation, and final UI assembly in one hook. That shape makes local-first POS changes risky because unrelated flows share refs, queue locks, local-store reads, and inline presentation logic.</p>
+<p>The refactor must preserve Athena POS continuity: local sales should keep working first, sync/recovery state should remain visible, and the UI contract should stay stable while internals are extracted.</p>
+<h2>Requirements</h2>
+<ul>
+<li>R1. Preserve the public `RegisterViewModel` contract in `registerUiState.ts` and keep `POSRegisterView` behavior compatible throughout the refactor.</li>
+<li>R2. Extract pure mapping and presentation helpers from `useRegisterViewModel.ts` into testable modules without changing user-facing behavior.</li>
+<li>R3. Move local runtime/store ownership into one boundary that owns store creation, projected read-model refresh, event-append tokens, seed readiness checks, and sync-status wiring.</li>
+<li>R4. Move cashier presence restore/sign-in/sign-out handling into a dedicated boundary that preserves local staff proof, stale-presence, and validation-pending behavior.</li>
+<li>R5. Move drawer lifecycle and gate presentation into a dedicated boundary that preserves opening, closeout, reopen, opening-float correction, terminal repair, and drawer-authority repair flows.</li>
+<li>R6. Improve drawer-open failure presentation by mapping local command `user_error` results to durable operator messages instead of collapsing every failure to generic retry copy.</li>
+<li>R7. Move sale-draft, product/service cart, optimistic quantity, and local availability projection behavior into focused boundaries without weakening local-first durability.</li>
+<li>R8. Move payment queueing and checkout completion behavior into a focused boundary that preserves ordered writes and checkout locks.</li>
+<li>R9. Keep existing integration coverage passing while adding focused unit tests for extracted modules so future changes do not require editing the 12k-line integration test for every helper-level behavior.</li>
+<li>R10. Rebuild Graphify after code changes so `graphify-out/` stays current.</li>
+</ul>
+<h2>Scope Boundaries</h2>
+<ul>
+<li>Do not redesign POS product behavior, payment semantics, local sync ingestion, or the local event contract.</li>
+<li>Do not change `RegisterViewModel` field names or remove existing optional states without a separate UI migration plan.</li>
+<li>Do not move Convex command/query implementations as part of this refactor.</li>
+<li>Do not convert the full register view to a new state-management library.</li>
+<li>Do not rewrite `POSRegisterView.tsx`; only adjust call sites if an extracted boundary changes the import location of type-safe helpers.</li>
+<li>Do not add new support-evidence storage, query, or timeline surfaces as part of this refactor.</li>
+</ul>
+<h3>Deferred to Follow-Up Work</h3>
+<ul>
+<li>Full test-file decomposition: keep `useRegisterViewModel.test.ts` as the integration guard in this pass; split it into domain-specific integration files only after extracted modules stabilize.</li>
+<li>Larger `POSRegisterView.tsx` component decomposition: this plan focuses on the hook and adjacent presentation helpers, not the 1.9k-line view component.</li>
+<li>Reusable operations support-evidence foundation: plan this as standalone work with sanitized operational events, redaction, timeline/query adapters, and POS drawer/register lifecycle as the first producer.</li>
+<li>Broad support-dashboard redesign: defer until the reusable support-evidence foundation exists.</li>
+</ul>
+<h2>Context &amp; Research</h2>
+<h3>Relevant Code and Patterns</h3>
+<ul>
+<li>`graphify-out/wiki/index.md` identifies `useRegisterViewModel.ts` as a 72-edge hotspot and a top Athena webapp graph hotspot.</li>
+<li>`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts` is about 6.8k lines and currently defines many pure helpers before the hook plus many runtime handlers inside the hook.</li>
+<li>`packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts` is about 420 lines and already expresses the stable UI-facing contract.</li>
+<li>`packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx` imports `useRegisterViewModel` and consumes the facade; the view should remain a caller, not become the new orchestration home.</li>
+<li>`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`, `localCommandGateway.ts`, `localRegisterReader.ts`, `registerReadModel.ts`, `posLocalStore.ts`, `syncStatus.ts`, and `terminalRuntimeStatus.ts` are existing local runtime seams to reuse.</li>
+<li>`packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts`, `catalogSearchPresentation.ts`, `selectors.ts`, and `useRegisterCatalogIndex.ts` show the existing pattern for extracting register presentation logic beside focused tests.</li>
+<li>`packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts` provides a smaller parallel register view-model implementation that can inform facade shape, but POS behavior is broader and should not be forced into expense abstractions.</li>
+</ul>
+<h3>Institutional Learnings</h3>
+<ul>
+<li>`docs/solutions/logic-errors/athena-pos-register-local-catalog-search-2026-05-04.md` says the active POS register is a hot path; local catalog lookup should stay deterministic, with durable command boundaries remaining the authority for inventory/session invariants.</li>
+<li>`docs/solutions/logic-errors/athena-pos-local-sync-review-and-service-lines-2026-05-29.md` says service lines and sync review are first-class POS read-model inputs; do not copy product quantity semantics into service behavior, and keep register-session visibility for synced activity that affects the drawer.</li>
+<li>`docs/brainstorms/2026-05-13-pos-local-first-register-requirements.md` anchors the local-first POS invariant: POS actions should be durably recorded locally before the cashier sees them as complete, with sync/reconciliation separated from ordinary selling.</li>
+</ul>
+<h3>External References</h3>
+<ul>
+<li>External research was skipped. The work is an internal refactor against established local patterns, with no new framework, API, payment provider, or security primitive.</li>
+</ul>
+<h2>Key Technical Decisions</h2>
+<ul>
+<li>Preserve the facade first: `useRegisterViewModel()` remains the only hook imported by `POSRegisterView` during this pass, so extracted hooks can be introduced without a UI migration.</li>
+<li>Extract by behavior boundary, not by line count: split cashier presence, local runtime, drawer lifecycle, sale draft, checkout/payment, and final assembly because those are independently testable state machines.</li>
+<li>Keep infrastructure under `infrastructure/local`: presentation hooks should compose existing local runtime primitives instead of moving IndexedDB, sync scheduler, or command gateway code into presentation.</li>
+<li>Add pure-helper tests before moving large chunks: helper extraction should be behavior-preserving and covered with fast tests where possible before the integration facade changes.</li>
+<li>Improve drawer error presentation inside the drawer boundary: local command results already carry `CommandResult` shape; mapping known `user_error` messages gives operators better recovery guidance without changing command semantics.</li>
+<li>Treat the current integration test as the compatibility suite: focused tests should grow around extracted modules, but the existing `useRegisterViewModel.test.ts` remains the end-to-end view-model regression guard.</li>
+<li>Rebuild generated graph output after code changes: repo instructions require `bun run graphify:rebuild` after modifying code files.</li>
+</ul>
+<h2>Open Questions</h2>
+<h3>Resolved During Planning</h3>
+<ul>
+<li>Primary extraction boundary: preserve the `RegisterViewModel` facade and extract internal modules behind it rather than changing `POSRegisterView`.</li>
+<li>Origin document usage: the local-first POS requirements are relevant constraints, but there is no direct upstream requirements document for this refactor.</li>
+<li>External research: skip; current repo patterns are sufficient.</li>
+</ul>
+<h3>Deferred to Implementation</h3>
+<ul>
+<li>Exact extracted module names: use the names in this plan as directional names; adjust if implementation reveals clearer local naming.</li>
+<li>Exact helper grouping: pure helpers may split into several files if a single helper module becomes too broad.</li>
+<li>Exact drawer error mapping table: derive it from current `localCommandGateway` `CommandResult` outputs and existing operator-copy tone during implementation.</li>
+<li>Whether to move all helper tests out of `useRegisterViewModel.test.ts`: defer broad test reorganization until extracted modules are stable.</li>
+</ul>
+<h2>High-Level Technical Design</h2>
+<p>&gt; *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*</p>
+<pre><code>flowchart TB
+  facade[useRegisterViewModel facade]
+  localRuntime[useRegisterLocalRuntime]
+  cashier[useRegisterCashierPresence]
+  drawer[useRegisterDrawerLifecycle]
+  sale[useRegisterSaleDraft]
+  checkout[useRegisterCheckoutDraft]
+  assembly[buildRegisterViewModelState]
+
+  facade --&gt; localRuntime
+  facade --&gt; cashier
+  facade --&gt; drawer
+  facade --&gt; sale
+  facade --&gt; checkout
+  localRuntime --&gt; drawer
+  localRuntime --&gt; sale
+  localRuntime --&gt; checkout
+  cashier --&gt; drawer
+  cashier --&gt; sale
+  sale --&gt; checkout
+  drawer --&gt; assembly
+  sale --&gt; assembly
+  checkout --&gt; assembly
+  cashier --&gt; assembly</code></pre>
+<p>The facade should mostly gather store, terminal, staff, route, and Convex gateway inputs, then compose extracted hooks and return the existing `RegisterViewModel`. Each extracted hook should expose stable state/actions to the facade, not directly to `POSRegisterView`.</p>
+<h2>Implementation Units</h2>
+<pre><code>flowchart TB
+  U1[U1 Pure helpers]
+  U2[U2 Local runtime bridge]
+  U3[U3 Cashier presence]
+  U4[U4 Drawer lifecycle]
+  U5[U5 Sale draft]
+  U6[U6 Checkout draft]
+  U7[U7 Facade assembly]
+
+  U1 --&gt; U2
+  U1 --&gt; U3
+  U1 --&gt; U4
+  U1 --&gt; U5
+  U1 --&gt; U6
+  U2 --&gt; U4
+  U2 --&gt; U5
+  U2 --&gt; U6
+  U3 --&gt; U4
+  U3 --&gt; U5
+  U4 --&gt; U7
+  U5 --&gt; U6
+  U5 --&gt; U7
+  U6 --&gt; U7</code></pre>
+<ul>
+<li>U1. **Extract pure register mapping helpers**</li>
+</ul>
+<p>**Goal:** Move behavior-free helper functions out of `useRegisterViewModel.ts` so later hook extraction can depend on small tested modules.</p>
+<p>**Requirements:** R1, R2, R9</p>
+<p>**Dependencies:** None</p>
+<p>**Files:**</p>
+<ul>
+<li>Create: `packages/athena-webapp/src/lib/pos/presentation/register/registerCashierPresence.ts`</li>
+<li>Create: `packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts`</li>
+<li>Create: `packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts`</li>
+<li>Create: `packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts`</li>
+<li>Test: `packages/athena-webapp/src/lib/pos/presentation/register/registerCashierPresence.test.ts`</li>
+<li>Test: `packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.test.ts`</li>
+<li>Test: `packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.test.ts`</li>
+<li>Test: `packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.test.ts`</li>
+<li>Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`</li>
+</ul>
+<p>**Approach:**</p>
+<ul>
+<li>Start with pure functions that already accept complete inputs and return values: cashier presence validation, service checkout block messages, local cart item mapping, payment combining, local availability consumption, completed-sale payload construction, closeout id selection, and drawer gate mode derivation.</li>
+<li>Keep imports one-directional: extracted helpers may import shared types and existing presentation/domain helpers, but must not import `useRegisterViewModel.ts`.</li>
+<li>Avoid broad &quot;utils&quot; files. Group helpers by behavior so future hook modules have obvious homes.</li>
+</ul>
+<p>**Execution note:** Add characterization tests for extracted helpers before deleting their inline copies from the hook.</p>
+<p>**Patterns to follow:**</p>
+<ul>
+<li>`packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts`</li>
+<li>`packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.ts`</li>
+<li>`packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts`</li>
+</ul>
+<p>**Test scenarios:**</p>
+<ul>
+<li>Happy path: valid restored cashier presence for the current store/terminal returns restored state with display metadata intact.</li>
+<li>Edge case: mismatched restored cashier presence scope returns the existing failed or missing state without setting staff proof.</li>
+<li>Happy path: local cart read-model items map to `CartItem` shape with pending checkout and provisional import identifiers preserved.</li>
+<li>Edge case: service checkout block returns no message when service lines have profile-backed customer attribution.</li>
+<li>Error path: service checkout block returns an actionable customer-attribution message when service lines exist without usable customer details.</li>
+<li>Happy path: payment combining merges same-method payments while preserving total amount and current payment method semantics.</li>
+<li>Edge case: closeout id resolution prefers the active local register session where current behavior expects it.</li>
+<li>Integration: extracted drawer gate mode helper returns the same modes currently asserted by `useRegisterViewModel.test.ts` for terminal repair, drawer-authority repair, closeout blocked, and opening-float correction.</li>
+</ul>
+<p>**Verification:**</p>
+<ul>
+<li>Pure helper tests pass.</li>
+<li>`useRegisterViewModel.test.ts` remains behaviorally unchanged after helper extraction.</li>
+</ul>
+<ul>
+<li>U2. **Extract local runtime and store bridge**</li>
+</ul>
+<p>**Goal:** Move IndexedDB store ownership, local command gateway creation, projected read-model refresh, seed readiness checks, event-append tokens, and sync-status runtime wiring out of the main hook.</p>
+<p>**Requirements:** R1, R3, R7, R9, R10</p>
+<p>**Dependencies:** U1</p>
+<p>**Files:**</p>
+<ul>
+<li>Create: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterLocalRuntime.ts`</li>
+<li>Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterLocalRuntime.test.ts`</li>
+<li>Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`</li>
+<li>Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts` *(only if extracted wiring reveals missing coverage in the existing runtime hook)*</li>
+</ul>
+<p>**Approach:**</p>
+<ul>
+<li>Keep `createPosLocalStore`, `createLocalCommandGateway`, `readProjectedLocalRegisterModel`, and `usePosLocalSyncRuntimeStatus` composition inside one register-local runtime hook.</li>
+<li>Expose a narrow result to the facade: `localStore`, `localCommandGateway`, `localRegisterReadModel`, `refreshLocalRegisterReadModel`, `noteLocalRegisterEventChanged`, `hasProvisionedLocalSyncSeed`, sync source/presentation inputs, local staff authority readiness, and stable refs needed for staff proof lookup.</li>
+<li>Ensure there is one store factory path for register presentation instead of creating fresh stores in unrelated callbacks.</li>
+<li>Keep `usePosLocalSyncRuntimeStatus` in infrastructure; this unit only centralizes how the register facade consumes it.</li>
+</ul>
+<p>**Execution note:** Characterize current event-token and read-model refresh behavior before moving callbacks.</p>
+<p>**Patterns to follow:**</p>
+<ul>
+<li>`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`</li>
+<li>`packages/athena-webapp/src/lib/pos/infrastructure/local/localRegisterReader.ts`</li>
+<li>`packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`</li>
+</ul>
+<p>**Test scenarios:**</p>
+<ul>
+<li>Happy path: the hook creates a stable local store and command gateway across rerenders when terminal identity is unchanged.</li>
+<li>Happy path: appending a local event increments the event token and causes the projected read model to refresh.</li>
+<li>Edge case: missing `activeStoreId`, missing terminal id, or unavailable IndexedDB returns seed readiness false without throwing.</li>
+<li>Edge case: staff proof lookup returns a token only for the currently authenticated staff profile.</li>
+<li>Integration: local sync retry invokes the runtime retry callback and the register bootstrap retry callback.</li>
+<li>Integration: projected local read-model sync status still feeds `buildPosSyncStatusPresentation` through the same status source precedence.</li>
+</ul>
+<p>**Verification:**</p>
+<ul>
+<li>`useRegisterLocalRuntime.test.ts` covers local store and sync wiring.</li>
+<li>Existing local runtime tests continue to pass.</li>
+<li>`useRegisterViewModel.ts` no longer directly creates ad hoc local stores for seed/read-model checks.</li>
+</ul>
+<ul>
+<li>U3. **Extract cashier presence and staff authority flow**</li>
+</ul>
+<p>**Goal:** Move cashier restore, validation-pending state, staff proof attachment, local staff authority readiness, authenticated-staff display, and sign-out presence cleanup into a focused boundary.</p>
+<p>**Requirements:** R1, R4, R7, R9</p>
+<p>**Dependencies:** U1, U2</p>
+<p>**Files:**</p>
+<ul>
+<li>Create: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterCashierPresence.ts`</li>
+<li>Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterCashierPresence.test.ts`</li>
+<li>Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`</li>
+<li>Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`</li>
+</ul>
+<p>**Approach:**</p>
+<ul>
+<li>Encapsulate `staffProfileId`, `staffProofToken`, `localAuthenticatedStaff`, `cashierPresenceRestore`, and local staff authority status.</li>
+<li>Keep the restoration sequence intact: wait for store day readiness, read organization-scoped cashier presence where available, validate offline freshness, clear mismatched/expired presence, and expose validation-pending restored cashier metadata to the auth dialog.</li>
+<li>Keep sign-out local presence cleanup inside this boundary, but let the facade provide sale-hold/void callbacks so sign-out still respects active sale continuity.</li>
+<li>Keep staff proof attachment to pending local events tied to successful proof-bearing authentication.</li>
+</ul>
+<p>**Execution note:** Preserve existing cashier-presence integration tests before extracting; add focused hook tests for stale/mismatched presence cases.</p>
+<p>**Patterns to follow:**</p>
+<ul>
+<li>`packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx`</li>
+<li>`packages/athena-webapp/src/lib/pos/infrastructure/local/terminalStaffAuthorityRefresh.ts`</li>
+<li>`packages/athena-webapp/src/lib/pos/presentation/register/registerCashierPresence.ts`</li>
+</ul>
+<p>**Test scenarios:**</p>
+<ul>
+<li>Happy path: proof-bearing authentication sets staff id, staff proof token, local authenticated staff display, and writes cashier presence.</li>
+<li>Happy path: valid restored presence restores the cashier and exposes no auth dialog.</li>
+<li>Edge case: restored presence with expired offline freshness enters validation-pending or failed state according to current behavior.</li>
+<li>Edge case: mismatched organization/store/terminal presence is cleared and does not authenticate the cashier.</li>
+<li>Error path: local presence clear failure keeps the cashier signed in and surfaces the existing sign-out failure copy.</li>
+<li>Integration: attaching a new staff proof to pending events nudges local sync.</li>
+<li>Integration: auth dialog props from the facade remain unchanged for validation-pending restored cashier unlock.</li>
+</ul>
+<p>**Verification:**</p>
+<ul>
+<li>Cashier-presence focused tests cover restore/sign-in/sign-out branches.</li>
+<li>Existing `useRegisterViewModel.test.ts` cashier presence cases remain green.</li>
+</ul>
+<ul>
+<li>U4. **Extract drawer lifecycle and gate presentation**</li>
+</ul>
+<p>**Goal:** Move drawer gate mode derivation, drawer opening, closeout, reopen, opening-float correction, terminal setup repair, drawer-authority retry, and closeout control assembly out of the main hook.</p>
+<p>**Requirements:** R1, R5, R6, R9</p>
+<p>**Dependencies:** U1, U2, U3</p>
+<p>**Files:**</p>
+<ul>
+<li>Create: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterDrawerLifecycle.ts`</li>
+<li>Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterDrawerLifecycle.test.ts`</li>
+<li>Modify: `packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts`</li>
+<li>Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`</li>
+<li>Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`</li>
+<li>Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts`</li>
+</ul>
+<p>**Approach:**</p>
+<ul>
+<li>Encapsulate drawer draft state (`openingFloat`, notes, correction fields, closeout counted cash/notes), submitting flags, drawer error message, and drawer gate mode.</li>
+<li>Keep lifecycle commands local-first: open drawer, start closeout, reopen register, and terminal repair must record local evidence or preserve existing failure behavior before the UI proceeds.</li>
+<li>Map `LocalOpenDrawerResult` `user_error` messages to durable operator-facing drawer messages. The first pass should normalize known local command causes, such as missing cashier identity, drawer authority blocks, lifecycle review blocks, another active drawer, missing terminal seed, and local persistence failure.</li>
+<li>Keep closeout approval and opening-float correction command approval behavior unchanged.</li>
+<li>Expose `drawerGate` and `closeoutControl` objects that still satisfy `RegisterViewModel`.</li>
+</ul>
+<p>**Execution note:** Implement drawer error mapping test-first because it is the only intentional behavior improvement in this refactor.</p>
+<p>**Patterns to follow:**</p>
+<ul>
+<li>`packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`</li>
+<li>`packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx`</li>
+<li>`packages/athena-webapp/src/lib/errors/operatorMessages.ts`</li>
+<li>`docs/product-copy-tone.md`</li>
+</ul>
+<p>**Test scenarios:**</p>
+<ul>
+<li>Happy path: opening a drawer locally sets a local operable register session and clears drawer error state.</li>
+<li>Error path: local open-drawer `user_error` for missing cashier identity maps to sign-in recovery copy, not generic retry copy.</li>
+<li>Error path: drawer-authority and lifecycle review failures map to drawer repair or review-oriented copy without claiming the sale is lost.</li>
+<li>Error path: local append/store failure maps to retryable local persistence copy and keeps the drawer gate open.</li>
+<li>Edge case: online drawer opening still requires fresh staff proof; offline drawer opening preserves current proof behavior.</li>
+<li>Happy path: zero-variance cloud-backed closeout still records locally and marks the local event synced when the server closeout succeeds.</li>
+<li>Happy path: manager reopening of a local closing register restores local operable register state.</li>
+<li>Integration: terminal repair mode still auto-attempts repair once per store/terminal key.</li>
+<li>Integration: `drawerGate` and `closeoutControl` props consumed by `RegisterDrawerGate` remain shape-compatible.</li>
+</ul>
+<p>**Verification:**</p>
+<ul>
+<li>Drawer lifecycle focused tests pass.</li>
+<li>Existing drawer/open/closeout/reopen cases in `useRegisterViewModel.test.ts` pass.</li>
+<li>Operator-facing drawer failure copy follows `docs/product-copy-tone.md`.</li>
+</ul>
+<ul>
+<li>U5. **Extract sale draft, catalog, service, and optimistic cart behavior**</li>
+</ul>
+<p>**Goal:** Move active-session projection, local active sale reconciliation, product search overlay, service search/drafts, local availability overlay, optimistic cart quantities/products, and cart mutation queue behavior into focused boundaries.</p>
+<p>**Requirements:** R1, R2, R7, R9</p>
+<p>**Dependencies:** U1, U2, U3</p>
+<p>**Files:**</p>
+<ul>
+<li>Create: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterSaleDraft.ts`</li>
+<li>Create: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterProductAndServiceSearch.ts`</li>
+<li>Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterSaleDraft.test.ts`</li>
+<li>Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterProductAndServiceSearch.test.ts`</li>
+<li>Modify: `packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts`</li>
+<li>Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`</li>
+<li>Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`</li>
+<li>Test: `packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.test.ts`</li>
+<li>Test: `packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.test.ts`</li>
+</ul>
+<p>**Approach:**</p>
+<ul>
+<li>Keep product catalog indexing in existing `catalogSearch` modules; this unit only extracts the register-specific composition of catalog rows, bounded availability queries, pending checkout overlays, exact auto-add, and service search.</li>
+<li>Encapsulate optimistic cart refs/state and the cart mutation queue so product add/update/remove/clear logic no longer shares low-level refs across the entire view-model hook.</li>
+<li>Keep service lines first-class and distinct from product quantity semantics: duplicate services stay disabled/no-op, amount-required service drafts persist locally, and checkout blocking remains customer-attribution based.</li>
+<li>Preserve the local-first invariant: cart/service UI state should advance only after durable local event writes, except for existing optimistic UI states that already roll back on local write failure.</li>
+</ul>
+<p>**Execution note:** Add characterization coverage around optimistic cart rollback and service duplicate behavior before extracting handlers.</p>
+<p>**Patterns to follow:**</p>
+<ul>
+<li>`packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts`</li>
+<li>`packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.ts`</li>
+<li>`packages/athena-webapp/src/lib/pos/infrastructure/local/registerAvailabilitySnapshot.ts`</li>
+<li>`docs/solutions/logic-errors/athena-pos-register-local-catalog-search-2026-05-04.md`</li>
+<li>`docs/solutions/logic-errors/athena-pos-local-sync-review-and-service-lines-2026-05-29.md`</li>
+</ul>
+<p>**Test scenarios:**</p>
+<ul>
+<li>Happy path: exact barcode product auto-add still happens once and clears the search query after durable local write.</li>
+<li>Edge case: exact out-of-stock and availability-unknown products remain visible without auto-adding.</li>
+<li>Edge case: trusted availability subtracts unsynced local cart consumption but does not subtract provisional import or pending checkout rows incorrectly.</li>
+<li>Error path: local cart append failure rolls back optimistic product additions and existing quantity updates.</li>
+<li>Error path: local clear-cart failure restores visible cart items.</li>
+<li>Happy path: service search results add one local service line and clear product/search entry state.</li>
+<li>Edge case: adding the same service twice does not append a second local service event or visible duplicate.</li>
+<li>Error path: service edit/remove failure keeps previous service draft state and surfaces safe retry copy.</li>
+<li>Integration: pending checkout item definitions are recorded before the cart line that references them.</li>
+<li>Integration: product and service result composition does not show product no-results copy when service results match.</li>
+</ul>
+<p>**Verification:**</p>
+<ul>
+<li>New sale draft/search tests cover extracted behavior.</li>
+<li>Existing catalog and register view-model search/cart/service tests remain green.</li>
+</ul>
+<ul>
+<li>U6. **Extract checkout, payment, and session action queues**</li>
+</ul>
+<p>**Goal:** Move payment state, payment mutation queueing, checkout completion lock, local checkout persistence, completed transaction projection, hold/void/resume/start session orchestration, customer commit queue, and start-new-transaction behavior into focused boundaries.</p>
+<p>**Requirements:** R1, R7, R8, R9</p>
+<p>**Dependencies:** U1, U2, U5</p>
+<p>**Files:**</p>
+<ul>
+<li>Create: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterCheckoutDraft.ts`</li>
+<li>Create: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterSessionActions.ts`</li>
+<li>Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterCheckoutDraft.test.ts`</li>
+<li>Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterSessionActions.test.ts`</li>
+<li>Modify: `packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts`</li>
+<li>Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`</li>
+<li>Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`</li>
+</ul>
+<p>**Approach:**</p>
+<ul>
+<li>Centralize the three checkout queues (`cart`, `payment`, `service`) behind a narrow queue/lock interface shared by sale draft and checkout draft modules.</li>
+<li>Keep local payment persistence ordered: add/update/remove/clear writes local payment state before updating UI payment state.</li>
+<li>Preserve checkout completion behavior: wait for queued sale/payment/service mutations, refresh local cart projection, require cart/service content, enforce service customer attribution, require sufficient payment, write a local completed transaction, then set completion UI state.</li>
+<li>Keep session actions focused on sale lifecycle: hold current cloud session, clear/void local or cloud sale, resume held session, start a new local sale, and navigate/sign-out guards.</li>
+<li>Keep customer attribution commits serialized and session-scoped so delayed writes cannot apply to previous sessions.</li>
+</ul>
+<p>**Execution note:** Characterize queue ordering and completion-lock behavior before extraction.</p>
+<p>**Patterns to follow:**</p>
+<ul>
+<li>`packages/athena-webapp/src/lib/pos/application/useCases/holdSession.ts`</li>
+<li>`packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts`</li>
+<li>`packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`</li>
+<li>`packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts`</li>
+</ul>
+<p>**Test scenarios:**</p>
+<ul>
+<li>Happy path: adding same-method payments combines totals and persists the local payment state before UI update.</li>
+<li>Edge case: rapid payment additions use the latest queued payment state instead of dropping an update.</li>
+<li>Error path: local payment persistence failure keeps previous payment UI state.</li>
+<li>Error path: payment edits starting during checkout completion are rejected with the existing lock message.</li>
+<li>Happy path: checkout completion waits for pending service and payment writes before building the local completed sale.</li>
+<li>Edge case: checkout completion uses refreshed local cart items when local projection has newer state than the visible cart.</li>
+<li>Error path: local transaction write failure does not show a completed transaction.</li>
+<li>Integration: completing a cloud-backed local sale does not resurrect the cloud active session after reload.</li>
+<li>Integration: customer attribution commits are serialized and ignored after unmount or active session change.</li>
+<li>Integration: starting a new transaction resets draft state while preserving cashier identity and bootstrap behavior.</li>
+</ul>
+<p>**Verification:**</p>
+<ul>
+<li>Checkout/session focused tests pass.</li>
+<li>Existing payment, completion, hold/void/resume/customer attribution tests in `useRegisterViewModel.test.ts` pass.</li>
+</ul>
+<ul>
+<li>U7. **Recompose the facade and update validation ownership**</li>
+</ul>
+<p>**Goal:** Make `useRegisterViewModel.ts` a thin composition facade, assemble the final `RegisterViewModel` through focused builders, update tests to cover extracted module ownership, and rebuild generated graph artifacts.</p>
+<p>**Requirements:** R1, R9, R10</p>
+<p>**Dependencies:** U2, U3, U4, U5, U6</p>
+<p>**Files:**</p>
+<ul>
+<li>Create: `packages/athena-webapp/src/lib/pos/presentation/register/buildRegisterViewModelState.ts`</li>
+<li>Test: `packages/athena-webapp/src/lib/pos/presentation/register/buildRegisterViewModelState.test.ts`</li>
+<li>Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`</li>
+<li>Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`</li>
+<li>Modify: `packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`</li>
+<li>Modify: `scripts/harness-app-registry.ts` *(only if new test files should be added to a focused validation slice)*</li>
+<li>Modify: `graphify-out/`</li>
+</ul>
+<p>**Approach:**</p>
+<ul>
+<li>Keep the facade responsible for cross-boundary composition only: active store/terminal/route inputs, Convex gateway hooks, extracted hook calls, and the final `RegisterViewModel` object.</li>
+<li>Move return-object assembly into a pure builder where practical, especially for disabled states, auth dialog props, sync status props, product/service entry props, cart props, checkout props, drawer gate props, and debug shape.</li>
+<li>Keep `debug` output semantically compatible because it is used for support/runtime diagnosis.</li>
+<li>Update validation-map or harness registry only if new files need explicit focused validation routing.</li>
+<li>Run Graphify rebuild after code edits and stage generated outputs with the plan implementation.</li>
+</ul>
+<p>**Execution note:** Treat `useRegisterViewModel.test.ts` as the compatibility gate for the facade. Do not delete integration cases just because focused tests exist.</p>
+<p>**Patterns to follow:**</p>
+<ul>
+<li>`packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts`</li>
+<li>`packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`</li>
+<li>`packages/athena-webapp/docs/agent/testing.md`</li>
+<li>`scripts/harness-app-registry.ts`</li>
+</ul>
+<p>**Test scenarios:**</p>
+<ul>
+<li>Happy path: facade returns a complete `RegisterViewModel` for active store, terminal, cashier, open drawer, active sale, and mixed product/service checkout.</li>
+<li>Edge case: no active store or no terminal still returns the existing onboarding/auth/dialog behavior.</li>
+<li>Edge case: product and service entry disabled states stay aligned when cashier presence blocks sale, drawer gate is visible, or drawer binding is blocked.</li>
+<li>Integration: `POSRegisterView` still renders with a mocked `RegisterViewModel` and does not import extracted internal hooks.</li>
+<li>Integration: debug sync flow keeps runtime/read-model/register-state source precedence.</li>
+<li>Integration: focused validation slice includes new module tests when harness ownership requires it.</li>
+</ul>
+<p>**Verification:**</p>
+<ul>
+<li>`useRegisterViewModel.ts` is substantially smaller and mostly composition-oriented.</li>
+<li>All new focused tests pass.</li>
+<li>Existing register view-model and POS register view tests pass.</li>
+<li>`bun run graphify:rebuild` is reflected in generated graph artifacts.</li>
+</ul>
+<h2>System-Wide Impact</h2>
+<pre><code>flowchart TB
+  view[POSRegisterView]
+  facade[useRegisterViewModel facade]
+  presentation[Extracted presentation hooks]
+  localInfra[POS local infrastructure]
+  convex[Convex POS and cash-control gateways]
+  tests[Focused and integration tests]
+
+  view --&gt; facade
+  facade --&gt; presentation
+  presentation --&gt; localInfra
+  presentation --&gt; convex
+  presentation --&gt; tests
+  facade --&gt; tests</code></pre>
+<ul>
+<li>**Interaction graph:** The register view remains connected to one facade, while behavior-specific hooks own cashier presence, drawer lifecycle, sale draft, and checkout state.</li>
+<li>**Error propagation:** Local command failures should remain browser-safe `CommandResult` values; drawer-open errors should render durable operator copy instead of generic fallback where known.</li>
+<li>**State lifecycle risks:** Queue locks and refs must remain coherent across extracted hooks, especially cart/payment/service queues, checkout completion, local read-model refresh, and unmount cleanup.</li>
+<li>**API surface parity:** `RegisterViewModel` and `POSRegisterView` props remain unchanged; extracted modules are internal implementation details.</li>
+<li>**Integration coverage:** Existing `useRegisterViewModel.test.ts` and `POSRegisterView.test.tsx` remain required because focused hook tests will not prove the complete register workflow.</li>
+<li>**Unchanged invariants:** POS actions that appear complete to the cashier must still be durably recorded locally first where current local-first behavior requires it.</li>
+</ul>
+<h2>Risks &amp; Dependencies</h2>
+<p>| Risk | Mitigation |</p>
+<p>|------|------------|</p>
+<p>| Extracted hooks accidentally change checkout/cart ordering | Characterize queue behavior before extraction and keep integration tests for rapid payment edits, pending service writes, and checkout locks. |</p>
+<p>| Facade contract drift breaks `POSRegisterView` | Preserve `registerUiState.ts`, add builder tests, and keep `POSRegisterView.test.tsx` mocked against the same facade shape. |</p>
+<p>| Drawer error improvement overstates backend/local state | Map only known `CommandResult` causes and fall back to existing generic retry copy for unknown failures. |</p>
+<p>| Test suite becomes fragmented without integration confidence | Add focused tests but keep the current view-model integration test as the high-level compatibility suite. |</p>
+<p>| Local runtime store creation gets duplicated again | Centralize local store/gateway/read-model/sync wiring in `useRegisterLocalRuntime` and make ad hoc store creation a review smell. |</p>
+<p>| Graphify generated files drift after code movement | Run `bun run graphify:rebuild` after implementation changes. |</p>
+<h2>Documentation / Operational Notes</h2>
+<ul>
+<li>No operator documentation change is required for a behavior-preserving refactor.</li>
+<li>If drawer-open failure copy changes materially, keep language aligned with `docs/product-copy-tone.md`: calm, operational, and recovery-oriented.</li>
+<li>Update `docs/solutions/` only if implementation uncovers a reusable bug pattern or `pr:athena` requires a solution note.</li>
+<li>Use the Athena webapp testing guide to choose focused validation; this surface falls under POS local sync/register infrastructure and POS register bootstrap/drawer-gate validation.</li>
+</ul>
+<h2>Sources &amp; References</h2>
+<ul>
+<li>Related requirements: `docs/brainstorms/2026-05-13-pos-local-first-register-requirements.md`</li>
+<li>Related prior plan: `docs/plans/2026-05-13-001-feat-pos-local-first-register-plan.md`</li>
+<li>Graph navigation: `graphify-out/wiki/index.md`</li>
+<li>Package guide: `packages/athena-webapp/AGENTS.md`</li>
+<li>Testing guide: `packages/athena-webapp/docs/agent/testing.md`</li>
+<li>Code map: `packages/athena-webapp/docs/agent/code-map.md`</li>
+<li>Related code: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`</li>
+<li>Related code: `packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts`</li>
+<li>Related code: `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx`</li>
+<li>Related code: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`</li>
+<li>Related code: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`</li>
+<li>Institutional learning: `docs/solutions/logic-errors/athena-pos-register-local-catalog-search-2026-05-04.md`</li>
+<li>Institutional learning: `docs/solutions/logic-errors/athena-pos-local-sync-review-and-service-lines-2026-05-29.md`</li>
+</ul>
+</main>
+</body>
+</html>

--- a/docs/plans/2026-06-16-001-refactor-register-viewmodel-boundaries-plan.md
+++ b/docs/plans/2026-06-16-001-refactor-register-viewmodel-boundaries-plan.md
@@ -1,0 +1,565 @@
+---
+title: "refactor: Modularize POS register view model boundaries"
+type: refactor
+status: active
+date: 2026-06-16
+---
+
+# refactor: Modularize POS register view model boundaries
+
+## Summary
+
+Split the POS register view-model internals into focused presentation and runtime hooks while preserving the existing `RegisterViewModel` facade consumed by `POSRegisterView`. The implementation should reduce `useRegisterViewModel.ts` from a monolithic orchestration hotspot into composable cashier-presence, local-runtime, drawer-lifecycle, sale-draft, checkout, and view-model assembly boundaries, with focused tests guarding each extracted behavior.
+
+---
+
+## Problem Frame
+
+`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts` is a Graphify hotspot and currently concentrates local POS runtime state, cashier restore, drawer lifecycle, service lines, optimistic cart updates, payment queues, checkout completion, sync presentation, and final UI assembly in one hook. That shape makes local-first POS changes risky because unrelated flows share refs, queue locks, local-store reads, and inline presentation logic.
+
+The refactor must preserve Athena POS continuity: local sales should keep working first, sync/recovery state should remain visible, and the UI contract should stay stable while internals are extracted.
+
+## Requirements
+
+- R1. Preserve the public `RegisterViewModel` contract in `registerUiState.ts` and keep `POSRegisterView` behavior compatible throughout the refactor.
+- R2. Extract pure mapping and presentation helpers from `useRegisterViewModel.ts` into testable modules without changing user-facing behavior.
+- R3. Move local runtime/store ownership into one boundary that owns store creation, projected read-model refresh, event-append tokens, seed readiness checks, and sync-status wiring.
+- R4. Move cashier presence restore/sign-in/sign-out handling into a dedicated boundary that preserves local staff proof, stale-presence, and validation-pending behavior.
+- R5. Move drawer lifecycle and gate presentation into a dedicated boundary that preserves opening, closeout, reopen, opening-float correction, terminal repair, and drawer-authority repair flows.
+- R6. Improve drawer-open failure presentation by mapping local command `user_error` results to durable operator messages instead of collapsing every failure to generic retry copy.
+- R7. Move sale-draft, product/service cart, optimistic quantity, and local availability projection behavior into focused boundaries without weakening local-first durability.
+- R8. Move payment queueing and checkout completion behavior into a focused boundary that preserves ordered writes and checkout locks.
+- R9. Keep existing integration coverage passing while adding focused unit tests for extracted modules so future changes do not require editing the 12k-line integration test for every helper-level behavior.
+- R10. Rebuild Graphify after code changes so `graphify-out/` stays current.
+
+---
+
+## Scope Boundaries
+
+- Do not redesign POS product behavior, payment semantics, local sync ingestion, or the local event contract.
+- Do not change `RegisterViewModel` field names or remove existing optional states without a separate UI migration plan.
+- Do not move Convex command/query implementations as part of this refactor.
+- Do not convert the full register view to a new state-management library.
+- Do not rewrite `POSRegisterView.tsx`; only adjust call sites if an extracted boundary changes the import location of type-safe helpers.
+- Do not add new support-evidence storage, query, or timeline surfaces as part of this refactor.
+
+### Deferred to Follow-Up Work
+
+- Full test-file decomposition: keep `useRegisterViewModel.test.ts` as the integration guard in this pass; split it into domain-specific integration files only after extracted modules stabilize.
+- Larger `POSRegisterView.tsx` component decomposition: this plan focuses on the hook and adjacent presentation helpers, not the 1.9k-line view component.
+- Reusable operations support-evidence foundation: plan this as standalone work with sanitized operational events, redaction, timeline/query adapters, and POS drawer/register lifecycle as the first producer.
+- Broad support-dashboard redesign: defer until the reusable support-evidence foundation exists.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `graphify-out/wiki/index.md` identifies `useRegisterViewModel.ts` as a 72-edge hotspot and a top Athena webapp graph hotspot.
+- `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts` is about 6.8k lines and currently defines many pure helpers before the hook plus many runtime handlers inside the hook.
+- `packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts` is about 420 lines and already expresses the stable UI-facing contract.
+- `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx` imports `useRegisterViewModel` and consumes the facade; the view should remain a caller, not become the new orchestration home.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`, `localCommandGateway.ts`, `localRegisterReader.ts`, `registerReadModel.ts`, `posLocalStore.ts`, `syncStatus.ts`, and `terminalRuntimeStatus.ts` are existing local runtime seams to reuse.
+- `packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts`, `catalogSearchPresentation.ts`, `selectors.ts`, and `useRegisterCatalogIndex.ts` show the existing pattern for extracting register presentation logic beside focused tests.
+- `packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts` provides a smaller parallel register view-model implementation that can inform facade shape, but POS behavior is broader and should not be forced into expense abstractions.
+
+### Institutional Learnings
+
+- `docs/solutions/logic-errors/athena-pos-register-local-catalog-search-2026-05-04.md` says the active POS register is a hot path; local catalog lookup should stay deterministic, with durable command boundaries remaining the authority for inventory/session invariants.
+- `docs/solutions/logic-errors/athena-pos-local-sync-review-and-service-lines-2026-05-29.md` says service lines and sync review are first-class POS read-model inputs; do not copy product quantity semantics into service behavior, and keep register-session visibility for synced activity that affects the drawer.
+- `docs/brainstorms/2026-05-13-pos-local-first-register-requirements.md` anchors the local-first POS invariant: POS actions should be durably recorded locally before the cashier sees them as complete, with sync/reconciliation separated from ordinary selling.
+
+### External References
+
+- External research was skipped. The work is an internal refactor against established local patterns, with no new framework, API, payment provider, or security primitive.
+
+---
+
+## Key Technical Decisions
+
+- Preserve the facade first: `useRegisterViewModel()` remains the only hook imported by `POSRegisterView` during this pass, so extracted hooks can be introduced without a UI migration.
+- Extract by behavior boundary, not by line count: split cashier presence, local runtime, drawer lifecycle, sale draft, checkout/payment, and final assembly because those are independently testable state machines.
+- Keep infrastructure under `infrastructure/local`: presentation hooks should compose existing local runtime primitives instead of moving IndexedDB, sync scheduler, or command gateway code into presentation.
+- Add pure-helper tests before moving large chunks: helper extraction should be behavior-preserving and covered with fast tests where possible before the integration facade changes.
+- Improve drawer error presentation inside the drawer boundary: local command results already carry `CommandResult` shape; mapping known `user_error` messages gives operators better recovery guidance without changing command semantics.
+- Treat the current integration test as the compatibility suite: focused tests should grow around extracted modules, but the existing `useRegisterViewModel.test.ts` remains the end-to-end view-model regression guard.
+- Rebuild generated graph output after code changes: repo instructions require `bun run graphify:rebuild` after modifying code files.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Primary extraction boundary: preserve the `RegisterViewModel` facade and extract internal modules behind it rather than changing `POSRegisterView`.
+- Origin document usage: the local-first POS requirements are relevant constraints, but there is no direct upstream requirements document for this refactor.
+- External research: skip; current repo patterns are sufficient.
+
+### Deferred to Implementation
+
+- Exact extracted module names: use the names in this plan as directional names; adjust if implementation reveals clearer local naming.
+- Exact helper grouping: pure helpers may split into several files if a single helper module becomes too broad.
+- Exact drawer error mapping table: derive it from current `localCommandGateway` `CommandResult` outputs and existing operator-copy tone during implementation.
+- Whether to move all helper tests out of `useRegisterViewModel.test.ts`: defer broad test reorganization until extracted modules are stable.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  facade[useRegisterViewModel facade]
+  localRuntime[useRegisterLocalRuntime]
+  cashier[useRegisterCashierPresence]
+  drawer[useRegisterDrawerLifecycle]
+  sale[useRegisterSaleDraft]
+  checkout[useRegisterCheckoutDraft]
+  assembly[buildRegisterViewModelState]
+
+  facade --> localRuntime
+  facade --> cashier
+  facade --> drawer
+  facade --> sale
+  facade --> checkout
+  localRuntime --> drawer
+  localRuntime --> sale
+  localRuntime --> checkout
+  cashier --> drawer
+  cashier --> sale
+  sale --> checkout
+  drawer --> assembly
+  sale --> assembly
+  checkout --> assembly
+  cashier --> assembly
+```
+
+The facade should mostly gather store, terminal, staff, route, and Convex gateway inputs, then compose extracted hooks and return the existing `RegisterViewModel`. Each extracted hook should expose stable state/actions to the facade, not directly to `POSRegisterView`.
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1[U1 Pure helpers]
+  U2[U2 Local runtime bridge]
+  U3[U3 Cashier presence]
+  U4[U4 Drawer lifecycle]
+  U5[U5 Sale draft]
+  U6[U6 Checkout draft]
+  U7[U7 Facade assembly]
+
+  U1 --> U2
+  U1 --> U3
+  U1 --> U4
+  U1 --> U5
+  U1 --> U6
+  U2 --> U4
+  U2 --> U5
+  U2 --> U6
+  U3 --> U4
+  U3 --> U5
+  U4 --> U7
+  U5 --> U6
+  U5 --> U7
+  U6 --> U7
+```
+
+- U1. **Extract pure register mapping helpers**
+
+**Goal:** Move behavior-free helper functions out of `useRegisterViewModel.ts` so later hook extraction can depend on small tested modules.
+
+**Requirements:** R1, R2, R9
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/athena-webapp/src/lib/pos/presentation/register/registerCashierPresence.ts`
+- Create: `packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts`
+- Create: `packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts`
+- Create: `packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/registerCashierPresence.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+
+**Approach:**
+- Start with pure functions that already accept complete inputs and return values: cashier presence validation, service checkout block messages, local cart item mapping, payment combining, local availability consumption, completed-sale payload construction, closeout id selection, and drawer gate mode derivation.
+- Keep imports one-directional: extracted helpers may import shared types and existing presentation/domain helpers, but must not import `useRegisterViewModel.ts`.
+- Avoid broad "utils" files. Group helpers by behavior so future hook modules have obvious homes.
+
+**Execution note:** Add characterization tests for extracted helpers before deleting their inline copies from the hook.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts`
+- `packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.ts`
+- `packages/athena-webapp/src/lib/pos/presentation/register/selectors.ts`
+
+**Test scenarios:**
+- Happy path: valid restored cashier presence for the current store/terminal returns restored state with display metadata intact.
+- Edge case: mismatched restored cashier presence scope returns the existing failed or missing state without setting staff proof.
+- Happy path: local cart read-model items map to `CartItem` shape with pending checkout and provisional import identifiers preserved.
+- Edge case: service checkout block returns no message when service lines have profile-backed customer attribution.
+- Error path: service checkout block returns an actionable customer-attribution message when service lines exist without usable customer details.
+- Happy path: payment combining merges same-method payments while preserving total amount and current payment method semantics.
+- Edge case: closeout id resolution prefers the active local register session where current behavior expects it.
+- Integration: extracted drawer gate mode helper returns the same modes currently asserted by `useRegisterViewModel.test.ts` for terminal repair, drawer-authority repair, closeout blocked, and opening-float correction.
+
+**Verification:**
+- Pure helper tests pass.
+- `useRegisterViewModel.test.ts` remains behaviorally unchanged after helper extraction.
+
+---
+
+- U2. **Extract local runtime and store bridge**
+
+**Goal:** Move IndexedDB store ownership, local command gateway creation, projected read-model refresh, seed readiness checks, event-append tokens, and sync-status runtime wiring out of the main hook.
+
+**Requirements:** R1, R3, R7, R9, R10
+
+**Dependencies:** U1
+
+**Files:**
+- Create: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterLocalRuntime.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterLocalRuntime.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts` *(only if extracted wiring reveals missing coverage in the existing runtime hook)*
+
+**Approach:**
+- Keep `createPosLocalStore`, `createLocalCommandGateway`, `readProjectedLocalRegisterModel`, and `usePosLocalSyncRuntimeStatus` composition inside one register-local runtime hook.
+- Expose a narrow result to the facade: `localStore`, `localCommandGateway`, `localRegisterReadModel`, `refreshLocalRegisterReadModel`, `noteLocalRegisterEventChanged`, `hasProvisionedLocalSyncSeed`, sync source/presentation inputs, local staff authority readiness, and stable refs needed for staff proof lookup.
+- Ensure there is one store factory path for register presentation instead of creating fresh stores in unrelated callbacks.
+- Keep `usePosLocalSyncRuntimeStatus` in infrastructure; this unit only centralizes how the register facade consumes it.
+
+**Execution note:** Characterize current event-token and read-model refresh behavior before moving callbacks.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/localRegisterReader.ts`
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`
+
+**Test scenarios:**
+- Happy path: the hook creates a stable local store and command gateway across rerenders when terminal identity is unchanged.
+- Happy path: appending a local event increments the event token and causes the projected read model to refresh.
+- Edge case: missing `activeStoreId`, missing terminal id, or unavailable IndexedDB returns seed readiness false without throwing.
+- Edge case: staff proof lookup returns a token only for the currently authenticated staff profile.
+- Integration: local sync retry invokes the runtime retry callback and the register bootstrap retry callback.
+- Integration: projected local read-model sync status still feeds `buildPosSyncStatusPresentation` through the same status source precedence.
+
+**Verification:**
+- `useRegisterLocalRuntime.test.ts` covers local store and sync wiring.
+- Existing local runtime tests continue to pass.
+- `useRegisterViewModel.ts` no longer directly creates ad hoc local stores for seed/read-model checks.
+
+---
+
+- U3. **Extract cashier presence and staff authority flow**
+
+**Goal:** Move cashier restore, validation-pending state, staff proof attachment, local staff authority readiness, authenticated-staff display, and sign-out presence cleanup into a focused boundary.
+
+**Requirements:** R1, R4, R7, R9
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Create: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterCashierPresence.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterCashierPresence.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+
+**Approach:**
+- Encapsulate `staffProfileId`, `staffProofToken`, `localAuthenticatedStaff`, `cashierPresenceRestore`, and local staff authority status.
+- Keep the restoration sequence intact: wait for store day readiness, read organization-scoped cashier presence where available, validate offline freshness, clear mismatched/expired presence, and expose validation-pending restored cashier metadata to the auth dialog.
+- Keep sign-out local presence cleanup inside this boundary, but let the facade provide sale-hold/void callbacks so sign-out still respects active sale continuity.
+- Keep staff proof attachment to pending local events tied to successful proof-bearing authentication.
+
+**Execution note:** Preserve existing cashier-presence integration tests before extracting; add focused hook tests for stale/mismatched presence cases.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx`
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalStaffAuthorityRefresh.ts`
+- `packages/athena-webapp/src/lib/pos/presentation/register/registerCashierPresence.ts`
+
+**Test scenarios:**
+- Happy path: proof-bearing authentication sets staff id, staff proof token, local authenticated staff display, and writes cashier presence.
+- Happy path: valid restored presence restores the cashier and exposes no auth dialog.
+- Edge case: restored presence with expired offline freshness enters validation-pending or failed state according to current behavior.
+- Edge case: mismatched organization/store/terminal presence is cleared and does not authenticate the cashier.
+- Error path: local presence clear failure keeps the cashier signed in and surfaces the existing sign-out failure copy.
+- Integration: attaching a new staff proof to pending events nudges local sync.
+- Integration: auth dialog props from the facade remain unchanged for validation-pending restored cashier unlock.
+
+**Verification:**
+- Cashier-presence focused tests cover restore/sign-in/sign-out branches.
+- Existing `useRegisterViewModel.test.ts` cashier presence cases remain green.
+
+---
+
+- U4. **Extract drawer lifecycle and gate presentation**
+
+**Goal:** Move drawer gate mode derivation, drawer opening, closeout, reopen, opening-float correction, terminal setup repair, drawer-authority retry, and closeout control assembly out of the main hook.
+
+**Requirements:** R1, R5, R6, R9
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Create: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterDrawerLifecycle.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterDrawerLifecycle.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts`
+
+**Approach:**
+- Encapsulate drawer draft state (`openingFloat`, notes, correction fields, closeout counted cash/notes), submitting flags, drawer error message, and drawer gate mode.
+- Keep lifecycle commands local-first: open drawer, start closeout, reopen register, and terminal repair must record local evidence or preserve existing failure behavior before the UI proceeds.
+- Map `LocalOpenDrawerResult` `user_error` messages to durable operator-facing drawer messages. The first pass should normalize known local command causes, such as missing cashier identity, drawer authority blocks, lifecycle review blocks, another active drawer, missing terminal seed, and local persistence failure.
+- Keep closeout approval and opening-float correction command approval behavior unchanged.
+- Expose `drawerGate` and `closeoutControl` objects that still satisfy `RegisterViewModel`.
+
+**Execution note:** Implement drawer error mapping test-first because it is the only intentional behavior improvement in this refactor.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`
+- `packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx`
+- `packages/athena-webapp/src/lib/errors/operatorMessages.ts`
+- `docs/product-copy-tone.md`
+
+**Test scenarios:**
+- Happy path: opening a drawer locally sets a local operable register session and clears drawer error state.
+- Error path: local open-drawer `user_error` for missing cashier identity maps to sign-in recovery copy, not generic retry copy.
+- Error path: drawer-authority and lifecycle review failures map to drawer repair or review-oriented copy without claiming the sale is lost.
+- Error path: local append/store failure maps to retryable local persistence copy and keeps the drawer gate open.
+- Edge case: online drawer opening still requires fresh staff proof; offline drawer opening preserves current proof behavior.
+- Happy path: zero-variance cloud-backed closeout still records locally and marks the local event synced when the server closeout succeeds.
+- Happy path: manager reopening of a local closing register restores local operable register state.
+- Integration: terminal repair mode still auto-attempts repair once per store/terminal key.
+- Integration: `drawerGate` and `closeoutControl` props consumed by `RegisterDrawerGate` remain shape-compatible.
+
+**Verification:**
+- Drawer lifecycle focused tests pass.
+- Existing drawer/open/closeout/reopen cases in `useRegisterViewModel.test.ts` pass.
+- Operator-facing drawer failure copy follows `docs/product-copy-tone.md`.
+
+---
+
+- U5. **Extract sale draft, catalog, service, and optimistic cart behavior**
+
+**Goal:** Move active-session projection, local active sale reconciliation, product search overlay, service search/drafts, local availability overlay, optimistic cart quantities/products, and cart mutation queue behavior into focused boundaries.
+
+**Requirements:** R1, R2, R7, R9
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Create: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterSaleDraft.ts`
+- Create: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterProductAndServiceSearch.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterSaleDraft.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterProductAndServiceSearch.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.test.ts`
+
+**Approach:**
+- Keep product catalog indexing in existing `catalogSearch` modules; this unit only extracts the register-specific composition of catalog rows, bounded availability queries, pending checkout overlays, exact auto-add, and service search.
+- Encapsulate optimistic cart refs/state and the cart mutation queue so product add/update/remove/clear logic no longer shares low-level refs across the entire view-model hook.
+- Keep service lines first-class and distinct from product quantity semantics: duplicate services stay disabled/no-op, amount-required service drafts persist locally, and checkout blocking remains customer-attribution based.
+- Preserve the local-first invariant: cart/service UI state should advance only after durable local event writes, except for existing optimistic UI states that already roll back on local write failure.
+
+**Execution note:** Add characterization coverage around optimistic cart rollback and service duplicate behavior before extracting handlers.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts`
+- `packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.ts`
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/registerAvailabilitySnapshot.ts`
+- `docs/solutions/logic-errors/athena-pos-register-local-catalog-search-2026-05-04.md`
+- `docs/solutions/logic-errors/athena-pos-local-sync-review-and-service-lines-2026-05-29.md`
+
+**Test scenarios:**
+- Happy path: exact barcode product auto-add still happens once and clears the search query after durable local write.
+- Edge case: exact out-of-stock and availability-unknown products remain visible without auto-adding.
+- Edge case: trusted availability subtracts unsynced local cart consumption but does not subtract provisional import or pending checkout rows incorrectly.
+- Error path: local cart append failure rolls back optimistic product additions and existing quantity updates.
+- Error path: local clear-cart failure restores visible cart items.
+- Happy path: service search results add one local service line and clear product/search entry state.
+- Edge case: adding the same service twice does not append a second local service event or visible duplicate.
+- Error path: service edit/remove failure keeps previous service draft state and surfaces safe retry copy.
+- Integration: pending checkout item definitions are recorded before the cart line that references them.
+- Integration: product and service result composition does not show product no-results copy when service results match.
+
+**Verification:**
+- New sale draft/search tests cover extracted behavior.
+- Existing catalog and register view-model search/cart/service tests remain green.
+
+---
+
+- U6. **Extract checkout, payment, and session action queues**
+
+**Goal:** Move payment state, payment mutation queueing, checkout completion lock, local checkout persistence, completed transaction projection, hold/void/resume/start session orchestration, customer commit queue, and start-new-transaction behavior into focused boundaries.
+
+**Requirements:** R1, R7, R8, R9
+
+**Dependencies:** U1, U2, U5
+
+**Files:**
+- Create: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterCheckoutDraft.ts`
+- Create: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterSessionActions.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterCheckoutDraft.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterSessionActions.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+
+**Approach:**
+- Centralize the three checkout queues (`cart`, `payment`, `service`) behind a narrow queue/lock interface shared by sale draft and checkout draft modules.
+- Keep local payment persistence ordered: add/update/remove/clear writes local payment state before updating UI payment state.
+- Preserve checkout completion behavior: wait for queued sale/payment/service mutations, refresh local cart projection, require cart/service content, enforce service customer attribution, require sufficient payment, write a local completed transaction, then set completion UI state.
+- Keep session actions focused on sale lifecycle: hold current cloud session, clear/void local or cloud sale, resume held session, start a new local sale, and navigate/sign-out guards.
+- Keep customer attribution commits serialized and session-scoped so delayed writes cannot apply to previous sessions.
+
+**Execution note:** Characterize queue ordering and completion-lock behavior before extraction.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/lib/pos/application/useCases/holdSession.ts`
+- `packages/athena-webapp/src/lib/pos/infrastructure/convex/sessionGateway.ts`
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`
+- `packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts`
+
+**Test scenarios:**
+- Happy path: adding same-method payments combines totals and persists the local payment state before UI update.
+- Edge case: rapid payment additions use the latest queued payment state instead of dropping an update.
+- Error path: local payment persistence failure keeps previous payment UI state.
+- Error path: payment edits starting during checkout completion are rejected with the existing lock message.
+- Happy path: checkout completion waits for pending service and payment writes before building the local completed sale.
+- Edge case: checkout completion uses refreshed local cart items when local projection has newer state than the visible cart.
+- Error path: local transaction write failure does not show a completed transaction.
+- Integration: completing a cloud-backed local sale does not resurrect the cloud active session after reload.
+- Integration: customer attribution commits are serialized and ignored after unmount or active session change.
+- Integration: starting a new transaction resets draft state while preserving cashier identity and bootstrap behavior.
+
+**Verification:**
+- Checkout/session focused tests pass.
+- Existing payment, completion, hold/void/resume/customer attribution tests in `useRegisterViewModel.test.ts` pass.
+
+---
+
+- U7. **Recompose the facade and update validation ownership**
+
+**Goal:** Make `useRegisterViewModel.ts` a thin composition facade, assemble the final `RegisterViewModel` through focused builders, update tests to cover extracted module ownership, and rebuild generated graph artifacts.
+
+**Requirements:** R1, R9, R10
+
+**Dependencies:** U2, U3, U4, U5, U6
+
+**Files:**
+- Create: `packages/athena-webapp/src/lib/pos/presentation/register/buildRegisterViewModelState.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/buildRegisterViewModelState.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Modify: `packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`
+- Modify: `scripts/harness-app-registry.ts` *(only if new test files should be added to a focused validation slice)*
+- Modify: `graphify-out/`
+
+**Approach:**
+- Keep the facade responsible for cross-boundary composition only: active store/terminal/route inputs, Convex gateway hooks, extracted hook calls, and the final `RegisterViewModel` object.
+- Move return-object assembly into a pure builder where practical, especially for disabled states, auth dialog props, sync status props, product/service entry props, cart props, checkout props, drawer gate props, and debug shape.
+- Keep `debug` output semantically compatible because it is used for support/runtime diagnosis.
+- Update validation-map or harness registry only if new files need explicit focused validation routing.
+- Run Graphify rebuild after code edits and stage generated outputs with the plan implementation.
+
+**Execution note:** Treat `useRegisterViewModel.test.ts` as the compatibility gate for the facade. Do not delete integration cases just because focused tests exist.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts`
+- `packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`
+- `packages/athena-webapp/docs/agent/testing.md`
+- `scripts/harness-app-registry.ts`
+
+**Test scenarios:**
+- Happy path: facade returns a complete `RegisterViewModel` for active store, terminal, cashier, open drawer, active sale, and mixed product/service checkout.
+- Edge case: no active store or no terminal still returns the existing onboarding/auth/dialog behavior.
+- Edge case: product and service entry disabled states stay aligned when cashier presence blocks sale, drawer gate is visible, or drawer binding is blocked.
+- Integration: `POSRegisterView` still renders with a mocked `RegisterViewModel` and does not import extracted internal hooks.
+- Integration: debug sync flow keeps runtime/read-model/register-state source precedence.
+- Integration: focused validation slice includes new module tests when harness ownership requires it.
+
+**Verification:**
+- `useRegisterViewModel.ts` is substantially smaller and mostly composition-oriented.
+- All new focused tests pass.
+- Existing register view-model and POS register view tests pass.
+- `bun run graphify:rebuild` is reflected in generated graph artifacts.
+
+---
+
+## System-Wide Impact
+
+```mermaid
+flowchart TB
+  view[POSRegisterView]
+  facade[useRegisterViewModel facade]
+  presentation[Extracted presentation hooks]
+  localInfra[POS local infrastructure]
+  convex[Convex POS and cash-control gateways]
+  tests[Focused and integration tests]
+
+  view --> facade
+  facade --> presentation
+  presentation --> localInfra
+  presentation --> convex
+  presentation --> tests
+  facade --> tests
+```
+
+- **Interaction graph:** The register view remains connected to one facade, while behavior-specific hooks own cashier presence, drawer lifecycle, sale draft, and checkout state.
+- **Error propagation:** Local command failures should remain browser-safe `CommandResult` values; drawer-open errors should render durable operator copy instead of generic fallback where known.
+- **State lifecycle risks:** Queue locks and refs must remain coherent across extracted hooks, especially cart/payment/service queues, checkout completion, local read-model refresh, and unmount cleanup.
+- **API surface parity:** `RegisterViewModel` and `POSRegisterView` props remain unchanged; extracted modules are internal implementation details.
+- **Integration coverage:** Existing `useRegisterViewModel.test.ts` and `POSRegisterView.test.tsx` remain required because focused hook tests will not prove the complete register workflow.
+- **Unchanged invariants:** POS actions that appear complete to the cashier must still be durably recorded locally first where current local-first behavior requires it.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Extracted hooks accidentally change checkout/cart ordering | Characterize queue behavior before extraction and keep integration tests for rapid payment edits, pending service writes, and checkout locks. |
+| Facade contract drift breaks `POSRegisterView` | Preserve `registerUiState.ts`, add builder tests, and keep `POSRegisterView.test.tsx` mocked against the same facade shape. |
+| Drawer error improvement overstates backend/local state | Map only known `CommandResult` causes and fall back to existing generic retry copy for unknown failures. |
+| Test suite becomes fragmented without integration confidence | Add focused tests but keep the current view-model integration test as the high-level compatibility suite. |
+| Local runtime store creation gets duplicated again | Centralize local store/gateway/read-model/sync wiring in `useRegisterLocalRuntime` and make ad hoc store creation a review smell. |
+| Graphify generated files drift after code movement | Run `bun run graphify:rebuild` after implementation changes. |
+
+---
+
+## Documentation / Operational Notes
+
+- No operator documentation change is required for a behavior-preserving refactor.
+- If drawer-open failure copy changes materially, keep language aligned with `docs/product-copy-tone.md`: calm, operational, and recovery-oriented.
+- Update `docs/solutions/` only if implementation uncovers a reusable bug pattern or `pr:athena` requires a solution note.
+- Use the Athena webapp testing guide to choose focused validation; this surface falls under POS local sync/register infrastructure and POS register bootstrap/drawer-gate validation.
+
+---
+
+## Sources & References
+
+- Related requirements: `docs/brainstorms/2026-05-13-pos-local-first-register-requirements.md`
+- Related prior plan: `docs/plans/2026-05-13-001-feat-pos-local-first-register-plan.md`
+- Graph navigation: `graphify-out/wiki/index.md`
+- Package guide: `packages/athena-webapp/AGENTS.md`
+- Testing guide: `packages/athena-webapp/docs/agent/testing.md`
+- Code map: `packages/athena-webapp/docs/agent/code-map.md`
+- Related code: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Related code: `packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts`
+- Related code: `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx`
+- Related code: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`
+- Related code: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Institutional learning: `docs/solutions/logic-errors/athena-pos-register-local-catalog-search-2026-05-04.md`
+- Institutional learning: `docs/solutions/logic-errors/athena-pos-local-sync-review-and-service-lines-2026-05-29.md`


### PR DESCRIPTION
## Summary
- Restore the sale-level register sync review plan artifacts recovered from the stale worktree audit
- Restore the POS register view-model modularization plan artifacts so they are tracked on main

## Validation
- git diff --check origin/main...HEAD
- bun scripts/validate-plan-html.ts docs/plans/2026-06-16-001-refactor-register-viewmodel-boundaries-plan.html
- bun scripts/validate-plan-html.ts docs/plans/2026-06-13-002-feat-register-sale-review-detail-plan.html