### PR TITLE
[V26-836 V26-837 V26-838 V26-839 V26-840]: Share POS register lifecycle policy

### DIFF
--- a/docs/plans/2026-06-23-001-refactor-pos-register-lifecycle-policy-plan.html
+++ b/docs/plans/2026-06-23-001-refactor-pos-register-lifecycle-policy-plan.html
@@ -1,0 +1,226 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Plan: Share POS Register Lifecycle Policy</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8f8;
+      --panel: #ffffff;
+      --ink: #172026;
+      --muted: #5f6b74;
+      --line: #d9e0e4;
+      --accent: #1d6f8f;
+      --accent-soft: #e7f4f7;
+    }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 40px 24px 64px;
+    }
+    header {
+      border-bottom: 1px solid var(--line);
+      margin-bottom: 28px;
+      padding-bottom: 20px;
+    }
+    h1 {
+      font-size: 32px;
+      line-height: 1.15;
+      margin: 0 0 12px;
+    }
+    h2 {
+      border-top: 1px solid var(--line);
+      font-size: 22px;
+      margin: 32px 0 12px;
+      padding-top: 24px;
+    }
+    h3 {
+      font-size: 17px;
+      margin: 22px 0 8px;
+    }
+    a {
+      color: var(--accent);
+    }
+    code {
+      background: #eef2f3;
+      border-radius: 4px;
+      padding: 1px 5px;
+    }
+    .meta,
+    .summary,
+    .unit,
+    .callout {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px;
+    }
+    .meta {
+      color: var(--muted);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+    .summary {
+      background: var(--accent-soft);
+      border-color: #c5e5ec;
+      font-size: 16px;
+    }
+    nav {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      margin: 20px 0 28px;
+      padding: 12px 16px;
+    }
+    nav ul {
+      columns: 2;
+      margin: 0;
+      padding-left: 18px;
+    }
+    table {
+      border-collapse: collapse;
+      width: 100%;
+    }
+    th,
+    td {
+      border: 1px solid var(--line);
+      padding: 8px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th {
+      background: #eef2f3;
+    }
+    .units {
+      display: grid;
+      gap: 14px;
+    }
+    .unit h3 {
+      margin-top: 0;
+    }
+    .tag {
+      background: #eef2f3;
+      border-radius: 999px;
+      color: var(--muted);
+      display: inline-block;
+      font-size: 12px;
+      margin-right: 6px;
+      padding: 2px 8px;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>refactor: Share POS Register Lifecycle Policy</h1>
+      <div class="meta">
+        <span>Type: refactor</span>
+        <span>Status: active</span>
+        <span>Date: 2026-06-23</span>
+        <span>Source: <a href="./2026-06-23-001-refactor-pos-register-lifecycle-policy-plan.md">markdown plan</a></span>
+      </div>
+    </header>
+
+    <section class="summary">
+      Extract the POS register and drawer lifecycle invariants into a shared policy layer consumed by browser-local POS and Convex projection. The work preserves multi-session drawer behavior while removing duplicated rules around closeout review, drawer authority, runtime evidence, and sale usability.
+    </section>
+
+    <nav aria-label="Plan sections">
+      <ul>
+        <li><a href="#problem">Problem Frame</a></li>
+        <li><a href="#requirements">Requirements</a></li>
+        <li><a href="#decisions">Key Decisions</a></li>
+        <li><a href="#units">Implementation Units</a></li>
+        <li><a href="#risks">Risks</a></li>
+        <li><a href="#validation">Validation Strategy</a></li>
+      </ul>
+    </nav>
+
+    <section id="problem">
+      <h2>Problem Frame</h2>
+      <p>The current POS register patch encodes drawer lifecycle invariants in local read-model projection, local command gating, runtime status, Convex sync projection, repository conflict lookup, and register review presentation. That can drift when a cashier closes one drawer and opens another while browser-local POS and server projection reconcile at different times.</p>
+    </section>
+
+    <section id="requirements">
+      <h2>Requirements</h2>
+      <ul>
+        <li>Define shared lifecycle policy once for browser and Convex consumers.</li>
+        <li>Keep <code>open</code> and <code>active</code> sale-usable; keep <code>closing</code> lifecycle-visible but not sale-usable.</li>
+        <li>Allow safe replacement drawers after settled closeout, submitted closeout review, or <code>cloud_closed</code> drawer authority.</li>
+        <li>Close the direct-cloud-id reviewed-closeout sale projection bypass.</li>
+        <li>Define scoped session as same store, terminal, and register-session scope.</li>
+        <li>Preserve truthful Cash Controls and Daily Close review surfaces.</li>
+        <li>Refresh Graphify after code changes.</li>
+      </ul>
+    </section>
+
+    <section id="decisions">
+      <h2>Key Decisions</h2>
+      <ul>
+        <li>Create a pure shared lifecycle policy module under <code>packages/athena-webapp/shared/</code>.</li>
+        <li>Expose separate decisions for sale usability, lifecycle visibility, replacement-open eligibility for later new register-session scopes, reviewed-closeout supersedability, and runtime evidence.</li>
+        <li>Keep repository data access outside the policy; repositories return facts and ordering evidence to application-layer policy callers.</li>
+        <li>Integrate Convex projection before frontend cleanup because projection guards stale clients.</li>
+        <li>Land as one coordinated integration PR to avoid repeated generated-artifact churn.</li>
+      </ul>
+    </section>
+
+    <section id="units">
+      <h2>Implementation Units</h2>
+      <div class="units">
+        <article class="unit">
+          <h3>U1. Shared Lifecycle Policy Foundation</h3>
+          <p><span class="tag">test-first</span>Create <code>shared/registerSessionLifecyclePolicy.ts</code> and focused tests for status, authority, closeout, and review decisions.</p>
+        </article>
+        <article class="unit">
+          <h3>U2. Browser-Local POS Policy Integration</h3>
+          <p>Replace duplicated predicates in the local read model, command gateway, sync runtime, runtime status, and register view model while preserving local-first command behavior.</p>
+        </article>
+        <article class="unit">
+          <h3>U3. Convex Projection and Repository Policy Integration</h3>
+          <p>Move pure interpretation into shared helpers, keep DB lookup in repositories, and fix direct-cloud-id sale projection against reviewed closeouts.</p>
+        </article>
+        <article class="unit">
+          <h3>U4. Review Surface and Daily Close Alignment</h3>
+          <p>Keep closeout review and mixed review queues visible and actionable even when POS can open a later drawer.</p>
+        </article>
+        <article class="unit">
+          <h3>U5. Harness, Generated Artifacts, and Delivery Documentation</h3>
+          <p>Regenerate Graphify, update validation-map coverage if needed, and document the new lifecycle policy boundary.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="risks">
+      <h2>Risks</h2>
+      <table>
+        <thead>
+          <tr><th>Risk</th><th>Mitigation</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>closing</code> accidentally becomes sale-usable</td><td>Policy table tests plus browser and Convex projection regressions.</td></tr>
+          <tr><td>Direct-cloud-id bypass remains open</td><td>Focused projection regression before changing projection logic.</td></tr>
+          <tr><td>UI hides closeout review after later drawer opens</td><td>Cash Controls mixed-review tests keep closeout review visible.</td></tr>
+          <tr><td>Generated artifacts drift</td><td>Run Graphify rebuild and inspect generated output before handoff.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="validation">
+      <h2>Validation Strategy</h2>
+      <p>Run focused shared policy, local POS, Convex projection, terminal runtime, Cash Controls, and Daily Close tests first. Then run Athena Convex audit, changed lint/type/build sensors, Graphify rebuild, and the full <code>bun run pr:athena</code> merge gate before PR delivery.</p>
+      <p>Post-merge production deploy should include <code>scripts/deploy-vps.sh convex-prod</code> and <code>scripts/deploy-vps.sh athena-local</code> from a clean root checkout.</p>
+      <p>Delivery stays limited to the owned POS register lifecycle dirty path set plus required plan, ticket, generated-artifact, and solution-doc updates. After merge, local root <code>main</code> must fast-forward to the merged remote state before production deploy.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-06-23-001-refactor-pos-register-lifecycle-policy-plan.md
+++ b/docs/plans/2026-06-23-001-refactor-pos-register-lifecycle-policy-plan.md
@@ -1,0 +1,404 @@
+---
+title: "refactor: Share POS Register Lifecycle Policy"
+type: refactor
+status: active
+date: 2026-06-23
+---
+
+# refactor: Share POS Register Lifecycle Policy
+
+## Summary
+
+Extract the POS register and drawer lifecycle invariants into a shared policy layer consumed by browser-local POS and Convex projection. The work preserves the current multi-session drawer behavior while removing duplicated rules around closeout review, drawer authority, runtime evidence, and sale usability.
+
+---
+
+## Problem Frame
+
+The current POS register patch encodes the same drawer lifecycle invariants in multiple places: local read-model projection, local command gating, runtime status, Convex sync projection, repository conflict lookup, and register review presentation. That shape can drift and reintroduce the class of cashier blockers this work just fixed: a cashier opens a drawer, closes it, opens a later drawer, and POS/server disagree about whether the old or new drawer is authoritative.
+
+---
+
+## Requirements
+
+- R1. Define register lifecycle policy once for shared browser and Convex consumers.
+- R2. Preserve POS sale usability semantics: `open` and `active` are sale-usable; `closing` is lifecycle/review-visible but not sale-usable; `closed` is not sale-usable.
+- R3. Preserve cashier continuity by allowing a replacement drawer after settled closeout, submitted closeout review, or `cloud_closed` drawer authority when local evidence makes that safe.
+- R4. Keep unresolved closeouts and `cloud_closed` drawer authority blocks as sale blockers for their scoped session.
+- R5. Ensure Convex projection and browser-local POS agree on reviewed closeout drawers: a reviewed cloud drawer is not reusable for sale authority, but may be superseded by a new local drawer open.
+- R6. Fix the direct-cloud-id projection bypass so sale projection cannot attach to a reviewed closeout merely because the local register id already looks like a cloud id.
+- R7. Replace duplicated non-blocking lifecycle-review predicates for runtime status and sync runtime event selection.
+- R8. Keep Cash Controls and Daily Operations review surfaces truthful when closeout review coexists with later drawer activity.
+- R9. Preserve existing UI contracts unless a contract change is explicitly required by the invariant.
+- R10. Refresh generated Graphify artifacts after code changes.
+- Terminology: “scoped session” means the same store, terminal, and register-session scope used by the local drawer/read-model policy inputs.
+
+---
+
+## Scope Boundaries
+
+- This plan does not redesign POS drawer opening, closeout submission, manager review, or Cash Controls workflows.
+- This plan does not introduce new drawer lifecycle states beyond the existing register-session status vocabulary.
+- This plan does not turn runtime status into an authority source; runtime status remains evidence for reconciliation and support.
+- This plan does not add new production observability rails unless a current mutation boundary already emits the relevant audit/review evidence.
+- This plan does not split into separate PRs by default; the touched files share generated artifacts and should land through one integration PR after ticket-level tracking.
+
+### Deferred to Follow-Up Work
+
+- Broader POS terminal health IA cleanup outside the lifecycle policy drift.
+- Additional runtime status dashboards for lifecycle review evidence.
+- New repo sensors if implementation reveals a validation-map gap that is separate from the current invariant extraction.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/shared/registerSessionStatus.ts` already defines shared register-session status policy.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/saleBlockerPolicy.ts` is the existing local sale blocker policy boundary.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts` currently projects local register state and exposes `hasSettledRegisterCloseout`.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts` owns local command acceptance before durable local event append.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts` and `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts` both classify non-blocking lifecycle review evidence today.
+- `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts` owns server-side local event projection and is the highest-risk hotspot.
+- `packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts` should stay data-access oriented and should not re-derive closeout-review policy heuristically.
+- `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts` already has review-kind classification that should inform closeout-review conflict policy.
+- `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx` renders closeout review and mixed review queues for managers.
+
+### Institutional Learnings
+
+- `docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md`: drawer invariants must live at command boundaries, not only UI gates.
+- `docs/solutions/logic-errors/athena-pos-synced-closeout-readiness-2026-06-17.md`: settled closeout history must not block the next drawer for the same store/terminal after the prior register session settles.
+- `docs/solutions/logic-errors/athena-pos-drawer-authority-replacement-recovery-2026-06-06.md`: recoverable drawer authority blocks can be superseded only by later accepted replacement evidence.
+- `docs/solutions/logic-errors/athena-pos-stale-terminal-sale-block-2026-05-29.md`: terminal integrity and drawer authority remain durable inputs to `canSell`.
+- `docs/solutions/logic-errors/athena-pos-register-sync-closeout-review-recovery-2026-05-23.md`: closeout review projection must update source sync event, review row, and register session consistently.
+- `docs/solutions/architecture/athena-pos-register-viewmodel-boundaries-2026-06-17.md`: keep `useRegisterViewModel` as a facade and extract tested helper policy behind it.
+- `docs/solutions/architecture/athena-pos-runtime-decoupling-boundaries-2026-06-15.md`: readiness, drawer-authority reconciliation, sync drain, runtime status publish, and terminal health presentation are separate boundaries.
+
+### External References
+
+- None. Local Athena POS and Convex patterns are the source of truth.
+
+---
+
+## Key Technical Decisions
+
+- **Create a pure shared lifecycle policy module:** Put shared decisions under `packages/athena-webapp/shared/`, adjacent to `registerSessionStatus.ts`, so both browser code and Convex code can import it.
+- **Expose separate policy answers rather than one overloaded usable helper:** The policy should distinguish sale usability, lifecycle visibility, replacement-open eligibility, reviewed-closeout supersedability, and non-blocking runtime evidence.
+- **Keep repository queries outside the policy:** Repositories return facts such as `hasOpenCloseoutReview`, review kind, mapped register-session status, event ids, session ids, and evidence ordering. `projectLocalEvents.ts` or another application-layer sync service calls the shared policy with those facts; repositories must not become the durable lifecycle policy boundary.
+- **Use stable review classification where available:** Avoid summary-string coupling for closeout review decisions when typed review-kind classification can describe the conflict.
+- **Integrate server projection before frontend cleanup:** Convex is the authoritative guard against stale clients and direct-cloud-id projection bypass.
+- **Preserve `registerUiState.ts` as a stable UI contract:** Presentation consumers should receive policy-shaped decisions without broad UI contract churn.
+- **Land through one coordinated integration PR:** The dirty change set touches generated Graphify artifacts and cross-layer tests, so separate PRs would mostly fight over derived outputs.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should the shared layer live in browser-local infrastructure or `shared/`?** Use `shared/` because Convex projection and browser-local POS both need the same pure decisions.
+- **Should `closing` be POS-usable?** No. It is lifecycle/review-visible and can be superseded when reviewed, but sales must not attach to it.
+- **Should runtime status grant authority?** No. Runtime status reports evidence and receives reconciliation directives; it does not authorize sales.
+- **Should the current dirty root be split before planning?** No. It has been moved into one delivery worktree and should be tracked as a coordinated batch.
+
+### Deferred to Implementation
+
+- Exact helper names may change if implementation finds clearer local naming.
+- Whether the existing `selectPassiveCloseoutBlockedRegisterSession()` placeholder should be removed or replaced depends on how the final policy call reads in `useRegisterViewModel.ts`.
+- Whether `scripts/harness-app-registry.ts` needs an update depends on the final shared file location and existing validation-map coverage.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  Shared["shared register lifecycle policy"] --> LocalRead["local register read model"]
+  Shared --> LocalCmd["local command gateway"]
+  Shared --> Runtime["sync runtime and terminal runtime status"]
+  Shared --> Projection["Convex local event projection"]
+  Repo["repository fact lookup"] --> Projection
+  Shared --> Review["Cash Controls review presentation"]
+
+  LocalRead --> POS["POS register view model"]
+  LocalCmd --> POS
+  Projection --> Cloud["registerSession and sync review rows"]
+  Cloud --> Review
+  Runtime --> Support["terminal runtime evidence"]
+```
+
+### Policy Decision Matrix
+
+| State or evidence | Sale usable | Lifecycle visible | Replacement drawer may proceed |
+| --- | --- | --- | --- |
+| `open` / `active`, no blocker | Yes | Yes | No, unless same drawer idempotency applies |
+| `closing` with unresolved/unsynced closeout and no submitted review | No | Yes | No for the same scoped session |
+| `closing` with submitted closeout review | No | Yes | Yes by appending a new local drawer for the same store/terminal with a new register-session id, leaving the reviewed drawer non-sale-usable |
+| `closed` with settled closeout | No | Historical evidence | Yes because the settled session releases its own blocker; the next drawer opens under a new register-session scope for the same store/terminal |
+| `cloud_closed` drawer authority | No for the mapped drawer | Yes | Yes when later accepted local replacement evidence appends a replacement drawer |
+| same-session `lifecycle_rejected` review evidence | Not by itself | Yes | Depends on the current active/closing drawer state |
+
+---
+
+## Implementation Units
+
+- U1. **Shared Lifecycle Policy Foundation**
+
+**Goal:** Add a pure shared policy module and focused tests for POS register lifecycle decisions.
+
+**Requirements:** R1, R2, R3, R4, R5, R7
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts`
+- Test: `packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts`
+- Modify: `packages/athena-webapp/shared/registerSessionStatus.ts` only if status exports need small naming reuse
+
+**Approach:**
+- Build on the existing status policy instead of redefining status sets.
+- Keep inputs structural and serializable so Convex and browser code can both consume the helpers.
+- Require supersession inputs to include scoped store, terminal, register-session identity, and monotonic evidence ordering such as local sequence, server mapping time, or accepted sync event order so stale or foreign evidence cannot release a blocker.
+- Cover separate decisions for sale usability, lifecycle visibility, replacement-open eligibility, non-blocking lifecycle review events, drawer authority sale blocking, and reviewed-closeout supersedability.
+
+**Execution note:** Implement the shared policy test-first using characterization cases from the current dirty callers before replacing those callers.
+
+**Patterns to follow:**
+- `packages/athena-webapp/shared/registerSessionStatus.ts`
+- `packages/athena-webapp/shared/registerSessionStatus.test.ts`
+
+**Test scenarios:**
+- Happy path: `open` and `active` classify as sale-usable.
+- Edge case: `closing` is lifecycle-visible and supersedable when reviewed, but never sale-usable.
+- Edge case: settled closeout can release a scoped local drawer block while unsynced closeout cannot.
+- Edge case: older replacement evidence does not supersede newer reviewed drawer evidence.
+- Error path: foreign store/terminal scope inputs do not classify as reusable/supersedable.
+- Integration: same-session `lifecycle_rejected` does not become a sale blocker by itself, while `cloud_closed` remains a sale blocker for the mapped drawer.
+
+**Verification:**
+- Shared policy tests prove the current invariant table before caller refactors depend on it.
+
+---
+
+- U2. **Browser-Local POS Policy Integration**
+
+**Goal:** Replace duplicated lifecycle and drawer-authority decisions in browser-local POS with shared policy calls.
+
+**Requirements:** R1, R2, R3, R4, R5, R7, R9
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts` only if the existing `hasSignedInStaff` addition remains required
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`
+
+**Approach:**
+- Replace private helpers and exact duplicated predicates with shared policy calls.
+- Pass scoped store, terminal, register-session identity, and local event ordering facts into supersession decisions instead of relying on status alone.
+- Keep local store access, event replay, and UI assembly inside existing local modules.
+- Treat the `selectPassiveCloseoutBlockedRegisterSession()` placeholder as an explicit implementation decision: either remove it if passive blocking is no longer needed, or replace it with a named policy-backed selector.
+- Preserve local-first command behavior: cashier success still follows durable local event append.
+
+**Execution note:** Characterize current dirty behavior in focused tests before replacing caller logic.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/saleBlockerPolicy.ts`
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts`
+- `docs/solutions/architecture/athena-pos-register-viewmodel-boundaries-2026-06-17.md`
+
+**Test scenarios:**
+- Happy path: first drawer open projects as sellable after local event append.
+- Edge case: active drawer with same-session lifecycle review remains sellable when no other blocker exists.
+- Edge case: submitted closeout blocks sales but allows opening a subsequent drawer.
+- Edge case: synced closeout releases a scoped local closeout block only for the matching session.
+- Edge case: reviewed cloud drawer is not sale-usable locally but can be superseded by a later new local drawer open under shared policy.
+- Edge case: older replacement evidence, foreign terminal evidence, and unsynced closeout evidence do not release the current blocker.
+- Error path: `cloud_closed` drawer authority blocks sales on the mapped drawer.
+- Integration: runtime status ignores non-blocking lifecycle review events without hiding actionable sale/payment review events.
+
+**Verification:**
+- Browser-local focused tests pass and no local POS caller redefines the moved lifecycle predicates.
+
+---
+
+- U3. **Convex Projection and Repository Policy Integration**
+
+**Goal:** Replace duplicated server-side lifecycle decisions and fix the reviewed-closeout direct-id projection bypass.
+
+**Requirements:** R1, R2, R5, R6
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/types.ts`
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/terminals.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/terminals.test.ts`
+
+**Approach:**
+- Keep DB lookup functions in repositories, but move pure interpretation of returned facts into shared policy at the application/sync layer.
+- Ensure repository methods expose fact data and evidence ordering needed by policy decisions without embedding lifecycle interpretations.
+- Block sale projection for any mapped register session with open closeout review, including direct cloud-id local histories.
+- Allow new local drawer projection to supersede a reviewed `open`, `active`, or `closing` cloud drawer only under shared policy.
+- Keep terminal runtime directive logic aligned with shared status semantics for `closing` lifecycle evidence.
+
+**Execution note:** Add or adjust the direct-cloud-id reviewed-closeout test before changing projection logic.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts`
+- `packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts`
+
+**Test scenarios:**
+- Happy path: duplicate open maps to an existing active drawer when no closeout review exists.
+- Edge case: reviewed `open`, `active`, or `closing` drawer can be superseded by a later new local drawer open with matching store/terminal and distinct register-session identity.
+- Edge case: older replacement evidence and foreign terminal evidence do not supersede the reviewed drawer.
+- Edge case: direct-cloud-id local register history cannot project sales into a reviewed closeout drawer.
+- Error path: sale projection conflicts when register mapping points to a reviewed closeout.
+- Integration: variance closeout patches register session to `closing`, creates one review conflict, and approved replay closes idempotently.
+
+**Verification:**
+- Convex projection tests prove server and local policy agree on reviewed drawers and direct-id bypass is closed.
+
+---
+
+- U4. **Review Surface and Daily Close Alignment**
+
+**Goal:** Keep manager-facing review surfaces accurate when closeout review coexists with subsequent POS drawer activity.
+
+**Requirements:** R5, R8, R9
+
+**Dependencies:** U1, U3
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts`
+- Modify: `packages/athena-webapp/convex/operations/dailyClose.ts`
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`
+- Test: `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyClose.test.ts`
+- Test: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+
+**Approach:**
+- Keep closeout review items visible and actionable even if POS can open a later drawer.
+- Suppress duplicate-closeout shadows only when the same event already has an open variance review.
+- Prefer typed review classification over summary-string heuristics where the current code allows it.
+- Preserve calm operational copy and existing permission boundaries.
+
+**Execution note:** Characterize mixed review queues before changing review item grouping or action rendering.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`
+- `docs/solutions/logic-errors/athena-cash-controls-closeout-review-ia-2026-06-08.md`
+- `docs/product-copy-tone.md`
+
+**Test scenarios:**
+- Happy path: closeout variance review shows expected/count/variance/note evidence.
+- Edge case: mixed closeout and sale/inventory review queue shows item-level actions without losing batch context.
+- Edge case: duplicate closeout review is suppressed when an open variance review for the same event exists.
+- Error path: already-closed duplicate closeout remains reject-only.
+- Integration: Daily Close continues to treat unresolved `closing` register sessions as blockers.
+
+**Verification:**
+- Cash Controls and Daily Close tests prove review surfaces remain manager-actionable and do not imply a reviewed drawer is sale-usable.
+
+---
+
+- U5. **Harness, Generated Artifacts, and Delivery Documentation**
+
+**Goal:** Keep repository sensors, Graphify output, and reusable architecture knowledge aligned with the new shared policy boundary.
+
+**Requirements:** R10
+
+**Dependencies:** U1, U2, U3, U4
+
+**Files:**
+- Modify: `scripts/harness-app-registry.ts` only if the new shared policy file needs validation-map coverage.
+- Modify: `graphify-out/GRAPH_REPORT.md`
+- Modify: `graphify-out/graph.json`
+- Modify: `graphify-out/wiki/index.md`
+- Modify: `graphify-out/wiki/packages/athena-webapp.md`
+- Create or Modify: `docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md`
+
+**Approach:**
+- Regenerate Graphify after source changes; do not hand-edit generated graph files.
+- If validation-map coverage changes, regenerate harness docs through the repo’s harness command.
+- Add a concise solution doc explaining the shared policy boundary, the states it owns, and the callers that should not re-derive those decisions.
+
+**Execution note:** Sensor-only for generated artifacts; behavior is proven by earlier units.
+
+**Patterns to follow:**
+- `docs/solutions/architecture/athena-pos-register-viewmodel-boundaries-2026-06-17.md`
+- `docs/solutions/architecture/athena-pos-runtime-decoupling-boundaries-2026-06-15.md`
+
+**Test scenarios:**
+- Test expectation: none for generated Graphify artifacts; validation is successful regeneration plus clean diff review.
+- Integration: validation-map updates, if any, include the shared policy test in the relevant POS local-sync scenario.
+
+**Verification:**
+- Generated artifacts reflect the final source tree and a durable solution doc captures the new architecture boundary.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Local POS, Convex projection, terminal runtime reporting, Cash Controls, Daily Close, and generated Graphify all observe the lifecycle policy.
+- **Error propagation:** Policy helpers should return decisions or booleans; user-facing copy remains in presentation/command boundaries.
+- **State lifecycle risks:** The highest-risk transitions are `open/active -> closing`, reviewed closeout superseded by new drawer, settled closeout release, and direct cloud-id sale projection.
+- **API surface parity:** Browser and Convex must consume the same pure policy; repository and UI layers should not fork status semantics.
+- **Integration coverage:** Unit policy tests are necessary but insufficient; projection, local command, runtime status, and review UI tests must all prove parity.
+- **Unchanged invariants:** POS remains local-first; runtime status remains evidence; manager review remains the closeout decision boundary.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Shared helper accidentally makes `closing` sale-usable | Policy table tests plus browser and Convex projection tests must cover `closing` explicitly. |
+| Repository data access leaks policy back into queries | Keep repository methods returning facts and run review against `localSyncRepository.ts`. |
+| Direct-cloud-id bypass remains open | Add focused projection regression before implementation and keep it in `projectLocalEvents.test.ts`. |
+| UI hides closeout review because POS can open a later drawer | Cash Controls mixed-review tests must prove closeout review remains visible and actionable. |
+| Generated artifacts drift | Run `bun run graphify:rebuild` after source changes and inspect generated output. |
+
+---
+
+## Documentation / Operational Notes
+
+- This change affects Athena admin runtime and Convex runtime surfaces. Post-merge deploy should include `scripts/deploy-vps.sh convex-prod` and `scripts/deploy-vps.sh athena-local` from a clean root checkout.
+- Delivery must stay limited to the owned POS register lifecycle dirty path set plus required plan, ticket, generated-artifact, and solution-doc updates. Avoid unrelated cleanup, run focused POS/Convex/Cash Controls tests first, then Graphify rebuild and `bun run pr:athena`, merge through PR, fast-forward local root `main`, and deploy the selected production surfaces from a clean checkout.
+- Create or update a solution doc after implementation because this introduces a durable shared architecture boundary.
+- No external service migration is expected.
+
+---
+
+## Sources & References
+
+- Related code: `packages/athena-webapp/shared/registerSessionStatus.ts`
+- Related code: `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts`
+- Related code: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts`
+- Related code: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`
+- Learning: `docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md`
+- Learning: `docs/solutions/logic-errors/athena-pos-synced-closeout-readiness-2026-06-17.md`
+- Learning: `docs/solutions/logic-errors/athena-pos-drawer-authority-replacement-recovery-2026-06-06.md`
+- Learning: `docs/solutions/architecture/athena-pos-register-viewmodel-boundaries-2026-06-17.md`
+- Learning: `docs/solutions/architecture/athena-pos-runtime-decoupling-boundaries-2026-06-15.md`

--- a/docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md
+++ b/docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md
@@ -1,0 +1,122 @@
+---
+title: Athena POS Register Lifecycle Policy Boundary
+date: 2026-06-23
+category: architecture
+module: athena-webapp
+problem_type: pos_register_lifecycle_policy_drift
+component: pos
+symptoms:
+  - "Browser-local POS and Convex projection can disagree about whether a drawer is sale-usable"
+  - "Submitted closeout reviews can accidentally become either hard sale blockers or reusable drawers depending on the layer"
+  - "Direct cloud register-session ids can bypass local-id-specific guards if sale usability is checked ad hoc"
+root_cause: drawer_lifecycle_rules_were_reimplemented_across_projection_view_model_runtime_and_repository_paths
+resolution_type: shared_pure_lifecycle_policy
+severity: high
+tags:
+  - pos
+  - drawer-lifecycle
+  - local-first
+  - cash-controls
+  - sync
+---
+
+# Athena POS Register Lifecycle Policy Boundary
+
+## Problem
+
+The register drawer lifecycle is consumed in several places:
+
+- browser-local read models and command gateways decide whether a cashier can
+  sell, reopen, close out, or open a replacement drawer;
+- local runtime sync decides whether `needs_review` lifecycle events should
+  keep the terminal in a blocking review state;
+- Convex projection decides whether synced local events can reuse an existing
+  cloud drawer, supersede a reviewed drawer, or project a sale; and
+- Cash Controls and Daily Close present closeout-review state to operators.
+
+When each layer encodes the rule locally, they drift. The dangerous cases are
+not simple status checks. A `closing` drawer is not sale-usable, but a submitted
+closeout review can allow a new local drawer under a new register-session
+scope. A `cloud_closed` drawer authority block is hard for sale reuse but can
+allow replacement drawer opening. A direct cloud register-session id should not
+skip an open closeout-review check just because the local id string equals the
+cloud id.
+
+## Decision
+
+Keep drawer lifecycle decisions in a pure shared policy module:
+
+`packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts`
+
+Callers adapt their local facts into structural policy inputs. The policy must
+not import React, Convex table types, local-store adapters, or repositories.
+
+Repositories stay on the fact side of the boundary. They can answer questions
+such as "is there an open closeout review for this mapped register session?"
+and return ordering or mapping evidence, but application/sync code asks the
+shared policy what those facts mean.
+
+## Solution
+
+Extract the drawer lifecycle predicates into
+`shared/registerSessionLifecyclePolicy.ts` and make each layer call it at the
+decision point:
+
+- the local read model asks the policy which drawer-authority facts block
+  sales;
+- the local command gateway asks whether a sale block still permits opening a
+  replacement drawer;
+- runtime sync diagnostics ask which lifecycle review events are non-blocking;
+- Convex projection asks whether a cloud drawer can be reused or superseded
+  before mapping a local open;
+- repository code uses the shared closeout-review classifier while still only
+  reading conflict and mapping facts; and
+- Cash Controls and Daily Close consume the same sale-usability and
+  closeout-review classifications as the projection layer.
+
+## Invariants
+
+- `open` and `active` are sale-usable.
+- `closing` is not sale-usable.
+- `closed` is historical unless an explicit reviewed replay path allows a
+  specific projection.
+- Submitted closeout review state can make a new drawer eligible under a new
+  register-session scope; it does not make the reviewed drawer sale-usable.
+- Settled closeout history releases its own blocker and must not block the next
+  drawer for the same store and terminal.
+- `cloud_closed` drawer authority blocks sale reuse and can allow replacement
+  drawer opening.
+- `lifecycle_rejected` for the same local drawer is recoverable local evidence,
+  not a hard sale blocker by itself.
+- Non-blocking register lifecycle review events are `needs_review`
+  `register.opened` and `register.closeout_started` events.
+- Closeout-review conflict classification uses one shared summary and shape
+  predicate so projection, repository facts, and Cash Controls review state do
+  not fork.
+
+## Regression Targets
+
+- Shared policy tests should cover sale usability, drawer-authority blocking,
+  replacement drawer eligibility, cloud drawer reuse, reviewed drawer
+  supersession, closeout-review conflict classification, and non-blocking
+  lifecycle review events.
+- Local read-model and command-gateway tests should prove command-boundary
+  enforcement matches UI readiness.
+- Projection tests should prove direct cloud register-session ids still conflict
+  when the mapped drawer has an open closeout review.
+- Runtime sync tests should prove uploaded lifecycle review events do not keep
+  terminal runtime status in a blocking review state.
+- Cash Controls and Daily Close tests should prove submitted closeout review is
+  visible/reviewable without making the drawer sale-usable.
+
+## Prevention
+
+- Do not add new POS drawer status sets in browser or Convex code. Add a policy
+  helper when a new lifecycle question appears.
+- Keep helper names behavior-specific: sale usability, replacement eligibility,
+  cloud drawer reuse, runtime inspection, review classification.
+- Do not move repository access into the policy module. Convert repository rows
+  into plain inputs at the application boundary.
+- Treat "reuse the current drawer" and "open a replacement drawer" as different
+  decisions. They intentionally have different answers for reviewed closeouts
+  and closed cloud drawers.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2100 files · ~0 words
+- 2102 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7815 nodes · 9139 edges · 2028 communities detected
+- 7833 nodes · 9164 edges · 2030 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2038,6 +2038,8 @@
 - [[_COMMUNITY_Community 2025|Community 2025]]
 - [[_COMMUNITY_Community 2026|Community 2026]]
 - [[_COMMUNITY_Community 2027|Community 2027]]
+- [[_COMMUNITY_Community 2028|Community 2028]]
+- [[_COMMUNITY_Community 2029|Community 2029]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2078,12 +2080,12 @@ Cohesion: 0.06
 Nodes (65): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildApprovalRequestsById(), buildDailyCloseApprovalSubject() (+57 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.07
-Nodes (57): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildRegisterCloseoutTimelineMessage(), buildWeekMetricForDate(), buildWeekMetrics() (+49 more)
+Cohesion: 0.1
+Nodes (57): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), capNonCashPaymentsToExpectedTotal(), collectExistingSaleMappings() (+49 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.1
-Nodes (55): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), capNonCashPaymentsToExpectedTotal(), collectExistingSaleMappings(), collectSaleSkuQuantities(), conflictResult() (+47 more)
+Cohesion: 0.07
+Nodes (57): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildRegisterCloseoutTimelineMessage(), buildWeekMetricForDate(), buildWeekMetrics() (+49 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.09
@@ -2334,36 +2336,36 @@ Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
 
 ### Community 67 - "Community 67"
+Cohesion: 0.15
+Nodes (9): asCloudOperableSession(), countPendingSyncableLocalEventsForStaff(), hasSyncedSaleLocalEventsForStaff(), hasUploadedLocalEventsForStaff(), isCloudOperableSession(), isEmptyLocalSaleShell(), selectPassiveCloseoutBlockedRegisterSession(), trimOptional() (+1 more)
+
+### Community 68 - "Community 68"
 Cohesion: 0.22
 Nodes (18): assertPrAthenaProofReady(), classifySnapshotError(), collectFilesUnder(), collectProofSnapshot(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof() (+10 more)
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.14
 Nodes (6): asBoolean(), asNumber(), asRecord(), buildRegisterCloseoutVarianceTimelineMessage(), formatCloseoutVarianceAmount(), getCashControlsConfig()
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.17
 Nodes (13): buildProviderRegistry(), createIntelligenceRun(), defaultFakeOutput(), failedGenerationResult(), getStoreInsightsSnapshotFallback(), isActivityTrend(), isDeviceDistribution(), isInsightGenerationInProgressError() (+5 more)
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.12
 Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.22
 Nodes (15): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+7 more)
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.14
 Nodes (7): formatLocalStartTime(), formatLocalStartTimeFromParts(), getLocalStartTimeParts(), handleSave(), parseLocalStartMinutes(), updateLocalCompletionWindowPart(), updateLocalStartTimePart()
-
-### Community 74 - "Community 74"
-Cohesion: 0.16
-Nodes (8): asCloudOperableSession(), countPendingSyncableLocalEventsForStaff(), hasSyncedSaleLocalEventsForStaff(), hasUploadedLocalEventsForStaff(), isCloudOperableSession(), isEmptyLocalSaleShell(), trimOptional(), useRegisterViewModel()
 
 ### Community 75 - "Community 75"
 Cohesion: 0.25
@@ -2570,156 +2572,156 @@ Cohesion: 0.2
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
 ### Community 126 - "Community 126"
+Cohesion: 0.24
+Nodes (6): canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), getSaleBlockingDrawerAuthority(), isDrawerAuthoritySaleBlocking(), isRegisterSessionSaleUsable(), isScopedRegisterSession()
+
+### Community 127 - "Community 127"
 Cohesion: 0.2
 Nodes (4): formatProductLineMeta(), formatServiceLabel(), formatServiceLineMeta(), formatStoredAmount()
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.21
 Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.24
 Nodes (6): blocked(), evaluateLocalPosReadiness(), hasSettledLocalCloseout(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.18
 Nodes (2): expenseItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.29
 Nodes (8): isFiniteNumber(), isPointInsideViewport(), isPositiveFiniteNumber(), isRecord(), isValidViewport(), validateKeyEvent(), validatePointerEvent(), validateRemoteAssistControlEvent()
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.33
 Nodes (7): createAthenaProviderError(), createProviderFailureResult(), getProviderFailureDiagnostic(), invokeStructuredTextProvider(), isJsonObject(), isJsonValue(), sanitizeDiagnostic()
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.22
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.31
 Nodes (7): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), parseVariantDisplayMoney(), saveProduct(), updateVariantSku()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.27
 Nodes (5): clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), runProcess(), writePrAthenaProviderEvidence()
-
-### Community 163 - "Community 163"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 164 - "Community 164"
 Cohesion: 0.39
@@ -2731,523 +2733,523 @@ Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getAc
 
 ### Community 166 - "Community 166"
 Cohesion: 0.39
-Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 167 - "Community 167"
+Cohesion: 0.39
+Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
+
+### Community 168 - "Community 168"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.25
 Nodes (2): isValidMessageBlocker(), isValidPriority()
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.22
 Nodes (0):
-
-### Community 178 - "Community 178"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 179 - "Community 179"
 Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 180 - "Community 180"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 181 - "Community 181"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
+Cohesion: 0.29
+Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
+
+### Community 189 - "Community 189"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 188 - "Community 188"
+### Community 190 - "Community 190"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 189 - "Community 189"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 190 - "Community 190"
-Cohesion: 0.25
-Nodes (0):
-
 ### Community 191 - "Community 191"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 192 - "Community 192"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 193 - "Community 193"
 Cohesion: 0.36
 Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
 
-### Community 192 - "Community 192"
+### Community 194 - "Community 194"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 193 - "Community 193"
+### Community 195 - "Community 195"
 Cohesion: 0.29
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 194 - "Community 194"
+### Community 196 - "Community 196"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 195 - "Community 195"
+### Community 197 - "Community 197"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 196 - "Community 196"
+### Community 198 - "Community 198"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
-
-### Community 197 - "Community 197"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 198 - "Community 198"
-Cohesion: 0.29
-Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 200 - "Community 200"
+Cohesion: 0.29
+Nodes (2): handleKeyDown(), isDebugShortcut()
+
+### Community 201 - "Community 201"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 202 - "Community 202"
 Cohesion: 0.39
 Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
-### Community 201 - "Community 201"
+### Community 203 - "Community 203"
 Cohesion: 0.39
 Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
 
-### Community 202 - "Community 202"
+### Community 204 - "Community 204"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 203 - "Community 203"
+### Community 205 - "Community 205"
 Cohesion: 0.29
 Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
 
-### Community 204 - "Community 204"
+### Community 206 - "Community 206"
 Cohesion: 0.29
 Nodes (2): findRegisterCloseoutReviewItem(), readLocalSyncStatus()
 
-### Community 205 - "Community 205"
+### Community 207 - "Community 207"
 Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
-### Community 206 - "Community 206"
+### Community 208 - "Community 208"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 207 - "Community 207"
+### Community 209 - "Community 209"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 208 - "Community 208"
+### Community 210 - "Community 210"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 209 - "Community 209"
+### Community 211 - "Community 211"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 210 - "Community 210"
+### Community 212 - "Community 212"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 211 - "Community 211"
+### Community 213 - "Community 213"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 212 - "Community 212"
+### Community 214 - "Community 214"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 213 - "Community 213"
+### Community 215 - "Community 215"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 214 - "Community 214"
-Cohesion: 0.33
-Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
-
-### Community 215 - "Community 215"
+### Community 216 - "Community 216"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 216 - "Community 216"
+### Community 217 - "Community 217"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 219 - "Community 219"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 220 - "Community 220"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 221 - "Community 221"
-Cohesion: 0.48
-Nodes (6): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), isDuplicateRegisterOpenConflict(), skipped()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 222 - "Community 222"
 Cohesion: 0.48
-Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
+Nodes (6): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), isDuplicateRegisterOpenConflict(), skipped()
 
 ### Community 223 - "Community 223"
+Cohesion: 0.48
+Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
+
+### Community 224 - "Community 224"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.33
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
-
-### Community 236 - "Community 236"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 237 - "Community 237"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 238 - "Community 238"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 239 - "Community 239"
 Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 240 - "Community 240"
 Cohesion: 0.33
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 241 - "Community 241"
+Cohesion: 0.33
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+
+### Community 242 - "Community 242"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 245 - "Community 245"
-Cohesion: 0.52
-Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 246 - "Community 246"
 Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 247 - "Community 247"
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+
+### Community 248 - "Community 248"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.38
 Nodes (3): getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusSignature()
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.33
 Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
-
-### Community 251 - "Community 251"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 252 - "Community 252"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 253 - "Community 253"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 254 - "Community 254"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.47
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 262 - "Community 262"
+### Community 263 - "Community 263"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 263 - "Community 263"
+### Community 264 - "Community 264"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
 
-### Community 264 - "Community 264"
+### Community 265 - "Community 265"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 265 - "Community 265"
+### Community 266 - "Community 266"
 Cohesion: 0.4
 Nodes (2): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository()
 
-### Community 266 - "Community 266"
+### Community 267 - "Community 267"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 270 - "Community 270"
+### Community 271 - "Community 271"
 Cohesion: 0.6
 Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
-### Community 271 - "Community 271"
+### Community 272 - "Community 272"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 272 - "Community 272"
+### Community 273 - "Community 273"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.4
 Nodes (2): moveFeaturedItem(), saveOrder()
 
-### Community 280 - "Community 280"
+### Community 281 - "Community 281"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
-
-### Community 281 - "Community 281"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 282 - "Community 282"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 283 - "Community 283"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 284 - "Community 284"
 Cohesion: 0.4
 Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
-### Community 284 - "Community 284"
+### Community 285 - "Community 285"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
-
-### Community 285 - "Community 285"
-Cohesion: 0.4
-Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 286 - "Community 286"
 Cohesion: 0.4
-Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
+Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 287 - "Community 287"
+Cohesion: 0.4
+Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
+
+### Community 288 - "Community 288"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 288 - "Community 288"
+### Community 289 - "Community 289"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 289 - "Community 289"
+### Community 290 - "Community 290"
 Cohesion: 0.47
 Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
 
-### Community 290 - "Community 290"
+### Community 291 - "Community 291"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 291 - "Community 291"
+### Community 292 - "Community 292"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 292 - "Community 292"
+### Community 293 - "Community 293"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 293 - "Community 293"
+### Community 294 - "Community 294"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 294 - "Community 294"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 295 - "Community 295"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 296 - "Community 296"
 Cohesion: 0.33
@@ -3258,160 +3260,160 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 298 - "Community 298"
-Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 299 - "Community 299"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 300 - "Community 300"
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
+
+### Community 301 - "Community 301"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 301 - "Community 301"
+### Community 302 - "Community 302"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 303 - "Community 303"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 302 - "Community 302"
+### Community 304 - "Community 304"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 303 - "Community 303"
+### Community 305 - "Community 305"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 304 - "Community 304"
+### Community 306 - "Community 306"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 305 - "Community 305"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 306 - "Community 306"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 307 - "Community 307"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 308 - "Community 308"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 309 - "Community 309"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 308 - "Community 308"
+### Community 310 - "Community 310"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 309 - "Community 309"
+### Community 311 - "Community 311"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 310 - "Community 310"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 311 - "Community 311"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 312 - "Community 312"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 313 - "Community 313"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 314 - "Community 314"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 315 - "Community 315"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 316 - "Community 316"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 316 - "Community 316"
+### Community 317 - "Community 317"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 317 - "Community 317"
+### Community 318 - "Community 318"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 321 - "Community 321"
+### Community 322 - "Community 322"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 322 - "Community 322"
+### Community 323 - "Community 323"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
-### Community 323 - "Community 323"
+### Community 324 - "Community 324"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 324 - "Community 324"
+### Community 325 - "Community 325"
 Cohesion: 0.6
 Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
-### Community 325 - "Community 325"
+### Community 326 - "Community 326"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 326 - "Community 326"
+### Community 327 - "Community 327"
 Cohesion: 0.5
 Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
-### Community 327 - "Community 327"
+### Community 328 - "Community 328"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 328 - "Community 328"
+### Community 329 - "Community 329"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 329 - "Community 329"
+### Community 330 - "Community 330"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 330 - "Community 330"
+### Community 331 - "Community 331"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 331 - "Community 331"
+### Community 332 - "Community 332"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
-
-### Community 332 - "Community 332"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 333 - "Community 333"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 334 - "Community 334"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 335 - "Community 335"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 335 - "Community 335"
+### Community 336 - "Community 336"
 Cohesion: 0.6
 Nodes (3): isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult()
-
-### Community 336 - "Community 336"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 337 - "Community 337"
 Cohesion: 0.4
@@ -3422,68 +3424,68 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 339 - "Community 339"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 340 - "Community 340"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 340 - "Community 340"
+### Community 341 - "Community 341"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 341 - "Community 341"
+### Community 342 - "Community 342"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 342 - "Community 342"
+### Community 343 - "Community 343"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 343 - "Community 343"
+### Community 344 - "Community 344"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 344 - "Community 344"
+### Community 345 - "Community 345"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 345 - "Community 345"
+### Community 346 - "Community 346"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 346 - "Community 346"
+### Community 347 - "Community 347"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 347 - "Community 347"
+### Community 348 - "Community 348"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
 
-### Community 348 - "Community 348"
+### Community 349 - "Community 349"
 Cohesion: 0.5
 Nodes (2): handleChange(), parseVariantAttributeValue()
-
-### Community 349 - "Community 349"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 350 - "Community 350"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 351 - "Community 351"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 352 - "Community 352"
 Cohesion: 0.5
 Nodes (2): moveBestSeller(), saveOrder()
 
-### Community 352 - "Community 352"
+### Community 353 - "Community 353"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 353 - "Community 353"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 354 - "Community 354"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 355 - "Community 355"
 Cohesion: 0.4
@@ -3494,20 +3496,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 357 - "Community 357"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 358 - "Community 358"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 358 - "Community 358"
+### Community 359 - "Community 359"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 359 - "Community 359"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 360 - "Community 360"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 361 - "Community 361"
 Cohesion: 0.4
@@ -3538,80 +3540,80 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 368 - "Community 368"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 369 - "Community 369"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 369 - "Community 369"
+### Community 370 - "Community 370"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 370 - "Community 370"
+### Community 371 - "Community 371"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 371 - "Community 371"
+### Community 372 - "Community 372"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 372 - "Community 372"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 373 - "Community 373"
 Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 374 - "Community 374"
 Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
 ### Community 375 - "Community 375"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 376 - "Community 376"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 376 - "Community 376"
+### Community 377 - "Community 377"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 377 - "Community 377"
+### Community 378 - "Community 378"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 378 - "Community 378"
+### Community 379 - "Community 379"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 379 - "Community 379"
+### Community 380 - "Community 380"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 380 - "Community 380"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 381 - "Community 381"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 382 - "Community 382"
 Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 383 - "Community 383"
 Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
 ### Community 384 - "Community 384"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
 ### Community 385 - "Community 385"
-Cohesion: 0.7
-Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
-
-### Community 386 - "Community 386"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 386 - "Community 386"
+Cohesion: 0.7
+Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 387 - "Community 387"
 Cohesion: 0.4
@@ -3626,120 +3628,120 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 390 - "Community 390"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 391 - "Community 391"
 Cohesion: 0.5
-Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 392 - "Community 392"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
 ### Community 393 - "Community 393"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 394 - "Community 394"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 395 - "Community 395"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 396 - "Community 396"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 397 - "Community 397"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 397 - "Community 397"
+### Community 398 - "Community 398"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 398 - "Community 398"
+### Community 399 - "Community 399"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 399 - "Community 399"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 400 - "Community 400"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 401 - "Community 401"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 402 - "Community 402"
-Cohesion: 0.6
-Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
-
-### Community 403 - "Community 403"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 403 - "Community 403"
+Cohesion: 0.6
+Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
+
 ### Community 404 - "Community 404"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 405 - "Community 405"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 405 - "Community 405"
+### Community 406 - "Community 406"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 406 - "Community 406"
+### Community 407 - "Community 407"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 407 - "Community 407"
+### Community 408 - "Community 408"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 408 - "Community 408"
+### Community 409 - "Community 409"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 409 - "Community 409"
+### Community 410 - "Community 410"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 410 - "Community 410"
+### Community 411 - "Community 411"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 411 - "Community 411"
+### Community 412 - "Community 412"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 412 - "Community 412"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 413 - "Community 413"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 414 - "Community 414"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
-
-### Community 415 - "Community 415"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 415 - "Community 415"
+Cohesion: 0.67
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 416 - "Community 416"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 417 - "Community 417"
-Cohesion: 0.67
-Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
-
-### Community 418 - "Community 418"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 418 - "Community 418"
+Cohesion: 0.67
+Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
 ### Community 419 - "Community 419"
 Cohesion: 0.5
@@ -3758,96 +3760,96 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 423 - "Community 423"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 424 - "Community 424"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 424 - "Community 424"
+### Community 425 - "Community 425"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 425 - "Community 425"
+### Community 426 - "Community 426"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 426 - "Community 426"
+### Community 427 - "Community 427"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 427 - "Community 427"
+### Community 428 - "Community 428"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 428 - "Community 428"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 429 - "Community 429"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 430 - "Community 430"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 431 - "Community 431"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 432 - "Community 432"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 432 - "Community 432"
+### Community 433 - "Community 433"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 433 - "Community 433"
+### Community 434 - "Community 434"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 434 - "Community 434"
+### Community 435 - "Community 435"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 435 - "Community 435"
+### Community 436 - "Community 436"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 436 - "Community 436"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 437 - "Community 437"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 438 - "Community 438"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 439 - "Community 439"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 440 - "Community 440"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 441 - "Community 441"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 442 - "Community 442"
 Cohesion: 0.67
 Nodes (2): buildCtx(), buildQueryCtx()
 
-### Community 442 - "Community 442"
+### Community 443 - "Community 443"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 443 - "Community 443"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
 
 ### Community 444 - "Community 444"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 445 - "Community 445"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 446 - "Community 446"
 Cohesion: 0.5
@@ -3862,36 +3864,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 449 - "Community 449"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 450 - "Community 450"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 450 - "Community 450"
+### Community 451 - "Community 451"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 451 - "Community 451"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 452 - "Community 452"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 453 - "Community 453"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 454 - "Community 454"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 455 - "Community 455"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 456 - "Community 456"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 457 - "Community 457"
 Cohesion: 0.5
@@ -3902,24 +3904,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 459 - "Community 459"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 460 - "Community 460"
 Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 461 - "Community 461"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 462 - "Community 462"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 463 - "Community 463"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 464 - "Community 464"
 Cohesion: 0.5
@@ -3950,12 +3952,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 471 - "Community 471"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
-
-### Community 472 - "Community 472"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 472 - "Community 472"
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 473 - "Community 473"
 Cohesion: 0.5
@@ -3966,12 +3968,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 475 - "Community 475"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 476 - "Community 476"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 476 - "Community 476"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 477 - "Community 477"
 Cohesion: 0.5
@@ -3982,124 +3984,124 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 479 - "Community 479"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 480 - "Community 480"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 480 - "Community 480"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 481 - "Community 481"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 482 - "Community 482"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 483 - "Community 483"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 484 - "Community 484"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 485 - "Community 485"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 486 - "Community 486"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 486 - "Community 486"
+### Community 487 - "Community 487"
 Cohesion: 0.67
 Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
-### Community 487 - "Community 487"
+### Community 488 - "Community 488"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 488 - "Community 488"
+### Community 489 - "Community 489"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 489 - "Community 489"
+### Community 490 - "Community 490"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 490 - "Community 490"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 491 - "Community 491"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 492 - "Community 492"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 493 - "Community 493"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 494 - "Community 494"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 495 - "Community 495"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 495 - "Community 495"
+### Community 496 - "Community 496"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 496 - "Community 496"
+### Community 497 - "Community 497"
 Cohesion: 0.83
 Nodes (3): completedEvent(), event(), item()
 
-### Community 497 - "Community 497"
+### Community 498 - "Community 498"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 498 - "Community 498"
+### Community 499 - "Community 499"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 499 - "Community 499"
+### Community 500 - "Community 500"
 Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
-### Community 500 - "Community 500"
+### Community 501 - "Community 501"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
-
-### Community 501 - "Community 501"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 502 - "Community 502"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 503 - "Community 503"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 504 - "Community 504"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 504 - "Community 504"
+### Community 505 - "Community 505"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 505 - "Community 505"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 506 - "Community 506"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 507 - "Community 507"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 508 - "Community 508"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 509 - "Community 509"
 Cohesion: 0.5
@@ -4130,63 +4132,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 516 - "Community 516"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 517 - "Community 517"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 518 - "Community 518"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 519 - "Community 519"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 519 - "Community 519"
+### Community 520 - "Community 520"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 520 - "Community 520"
+### Community 521 - "Community 521"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 521 - "Community 521"
+### Community 522 - "Community 522"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 522 - "Community 522"
+### Community 523 - "Community 523"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 523 - "Community 523"
+### Community 524 - "Community 524"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 524 - "Community 524"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 525 - "Community 525"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 526 - "Community 526"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 527 - "Community 527"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 527 - "Community 527"
+### Community 528 - "Community 528"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 528 - "Community 528"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 529 - "Community 529"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 530 - "Community 530"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 531 - "Community 531"
@@ -4198,12 +4200,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 533 - "Community 533"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 534 - "Community 534"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 534 - "Community 534"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 535 - "Community 535"
 Cohesion: 0.67
@@ -4258,28 +4260,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 548 - "Community 548"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 549 - "Community 549"
 Cohesion: 1.0
 Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
-### Community 549 - "Community 549"
+### Community 550 - "Community 550"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 550 - "Community 550"
+### Community 551 - "Community 551"
 Cohesion: 1.0
 Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
-### Community 551 - "Community 551"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 552 - "Community 552"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 553 - "Community 553"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 554 - "Community 554"
 Cohesion: 0.67
@@ -4294,12 +4296,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 557 - "Community 557"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 558 - "Community 558"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 558 - "Community 558"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 559 - "Community 559"
 Cohesion: 0.67
@@ -4322,12 +4324,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 564 - "Community 564"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 565 - "Community 565"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 565 - "Community 565"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 566 - "Community 566"
 Cohesion: 0.67
@@ -4342,12 +4344,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 569 - "Community 569"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
-
-### Community 570 - "Community 570"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 570 - "Community 570"
+Cohesion: 1.0
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 571 - "Community 571"
 Cohesion: 0.67
@@ -4358,28 +4360,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 573 - "Community 573"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 574 - "Community 574"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 575 - "Community 575"
 Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 576 - "Community 576"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 577 - "Community 577"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 578 - "Community 578"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 578 - "Community 578"
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 579 - "Community 579"
 Cohesion: 0.67
@@ -4387,11 +4389,11 @@ Nodes (0):
 
 ### Community 580 - "Community 580"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 581 - "Community 581"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 582 - "Community 582"
 Cohesion: 0.67
@@ -4406,12 +4408,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 585 - "Community 585"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 586 - "Community 586"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 586 - "Community 586"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 587 - "Community 587"
 Cohesion: 0.67
@@ -4430,40 +4432,40 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 591 - "Community 591"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 592 - "Community 592"
 Cohesion: 1.0
 Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
-### Community 592 - "Community 592"
-Cohesion: 0.67
-Nodes (1): FadeIn()
-
 ### Community 593 - "Community 593"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 594 - "Community 594"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 595 - "Community 595"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 596 - "Community 596"
 Cohesion: 1.0
 Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
-### Community 596 - "Community 596"
+### Community 597 - "Community 597"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 597 - "Community 597"
+### Community 598 - "Community 598"
 Cohesion: 0.67
 Nodes (1): VideoPlayer()
 
-### Community 598 - "Community 598"
+### Community 599 - "Community 599"
 Cohesion: 1.0
 Nodes (2): handleRefundOrder(), toast()
-
-### Community 599 - "Community 599"
-Cohesion: 0.67
-Nodes (0):
 
 ### Community 600 - "Community 600"
 Cohesion: 0.67
@@ -4474,16 +4476,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 602 - "Community 602"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 603 - "Community 603"
 Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 604 - "Community 604"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 605 - "Community 605"
 Cohesion: 0.67
@@ -4518,12 +4520,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 613 - "Community 613"
-Cohesion: 1.0
-Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
-
-### Community 614 - "Community 614"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 614 - "Community 614"
+Cohesion: 1.0
+Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
 
 ### Community 615 - "Community 615"
 Cohesion: 0.67
@@ -4543,79 +4545,79 @@ Nodes (0):
 
 ### Community 619 - "Community 619"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 620 - "Community 620"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 621 - "Community 621"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 622 - "Community 622"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 623 - "Community 623"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 624 - "Community 624"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 625 - "Community 625"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 626 - "Community 626"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 627 - "Community 627"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 627 - "Community 627"
+### Community 628 - "Community 628"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 628 - "Community 628"
+### Community 629 - "Community 629"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 629 - "Community 629"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 630 - "Community 630"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 631 - "Community 631"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 632 - "Community 632"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 633 - "Community 633"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 634 - "Community 634"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 635 - "Community 635"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 636 - "Community 636"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 637 - "Community 637"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 638 - "Community 638"
 Cohesion: 0.67
@@ -4651,11 +4653,11 @@ Nodes (0):
 
 ### Community 646 - "Community 646"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 647 - "Community 647"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 648 - "Community 648"
 Cohesion: 0.67
@@ -4682,44 +4684,44 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 654 - "Community 654"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 655 - "Community 655"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 655 - "Community 655"
+### Community 656 - "Community 656"
 Cohesion: 0.67
 Nodes (1): isInMaintenanceMode()
 
-### Community 656 - "Community 656"
+### Community 657 - "Community 657"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 657 - "Community 657"
+### Community 658 - "Community 658"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 658 - "Community 658"
+### Community 659 - "Community 659"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 659 - "Community 659"
-Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 660 - "Community 660"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 661 - "Community 661"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 662 - "Community 662"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 663 - "Community 663"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 663 - "Community 663"
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 664 - "Community 664"
 Cohesion: 0.67
@@ -4746,76 +4748,76 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 670 - "Community 670"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 671 - "Community 671"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 672 - "Community 672"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 673 - "Community 673"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 674 - "Community 674"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 675 - "Community 675"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 676 - "Community 676"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 677 - "Community 677"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 678 - "Community 678"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 679 - "Community 679"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 680 - "Community 680"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 681 - "Community 681"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 682 - "Community 682"
 Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 683 - "Community 683"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 684 - "Community 684"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 685 - "Community 685"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 686 - "Community 686"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 687 - "Community 687"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 688 - "Community 688"
 Cohesion: 0.67
@@ -4830,12 +4832,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 691 - "Community 691"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 692 - "Community 692"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 692 - "Community 692"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 693 - "Community 693"
 Cohesion: 0.67
@@ -4846,12 +4848,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 695 - "Community 695"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 696 - "Community 696"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 696 - "Community 696"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 697 - "Community 697"
 Cohesion: 0.67
@@ -4918,16 +4920,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 713 - "Community 713"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 714 - "Community 714"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 715 - "Community 715"
+### Community 714 - "Community 714"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 715 - "Community 715"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 716 - "Community 716"
 Cohesion: 1.0
@@ -4942,20 +4944,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 719 - "Community 719"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 720 - "Community 720"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 721 - "Community 721"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 722 - "Community 722"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 723 - "Community 723"
 Cohesion: 1.0
@@ -6087,11 +6089,11 @@ Nodes (0):
 
 ### Community 1005 - "Community 1005"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1006 - "Community 1006"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1007 - "Community 1007"
 Cohesion: 1.0
@@ -10177,376 +10179,384 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2028 - "Community 2028"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2029 - "Community 2029"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 722`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 723`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 724`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 725`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 726`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 727`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 728`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 729`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 730`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 731`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 732`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 733`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 734`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 735`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 736`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 737`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 738`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 739`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 740`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 741`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 742`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 743`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 744`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 745`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `createMutationCtx()`, `catalogImport.test.ts`
+- **Thin community `Community 746`** (2 nodes): `createMutationCtx()`, `catalogImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 747`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 748`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 749`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 750`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 751`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 752`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 753`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 754`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 755`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 756`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 757`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 758`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 759`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 760`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 761`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 762`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 763`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 764`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 765`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 766`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 767`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 768`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 769`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 770`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 771`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 772`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 773`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 774`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 775`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `resolveTerminalCloudRepair.ts`, `resolveTerminalCloudRepair()`
+- **Thin community `Community 776`** (2 nodes): `resolveTerminalCloudRepair.ts`, `resolveTerminalCloudRepair()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 777`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 778`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 779`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 780`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 781`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 782`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 783`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 784`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 785`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 786`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 787`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 788`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 789`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 790`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 791`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 792`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 793`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 794`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 795`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 796`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 797`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 798`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 799`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 800`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 801`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 802`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 803`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 804`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 805`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 806`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 807`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 808`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 809`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 810`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 811`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 812`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 813`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 814`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 815`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 816`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 817`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 818`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 819`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 820`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 821`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 822`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 823`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 824`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 825`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 826`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 827`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 828`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 829`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 830`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 831`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 832`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 833`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 834`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 835`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 836`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 837`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 838`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 839`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 840`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 841`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 842`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 843`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 844`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 845`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 846`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 847`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 848`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 849`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 850`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 851`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 852`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 853`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 854`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 855`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 856`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 857`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 858`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 859`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 860`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 861`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 862`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 863`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 864`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 865`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 866`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 867`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `PickerHarness()`, `HomepageProductPickerDialog.test.tsx`
+- **Thin community `Community 868`** (2 nodes): `PickerHarness()`, `HomepageProductPickerDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 869`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 870`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 871`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 872`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 873`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 874`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 875`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 876`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 877`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 878`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 879`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 880`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 881`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 882`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 883`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 884`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 885`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 886`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 887`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 888`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 889`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 890`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
+- **Thin community `Community 891`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 892`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 893`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 894`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 895`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 896`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 897`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 898`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 899`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 900`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 901`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 902`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 903`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 904`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
+- **Thin community `Community 905`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 906`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -10582,2249 +10592,2251 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 907`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 908`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 909`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 910`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 911`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 912`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 913`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 914`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 915`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 916`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
+- **Thin community `Community 917`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 918`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 919`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 920`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 921`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 922`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 923`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 924`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 925`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 926`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 927`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 928`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 929`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 930`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 931`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 932`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 933`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 934`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 935`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 936`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 937`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 938`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 939`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 940`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 941`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 942`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 943`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 944`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 945`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 946`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 947`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 948`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 949`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 950`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 951`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 952`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 953`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 954`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 955`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 956`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 957`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 958`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 959`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 960`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 961`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 962`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 963`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 964`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 965`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 966`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 967`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 968`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 969`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 970`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 971`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 972`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 973`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 974`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 975`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 976`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 977`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 978`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 979`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 980`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 981`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 982`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 983`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 984`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 985`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 986`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 987`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 988`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 989`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 990`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 991`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 992`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 993`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 994`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 995`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 996`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 997`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 998`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 999`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1000`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1001`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1002`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1003`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1004`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1005`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1006`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1007`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1008`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1009`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1010`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1011`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1012`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 1013`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1014`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1015`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1016`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1017`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1018`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1019`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1020`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1021`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1022`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1023`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1024`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
+- **Thin community `Community 1025`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1026`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1027`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1028`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1029`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
+- **Thin community `Community 1030`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1031`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1032`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1033`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1034`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1035`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1036`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1037`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1038`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1039`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1040`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1041`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1042`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1043`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1044`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1045`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1046`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1047`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1048`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1049`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1050`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1051`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1052`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1053`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 1054`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 1055`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1056`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1057`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1058`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1059`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1060`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1061`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1062`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1063`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1064`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1065`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1066`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1067`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1068`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1069`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1070`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1071`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1072`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1073`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1074`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1075`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1076`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1077`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1078`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1079`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1080`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1081`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1082`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1083`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1084`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1085`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1086`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1087`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1088`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1089`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1090`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1091`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1092`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1093`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1094`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1095`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1096`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1097`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1098`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1099`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1100`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1101`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1102`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1103`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1104`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1105`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1106`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1107`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1108`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1109`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1110`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1111`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1112`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1113`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1114`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1115`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1116`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1117`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1118`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1119`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1120`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1121`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1122`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1123`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1124`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1125`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1126`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1127`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1128`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1129`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1130`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1131`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1132`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1133`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1134`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1135`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1136`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1137`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1138`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1139`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1140`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1141`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1142`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1143`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1144`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1145`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1146`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1147`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1148`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1149`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1150`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1151`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1152`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1153`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1154`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1155`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1156`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1157`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1158`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1159`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1160`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1161`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1162`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1163`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1164`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1165`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1166`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1167`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1168`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1169`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1170`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1171`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1172`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1173`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1174`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1175`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1176`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1177`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1178`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1179`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1180`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1181`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1182`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1183`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1184`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1185`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1186`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1187`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1188`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1189`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1190`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1191`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1192`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1193`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `runGit()`, `pr-athena-delivery-run.test.ts`
+- **Thin community `Community 1194`** (2 nodes): `runGit()`, `pr-athena-delivery-run.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1195`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1196`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `api.js`
+- **Thin community `Community 1197`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1198`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1199`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `server.js`
+- **Thin community `Community 1200`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `app.ts`
+- **Thin community `Community 1201`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1202`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1203`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1204`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1205`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `auth.ts`
+- **Thin community `Community 1206`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1207`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1208`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1209`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `countries.ts`
+- **Thin community `Community 1210`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `email.ts`
+- **Thin community `Community 1211`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1212`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `payment.ts`
+- **Thin community `Community 1213`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `contextEvents.test.ts`
+- **Thin community `Community 1214`** (1 nodes): `contextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1215`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `types.ts`
+- **Thin community `Community 1216`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1217`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `crons.ts`
+- **Thin community `Community 1218`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1219`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `internal.ts`
+- **Thin community `Community 1220`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1221`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1222`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1223`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1224`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1225`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1226`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1227`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1228`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1229`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1230`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1231`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `env.ts`
+- **Thin community `Community 1232`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1233`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `auth.ts`
+- **Thin community `Community 1234`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1235`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `colors.ts`
+- **Thin community `Community 1236`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `index.ts`
+- **Thin community `Community 1237`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1238`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `products.ts`
+- **Thin community `Community 1239`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1240`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `stores.ts`
+- **Thin community `Community 1241`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1242`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `bag.ts`
+- **Thin community `Community 1243`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `guest.ts`
+- **Thin community `Community 1244`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1245`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `index.ts`
+- **Thin community `Community 1246`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `me.ts`
+- **Thin community `Community 1247`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `offers.ts`
+- **Thin community `Community 1248`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1249`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1250`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1251`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1252`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1253`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1254`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1255`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1256`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1257`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `user.ts`
+- **Thin community `Community 1258`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1259`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `index.ts`
+- **Thin community `Community 1260`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1261`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `http.ts`
+- **Thin community `Community 1262`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `access.ts`
+- **Thin community `Community 1263`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1264`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1265`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1266`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `index.ts`
+- **Thin community `Community 1267`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1268`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `types.ts`
+- **Thin community `Community 1269`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1270`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `categories.ts`
+- **Thin community `Community 1271`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `colors.ts`
+- **Thin community `Community 1272`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1273`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1274`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1275`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1276`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `pos.ts`
+- **Thin community `Community 1277`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1278`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1279`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1280`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1281`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1282`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1283`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1284`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1285`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1286`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1287`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1288`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1289`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1290`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1291`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1292`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1293`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `types.ts`
+- **Thin community `Community 1294`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1295`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1296`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1297`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1298`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1299`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1300`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `dto.ts`
+- **Thin community `Community 1301`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1302`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1303`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `searchCatalog.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `types.ts`
+- **Thin community `Community 1304`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1305`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1306`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1307`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1308`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `customers.ts`
+- **Thin community `Community 1309`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `register.ts`
+- **Thin community `Community 1310`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `sync.ts`
+- **Thin community `Community 1311`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1312`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1313`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1314`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `schema.ts`
+- **Thin community `Community 1315`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `automation.ts`
+- **Thin community `Community 1316`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1317`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1318`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `index.ts`
+- **Thin community `Community 1319`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1320`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1321`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1322`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1323`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1324`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1325`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `category.ts`
+- **Thin community `Community 1326`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `color.ts`
+- **Thin community `Community 1327`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1328`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1329`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `index.ts`
+- **Thin community `Community 1330`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1331`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1332`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1333`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1334`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `organization.ts`
+- **Thin community `Community 1335`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1336`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `product.ts`
+- **Thin community `Community 1337`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1338`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1339`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `store.ts`
+- **Thin community `Community 1340`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1341`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `index.ts`
+- **Thin community `Community 1342`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1343`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1344`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1345`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1346`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1347`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1348`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1349`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `index.ts`
+- **Thin community `Community 1350`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1351`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1352`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1353`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1354`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1355`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1356`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1357`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1358`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1359`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1360`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1361`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `customer.ts`
+- **Thin community `Community 1362`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1363`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1364`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1365`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1366`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `index.ts`
+- **Thin community `Community 1367`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1368`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1369`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1370`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1371`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1372`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1373`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1374`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1375`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1376`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1377`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1378`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1379`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1380`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1381`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1382`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1383`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1384`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1385`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1386`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `index.ts`
+- **Thin community `Community 1387`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1388`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1389`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `index.ts`
+- **Thin community `Community 1390`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1391`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1392`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1393`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1394`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1395`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1396`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `index.ts`
+- **Thin community `Community 1397`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1398`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1399`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1400`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1401`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1402`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1403`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `bag.ts`
+- **Thin community `Community 1404`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1405`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1406`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1407`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `guest.ts`
+- **Thin community `Community 1408`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `index.ts`
+- **Thin community `Community 1409`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `offer.ts`
+- **Thin community `Community 1410`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1411`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1412`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `review.ts`
+- **Thin community `Community 1413`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1414`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1415`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1416`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1417`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1418`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1419`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1420`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1421`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1422`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `bag.ts`
+- **Thin community `Community 1423`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1424`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `customer.ts`
+- **Thin community `Community 1425`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `guest.ts`
+- **Thin community `Community 1426`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1427`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1428`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1429`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1430`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1431`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1432`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1433`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `users.ts`
+- **Thin community `Community 1434`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `payment.ts`
+- **Thin community `Community 1435`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1436`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1437`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1438`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1439`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1440`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1441`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1442`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `index.ts`
+- **Thin community `Community 1443`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1444`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1445`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1446`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1447`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `auth.ts`
+- **Thin community `Community 1448`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1449`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1450`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1451`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1452`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1453`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1454`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1455`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `index.ts`
+- **Thin community `Community 1456`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1457`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1458`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1459`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1460`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1461`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1462`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1463`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1464`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1465`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1466`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1467`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1468`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1469`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1470`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1471`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1472`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1473`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1474`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `constants.ts`
+- **Thin community `Community 1475`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1476`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1477`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1478`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `types.ts`
+- **Thin community `Community 1479`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1480`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1481`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1482`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1483`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1484`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1485`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1486`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1487`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1488`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1489`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1490`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1491`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1492`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1493`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1494`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1495`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1496`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1497`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1498`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1499`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `constants.ts`
+- **Thin community `Community 1500`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1501`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1502`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1503`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `data.ts`
+- **Thin community `Community 1504`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1505`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1506`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1507`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1508`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1509`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1510`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1511`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1512`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1513`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `constants.ts`
+- **Thin community `Community 1514`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1515`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1516`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1517`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `data.ts`
+- **Thin community `Community 1518`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1519`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1520`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1521`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1522`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1523`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1524`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1525`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1526`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1527`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1528`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1529`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1530`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `constants.ts`
+- **Thin community `Community 1531`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1532`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1533`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1534`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1535`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1536`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1537`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1538`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1539`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1540`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1541`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1542`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1543`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1544`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1545`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1546`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1547`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1548`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1549`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1550`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1551`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1552`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1553`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1554`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1555`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1556`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1557`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1558`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1559`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1560`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1561`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1562`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1563`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1564`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1565`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `constants.ts`
+- **Thin community `Community 1566`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1567`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1568`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1569`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `data.ts`
+- **Thin community `Community 1570`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1571`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1572`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `constants.ts`
+- **Thin community `Community 1573`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1574`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1575`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1576`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1577`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `data.ts`
+- **Thin community `Community 1578`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1579`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `constants.ts`
+- **Thin community `Community 1580`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1581`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1582`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1583`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1584`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `data.ts`
+- **Thin community `Community 1585`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1586`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1587`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1588`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1589`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1590`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1591`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1592`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1593`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1594`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1595`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1596`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1597`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1598`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1599`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1600`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1601`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1602`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1603`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1604`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1605`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1606`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1607`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1608`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1609`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1610`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1611`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1612`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1613`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `types.ts`
+- **Thin community `Community 1614`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1615`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1616`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1617`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1618`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1619`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1620`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1621`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1622`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1623`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1624`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1625`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1626`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1627`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1628`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1629`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1630`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1631`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `data.ts`
+- **Thin community `Community 1632`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1633`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1634`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1635`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1636`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1637`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1638`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1639`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1640`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1641`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1642`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1643`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1644`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `constants.ts`
+- **Thin community `Community 1645`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1646`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1647`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1648`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `data.ts`
+- **Thin community `Community 1649`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `types.ts`
+- **Thin community `Community 1650`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1651`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1652`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1653`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1654`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1655`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `index.ts`
+- **Thin community `Community 1656`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1657`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1658`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1659`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1660`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `index.tsx`
+- **Thin community `Community 1661`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1662`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1663`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1664`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1665`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1666`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1667`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1668`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1669`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `index.tsx`
+- **Thin community `Community 1670`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1671`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1672`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1673`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `button.tsx`
+- **Thin community `Community 1674`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1675`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `card.tsx`
+- **Thin community `Community 1676`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1677`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1678`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `command.tsx`
+- **Thin community `Community 1679`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1680`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1681`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1682`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `form.tsx`
+- **Thin community `Community 1683`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1684`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1685`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `input.tsx`
+- **Thin community `Community 1686`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1687`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1688`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1689`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1690`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1691`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1692`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `select.tsx`
+- **Thin community `Community 1693`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1694`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1695`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1696`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1697`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `table.tsx`
+- **Thin community `Community 1698`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1699`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1700`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1701`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1702`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1703`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1704`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1705`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1706`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `constants.ts`
+- **Thin community `Community 1707`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1708`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1709`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1710`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `data.ts`
+- **Thin community `Community 1711`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1712`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1713`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1714`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1715`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1716`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1717`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1718`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1719`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1720`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1721`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `index.ts`
+- **Thin community `Community 1722`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1723`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1724`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1725`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 1726`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1727`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1728`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1729`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1730`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1731`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1732`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1733`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1734`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 1735`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 1736`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `index.ts`
+- **Thin community `Community 1737`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 1738`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1739`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 1740`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 1741`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `aws.ts`
+- **Thin community `Community 1742`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `constants.ts`
+- **Thin community `Community 1743`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `countries.ts`
+- **Thin community `Community 1744`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1745`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1746`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1747`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1748`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1749`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1750`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1751`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `dto.ts`
+- **Thin community `Community 1752`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `ports.ts`
+- **Thin community `Community 1753`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `constants.ts`
+- **Thin community `Community 1754`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1755`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1756`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `index.ts`
+- **Thin community `Community 1757`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1758`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `types.ts`
+- **Thin community `Community 1759`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1760`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1761`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1762`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1763`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1764`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1765`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1766`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1767`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1768`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 1769`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 1770`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 1771`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 1772`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1773`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1774`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1775`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1776`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `index.ts`
+- **Thin community `Community 1777`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1778`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `category.ts`
+- **Thin community `Community 1779`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `product.ts`
+- **Thin community `Community 1780`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `store.ts`
+- **Thin community `Community 1781`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1782`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `user.ts`
+- **Thin community `Community 1783`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1784`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1785`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1786`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1787`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1788`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `main.tsx`
+- **Thin community `Community 1789`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 1790`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1791`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1792`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1793`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1794`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1795`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `index.tsx`
+- **Thin community `Community 1796`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `index.tsx`
+- **Thin community `Community 1797`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1798`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1799`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1800`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1801`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1802`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1803`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `index.tsx`
+- **Thin community `Community 1804`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1805`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1806`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1807`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `home.tsx`
+- **Thin community `Community 1808`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1809`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1810`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1811`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `index.tsx`
+- **Thin community `Community 1812`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `review.tsx`
+- **Thin community `Community 1813`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1814`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1815`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `index.tsx`
+- **Thin community `Community 1816`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1817`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1818`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1819`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `index.tsx`
+- **Thin community `Community 1820`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1821`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1822`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1823`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1824`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1825`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1826`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `index.tsx`
+- **Thin community `Community 1827`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1828`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1829`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1830`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1831`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1832`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1833`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1834`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1835`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1836`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `index.tsx`
+- **Thin community `Community 1837`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1838`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1839`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `new.tsx`
+- **Thin community `Community 1840`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1841`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1842`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1843`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1844`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `index.tsx`
+- **Thin community `Community 1845`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `new.tsx`
+- **Thin community `Community 1846`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1847`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1848`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1849`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1850`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1851`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `index.tsx`
+- **Thin community `Community 1852`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1853`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1854`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1855`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `index.tsx`
+- **Thin community `Community 1856`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1857`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1858`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1859`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1860`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1861`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1862`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1863`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 1864`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1865`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1866`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1867`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1868`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1869`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1870`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1871`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1872`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1873`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1874`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1875`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1876`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1877`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1878`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1879`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1880`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `setup.ts`
+- **Thin community `Community 1881`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1882`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `types.ts`
+- **Thin community `Community 1883`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1884`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1885`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1886`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1887`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1888`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1889`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1890`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `types.ts`
+- **Thin community `Community 1891`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1892`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1893`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1894`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1895`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1896`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1897`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1898`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1899`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `schema.ts`
+- **Thin community `Community 1900`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1901`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1902`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1903`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1904`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1905`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1906`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1907`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1908`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1909`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `types.ts`
+- **Thin community `Community 1910`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1911`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1912`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1913`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1914`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1915`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1916`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1917`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `constants.ts`
+- **Thin community `Community 1918`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1919`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `About.tsx`
+- **Thin community `Community 1920`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1921`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1922`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1923`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1924`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1925`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1926`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1927`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1928`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1929`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1930`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `types.ts`
+- **Thin community `Community 1931`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1932`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1933`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1934`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1935`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1936`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1937`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1938`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1939`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1940`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1941`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1942`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `button.tsx`
+- **Thin community `Community 1943`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `card.tsx`
+- **Thin community `Community 1944`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1945`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `command.tsx`
+- **Thin community `Community 1946`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1947`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1948`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1949`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `form.tsx`
+- **Thin community `Community 1950`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1951`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1952`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1953`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1954`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `input.tsx`
+- **Thin community `Community 1955`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `label.tsx`
+- **Thin community `Community 1956`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1957`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1958`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1959`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `index.ts`
+- **Thin community `Community 1960`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `types.ts`
+- **Thin community `Community 1961`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1962`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1963`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1964`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1965`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `select.tsx`
+- **Thin community `Community 1966`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1967`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1968`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `table.tsx`
+- **Thin community `Community 1969`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1970`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1971`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1972`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1973`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1974`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `config.ts`
+- **Thin community `Community 1975`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 1976`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1977`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1978`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1979`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1980`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `constants.ts`
+- **Thin community `Community 1981`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `countries.ts`
+- **Thin community `Community 1982`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1983`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1984`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1985`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1986`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `index.ts`
+- **Thin community `Community 1987`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1988`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `store.ts`
+- **Thin community `Community 1989`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `bag.ts`
+- **Thin community `Community 1990`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1991`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `category.ts`
+- **Thin community `Community 1992`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `organization.ts`
+- **Thin community `Community 1993`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `product.ts`
+- **Thin community `Community 1994`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `store.ts`
+- **Thin community `Community 1995`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1996`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `user.ts`
+- **Thin community `Community 1997`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `states.ts`
+- **Thin community `Community 1998`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 1999`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2000`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2001`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2002`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2003`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2004`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2005`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2006`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `index.tsx`
+- **Thin community `Community 2007`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2008`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2009`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2010`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2011`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2012`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2013`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2014`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `index.tsx`
+- **Thin community `Community 2015`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2016`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2017`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2018`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2019`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2020`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `index.js`
+- **Thin community `Community 2021`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2022`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2023`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2024`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2025`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2026`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2027`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2028`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2029`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -12839,8 +12851,8 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**
-  _Cohesion score 0.07 - nodes in this community are weakly interconnected._
-- **Should `Community 4` be split into smaller, more focused modules?**
   _Cohesion score 0.1 - nodes in this community are weakly interconnected._
+- **Should `Community 4` be split into smaller, more focused modules?**
+  _Cohesion score 0.07 - nodes in this community are weakly interconnected._
 - **Should `Community 5` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,17 +7,17 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2100
-- Graph nodes: 7815
-- Graph edges: 9139
-- Communities: 2028
+- Code files discovered: 2102
+- Graph nodes: 7833
+- Graph edges: 9164
+- Communities: 2030
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (89 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `harness-inferential-review.ts` (85 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `dailyClose.ts` (74 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `dailyOperations.ts` (59 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `projectLocalEvents.ts` (57 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `projectLocalEvents.ts` (60 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `dailyOperations.ts` (59 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 - `terminalHealthPresentation.ts` (53 edges, Community 6) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `posLocalStore.ts` (48 edges, Community 7) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -19,8 +19,8 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 ## Graph Hotspots
 - `DailyCloseView.tsx` (89 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (74 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `dailyOperations.ts` (59 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `projectLocalEvents.ts` (57 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `projectLocalEvents.ts` (60 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `dailyOperations.ts` (59 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 
 ## Navigation

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (15 edges, Community 88) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 180) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 181) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 88) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (4 edges, Community 88) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (4 edges, Community 88) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/cashControls/deposits.test.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.test.ts
@@ -713,6 +713,80 @@ describe("cash control deposits", () => {
     );
   });
 
+  it("hides duplicate closeout shadows while the variance closeout review is open", async () => {
+    const ctx = createQueryCtx({
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_variance",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_closeout",
+          sequence: 2,
+          conflictType: "permission",
+          status: "needs_review",
+          summary:
+            "Register closeout variance requires manager review before synced closeout can be applied.",
+          details: {
+            countedCash: 20000,
+            expectedCash: 23000,
+            variance: -3000,
+          },
+          createdAt: 1,
+        },
+        {
+          _id: "sync_conflict_duplicate",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_closeout",
+          sequence: 2,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Register session is not open for synced POS closeout.",
+          details: {
+            localRegisterSessionId: "local-register-1",
+            status: "closing",
+          },
+          createdAt: 2,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "sync_mapping_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "registerSession",
+          cloudId: "session_closing",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_closing",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+        },
+      ],
+    });
+
+    await expect(
+      listOpenLocalSyncConflictsByRegisterSession(
+        ctx as never,
+        "store_1" as Id<"store">,
+      ),
+    ).resolves.toEqual(
+      new Map([
+        [
+          "session_closing",
+          [expect.objectContaining({ _id: "sync_conflict_variance" })],
+        ],
+      ]),
+    );
+  });
+
   it("excludes resolved sync conflicts from register-session reconciliation", async () => {
     const ctx = createQueryCtx({
       posLocalSyncConflict: [
@@ -3501,6 +3575,150 @@ describe("cash control deposits", () => {
         }),
       ]),
     );
+  });
+
+  it("reopens drawers left closing by rejected variance closeout reviews", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      operationalEvent: [],
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_closeout",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_closeout",
+          sequence: 2,
+          conflictType: "permission",
+          status: "needs_review",
+          summary:
+            "Register closeout variance requires manager review before synced closeout can be applied.",
+          details: {
+            countedCash: 45000,
+            expectedCash: 50000,
+            notes: "cash count issue",
+            variance: -5000,
+          },
+          createdAt: 1,
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_closeout",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_closeout",
+          sequence: 2,
+          eventType: "register_closed",
+          occurredAt: 2,
+          staffProfileId: "staff_1",
+          payload: {
+            countedCash: 45000,
+            notes: "cash count issue",
+          },
+          status: "conflicted",
+          submittedAt: 4,
+          acceptedAt: 4,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "sync_mapping_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "registerSession",
+          cloudId: "session_open",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_open",
+          closeoutRecords: [],
+          countedCash: 45000,
+          expectedCash: 50000,
+          notes: "cash count issue",
+          openedAt: 1,
+          openingFloat: 50000,
+          organizationId: "org_1",
+          registerNumber: "1",
+          status: "closing",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          variance: -5000,
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "manager_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "staff_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      staffRoleAssignment: [
+        {
+          _id: "role_1",
+          organizationId: "org_1",
+          role: "manager",
+          staffProfileId: "manager_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+    });
+
+    const result = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        decision: "rejected",
+        registerSessionId: "session_open" as Id<"registerSession">,
+        reviewConflictIds: [
+          "sync_conflict_closeout" as Id<"posLocalSyncConflict">,
+        ],
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual(
+      ok({
+        action: "rejected",
+        projectedCount: 0,
+        registerSession: expect.objectContaining({ _id: "session_open" }),
+        resolvedCount: 1,
+      }),
+    );
+    expect(ctx.tables.get("registerSession")).toEqual([
+      expect.objectContaining({
+        _id: "session_open",
+        countedCash: undefined,
+        notes: undefined,
+        status: "active",
+        variance: undefined,
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncEvent")).toEqual([
+      expect.objectContaining({
+        _id: "sync_event_closeout",
+        rejectionCode: "manager_rejected",
+        status: "rejected",
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncConflict")).toEqual([
+      expect.objectContaining({
+        _id: "sync_conflict_closeout",
+        status: "resolved",
+      }),
+    ]);
   });
 
   it("does not report success when a scoped review id is no longer present", async () => {

--- a/packages/athena-webapp/convex/cashControls/deposits.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.ts
@@ -34,7 +34,7 @@ import {
   requireOrganizationMemberRoleWithCtx,
 } from "../lib/athenaUserAuth";
 import { ok, userError, type CommandResult } from "../../shared/commandResult";
-import { isPosUsableRegisterSessionStatus } from "../../shared/registerSessionStatus";
+import { isRegisterSessionSaleUsable } from "../../shared/registerSessionLifecyclePolicy";
 import { formatStaffDisplayName } from "../../shared/staffDisplayName";
 
 export { listOpenLocalSyncConflictsByRegisterSession } from "../pos/application/sync/registerSessionSyncReview";
@@ -557,7 +557,7 @@ export function buildCashControlsDashboardSnapshot(args: {
   return {
     registerSessions: sessionSummaries,
     openSessions: sessionSummaries.filter((registerSession) =>
-      isPosUsableRegisterSessionStatus(registerSession.status),
+      isRegisterSessionSaleUsable(registerSession),
     ),
     pendingCloseouts: sessionSummaries.filter(
       (registerSession) => registerSession.status === "closing",
@@ -1129,7 +1129,7 @@ export const recordRegisterSessionDeposit = mutation({
       });
     }
 
-    if (!isPosUsableRegisterSessionStatus(registerSession.status)) {
+    if (!isRegisterSessionSaleUsable(registerSession)) {
       return userError({
         code: "precondition_failed",
         message: "Register session is not accepting new deposits.",
@@ -1381,6 +1381,14 @@ export const resolveRegisterSessionSyncReview = mutation({
         ) {
           const conflictDetails = conflict.details ?? {};
           rejectedCloseoutLocalEventIds.add(syncEvent.localEventId);
+          if (review.reviewKind === "register_closeout_variance") {
+            await ctx.db.patch("registerSession", args.registerSessionId, {
+              countedCash: undefined,
+              notes: undefined,
+              status: "active",
+              variance: undefined,
+            });
+          }
           await recordOperationalEventWithCtx(ctx, {
             ...(args.actorStaffProfileId
               ? { actorStaffProfileId: args.actorStaffProfileId }

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -7,6 +7,7 @@ import {
   completeDailyCloseForAutomationWithCtx,
   completeDailyCloseWithCtx,
   getCompletedDailyCloseHistoryDetailWithCtx,
+  getDailyCloseSnapshot,
   getDailyCloseOpeningContextWithCtx,
   listCompletedDailyCloseHistoryWithCtx,
   reopenDailyClose,
@@ -33,6 +34,11 @@ type TableName =
   | "store";
 
 type Row = Record<string, unknown> & { _id: string };
+
+function getHandler<TArgs, TResult>(definition: unknown) {
+  return (definition as { _handler: (ctx: unknown, args: TArgs) => TResult })
+    ._handler;
+}
 
 function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
   const tables = new Map<TableName, Map<string, Row>>();
@@ -1006,6 +1012,65 @@ describe("end-of-day review backend foundation", () => {
         },
       ]),
     );
+  });
+
+  it("keeps active register blocker metadata on the exported snapshot query", async () => {
+    const { db } = createDb({
+      posTerminal: [
+        {
+          _id: "terminal-1",
+          name: "Front counter terminal",
+          storeId: "store-1",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "register-open",
+          expectedCash: 10000,
+          openedAt: Date.UTC(2026, 4, 7, 10),
+          openingFloat: 10000,
+          registerNumber: "A1",
+          status: "open",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        },
+      ],
+      store: [store],
+    });
+    const handler = getHandler<
+      {
+        operatingDate: string;
+        storeId: Id<"store">;
+      },
+      Promise<Awaited<ReturnType<typeof buildDailyCloseSnapshotWithCtx>>>
+    >(getDailyCloseSnapshot);
+
+    const snapshot = await handler(
+      { db } as unknown as QueryCtx,
+      {
+        operatingDate: "2026-05-07",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(snapshot.blockers).toHaveLength(1);
+    expect(snapshot.blockers[0]).toMatchObject({
+      category: "register_session",
+      link: {
+        label: "View session",
+        params: { sessionId: "register-open" },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId",
+      },
+      metadata: {
+        expectedCash: 10000,
+        openedAt: Date.UTC(2026, 4, 7, 10),
+        operatingScope: "Opened today",
+        register: "Register A1",
+        status: "open",
+        terminal: "terminal-1",
+      },
+      title: "Register session is still open",
+    });
   });
 
   it("adds explicit applied item-adjustment settlement totals without changing original sale totals", async () => {

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -3527,11 +3527,7 @@ export const getDailyCloseSnapshot = query({
     startAt: v.optional(v.number()),
     storeId: v.id("store"),
   },
-  handler: (ctx, args) =>
-    buildDailyCloseSnapshotWithCtx(ctx, {
-      ...args,
-      includeManagerReviewEvidence: false,
-    }),
+  handler: (ctx, args) => buildDailyCloseSnapshotWithCtx(ctx, args),
 });
 
 export const completeDailyClose = mutation({

--- a/packages/athena-webapp/convex/pos/application/commands/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/terminals.ts
@@ -13,7 +13,10 @@ import {
   normalizePosTerminalLoginMode,
   type PosTerminalLoginMode,
 } from "../../../../shared/posTerminalLoginMode";
-import { isPosUsableRegisterSessionStatus } from "../../../../shared/registerSessionStatus";
+import {
+  canInspectRuntimeCloudDrawerAuthority,
+  isRegisterSessionSaleUsable,
+} from "../../../../shared/registerSessionLifecyclePolicy";
 
 import {
   getTerminalByFingerprint,
@@ -560,7 +563,7 @@ async function buildRuntimeDrawerAuthorityDirective(
   if (
     !session ||
     !session.cloudRegisterSessionId ||
-    !isPosUsableRegisterSessionStatus(session.status)
+    !canInspectRuntimeCloudDrawerAuthority(session)
   ) {
     return undefined;
   }
@@ -589,7 +592,7 @@ async function buildRuntimeDrawerAuthorityDirective(
   if (
     !cloudRegisterSession ||
     cloudRegisterSession.storeId !== args.storeId ||
-    isPosUsableRegisterSessionStatus(cloudRegisterSession.status)
+    isRegisterSessionSaleUsable(cloudRegisterSession)
   ) {
     return undefined;
   }

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
@@ -5,6 +5,7 @@ import {
   type PosLocalSyncBatchInput,
 } from "./ingestLocalEvents";
 import { createConvexLocalSyncRepository } from "../../infrastructure/repositories/localSyncRepository";
+import type { Id } from "../../../_generated/dataModel";
 import { hashPosLocalStaffProofToken } from "./staffProof";
 import type {
   LocalSyncConflictRecord,
@@ -2925,6 +2926,132 @@ describe("createLocalSyncIngestionService", () => {
     });
   });
 
+  it("returns direct and mapped register-session facts for open review conflicts in the production repository", async () => {
+    const ctx = createFakeConvexCtx({
+      registerSession: [
+        {
+          _id: "register-session-1",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          status: "active",
+        },
+        {
+          _id: "register-session-2",
+          storeId: "store-2",
+          terminalId: "terminal-1",
+          status: "active",
+        },
+        {
+          _id: "register-session-3",
+          storeId: "store-1",
+          terminalId: "terminal-2",
+          status: "active",
+        },
+      ],
+      posLocalSyncConflict: [
+        {
+          _id: "conflict-1",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          localRegisterSessionId: "register-session-1",
+          localEventId: "event-closeout-1",
+          sequence: 2,
+          conflictType: "permission",
+          status: "needs_review",
+          summary:
+            "Register closeout variance requires manager review before synced closeout can be applied.",
+          details: { countedCash: 100, expectedCash: 90, variance: 10 },
+          createdAt: 100,
+        },
+        {
+          _id: "conflict-mapped",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event-closeout-mapped",
+          sequence: 5,
+          conflictType: "permission",
+          status: "needs_review",
+          summary:
+            "Register closeout variance requires manager review before synced closeout can be applied.",
+          details: { countedCash: 100, expectedCash: 90, variance: 10 },
+          createdAt: 103,
+        },
+        {
+          _id: "conflict-2",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          localRegisterSessionId: "register-session-2",
+          localEventId: "event-closeout-2",
+          sequence: 3,
+          conflictType: "permission",
+          status: "needs_review",
+          summary:
+            "Register closeout variance requires manager review before synced closeout can be applied.",
+          details: { countedCash: 100, expectedCash: 90, variance: 10 },
+          createdAt: 101,
+        },
+        {
+          _id: "conflict-3",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          localRegisterSessionId: "register-session-3",
+          localEventId: "event-closeout-3",
+          sequence: 4,
+          conflictType: "permission",
+          status: "needs_review",
+          summary:
+            "Register closeout variance requires manager review before synced closeout can be applied.",
+          details: { countedCash: 100, expectedCash: 90, variance: 10 },
+          createdAt: 102,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "mapping-register",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event-register-opened-1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "registerSession",
+          cloudId: "register-session-1",
+          createdAt: 1,
+        },
+      ],
+    });
+    const repository = createConvexLocalSyncRepository(ctx as never);
+
+    const facts = await repository.listOpenRegisterReviewConflictFacts({
+      registerSessionId: "register-session-1" as never,
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+    });
+
+    expect(facts).toHaveLength(2);
+    expect(facts[0]).toEqual(
+      expect.objectContaining({
+        directRegisterSession: {
+          _id: "register-session-1",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        },
+        registerSessionMapping: null,
+      }),
+    );
+    expect(facts[1]).toEqual(
+      expect.objectContaining({
+        conflict: expect.objectContaining({ _id: "conflict-mapped" }),
+        directRegisterSession: null,
+        registerSessionMapping: expect.objectContaining({
+          cloudId: "register-session-1",
+          localRegisterSessionId: "local-register-1",
+        }),
+      }),
+    );
+  });
+
   it("sums only active unexpired inventory holds in the production repository", async () => {
     const ctx = createFakeConvexCtx({
       inventoryHold: [
@@ -3544,6 +3671,7 @@ function createFakeSyncRepository(
       terminalId: string;
     } | null;
     invalidCloudIds: Set<string>;
+    registerSessionsWithCloseoutReview: Set<string>;
     validCloudIds: Set<string>;
     validateLocalStaffProof: SyncProjectionRepository["validateLocalStaffProof"];
   }> = {},
@@ -3895,6 +4023,35 @@ function createFakeSyncRepository(
     },
     async findBlockingRegisterSession() {
       return null;
+    },
+    async listOpenRegisterReviewConflictFacts(args) {
+      return [...(overrides.registerSessionsWithCloseoutReview ?? new Set())]
+        .map((registerSessionId, index) => ({
+          conflict: {
+            _id: `review-conflict-${registerSessionId}`,
+            conflictType: "permission" as const,
+            createdAt: 1_700_000_000_000 + index,
+            details: {
+              countedCash: 100,
+              expectedCash: 90,
+              variance: 10,
+            },
+            localEventId: `review-event-${registerSessionId}`,
+            localRegisterSessionId: registerSessionId,
+            sequence: 0,
+            status: "needs_review" as const,
+            storeId: args.storeId,
+            summary:
+              "Register closeout variance requires manager review before synced closeout can be applied.",
+            terminalId: args.terminalId,
+          },
+          directRegisterSession: {
+            _id: registerSessionId as Id<"registerSession">,
+            storeId: args.storeId,
+            terminalId: args.terminalId,
+          },
+          registerSessionMapping: null,
+        }));
     },
     async getRegisterSessionByLocalId(args) {
       const mapping = mappings.find(

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
+import type { Id } from "../../../_generated/dataModel";
 import { projectLocalSyncEvent } from "./projectLocalEvents";
 import type {
   LocalSyncConflictRecord,
   LocalSyncMappingRecord,
+  LocalSyncRegisterReviewConflictFact,
   ParsedPosLocalSyncEventInput,
   PosLocalSalePayload,
   PosLocalSyncEventInput,
@@ -898,6 +900,90 @@ describe("projectLocalSyncEvent", () => {
           transactionNumber: "LR-001",
         }),
         posTransactionId: "transaction-1",
+      }),
+    ]);
+  });
+
+  it("conflicts sale projection when a direct cloud drawer id has an open closeout review", async () => {
+    const repository = createProjectionRepository({
+      registerSessionsWithCloseoutReview: new Set(["register-session-1"]),
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent({
+        localRegisterSessionId: "register-session-1",
+      }),
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("conflicted");
+    expect(repository.createdTransactions).toEqual([]);
+    expect(result.conflicts).toEqual([
+      expect.objectContaining({
+        conflictType: "permission",
+        summary: "Register session mapping points to a reviewed closeout.",
+      }),
+    ]);
+  });
+
+  it("conflicts sale projection when a mapped local drawer has an open closeout review", async () => {
+    const repository = createProjectionRepository({
+      registerReviewConflictFacts: [
+        {
+          conflict: {
+            _id: "review-conflict-local-register-1",
+            conflictType: "permission",
+            createdAt: 1_700_000_000_000,
+            details: {
+              countedCash: 100,
+              expectedCash: 90,
+              variance: 10,
+            },
+            localEventId: "review-event-local-register-1",
+            localRegisterSessionId: "local-register-1",
+            sequence: 3,
+            status: "needs_review",
+            storeId: "store-1" as never,
+            summary:
+              "Register closeout variance requires manager review before synced closeout can be applied.",
+            terminalId: "terminal-1" as never,
+          },
+          directRegisterSession: null,
+          registerSessionMapping: {
+            _id: "mapping-register",
+            storeId: "store-1" as never,
+            terminalId: "terminal-1" as never,
+            localRegisterSessionId: "local-register-1",
+            localEventId: "event-register-opened-1",
+            localIdKind: "registerSession",
+            localId: "local-register-1",
+            cloudTable: "registerSession",
+            cloudId: "register-session-1" as never,
+            createdAt: 1,
+          },
+        },
+      ],
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent({
+        localRegisterSessionId: "local-register-1",
+      }),
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("conflicted");
+    expect(repository.createdTransactions).toEqual([]);
+    expect(result.conflicts).toEqual([
+      expect.objectContaining({
+        conflictType: "permission",
+        summary: "Register session mapping points to a reviewed closeout.",
       }),
     ]);
   });
@@ -3577,6 +3663,8 @@ describe("projectLocalSyncEvent", () => {
         closeoutRecords: [],
         registerNumber: "1",
         status: "active",
+        storeId: "store-1",
+        terminalId: "terminal-1",
       },
     });
 
@@ -3608,6 +3696,116 @@ describe("projectLocalSyncEvent", () => {
         localId: "local-register-2",
         cloudTable: "registerSession",
         cloudId: "register-session-open",
+      }),
+    ]);
+  });
+
+  it("creates a new register open when the active drawer has a closeout review", async () => {
+    const repository = createProjectionRepository({
+      blockingRegisterSession: {
+        _id: "register-session-reviewed",
+        expectedCash: 100,
+        closeoutRecords: [],
+        registerNumber: "1",
+        status: "active",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      },
+      registerSessionsWithCloseoutReview: new Set([
+        "register-session-reviewed",
+      ]),
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-opened-2",
+        localRegisterSessionId: "local-register-2",
+        sequence: 1,
+        eventType: "register_opened",
+        occurredAt: 10,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: {
+          openingFloat: 250,
+          registerNumber: "1",
+        },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("projected");
+    expect(result.conflicts).toEqual([]);
+    expect(result.mappings).toEqual([
+      expect.objectContaining({
+        localIdKind: "registerSession",
+        localId: "local-register-2",
+        cloudTable: "registerSession",
+        cloudId: "register-session-1",
+      }),
+    ]);
+    expect(repository.createdRegisterSessions).toEqual([
+      expect.objectContaining({
+        expectedCash: 250,
+        openingFloat: 250,
+        registerNumber: "1",
+      }),
+    ]);
+  });
+
+  it("creates a new register open when the closing drawer has a closeout review", async () => {
+    const repository = createProjectionRepository({
+      blockingRegisterSession: {
+        _id: "register-session-closing-review",
+        expectedCash: 100,
+        closeoutRecords: [],
+        registerNumber: "1",
+        status: "closing",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      },
+      registerSessionsWithCloseoutReview: new Set([
+        "register-session-closing-review",
+      ]),
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-opened-closing-review",
+        localRegisterSessionId: "local-register-2",
+        sequence: 1,
+        eventType: "register_opened",
+        occurredAt: 10,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: {
+          openingFloat: 250,
+          registerNumber: "1",
+        },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("projected");
+    expect(result.conflicts).toEqual([]);
+    expect(result.mappings).toEqual([
+      expect.objectContaining({
+        localIdKind: "registerSession",
+        localId: "local-register-2",
+        cloudTable: "registerSession",
+        cloudId: "register-session-1",
+      }),
+    ]);
+    expect(repository.createdRegisterSessions).toEqual([
+      expect.objectContaining({
+        expectedCash: 250,
+        openingFloat: 250,
+        registerNumber: "1",
       }),
     ]);
   });
@@ -3950,7 +4148,17 @@ describe("projectLocalSyncEvent", () => {
     });
 
     expect(result.status).toBe("conflicted");
-    expect(repository.registerSessionPatches).toEqual([]);
+    expect(repository.registerSessionPatches).toEqual([
+      {
+        registerSessionId: "register-session-1",
+        patch: {
+          countedCash: 90,
+          notes: "Short drawer",
+          status: "closing",
+          variance: -10,
+        },
+      },
+    ]);
     expect(result.conflicts).toEqual([
       expect.objectContaining({
         conflictType: "permission",
@@ -4439,6 +4647,127 @@ describe("projectLocalSyncEvent", () => {
         summary: "Register session is not open for synced POS closeout.",
       }),
     ]);
+  });
+
+  it("projects an approved variance closeout when the register is already waiting in closing", async () => {
+    const repository = createProjectionRepository({
+      registerSession: {
+        _id: "register-session-1",
+        expectedCash: 100,
+        closeoutRecords: [],
+        countedCash: 90,
+        registerNumber: "1",
+        status: "closing",
+        variance: -10,
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-closed-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 3,
+        eventType: "register_closed",
+        occurredAt: 30,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: { countedCash: 90 },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+      options: {
+        allowRegisterCloseoutVarianceProjection: true,
+      },
+    });
+
+    expect(result.status).toBe("projected");
+    expect(result.conflicts).toEqual([]);
+    expect(repository.registerSessionPatches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          registerSessionId: "register-session-1",
+          patch: expect.objectContaining({
+            countedCash: 90,
+            status: "closed",
+            variance: -10,
+          }),
+        }),
+      ]),
+    );
+    expect(result.mappings).toEqual([
+      expect.objectContaining({
+        cloudId: "register-session-1",
+        cloudTable: "registerSession",
+        localId: "event-register-closed-1",
+        localIdKind: "closeout",
+      }),
+    ]);
+  });
+
+  it("keeps a pending variance closeout review from turning into a duplicate closeout review", async () => {
+    const repository = createProjectionRepository({
+      registerSession: {
+        _id: "register-session-1",
+        expectedCash: 100,
+        closeoutRecords: [],
+        countedCash: 90,
+        registerNumber: "1",
+        status: "closing",
+        variance: -10,
+      },
+    });
+    repository.createdConflicts.push({
+      _id: "conflict-existing-variance",
+      conflictType: "permission",
+      createdAt: 10,
+      details: {
+        countedCash: 90,
+        expectedCash: 100,
+        variance: -10,
+      },
+      localEventId: "event-register-closed-1",
+      localRegisterSessionId: "local-register-1",
+      sequence: 3,
+      status: "needs_review",
+      storeId: "store-1" as never,
+      summary:
+        "Register closeout variance requires manager review before synced closeout can be applied.",
+      terminalId: "terminal-1" as never,
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-closed-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 3,
+        eventType: "register_closed",
+        occurredAt: 30,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: { countedCash: 90 },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("conflicted");
+    expect(result.conflicts).toEqual([
+      expect.objectContaining({
+        _id: "conflict-existing-variance",
+      }),
+    ]);
+    expect(repository.createdConflicts).toHaveLength(1);
+    expect(repository.createdConflicts).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          summary: "Register session is not open for synced POS closeout.",
+        }),
+      ]),
+    );
   });
 
   it("conflicts reopen attempts against a register session that is not closed", async () => {
@@ -5385,7 +5714,11 @@ function createProjectionRepository(
       closeoutRecords: unknown[];
       registerNumber?: string;
       status: string;
+      storeId?: string;
+      terminalId?: string;
     };
+    registerReviewConflictFacts: LocalSyncRegisterReviewConflictFact[];
+    registerSessionsWithCloseoutReview: Set<string>;
     sku: {
       _id: string;
       storeId: string;
@@ -5880,6 +6213,39 @@ function createProjectionRepository(
     },
     async findBlockingRegisterSession() {
       return (overrides.blockingRegisterSession as never) ?? null;
+    },
+    async listOpenRegisterReviewConflictFacts(args) {
+      if (overrides.registerReviewConflictFacts) {
+        return overrides.registerReviewConflictFacts;
+      }
+
+      return [...(overrides.registerSessionsWithCloseoutReview ?? new Set())]
+        .map((registerSessionId, index) => ({
+          conflict: {
+            _id: `review-conflict-${registerSessionId}`,
+            conflictType: "permission" as const,
+            createdAt: 1_700_000_000_000 + index,
+            details: {
+              countedCash: 100,
+              expectedCash: 90,
+              variance: 10,
+            },
+            localEventId: `review-event-${registerSessionId}`,
+            localRegisterSessionId: registerSessionId,
+            sequence: 0,
+            status: "needs_review" as const,
+            storeId: args.storeId,
+            summary:
+              "Register closeout variance requires manager review before synced closeout can be applied.",
+            terminalId: args.terminalId,
+          },
+          directRegisterSession: {
+            _id: registerSessionId as Id<"registerSession">,
+            storeId: args.storeId,
+            terminalId: args.terminalId,
+          },
+          registerSessionMapping: null,
+        }));
     },
     async getRegisterSessionByLocalId() {
       return registerSession as never;

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -2,11 +2,19 @@ import type { Id } from "../../../_generated/dataModel";
 import { normalizeInStorePayments } from "../../../cashControls/paymentAllocationAttribution";
 import { toDisplayAmount } from "../../../lib/currency";
 import { currencyFormatter, generateTransactionNumber } from "../../../utils";
+import {
+  canReuseCloudRegisterSessionForLocalOpen as canReuseCloudRegisterSessionForLocalOpenPolicy,
+  canSupersedeReviewedRegisterSessionForLocalOpen as canSupersedeReviewedRegisterSessionForLocalOpenPolicy,
+  isRegisterCloseoutReviewConflict,
+  isRegisterSessionSaleUsable,
+  REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY,
+} from "../../../../shared/registerSessionLifecyclePolicy";
 import type {
   LocalSyncConflictRecord,
   LocalSyncMappingRecord,
   LocalSyncMappingRecordInput,
   LocalSyncMappingProjectionInput,
+  LocalSyncRegisterReviewConflictFact,
   ParsedPosLocalSyncEventInput,
   PosLocalSalePayload,
   PosLocalSyncEventType,
@@ -55,6 +63,11 @@ type RegisterSessionRecord = NonNullable<
 type PosSessionRecord = Awaited<
   ReturnType<SyncProjectionRepository["getPosSessionByLocalId"]>
 >;
+
+type OpenRegisterCloseoutReviewState = {
+  hasOpenRegisterCloseoutReview: boolean;
+  latestReviewSequence?: number;
+};
 
 type CanonicalSaleItem = {
   barcode?: string;
@@ -166,8 +179,6 @@ async function persistRegisterSessionWorkflowTraceId(
     workflowTraceId: args.traceId,
   });
 }
-
-const POS_USABLE_REGISTER_SESSION_STATUSES = new Set(["open", "active"]);
 
 const INVENTORY_CONFLICT_SUMMARY =
   "Inventory needs manager review for a synced offline sale.";
@@ -768,11 +779,10 @@ async function canMapExistingCloudRegisterSession(
   const registerSession = await repository.getRegisterSession(
     directRegisterSessionId,
   );
-  return Boolean(
-    registerSession &&
-      registerSession.storeId === args.storeId &&
-      registerSession.terminalId === args.terminalId &&
-      isPosUsableRegisterSession(registerSession),
+  return canReuseCloudRegisterSessionForLocalOpen(
+    repository,
+    args,
+    registerSession,
   );
 }
 
@@ -782,6 +792,97 @@ type ProjectEventArgsFor<EventType extends PosLocalSyncEventType> = Omit<
 > & {
   event: Extract<ParsedPosLocalSyncEventInput, { eventType: EventType }>;
 };
+
+async function canReuseCloudRegisterSessionForLocalOpen(
+  repository: SyncProjectionRepository,
+  args: ProjectEventArgsFor<"register_opened">,
+  registerSession: Awaited<
+    ReturnType<SyncProjectionRepository["getRegisterSession"]>
+  >,
+) {
+  const hasOpenRegisterCloseoutReview =
+    registerSession === null || registerSession === undefined
+      ? { hasOpenRegisterCloseoutReview: false }
+      : await getOpenRegisterCloseoutReviewState(repository, args, {
+          registerSessionId: registerSession._id,
+        });
+
+  return canReuseCloudRegisterSessionForLocalOpenPolicy({
+    hasOpenRegisterCloseoutReview:
+      hasOpenRegisterCloseoutReview.hasOpenRegisterCloseoutReview,
+    registerSession,
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+  });
+}
+
+async function canSupersedeReviewedRegisterSessionForLocalOpen(
+  repository: SyncProjectionRepository,
+  args: ProjectEventArgsFor<"register_opened">,
+  registerSession: Awaited<
+    ReturnType<SyncProjectionRepository["getRegisterSession"]>
+  >,
+) {
+  const hasOpenRegisterCloseoutReview =
+    registerSession === null || registerSession === undefined
+      ? { hasOpenRegisterCloseoutReview: false }
+      : await getOpenRegisterCloseoutReviewState(repository, args, {
+          registerSessionId: registerSession._id,
+        });
+
+  return canSupersedeReviewedRegisterSessionForLocalOpenPolicy({
+    hasOpenRegisterCloseoutReview:
+      hasOpenRegisterCloseoutReview.hasOpenRegisterCloseoutReview,
+    replacementLocalRegisterSessionId: args.event.localRegisterSessionId,
+    replacementSequence: args.event.sequence,
+    registerSession,
+    reviewSequence: hasOpenRegisterCloseoutReview.latestReviewSequence,
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+  });
+}
+
+async function getOpenRegisterCloseoutReviewState(
+  repository: SyncProjectionRepository,
+  args: Pick<ProjectEventArgs, "storeId" | "terminalId">,
+  input: { registerSessionId: Id<"registerSession"> },
+): Promise<OpenRegisterCloseoutReviewState> {
+  const facts = await repository.listOpenRegisterReviewConflictFacts({
+    registerSessionId: input.registerSessionId,
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+  });
+  const closeoutReviewConflicts = facts
+    .filter((fact) =>
+      factMatchesRegisterSessionCloseoutReview(fact, input.registerSessionId),
+    )
+    .map((fact) => fact.conflict);
+
+  return {
+    hasOpenRegisterCloseoutReview: closeoutReviewConflicts.length > 0,
+    latestReviewSequence: closeoutReviewConflicts
+      .map((conflict) => conflict.sequence)
+      .sort((left, right) => right - left)
+      .at(0),
+  };
+}
+
+function factMatchesRegisterSessionCloseoutReview(
+  fact: LocalSyncRegisterReviewConflictFact,
+  registerSessionId: Id<"registerSession">,
+) {
+  if (!isRegisterCloseoutReviewConflict(fact.conflict)) {
+    return false;
+  }
+  if (
+    fact.registerSessionMapping?.cloudTable === "registerSession" &&
+    fact.registerSessionMapping.cloudId === registerSessionId
+  ) {
+    return true;
+  }
+
+  return fact.directRegisterSession?._id === registerSessionId;
+}
 
 async function projectRegisterOpened(
   repository: SyncProjectionRepository,
@@ -807,9 +908,11 @@ async function projectRegisterOpened(
     );
     if (
       registerSession &&
-      registerSession.storeId === args.storeId &&
-      registerSession.terminalId === args.terminalId &&
-      isPosUsableRegisterSession(registerSession)
+      await canReuseCloudRegisterSessionForLocalOpen(
+        repository,
+        args,
+        registerSession,
+      )
     ) {
       const mapping = await createMapping(repository, args, {
         localIdKind: "registerSession",
@@ -862,7 +965,13 @@ async function projectRegisterOpened(
     registerNumber: terminalRegisterNumber,
   });
   if (blockingRegisterSession) {
-    if (isPosUsableRegisterSession(blockingRegisterSession)) {
+    if (
+      await canReuseCloudRegisterSessionForLocalOpen(
+        repository,
+        args,
+        blockingRegisterSession,
+      )
+    ) {
       const mapping = await createMapping(repository, args, {
         localIdKind: "registerSession",
         localId: args.event.localRegisterSessionId,
@@ -872,16 +981,25 @@ async function projectRegisterOpened(
       return { status: "projected", mappings: [mapping], conflicts: [] };
     }
 
-    const conflict = await createConflict(repository, args, {
-      conflictType: "permission",
-      summary: "A register session is already open for this terminal.",
-      details: {
-        blockingRegisterSessionId: blockingRegisterSession._id,
-        localRegisterSessionId: args.event.localRegisterSessionId,
-        registerNumber: terminalRegisterNumber,
-      },
-    });
-    return { status: "conflicted", mappings: [], conflicts: [conflict] };
+    const canSupersedeReviewedRegisterSession =
+      await canSupersedeReviewedRegisterSessionForLocalOpen(
+        repository,
+        args,
+        blockingRegisterSession,
+      );
+
+    if (!canSupersedeReviewedRegisterSession) {
+      const conflict = await createConflict(repository, args, {
+        conflictType: "permission",
+        summary: "A register session is already open for this terminal.",
+        details: {
+          blockingRegisterSessionId: blockingRegisterSession._id,
+          localRegisterSessionId: args.event.localRegisterSessionId,
+          registerNumber: terminalRegisterNumber,
+        },
+      });
+      return { status: "conflicted", mappings: [], conflicts: [conflict] };
+    }
   }
 
   const openingFloat = payload.openingFloat ?? 0;
@@ -1319,7 +1437,27 @@ async function resolveSaleRegisterAndSession(
     return conflictResult(conflict);
   }
 
-  if (!isPosUsableRegisterSession(registerSession)) {
+  if (
+    isRegisterSessionSaleUsable(registerSession) &&
+    (
+      await getOpenRegisterCloseoutReviewState(repository, args, {
+        registerSessionId: registerSession._id,
+      })
+    ).hasOpenRegisterCloseoutReview
+  ) {
+    const conflict = await createConflict(repository, args, {
+      conflictType: "permission",
+      summary: "Register session mapping points to a reviewed closeout.",
+      details: {
+        localRegisterSessionId: args.event.localRegisterSessionId,
+        localTransactionId: payload.localTransactionId,
+        registerSessionId: registerSession._id,
+      },
+    });
+    return conflictResult(conflict);
+  }
+
+  if (!isRegisterSessionSaleUsable(registerSession)) {
     if (
       args.options?.allowClosedRegisterSaleProjection === true &&
       registerSession.status === "closed"
@@ -3290,9 +3428,19 @@ async function projectRegisterClosed(
   const payload = args.event.payload;
   const countedCash = payload.countedCash ?? registerSession.expectedCash;
   const variance = countedCash - registerSession.expectedCash;
+  const isPendingReviewedCloseout =
+    registerSession.status === "closing" &&
+    typeof registerSession.countedCash === "number" &&
+    typeof registerSession.variance === "number" &&
+    roundMoney(registerSession.countedCash) === roundMoney(countedCash) &&
+    roundMoney(registerSession.variance) === roundMoney(variance);
   if (
     registerSession.status !== "open" &&
-    registerSession.status !== "active"
+    registerSession.status !== "active" &&
+    !(
+      isPendingReviewedCloseout &&
+      args.options?.allowRegisterCloseoutVarianceProjection === true
+    )
   ) {
     const isAlreadyAppliedCloseout =
       registerSession.status === "closed" &&
@@ -3309,6 +3457,28 @@ async function projectRegisterClosed(
         cloudId: registerSession._id,
       });
       return { status: "projected", mappings: [mapping], conflicts: [] };
+    }
+
+    if (isPendingReviewedCloseout) {
+      const existingVarianceConflict = (
+        await repository.listConflictsForEvent({
+          storeId: args.storeId,
+          terminalId: args.terminalId,
+          localEventId: args.event.localEventId,
+        })
+      ).find(
+        (conflict) =>
+          conflict.status === "needs_review" &&
+          conflict.summary === REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY,
+      );
+
+      if (existingVarianceConflict) {
+        return {
+          status: "conflicted",
+          mappings: [],
+          conflicts: [existingVarianceConflict],
+        };
+      }
     }
 
     const conflict = await createConflict(repository, args, {
@@ -3329,8 +3499,7 @@ async function projectRegisterClosed(
     const store = await repository.getStore(args.storeId);
     const conflict = await createConflict(repository, args, {
       conflictType: "permission",
-      summary:
-        "Register closeout variance requires manager review before synced closeout can be applied.",
+      summary: REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY,
       details: {
         countedCash,
         expectedCash: registerSession.expectedCash,
@@ -3362,6 +3531,12 @@ async function projectRegisterClosed(
       registerSessionId: registerSession._id,
       terminalId: args.terminalId,
       localEventId: args.event.localEventId,
+    });
+    await repository.patchRegisterSession(registerSession._id, {
+      status: "closing",
+      countedCash,
+      variance,
+      notes: payload.notes,
     });
     return { status: "conflicted", mappings: [], conflicts: [conflict] };
   }
@@ -3617,14 +3792,6 @@ function createMapping(
   };
 
   return repository.createMapping(scopedInput);
-}
-
-function isPosUsableRegisterSession(
-  registerSession: Pick<RegisterSessionRecord, "status"> | null | undefined,
-) {
-  return POS_USABLE_REGISTER_SESSION_STATUSES.has(
-    registerSession?.status ?? "",
-  );
 }
 
 function createConflict(

--- a/packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts
@@ -1,5 +1,9 @@
 import type { Doc, Id } from "../../../_generated/dataModel";
 import type { QueryCtx } from "../../../_generated/server";
+import {
+  isRegisterCloseoutReviewConflict,
+  REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY,
+} from "../../../../shared/registerSessionLifecyclePolicy";
 
 const SYNC_CONFLICT_LIMIT = 500;
 const MANAGER_REJECTED_SYNC_REVIEW_CODE = "manager_rejected";
@@ -13,8 +17,6 @@ export const SERVICE_CUSTOMER_ATTRIBUTION_SYNC_REVIEW_SUMMARY =
   "Service line is missing customer attribution.";
 export const CLOSED_REGISTER_SYNCED_CLOSEOUT_SUMMARY =
   "Register session is not open for synced POS closeout.";
-export const REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY =
-  "Register closeout variance requires manager review before synced closeout can be applied.";
 export const INVENTORY_SYNC_REVIEW_SUMMARY =
   "Inventory needs manager review for a synced offline sale.";
 
@@ -132,14 +134,8 @@ export function classifyRegisterSessionSyncReview(
     "conflictType" | "details" | "localEventId" | "status" | "summary"
   >,
 ): RegisterSessionSyncReviewClassification {
-  const localEventId = conflict.localEventId?.toLowerCase() ?? "";
   const summary = conflict.summary?.trim() ?? "";
-  const normalizedSummary = summary.toLowerCase();
   const details = conflict.details ?? {};
-  const hasVarianceDetails =
-    typeof details.countedCash === "number" ||
-    typeof details.expectedCash === "number" ||
-    typeof details.variance === "number";
 
   if (
     conflict.status === "rejected" ||
@@ -161,11 +157,12 @@ export function classifyRegisterSessionSyncReview(
   }
 
   if (
-    summary === REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY ||
-    localEventId.includes("register-closed") ||
-    localEventId.includes("register-closeout") ||
-    normalizedSummary.includes("register closeout") ||
-    hasVarianceDetails
+    isRegisterCloseoutReviewConflict({
+      details,
+      localEventId: conflict.localEventId,
+      status: conflict.status,
+      summary,
+    })
   ) {
     return {
       actionPolicy: "apply_or_reject",
@@ -554,8 +551,25 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
   const activeNeedsReviewConflicts = projectedInventoryReviewResults
     .filter((result) => !result.hasInventoryWorkItem)
     .map((result) => result.conflict);
+  const varianceCloseoutEventKeys = new Set(
+    activeNeedsReviewConflicts
+      .filter(
+        (conflict) =>
+          classifyRegisterSessionSyncReview(conflict).reviewKind ===
+          "register_closeout_variance",
+      )
+      .map(syncConflictEventKey),
+  );
+  const reviewableNeedsReviewConflicts = activeNeedsReviewConflicts.filter(
+    (conflict) =>
+      !(
+        classifyRegisterSessionSyncReview(conflict).reviewKind ===
+          "duplicate_register_closeout" &&
+        varianceCloseoutEventKeys.has(syncConflictEventKey(conflict))
+      ),
+  );
   const openConflictEventKeys = new Set(
-    activeNeedsReviewConflicts.map(syncConflictEventKey),
+    reviewableNeedsReviewConflicts.map(syncConflictEventKey),
   );
   const staleResolvedConflicts = await Promise.all(
     resolvedConflicts.map(async (conflict) => {
@@ -600,7 +614,7 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
     }),
   );
   const conflicts: RegisterSessionSyncConflict[] = [
-    ...activeNeedsReviewConflicts,
+    ...reviewableNeedsReviewConflicts,
     ...staleResolvedConflicts.filter(
       (conflict): conflict is Doc<"posLocalSyncConflict"> => conflict !== null,
     ),

--- a/packages/athena-webapp/convex/pos/application/sync/types.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/types.ts
@@ -266,6 +266,15 @@ export type LocalSyncConflictRecord = {
   resolvedByUserId?: Id<"athenaUser">;
 };
 
+export type LocalSyncRegisterReviewConflictFact = {
+  conflict: LocalSyncConflictRecord;
+  directRegisterSession: Pick<
+    Doc<"registerSession">,
+    "_id" | "storeId" | "terminalId"
+  > | null;
+  registerSessionMapping: LocalSyncMappingRecord | null;
+};
+
 export type LocalSyncCursorRecord = {
   _id: string;
   storeId: Id<"store">;
@@ -397,6 +406,11 @@ export type SyncProjectionRepository = {
     terminalId: Id<"posTerminal">;
     registerNumber?: string;
   }): Promise<Doc<"registerSession"> | null>;
+  listOpenRegisterReviewConflictFacts(args: {
+    registerSessionId: Id<"registerSession">;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  }): Promise<LocalSyncRegisterReviewConflictFact[]>;
   getRegisterSessionByLocalId(args: {
     storeId: Id<"store">;
     terminalId: Id<"posTerminal">;

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -521,6 +521,57 @@ describe("submitTerminalRuntimeStatus", () => {
     });
   });
 
+  it("returns a cloud-closed drawer authority directive for closing local runtime evidence", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
+      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    );
+    const db = {
+      normalizeId: vi.fn(() => "cloud-register-1"),
+      get: vi.fn(async () => ({
+        _id: "cloud-register-1",
+        status: "closed",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      })),
+    };
+
+    const result = await submitTerminalRuntimeStatus(
+      { db } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        status: {
+          ...buildRuntimeStatus(),
+          activeRegisterSession: {
+            cloudRegisterSessionId: "cloud-register-1",
+            localRegisterSessionId: "local-register-1",
+            observedAt: 120,
+            openedAt: 100,
+            registerNumber: "8",
+            status: "closing",
+          },
+        },
+      },
+    );
+
+    expect(db.get).toHaveBeenCalledWith(
+      "registerSession",
+      "cloud-register-1",
+    );
+    expect(result).toEqual({
+      kind: "ok",
+      data: expect.objectContaining({
+        drawerAuthorityDirective: expect.objectContaining({
+          cloudRegisterSessionId: "cloud-register-1",
+          localRegisterSessionId: "local-register-1",
+          reason: "cloud_closed",
+          status: "blocked",
+        }),
+      }),
+    });
+  });
+
   it("ignores malformed cloud register ids in runtime drawer authority evidence", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
     vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
@@ -375,6 +375,81 @@ export function createConvexLocalSyncRepository(
         ? latestByRegisterNumber
         : null;
     },
+    async listOpenRegisterReviewConflictFacts(args) {
+      const registerSessionMappings = await ctx.db
+        .query("posLocalSyncMapping")
+        .withIndex("by_store_terminal_cloud", (q) =>
+          q
+            .eq("storeId", args.storeId)
+            .eq("terminalId", args.terminalId)
+            .eq("cloudTable", "registerSession")
+            .eq("cloudId", args.registerSessionId),
+        )
+        .take(100);
+      const registerSessionMappingByLocalId = new Map(
+        registerSessionMappings.map((mapping) => [
+          mapping.localRegisterSessionId,
+          mapping,
+        ]),
+      );
+      const localRegisterSessionIds = new Set<string>([
+        args.registerSessionId,
+        ...registerSessionMappings.map(
+          (mapping) => mapping.localRegisterSessionId,
+        ),
+      ]);
+
+      const facts = [];
+      for (const localRegisterSessionId of localRegisterSessionIds) {
+        const conflicts = await ctx.db
+          .query("posLocalSyncConflict")
+          .withIndex("by_store_terminal_register_status_type", (q) =>
+            q
+              .eq("storeId", args.storeId)
+              .eq("terminalId", args.terminalId)
+              .eq("localRegisterSessionId", localRegisterSessionId)
+              .eq("status", "needs_review")
+              .eq("conflictType", "permission"),
+          )
+          .take(100);
+
+        for (const conflict of conflicts) {
+          if (!conflict.localRegisterSessionId) {
+            continue;
+          }
+
+          const registerSessionMapping = registerSessionMappingByLocalId.get(
+            conflict.localRegisterSessionId,
+          );
+          const directRegisterSessionId = normalizeCloudId(
+            "registerSession",
+            conflict.localRegisterSessionId,
+          );
+          const directRegisterSession = directRegisterSessionId
+            ? await ctx.db.get("registerSession", directRegisterSessionId)
+            : null;
+          facts.push({
+            conflict,
+            directRegisterSession:
+              directRegisterSession &&
+              directRegisterSession.storeId === args.storeId &&
+              directRegisterSession.terminalId === args.terminalId
+                ? {
+                    _id: directRegisterSession._id,
+                    storeId: directRegisterSession.storeId,
+                    terminalId: directRegisterSession.terminalId,
+                  }
+                : null,
+            registerSessionMapping:
+              registerSessionMapping?.cloudTable === "registerSession"
+                ? registerSessionMapping
+                : null,
+          });
+        }
+      }
+
+      return facts;
+    },
     async getRegisterSessionByLocalId(args) {
       const mapping = await ctx.db
         .query("posLocalSyncMapping")

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -673,6 +673,12 @@ const schema = defineSchema({
       "terminalId",
       "localEventId",
     ])
+    .index("by_store_terminal_cloud", [
+      "storeId",
+      "terminalId",
+      "cloudTable",
+      "cloudId",
+    ])
     .index("by_localEventId", ["localEventId"]),
   posLocalSyncConflict: defineTable(posLocalSyncConflictSchema)
     .index("by_store_status", ["storeId", "status"])
@@ -688,6 +694,13 @@ const schema = defineSchema({
       "storeId",
       "terminalId",
       "localRegisterSessionId",
+    ])
+    .index("by_store_terminal_register_status_type", [
+      "storeId",
+      "terminalId",
+      "localRegisterSessionId",
+      "status",
+      "conflictType",
     ]),
   posLocalStaffProof: defineTable(posLocalStaffProofSchema)
     .index("by_tokenHash", ["tokenHash"])

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -14,7 +14,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 46 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.test.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 8 file(s); key children: AppShellFullscreenContext.tsx, ManagerElevationContext.test.tsx, ManagerElevationContext.tsx, OnlineOrderContext.tsx, PermissionsContext.tsx.
 - [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 201 file(s); key children: access, app-messages, app-update, aws.ts, behaviorUtils.ts.
-- [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 30 file(s); key children: approvalPolicy.ts, auth.ts, commandResult.test.ts, commandResult.ts, currencyFormatter.test.ts.
+- [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 32 file(s); key children: approvalPolicy.ts, auth.ts, commandResult.test.ts, commandResult.ts, currencyFormatter.test.ts.
 - [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 4 file(s); key children: formatNumber.ts, index.ts, versionChecker.test.ts, versionChecker.ts.
 
 ## Backend and test surfaces

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -200,6 +200,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`shared/currencyFormatter.test.ts`](../../shared/currencyFormatter.test.ts)
 - [`shared/homepageRanking.test.ts`](../../shared/homepageRanking.test.ts)
 - [`shared/intelligence/contextTracking.test.ts`](../../shared/intelligence/contextTracking.test.ts)
+- [`shared/registerSessionLifecyclePolicy.test.ts`](../../shared/registerSessionLifecyclePolicy.test.ts)
 - [`shared/registerSessionStatus.test.ts`](../../shared/registerSessionStatus.test.ts)
 - [`shared/staffDisplayName.test.ts`](../../shared/staffDisplayName.test.ts)
 - [`shared/storefrontVisibility.test.ts`](../../shared/storefrontVisibility.test.ts)

--- a/packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts
+++ b/packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canOpenReplacementDrawerForLocalBlock,
+  canReuseCloudRegisterSessionForLocalOpen,
+  canSupersedeReviewedRegisterSessionForLocalOpen,
+  getSaleBlockingDrawerAuthority,
+  isNonBlockingRegisterLifecycleReviewEvent,
+  isRegisterCloseoutReviewConflict,
+  isRegisterSessionSaleUsable,
+  REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY,
+} from "./registerSessionLifecyclePolicy";
+
+describe("registerSessionLifecyclePolicy", () => {
+  it("keeps only open and active register sessions sale usable", () => {
+    expect(isRegisterSessionSaleUsable({ status: "open" })).toBe(true);
+    expect(isRegisterSessionSaleUsable({ status: "active" })).toBe(true);
+    expect(isRegisterSessionSaleUsable({ status: "closing" })).toBe(false);
+    expect(isRegisterSessionSaleUsable({ status: "closed" })).toBe(false);
+  });
+
+  it("treats same-drawer lifecycle rejection as recoverable for local sale blocking", () => {
+    expect(
+      getSaleBlockingDrawerAuthority({
+        activeRegisterSession: { localRegisterSessionId: "local-drawer-1" },
+        drawerAuthority: {
+          localRegisterSessionId: "local-drawer-1",
+          status: "healthy",
+        },
+      }),
+    ).toBeNull();
+
+    expect(
+      getSaleBlockingDrawerAuthority({
+        activeRegisterSession: { localRegisterSessionId: "local-drawer-1" },
+        drawerAuthority: {
+          localRegisterSessionId: "local-drawer-1",
+          reason: "lifecycle_rejected",
+          status: "blocked",
+        },
+      }),
+    ).toBeNull();
+
+    expect(
+      getSaleBlockingDrawerAuthority({
+        activeRegisterSession: { localRegisterSessionId: "local-drawer-1" },
+        drawerAuthority: {
+          localRegisterSessionId: "local-drawer-1",
+          reason: "cloud_closed",
+          status: "blocked",
+        },
+      })?.reason,
+    ).toBe("cloud_closed");
+  });
+
+  it("allows local replacement drawers only for cloud-closed, settled closeout, or submitted closeout blocks", () => {
+    expect(
+      canOpenReplacementDrawerForLocalBlock({
+        drawerAuthorityReason: "cloud_closed",
+        hasSettledCloseout: false,
+        saleBlockReason: "drawer_authority",
+      }),
+    ).toBe(true);
+    expect(
+      canOpenReplacementDrawerForLocalBlock({
+        activeRegisterSession: { status: "closing" },
+        hasSettledCloseout: false,
+        saleBlockReason: "drawer_closed",
+      }),
+    ).toBe(true);
+    expect(
+      canOpenReplacementDrawerForLocalBlock({
+        hasSettledCloseout: true,
+        saleBlockReason: "drawer_closed",
+      }),
+    ).toBe(true);
+    expect(
+      canOpenReplacementDrawerForLocalBlock({
+        hasSettledCloseout: false,
+        saleBlockReason: "terminal_integrity",
+      }),
+    ).toBe(false);
+  });
+
+  it("reuses cloud register sessions only when scoped, sale usable, and without open closeout review", () => {
+    expect(
+      canReuseCloudRegisterSessionForLocalOpen({
+        hasOpenRegisterCloseoutReview: false,
+        registerSession: {
+          status: "active",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        },
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toBe(true);
+    expect(
+      canReuseCloudRegisterSessionForLocalOpen({
+        hasOpenRegisterCloseoutReview: true,
+        registerSession: {
+          status: "active",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        },
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toBe(false);
+    expect(
+      canReuseCloudRegisterSessionForLocalOpen({
+        hasOpenRegisterCloseoutReview: false,
+        registerSession: {
+          status: "active",
+          storeId: "store-1",
+          terminalId: "terminal-2",
+        },
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("allows superseding reviewed sale-usable or closing sessions only in scope", () => {
+    expect(
+      canSupersedeReviewedRegisterSessionForLocalOpen({
+        hasOpenRegisterCloseoutReview: true,
+        replacementLocalRegisterSessionId: "replacement-local-drawer",
+        replacementSequence: 12,
+        registerSession: {
+          localRegisterSessionId: "reviewed-local-drawer",
+          status: "closing",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        },
+        reviewSequence: 10,
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toBe(true);
+    expect(
+      canSupersedeReviewedRegisterSessionForLocalOpen({
+        hasOpenRegisterCloseoutReview: true,
+        replacementLocalRegisterSessionId: "replacement-local-drawer",
+        replacementSequence: 12,
+        registerSession: {
+          localRegisterSessionId: "reviewed-local-drawer",
+          status: "closed",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        },
+        reviewSequence: 10,
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toBe(false);
+    expect(
+      canSupersedeReviewedRegisterSessionForLocalOpen({
+        hasOpenRegisterCloseoutReview: true,
+        replacementLocalRegisterSessionId: "reviewed-local-drawer",
+        replacementSequence: 12,
+        registerSession: {
+          localRegisterSessionId: "reviewed-local-drawer",
+          status: "closing",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        },
+        reviewSequence: 10,
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toBe(false);
+    expect(
+      canSupersedeReviewedRegisterSessionForLocalOpen({
+        hasOpenRegisterCloseoutReview: true,
+        replacementLocalRegisterSessionId: "replacement-local-drawer",
+        replacementSequence: 9,
+        registerSession: {
+          localRegisterSessionId: "reviewed-local-drawer",
+          status: "closing",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        },
+        reviewSequence: 10,
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toBe(false);
+    expect(
+      canSupersedeReviewedRegisterSessionForLocalOpen({
+        hasOpenRegisterCloseoutReview: true,
+        replacementLocalRegisterSessionId: "replacement-local-drawer",
+        replacementSequence: 12,
+        registerSession: {
+          localRegisterSessionId: "reviewed-local-drawer",
+          status: "closing",
+          storeId: "store-2",
+          terminalId: "terminal-1",
+        },
+        reviewSequence: 10,
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toBe(false);
+    expect(
+      canSupersedeReviewedRegisterSessionForLocalOpen({
+        hasOpenRegisterCloseoutReview: true,
+        replacementLocalRegisterSessionId: "replacement-local-drawer",
+        replacementSequence: 12,
+        registerSession: {
+          localRegisterSessionId: "reviewed-local-drawer",
+          status: "closing",
+          storeId: "store-1",
+          terminalId: "terminal-2",
+        },
+        reviewSequence: 10,
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("classifies closeout review conflicts from the shared summary or money details", () => {
+    expect(
+      isRegisterCloseoutReviewConflict({
+        summary: REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY,
+      }),
+    ).toBe(true);
+    expect(
+      isRegisterCloseoutReviewConflict({
+        details: { countedCash: 100, expectedCash: 90, variance: 10 },
+      }),
+    ).toBe(true);
+    expect(
+      isRegisterCloseoutReviewConflict({
+        summary: "Inventory needs manager review for a synced offline sale.",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps uploaded register lifecycle review events out of blocking sync status", () => {
+    expect(
+      isNonBlockingRegisterLifecycleReviewEvent({
+        sync: { status: "needs_review" },
+        type: "register.opened",
+      }),
+    ).toBe(true);
+    expect(
+      isNonBlockingRegisterLifecycleReviewEvent({
+        sync: { status: "needs_review" },
+        type: "cart.item_added",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts
+++ b/packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts
@@ -1,0 +1,205 @@
+import {
+  isPosUsableRegisterSessionStatus,
+  isRegisterSessionConflictBlockingStatus,
+  type RegisterSessionStatus,
+} from "./registerSessionStatus";
+
+export const REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY =
+  "Register closeout variance requires manager review before synced closeout can be applied.";
+
+export type RegisterSessionLifecycleEventType =
+  | "register.opened"
+  | "register.closeout_started"
+  | string;
+
+export type RegisterSessionLifecycleReviewStatus =
+  | "needs_review"
+  | "pending"
+  | "syncing"
+  | "synced"
+  | "failed"
+  | string;
+
+export type RegisterSessionLifecycleDrawerAuthorityReason =
+  | "cloud_closed"
+  | "lifecycle_rejected"
+  | "authority_unknown"
+  | string;
+
+export type RegisterSessionLifecycleDrawerAuthority = {
+  cloudRegisterSessionId?: string;
+  localRegisterSessionId: string;
+  reason?: RegisterSessionLifecycleDrawerAuthorityReason;
+  status: "blocked" | "healthy" | string;
+};
+
+export type RegisterSessionLifecycleScopedSession = {
+  localRegisterSessionId?: string | null;
+  cloudRegisterSessionId?: string | null;
+  status?: RegisterSessionStatus | string | null;
+  storeId?: string | null;
+  terminalId?: string | null;
+};
+
+export type RegisterSessionLifecycleReviewConflict = {
+  details?: Record<string, unknown>;
+  localEventId?: string | null;
+  status?: string | null;
+  summary?: string | null;
+};
+
+export function isNonBlockingRegisterLifecycleReviewEvent(input: {
+  sync?: { status?: RegisterSessionLifecycleReviewStatus } | null;
+  type: RegisterSessionLifecycleEventType;
+}) {
+  return (
+    input.sync?.status === "needs_review" &&
+    (input.type === "register.opened" ||
+      input.type === "register.closeout_started")
+  );
+}
+
+export function isRegisterSessionSaleUsable(
+  session: Pick<RegisterSessionLifecycleScopedSession, "status"> | null | undefined,
+) {
+  return isPosUsableRegisterSessionStatus(session?.status);
+}
+
+export function isRegisterSessionConflictBlocking(
+  session: Pick<RegisterSessionLifecycleScopedSession, "status"> | null | undefined,
+) {
+  return isRegisterSessionConflictBlockingStatus(session?.status);
+}
+
+export function getSaleBlockingDrawerAuthority<
+  Authority extends RegisterSessionLifecycleDrawerAuthority,
+>(input: {
+  activeRegisterSession?: RegisterSessionLifecycleScopedSession | null;
+  drawerAuthority?: Authority | null;
+}): Authority | null {
+  const drawerAuthority = input.drawerAuthority;
+  if (!drawerAuthority) return null;
+  if (drawerAuthority.status !== "blocked") return null;
+  if (
+    drawerAuthority.reason === "lifecycle_rejected" &&
+    drawerAuthority.localRegisterSessionId ===
+      input.activeRegisterSession?.localRegisterSessionId
+  ) {
+    return null;
+  }
+
+  return drawerAuthority;
+}
+
+export function isDrawerAuthoritySaleBlocking(input: {
+  activeRegisterSession?: RegisterSessionLifecycleScopedSession | null;
+  drawerAuthority?: RegisterSessionLifecycleDrawerAuthority | null;
+}) {
+  return Boolean(getSaleBlockingDrawerAuthority(input));
+}
+
+export function canReuseCloudRegisterSessionForLocalOpen(input: {
+  hasOpenRegisterCloseoutReview: boolean;
+  registerSession?: RegisterSessionLifecycleScopedSession | null;
+  storeId: string;
+  terminalId: string;
+}) {
+  return (
+    isScopedRegisterSession(input) &&
+    isRegisterSessionSaleUsable(input.registerSession) &&
+    !input.hasOpenRegisterCloseoutReview
+  );
+}
+
+export function canSupersedeReviewedRegisterSessionForLocalOpen(input: {
+  hasOpenRegisterCloseoutReview: boolean;
+  replacementLocalRegisterSessionId: string;
+  replacementSequence: number;
+  registerSession?: RegisterSessionLifecycleScopedSession | null;
+  reviewSequence?: number | null;
+  storeId: string;
+  terminalId: string;
+}) {
+  const isDistinctReplacement =
+    input.replacementLocalRegisterSessionId !==
+      input.registerSession?.localRegisterSessionId &&
+    input.replacementLocalRegisterSessionId !==
+      input.registerSession?.cloudRegisterSessionId;
+  const isNewerThanReview =
+    input.reviewSequence === null ||
+    input.reviewSequence === undefined ||
+    input.replacementSequence > input.reviewSequence;
+
+  return (
+    isScopedRegisterSession(input) &&
+    isDistinctReplacement &&
+    isNewerThanReview &&
+    (isRegisterSessionSaleUsable(input.registerSession) ||
+      input.registerSession?.status === "closing") &&
+    input.hasOpenRegisterCloseoutReview
+  );
+}
+
+export function canOpenReplacementDrawerForLocalBlock(input: {
+  activeRegisterSession?: RegisterSessionLifecycleScopedSession | null;
+  drawerAuthorityReason?: RegisterSessionLifecycleDrawerAuthorityReason | null;
+  hasSettledCloseout: boolean;
+  saleBlockReason?: string | null;
+}) {
+  if (!input.saleBlockReason) return true;
+  if (
+    input.saleBlockReason === "drawer_authority" &&
+    input.drawerAuthorityReason === "cloud_closed"
+  ) {
+    return true;
+  }
+  if (
+    input.saleBlockReason === "drawer_closed" &&
+    (input.hasSettledCloseout ||
+      input.activeRegisterSession?.status === "closing")
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+export function canInspectRuntimeCloudDrawerAuthority(
+  session: Pick<RegisterSessionLifecycleScopedSession, "status"> | null | undefined,
+) {
+  return (
+    session?.status === "open" ||
+    session?.status === "active" ||
+    session?.status === "closing"
+  );
+}
+
+export function isRegisterCloseoutReviewConflict(
+  input: RegisterSessionLifecycleReviewConflict,
+) {
+  const summary = input.summary?.trim() ?? "";
+  const normalizedSummary = summary.toLowerCase();
+  const details = input.details ?? {};
+  const localEventId = input.localEventId?.toLowerCase() ?? "";
+
+  return (
+    summary === REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY ||
+    normalizedSummary.includes("register closeout") ||
+    localEventId.includes("register-closed") ||
+    localEventId.includes("register-closeout") ||
+    typeof details.countedCash === "number" ||
+    typeof details.expectedCash === "number" ||
+    typeof details.variance === "number"
+  );
+}
+
+function isScopedRegisterSession(input: {
+  registerSession?: RegisterSessionLifecycleScopedSession | null;
+  storeId: string;
+  terminalId: string;
+}) {
+  return (
+    input.registerSession?.storeId === input.storeId &&
+    input.registerSession.terminalId === input.terminalId
+  );
+}

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -673,7 +673,9 @@ describe("RegisterSessionViewContent", () => {
         "Synced register closeout has a variance. Review it before this closeout can be applied.",
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText("Closeout variance review")).toBeInTheDocument();
+    expect(screen.getAllByText("Closeout variance review").length).toBeGreaterThan(
+      0,
+    );
     expect(
       screen.getByText(
         "Review the synced count before applying this closeout to the drawer.",
@@ -716,7 +718,7 @@ describe("RegisterSessionViewContent", () => {
     ).toBeInTheDocument();
   });
 
-  it("resolves only the displayed synced closeout review item", async () => {
+  it("surfaces mixed review items and scopes each decision to its conflict", async () => {
     const user = userEvent.setup();
     const onAuthenticateStaff = vi.fn().mockResolvedValue(
       ok({
@@ -775,6 +777,24 @@ describe("RegisterSessionViewContent", () => {
       />,
     );
 
+    expect(screen.getByText("Review queue needs attention")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "2 review items need manager review before this drawer can be settled.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Closeout variance review").length).toBeGreaterThan(
+      0,
+    );
+    expect(
+      screen.getAllByText(
+        "Service customer attribution is missing. Reject this item, then recreate the service work with a customer if needed.",
+      ).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.queryByRole("button", { name: "Apply reviewed activity" }),
+    ).not.toBeInTheDocument();
+
     await user.click(
       screen.getByRole("button", { name: "Apply synced closeout" }),
     );
@@ -789,6 +809,20 @@ describe("RegisterSessionViewContent", () => {
       decision: "approved",
       registerSessionId: "session-1",
       reviewConflictIds: ["sync_conflict_closeout"],
+    });
+
+    await user.click(screen.getByRole("button", { name: "Reject review item" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm staff for Reject review item",
+      }),
+    );
+
+    expect(onResolveSyncReview).toHaveBeenLastCalledWith({
+      actorStaffProfileId: "manager-1",
+      decision: "rejected",
+      registerSessionId: "session-1",
+      reviewConflictIds: ["sync_conflict_sale"],
     });
   });
 

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -1540,6 +1540,17 @@ function isDuplicateLocalIdRegisterSyncReviewItem(item: PosReconciliationItem) {
 }
 
 function getRegisterSyncReviewItemActionLabels(item: PosReconciliationItem) {
+  if (isRegisterCloseoutReviewItem(item)) {
+    return {
+      approveLabel: isClosedRegisterSyncedCloseoutReviewItem(item)
+        ? "Apply duplicate closeout"
+        : "Apply synced closeout",
+      rejectLabel: isClosedRegisterSyncedCloseoutReviewItem(item)
+        ? "Reject duplicate closeout"
+        : "Reject synced closeout",
+    };
+  }
+
   if (isDuplicateLocalIdRegisterSyncReviewItem(item)) {
     return {
       approveLabel: "Apply duplicate review item",
@@ -1673,12 +1684,19 @@ function RegisterSessionSyncNotice({
   const hasCloseoutReview = reconciliationItems.some(
     isRegisterCloseoutReviewItem,
   );
+  const closeoutReviewCount = reconciliationItems.filter(
+    isRegisterCloseoutReviewItem,
+  ).length;
+  const hasMixedReviewQueue =
+    hasCloseoutReview && reconciliationItems.length > closeoutReviewCount;
   const noticeLabel = hasClosedRegisterSyncedCloseout
     ? "Synced closeout cannot be applied"
     : hasOnlyRejectedReviewItems
       ? "Manager override available"
       : syncStatus.status === "locally_closed_pending_sync"
         ? "Pending reconciliation"
+        : hasMixedReviewQueue
+          ? "Review queue needs attention"
         : hasCloseoutReview
           ? "Closeout needs review"
           : syncStatus.label;
@@ -1686,19 +1704,10 @@ function RegisterSessionSyncNotice({
     ? "This register is already closed. Reject the duplicate synced activity to clear the review."
     : hasOnlyRejectedReviewItems
       ? "Rejected local activity can be synced from Cash Controls. A manager can override and apply these events without the cashier present."
+      : hasMixedReviewQueue
+        ? `${formatReviewItemCount(reconciliationItems.length)} need manager review before this drawer can be settled.`
       : syncStatus.description;
-  const closeoutReviewItem = hasCloseoutReview
-    ? reconciliationItems.find(isRegisterCloseoutReviewItem)
-    : null;
-  const reviewItems = hasCloseoutReview
-    ? closeoutReviewItem
-      ? [closeoutReviewItem]
-      : []
-    : reconciliationItems;
-  const closeoutVariance = closeoutReviewItem?.variance ?? null;
-  const closeoutNote = closeoutReviewItem?.notes?.trim();
-  const closeoutExpectedCash = closeoutReviewItem?.expectedCash;
-  const closeoutCountedCash = closeoutReviewItem?.countedCash;
+  const reviewItems = reconciliationItems;
   const canApproveSyncReview = !hasClosedRegisterSyncedCloseout;
   const shouldCombineReviewItems =
     syncStatus.status === "needs_review" &&
@@ -1727,7 +1736,15 @@ function RegisterSessionSyncNotice({
     syncStatus.status === "needs_review" &&
     !hasOnlyRejectedReviewItems &&
     Boolean(onReviewDecision) &&
-    hasUniformBatchReviewDecision;
+    hasUniformBatchReviewDecision &&
+    !hasMixedReviewQueue;
+  const shouldShowReviewItemActions =
+    syncStatus.status === "needs_review" &&
+    Boolean(onReviewDecision) &&
+    hasMixedReviewQueue;
+  const reviewItemDecisionHandler = shouldShowReviewItemActions
+    ? onReviewDecision
+    : undefined;
   const shouldShowSyncFooter =
     shouldShowRejectedReviewAction ||
     shouldShowRejectedReviewRetryLink ||
@@ -1754,14 +1771,18 @@ function RegisterSessionSyncNotice({
   const reviewReasonSummary = shouldCombineReviewItems
     ? formatReviewReasonSummary(reconciliationItems)
     : null;
+  const allSyncReviewSaleSummaries = getSyncReviewSaleSummaries(
+    reconciliationItems,
+  );
   const syncReviewSaleSummaries = shouldCombineReviewItems
-    ? getSyncReviewSaleSummaries(reconciliationItems)
+    ? allSyncReviewSaleSummaries
     : [];
   const actionCopy = getSyncReviewActionCopy({
     hasCloseoutReview,
     hasOnlyRejectedReviewItems,
     hasSaleReview:
       syncReviewSaleSummaries.length > 0 ||
+      allSyncReviewSaleSummaries.length > 0 ||
       rejectedSyncSaleSummaries.length > 0,
   });
   const rejectedSyncEvidenceDetails = hasOnlyRejectedReviewItems
@@ -1814,7 +1835,7 @@ function RegisterSessionSyncNotice({
           >
             {noticeLabel}
           </p>
-          <p className="text-sm leading-6 text-muted-foreground">
+          <p className="text-pretty text-sm leading-6 text-muted-foreground">
             {noticeDescription}
           </p>
           {hasOnlyRejectedReviewItems ? (
@@ -1882,7 +1903,7 @@ function RegisterSessionSyncNotice({
           ) : syncStatus.status === "needs_review" &&
             reconciliationItems.length > 0 ? (
             <div className="space-y-2 pt-layout-xs">
-              {!hasCloseoutReview ? (
+              {!hasCloseoutReview || hasMixedReviewQueue ? (
                 <p className="text-xs font-medium text-foreground">
                   {formatReviewItemCount(reconciliationItems.length)}
                 </p>
@@ -1891,11 +1912,15 @@ function RegisterSessionSyncNotice({
                 {reviewItems.map((item, index) => {
                   const reportedAt = formatReviewItemTimestamp(item.createdAt);
                   const isCloseoutItem = isRegisterCloseoutReviewItem(item);
+                  const itemVariance = item.variance ?? null;
+                  const itemExpectedCash = item.expectedCash;
+                  const itemCountedCash = item.countedCash;
+                  const itemNote = item.notes?.trim();
 
                   return (
                     <article
                       className={cn(
-                        "rounded-md border bg-background/80 p-layout-md",
+                        "rounded-md border bg-background/80 p-layout-md shadow-sm",
                         isCloseoutItem
                           ? "border-amber-200/80"
                           : "border-danger/15",
@@ -1909,13 +1934,13 @@ function RegisterSessionSyncNotice({
                             <p className="text-sm font-medium text-foreground">
                               Closeout variance review
                             </p>
-                            <p className="text-sm leading-6 text-muted-foreground">
+                            <p className="text-pretty text-sm leading-6 text-muted-foreground">
                               Review the synced count before applying this
                               closeout to the drawer.
                             </p>
                           </div>
                           <dl className="grid gap-layout-sm text-sm sm:grid-cols-3">
-                            {typeof closeoutExpectedCash === "number" ? (
+                            {typeof itemExpectedCash === "number" ? (
                               <div className="rounded-md border border-border/70 bg-muted/20 px-layout-sm py-layout-sm">
                                 <dt className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
                                   Expected
@@ -1923,12 +1948,12 @@ function RegisterSessionSyncNotice({
                                 <dd className="mt-1 font-numeric tabular-nums text-foreground">
                                   {formatCurrency(
                                     currency,
-                                    closeoutExpectedCash,
+                                    itemExpectedCash,
                                   )}
                                 </dd>
                               </div>
                             ) : null}
-                            {typeof closeoutCountedCash === "number" ? (
+                            {typeof itemCountedCash === "number" ? (
                               <div className="rounded-md border border-border/70 bg-muted/20 px-layout-sm py-layout-sm">
                                 <dt className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
                                   Counted
@@ -1936,7 +1961,7 @@ function RegisterSessionSyncNotice({
                                 <dd className="mt-1 font-numeric tabular-nums text-foreground">
                                   {formatCurrency(
                                     currency,
-                                    closeoutCountedCash,
+                                    itemCountedCash,
                                   )}
                                 </dd>
                               </div>
@@ -1948,24 +1973,24 @@ function RegisterSessionSyncNotice({
                               <dd
                                 className={cn(
                                   "mt-1 font-numeric tabular-nums",
-                                  typeof closeoutVariance === "number"
-                                    ? getVarianceTone(closeoutVariance)
+                                  typeof itemVariance === "number"
+                                    ? getVarianceTone(itemVariance)
                                     : "text-foreground",
                                 )}
                               >
-                                {typeof closeoutVariance === "number"
-                                  ? formatCurrency(currency, closeoutVariance)
+                                {typeof itemVariance === "number"
+                                  ? formatCurrency(currency, itemVariance)
                                   : "Needs review"}
                               </dd>
                             </div>
                           </dl>
-                          {closeoutNote ? (
+                          {itemNote ? (
                             <div className="space-y-2 border-t border-border/70 pt-layout-md">
                               <p className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
                                 Notes
                               </p>
-                              <p className="text-sm leading-6 text-muted-foreground">
-                                {closeoutNote}
+                              <p className="text-pretty text-sm leading-6 text-muted-foreground">
+                                {itemNote}
                               </p>
                             </div>
                           ) : null}
@@ -1977,15 +2002,14 @@ function RegisterSessionSyncNotice({
                               ? "Duplicate closeout"
                               : formatPosReconciliationType(item.type, item)}
                           </p>
-                          <p className="text-sm leading-6 text-muted-foreground">
+                          <p className="text-pretty text-sm leading-6 text-muted-foreground">
                             {isClosedRegisterSyncedCloseoutReviewItem(item)
                               ? "The synced closeout is from local activity for a register that is already closed."
-                              : item.summary?.trim() ||
-                                "Review synced register activity before closeout is settled."}
+                              : getRegisterSyncReviewItemSummary(item)}
                           </p>
                         </div>
                       )}
-                      {!isCloseoutItem &&
+                      {(!isCloseoutItem || hasMixedReviewQueue) &&
                       (item.localEventId ||
                         typeof item.sequence === "number" ||
                         reportedAt) ? (
@@ -2019,6 +2043,15 @@ function RegisterSessionSyncNotice({
                             </div>
                           ) : null}
                         </dl>
+                      ) : null}
+                      {reviewItemDecisionHandler && item.id ? (
+                        <div className="mt-layout-md border-t border-border/70 pt-layout-md">
+                          <RegisterSyncReviewItemDecisionList
+                            isResolving={isResolving}
+                            items={[item]}
+                            onReviewDecision={reviewItemDecisionHandler}
+                          />
+                        </div>
                       ) : null}
                     </article>
                   );

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -3263,6 +3263,7 @@ describe("POSRegisterView", () => {
         canOpenCashControls: true,
         cashControlsRegisterSessionId: "drawer-1",
         hasPendingCloseoutApproval: true,
+        hasSignedInStaff: false,
         isReopeningCloseout: false,
         onReopenRegister: vi.fn(),
         onSignOut,
@@ -3295,8 +3296,8 @@ describe("POSRegisterView", () => {
       screen.getByRole("button", { name: /reopen register/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /sign out/i }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: /sign out/i }),
+    ).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/counted cash/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/closeout notes/i)).not.toBeInTheDocument();
     expect(

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
@@ -91,6 +91,23 @@ describe("RegisterDrawerGate", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("hides submitted closeout sign-out when no staff is signed in", () => {
+    renderGate({
+      closeoutSubmittedCountedCash: 780_000,
+      closeoutSubmittedVariance: 40_000,
+      expectedCash: 740_000,
+      hasPendingCloseoutApproval: true,
+      hasSignedInStaff: false,
+      mode: "closeoutBlocked",
+      onReopenRegister: vi.fn(),
+    });
+
+    expect(screen.getByText("Manager approval required")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Sign out" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows synced zero-variance closeouts as submitted instead of rendering the closeout form", () => {
     renderGate({
       closeoutSubmittedCountedCash: 10000,

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -98,6 +98,7 @@ export function RegisterDrawerGate({
   const isAuthorityRepair =
     drawerGate.mode === "terminalRepair" ||
     drawerGate.mode === "drawerAuthorityRepair";
+  const canSignOut = drawerGate.hasSignedInStaff !== false;
 
   if (isAuthorityRepair) {
     const isTerminalRepair = drawerGate.mode === "terminalRepair";
@@ -155,10 +156,16 @@ export function RegisterDrawerGate({
                 Retry sync
               </Button>
             ) : null}
-            <Button type="button" variant="outline" onClick={drawerGate.onSignOut}>
-              <LogOutIcon className="mr-2 h-4 w-4" />
-              Sign out
-            </Button>
+            {canSignOut ? (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={drawerGate.onSignOut}
+              >
+                <LogOutIcon className="mr-2 h-4 w-4" />
+                Sign out
+              </Button>
+            ) : null}
           </div>
         </div>
       </div>
@@ -362,16 +369,18 @@ export function RegisterDrawerGate({
                 </LoadingButton>
               ) : null}
 
-              <Button
-                className="w-full sm:w-auto"
-                disabled={drawerGate.isReopeningCloseout}
-                onClick={() => void drawerGate.onSignOut()}
-                type="button"
-                variant="outline"
-              >
-                <LogOutIcon className="mr-2 h-4 w-4" />
-                Sign out
-              </Button>
+              {canSignOut ? (
+                <Button
+                  className="w-full sm:w-auto"
+                  disabled={drawerGate.isReopeningCloseout}
+                  onClick={() => void drawerGate.onSignOut()}
+                  type="button"
+                  variant="outline"
+                >
+                  <LogOutIcon className="mr-2 h-4 w-4" />
+                  Sign out
+                </Button>
+              ) : null}
             </div>
 
             {drawerGate.errorMessage ? (
@@ -492,19 +501,21 @@ export function RegisterDrawerGate({
                   />
                 ) : null}
 
-                <Button
-                  className="w-full sm:w-auto"
-                  disabled={
-                    drawerGate.isCloseoutSubmitting ||
-                    drawerGate.isReopeningCloseout
-                  }
-                  onClick={() => void drawerGate.onSignOut()}
-                  type="button"
-                  variant="outline"
-                >
-                  <LogOutIcon className="mr-2 h-4 w-4" />
-                  Sign out
-                </Button>
+                {canSignOut ? (
+                  <Button
+                    className="w-full sm:w-auto"
+                    disabled={
+                      drawerGate.isCloseoutSubmitting ||
+                      drawerGate.isReopeningCloseout
+                    }
+                    onClick={() => void drawerGate.onSignOut()}
+                    type="button"
+                    variant="outline"
+                  >
+                    <LogOutIcon className="mr-2 h-4 w-4" />
+                    Sign out
+                  </Button>
+                ) : null}
               </div>
             </form>
           </>
@@ -590,16 +601,18 @@ export function RegisterDrawerGate({
             {drawerGate.isSubmitting ? "Opening drawer" : "Open drawer"}
           </Button>
 
-          <Button
-            className="w-full sm:w-auto"
-            disabled={drawerGate.isSubmitting}
-            onClick={() => void drawerGate.onSignOut()}
-            type="button"
-            variant="outline"
-          >
-            <LogOutIcon className="mr-2 h-4 w-4" />
-            Sign out
-          </Button>
+          {canSignOut ? (
+            <Button
+              className="w-full sm:w-auto"
+              disabled={drawerGate.isSubmitting}
+              onClick={() => void drawerGate.onSignOut()}
+              type="button"
+              variant="outline"
+            >
+              <LogOutIcon className="mr-2 h-4 w-4" />
+              Sign out
+            </Button>
+          ) : null}
 
           {drawerGate.canOpenCashControls ? (
             <CashControlsButton

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts
@@ -421,7 +421,6 @@ function drawerAuthorityEventKey(input: {
 
 export function isDrawerAuthorityLifecycleEvent(event: PosLocalEventRecord) {
   return (
-    event.type === "register.opened" ||
     event.type === "register.closeout_started" ||
     event.type === "register.reopened"
   );

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
@@ -507,7 +507,7 @@ describe("createLocalCommandGateway", () => {
     });
   });
 
-  it("opens a replacement drawer when the active drawer is blocked by lifecycle review", async () => {
+  it("reuses the active local drawer when lifecycle review is still pending", async () => {
     const store = createPosLocalStore({
       adapter: createMemoryPosLocalStorageAdapter(),
       clock: () => 10_000,
@@ -552,8 +552,8 @@ describe("createLocalCommandGateway", () => {
     expect(result).toMatchObject({
       kind: "ok",
       data: {
-        localRegisterSessionId: "local-register-session-2",
-        openingFloat: 500,
+        localRegisterSessionId: "local-register-1",
+        openingFloat: 100,
       },
     });
     const started = await gateway.startSession({
@@ -561,14 +561,14 @@ describe("createLocalCommandGateway", () => {
       terminalId: "terminal-1" as never,
       staffProfileId: "staff-1" as never,
       registerNumber: "1",
-      localRegisterSessionId: "local-register-session-2",
+      localRegisterSessionId: "local-register-1",
     });
 
     expect(started).toMatchObject({
       kind: "ok",
       data: { localPosSessionId: "local-pos-session-2" },
     });
-    expect(onEventAppended).toHaveBeenCalledTimes(2);
+    expect(onEventAppended).toHaveBeenCalledTimes(1);
     await expect(store.listEvents()).resolves.toMatchObject({
       ok: true,
       value: [
@@ -577,11 +577,7 @@ describe("createLocalCommandGateway", () => {
           type: "register.opened",
         }),
         expect.objectContaining({
-          localRegisterSessionId: "local-register-session-2",
-          type: "register.opened",
-        }),
-        expect.objectContaining({
-          localRegisterSessionId: "local-register-session-2",
+          localRegisterSessionId: "local-register-1",
           type: "session.started",
         }),
       ],
@@ -647,6 +643,80 @@ describe("createLocalCommandGateway", () => {
         expect.objectContaining({
           localRegisterSessionId: "local-register-1",
           type: "register.opened",
+        }),
+        expect.objectContaining({
+          localRegisterSessionId: "local-register-session-2",
+          type: "register.opened",
+        }),
+      ],
+    });
+  });
+
+  it("opens a replacement drawer when a submitted closeout is under lifecycle review", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 10_000,
+    });
+    await store.appendEvent({
+      type: "register.opened",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "local-register-1",
+      staffProfileId: "staff-1",
+      payload: {
+        localRegisterSessionId: "local-register-1",
+        openingFloat: 100,
+      },
+    });
+    await store.appendEvent({
+      type: "register.closeout_started",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "local-register-1",
+      staffProfileId: "staff-1",
+      payload: { countedCash: 100 },
+    });
+    await store.writeDrawerAuthorityState({
+      localRegisterSessionId: "local-register-1",
+      observedAt: 10_010,
+      reason: "lifecycle_rejected",
+      status: "blocked",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    });
+    const gateway = createLocalCommandGateway({
+      store,
+      clock: () => 20_000,
+      createLocalId: (kind) => `${kind}-2`,
+    });
+
+    const result = await gateway.openDrawer({
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      staffProfileId: "staff-1" as never,
+      registerNumber: "1",
+      openingFloat: 500,
+    });
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        localRegisterSessionId: "local-register-session-2",
+        openingFloat: 500,
+      },
+    });
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: [
+        expect.objectContaining({
+          localRegisterSessionId: "local-register-1",
+          type: "register.opened",
+        }),
+        expect.objectContaining({
+          localRegisterSessionId: "local-register-1",
+          type: "register.closeout_started",
         }),
         expect.objectContaining({
           localRegisterSessionId: "local-register-session-2",

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
@@ -3,6 +3,10 @@ import type {
   PosOpenDrawerInput,
 } from "@/lib/pos/application/dto";
 import { ok, userError, type CommandResult } from "~/shared/commandResult";
+import {
+  canOpenReplacementDrawerForLocalBlock,
+  isDrawerAuthoritySaleBlocking,
+} from "~/shared/registerSessionLifecyclePolicy";
 import type { PosLocalSyncPendingCheckoutItemDefinedPayload } from "~/shared/posLocalSyncContract";
 
 import { readProjectedLocalRegisterModel } from "./localRegisterReader";
@@ -167,7 +171,12 @@ export function createLocalCommandGateway(
 
     return {
       ok: true as const,
-      blocked: drawerAuthority.value?.status === "blocked",
+      blocked: isDrawerAuthoritySaleBlocking({
+        activeRegisterSession: {
+          localRegisterSessionId: input.localRegisterSessionId,
+        },
+        drawerAuthority: drawerAuthority.value,
+      }),
     };
   }
 
@@ -440,23 +449,19 @@ export function createLocalCommandGateway(
       if (!existingModel.ok) {
         return toLocalUserError(existingModel.error.message);
       }
-      const isClosedCloudDrawerBlock =
-        existingModel.value.saleBlockReason === "drawer_authority" &&
-        existingModel.value.drawerAuthorityReason === "cloud_closed";
-      const isLifecycleReviewDrawerBlock =
-        existingModel.value.saleBlockReason === "drawer_authority" &&
-        existingModel.value.drawerAuthorityReason === "lifecycle_rejected";
-      const isSettledClosedDrawerBlock =
-        existingModel.value.saleBlockReason === "drawer_closed" &&
-        hasSettledRegisterCloseout({
-          events: existingModel.value.sourceEvents,
-          session: existingModel.value.activeRegisterSession,
-        });
+      const hasSettledCloseout = hasSettledRegisterCloseout({
+        events: existingModel.value.sourceEvents,
+        session: existingModel.value.activeRegisterSession,
+      });
+      const canOpenReplacementDrawer = canOpenReplacementDrawerForLocalBlock({
+        activeRegisterSession: existingModel.value.activeRegisterSession,
+        drawerAuthorityReason: existingModel.value.drawerAuthorityReason,
+        hasSettledCloseout,
+        saleBlockReason: existingModel.value.saleBlockReason,
+      });
       if (
         existingModel.value.saleBlockReason &&
-        !isClosedCloudDrawerBlock &&
-        !isLifecycleReviewDrawerBlock &&
-        !isSettledClosedDrawerBlock
+        !canOpenReplacementDrawer
       ) {
         return toLocalUserError(
           blockedSaleMessage(existingModel.value.saleBlockReason),
@@ -468,10 +473,7 @@ export function createLocalCommandGateway(
         activeRegisterSession &&
         isOpenLocalRegisterSessionStatus(activeRegisterSession.status)
       ) {
-        if (isClosedCloudDrawerBlock) {
-          return appendNewDrawer(input);
-        }
-        if (isLifecycleReviewDrawerBlock) {
+        if (canOpenReplacementDrawer && !existingModel.value.canSell) {
           return appendNewDrawer(input);
         }
         if (!existingModel.value.canSell) {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
@@ -1039,6 +1039,69 @@ describe("projectLocalRegisterReadModel", () => {
     expect(model.syncStatus.state).toBe("needs_review");
   });
 
+  it("ignores stale lifecycle drawer authority for an open local drawer", () => {
+    const model = projectLocalRegisterReadModel({
+      drawerAuthority: {
+        localRegisterSessionId: "local-register-1",
+        observedAt: 1_050,
+        reason: "lifecycle_rejected",
+        status: "blocked",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      },
+      events: [
+        event({
+          sequence: 1,
+          type: "register.opened",
+          payload: {
+            localRegisterSessionId: "local-register-1",
+            openingFloat: 100,
+          },
+        }),
+      ],
+    });
+
+    expect(model.canSell).toBe(true);
+    expect(model.saleBlockReason).toBeUndefined();
+    expect(model.drawerAuthorityReason).toBeUndefined();
+  });
+
+  it("treats lifecycle review authority on a submitted closeout as drawer closed", () => {
+    const model = projectLocalRegisterReadModel({
+      drawerAuthority: {
+        localRegisterSessionId: "local-register-1",
+        observedAt: 1_050,
+        reason: "lifecycle_rejected",
+        status: "blocked",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      },
+      events: [
+        event({
+          sequence: 1,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-1",
+          payload: {
+            localRegisterSessionId: "local-register-1",
+            openingFloat: 100,
+          },
+        }),
+        event({
+          sequence: 2,
+          type: "register.closeout_started",
+          localRegisterSessionId: "local-register-1",
+          payload: { countedCash: 100 },
+          sync: { status: "needs_review", uploaded: true },
+        }),
+      ],
+    });
+
+    expect(model.canSell).toBe(false);
+    expect(model.activeRegisterSession?.status).toBe("closing");
+    expect(model.saleBlockReason).toBe("drawer_closed");
+    expect(model.drawerAuthorityReason).toBeUndefined();
+  });
+
   it("keeps the current drawer active when a later duplicate drawer open needs review", () => {
     const model = projectLocalRegisterReadModel({
       mappings: [

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
@@ -3,6 +3,10 @@ import type {
   PosRegisterStateDto,
   PosTerminalDto,
 } from "@/lib/pos/application/dto";
+import {
+  getSaleBlockingDrawerAuthority,
+  isRegisterSessionSaleUsable,
+} from "~/shared/registerSessionLifecyclePolicy";
 
 import { derivePosLocalSyncStatus } from "./syncStatus";
 import {
@@ -422,22 +426,25 @@ export function projectLocalRegisterReadModel(input: {
   }
 
   const activeSale = [...sales.values()].at(-1) ?? null;
-  const saleBlockReason = getSaleBlockReason({
+  const drawerAuthority = getSaleBlockingDrawerAuthority({
     activeRegisterSession,
     drawerAuthority: input.drawerAuthority,
+  });
+  const saleBlockReason = getSaleBlockReason({
+    activeRegisterSession,
+    drawerAuthority,
     terminalIntegrity: input.terminalIntegrity,
   });
   const canSell =
-    Boolean(activeRegisterSession) &&
-    activeRegisterSession?.status !== "closing" &&
+    isRegisterSessionSaleUsable(activeRegisterSession) &&
     !saleBlockReason;
 
   return {
     activeRegisterSession,
     activeSale,
     canSell,
-    ...(input.drawerAuthority?.status === "blocked"
-      ? { drawerAuthorityReason: input.drawerAuthority.reason }
+    ...(drawerAuthority?.status === "blocked"
+      ? { drawerAuthorityReason: drawerAuthority.reason }
       : {}),
     ...(saleBlockReason ? { saleBlockReason } : {}),
     clearedSaleIds: [...clearedSaleIds],

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
@@ -2,6 +2,7 @@ import type { FunctionArgs } from "convex/server";
 
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
+import { isNonBlockingRegisterLifecycleReviewEvent } from "~/shared/registerSessionLifecyclePolicy";
 
 import {
   POS_LOCAL_STORE_SCHEMA_VERSION,
@@ -676,15 +677,21 @@ function buildSyncMetrics(
   const failedEventCount =
     input.syncDebug?.failedEventCount ??
     input.events.filter((event) => event.sync.status === "failed").length;
+  const statusEvents = input.events.filter(
+    (event) => !isNonBlockingRegisterLifecycleReviewEvent(event),
+  );
   const reviewEventCount =
     input.syncDebug?.reviewEventCount ??
     input.events.filter((event) => event.sync.status === "needs_review").length;
+  const actionableReviewEventCount = statusEvents.filter(
+    (event) => event.sync.status === "needs_review",
+  ).length;
   const localOnlyEventCount =
     input.syncDebug?.localOnlyEventCount ?? localOnlyEvents.length;
   const uploadableEventCount =
     input.syncDebug?.pendingUploadEventCount ?? uploadableEvents.length;
   const status = derivePosLocalSyncStatus({
-    events: input.events,
+    events: statusEvents,
     isOnline: input.browserInfo?.online ?? true,
   });
   const oldestPendingEvent = input.events
@@ -714,9 +721,9 @@ function buildSyncMetrics(
       ? "syncing"
       : mapSyncStatus(status.state, {
           failedEventCount,
-          hasEvents: input.events.length > 0,
+          hasEvents: statusEvents.length > 0,
           localStoreFailureMessage: input.localStoreFailureMessage,
-          reviewEventCount,
+          reviewEventCount: actionableReviewEventCount,
         }),
     uploadableEventCount,
   };

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -843,10 +843,13 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     await waitFor(() =>
       expect(result.current).toEqual(
         expect.objectContaining({
-          status: "needs_review",
+          runtimeStatus: expect.objectContaining({
+            sync: expect.objectContaining({ status: "idle" }),
+          }),
         }),
       ),
     );
+    expect(result.current?.debug?.reviewEventCount).toBe(1);
     expect(mocks.ingestLocalEvents).not.toHaveBeenCalled();
 
     act(() => {
@@ -930,10 +933,13 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     await waitFor(() =>
       expect(result.current).toEqual(
         expect.objectContaining({
-          status: "needs_review",
+          runtimeStatus: expect.objectContaining({
+            sync: expect.objectContaining({ status: "idle" }),
+          }),
         }),
       ),
     );
+    expect(result.current?.debug?.reviewEventCount).toBe(1);
     act(() => {
       result.current?.onRetrySync?.();
     });
@@ -1543,7 +1549,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     });
   });
 
-  it("writes drawer authority when mapping persistence fails during runtime upload", async () => {
+  it("does not write drawer authority when drawer-open mapping persistence fails during runtime upload", async () => {
     mocks.ingestLocalEvents.mockResolvedValue({
       kind: "ok",
       data: {
@@ -1636,15 +1642,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         ),
       { timeout: 3_000 },
     );
-    expect(store.writeDrawerAuthorityState).toHaveBeenCalledWith(
-      expect.objectContaining({
-        localRegisterSessionId: "register-1",
-        reason: "authority_unknown",
-        status: "blocked",
-        storeId: "store-1",
-        terminalId: "local-terminal-1",
-      }),
-    );
+    expect(store.writeDrawerAuthorityState).not.toHaveBeenCalled();
     expect(store.markEventsSynced).not.toHaveBeenCalled();
   });
 
@@ -3313,6 +3311,125 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     expect(onLocalEventsChanged).toHaveBeenCalled();
   });
 
+  it("passively reconciles a pending local closeout when the mapped cloud drawer is closed", async () => {
+    mocks.reportTerminalRuntimeStatus.mockResolvedValue({
+      kind: "ok",
+      data: {
+        drawerAuthorityDirective: {
+          cloudRegisterSessionId: "cloud-register-1",
+          localRegisterSessionId: "local-register-1",
+          message:
+            "The mapped cloud register is closed. Open a register before selling.",
+          observedAt: 200,
+          reason: "cloud_closed",
+          registerNumber: "8",
+          status: "blocked",
+        },
+      },
+    });
+    const onLocalEventsChanged = vi.fn();
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-open",
+            localRegisterSessionId: "local-register-1",
+            payload: {
+              expectedCash: 5_000,
+              localRegisterSessionId: "local-register-1",
+              openingFloat: 5_000,
+            },
+            sequence: 1,
+            sync: { status: "synced", uploaded: true },
+            type: "register.opened",
+          }),
+          buildLocalEvent({
+            localEventId: "event-closeout",
+            localRegisterSessionId: "local-register-1",
+            payload: {
+              countedCash: 5_000,
+              notes: null,
+            },
+            sequence: 2,
+            sync: { status: "pending", uploaded: false },
+            type: "register.closeout_started",
+          }),
+        ],
+      })),
+      listLocalCloudMappings: vi.fn(async () => ({
+        ok: true,
+        value: [
+          {
+            entity: "registerSession",
+            localId: "local-register-1",
+            cloudId: "cloud-register-1",
+            mappedAt: 100,
+          },
+        ],
+      })),
+      readDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      writeDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+    };
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        mode: "status-only",
+        onLocalEventsChanged,
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.reportTerminalRuntimeStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: expect.objectContaining({
+            activeRegisterSession: expect.objectContaining({
+              cloudRegisterSessionId: "cloud-register-1",
+              localRegisterSessionId: "local-register-1",
+              status: "closing",
+            }),
+          }),
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(store.writeDrawerAuthorityState).toHaveBeenCalledWith({
+        cloudRegisterSessionId: "cloud-register-1",
+        localRegisterSessionId: "local-register-1",
+        message:
+          "The mapped cloud register is closed. Open a register before selling.",
+        observedAt: 200,
+        reason: "cloud_closed",
+        registerNumber: "8",
+        status: "blocked",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+    );
+    expect(onLocalEventsChanged).toHaveBeenCalled();
+  });
+
   it("does not persist terminal integrity for generic runtime check-in rejections", async () => {
     mocks.reportTerminalRuntimeStatus.mockResolvedValue({
       kind: "user_error",
@@ -4211,7 +4328,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     );
   });
 
-  it("presents closeout reconciliation conflicts as needs review", () => {
+  it("keeps closeout reconciliation conflicts out of POS runtime review status", () => {
     expect(
       derivePosLocalRuntimeSyncStatus(
         [
@@ -4223,12 +4340,22 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         ],
         { isOnline: true },
       ),
-    ).toEqual(
-      expect.objectContaining({
-        pendingEventCount: 0,
-        status: "needs_review",
-      }),
-    );
+    ).toBeNull();
+  });
+
+  it("keeps drawer-open reconciliation conflicts out of POS runtime review status", () => {
+    expect(
+      derivePosLocalRuntimeSyncStatus(
+        [
+          buildLocalEvent({
+            localEventId: "event-open",
+            sync: { status: "needs_review", uploaded: true },
+            type: "register.opened",
+          }),
+        ],
+        { isOnline: true },
+      ),
+    ).toBeNull();
   });
 
   it("ignores local cart drafts that are not referenced by a pending completed sale", () => {
@@ -4285,15 +4412,15 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     );
   });
 
-  it("presents terminal-blocking uploaded review events from another staff profile", () => {
+  it("presents terminal-blocking uploaded reopen review events from another staff profile", () => {
     expect(
       derivePosLocalRuntimeSyncStatus(
         [
           buildLocalEvent({
-            localEventId: "event-other-staff-open",
+            localEventId: "event-other-staff-reopen",
             staffProfileId: "staff-2",
             sync: { status: "needs_review", uploaded: true },
-            type: "register.opened",
+            type: "register.reopened",
           }),
         ],
         { isOnline: true, staffProfileId: "staff-1" },

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -9,6 +9,7 @@ import {
   type AthenaWebappRuntimeBuildMetadata,
 } from "@/lib/runtimeBuildMetadata";
 import { isLocalPinVerifierMetadata } from "@/lib/security/localPinVerifier";
+import { isNonBlockingRegisterLifecycleReviewEvent } from "~/shared/registerSessionLifecyclePolicy";
 import {
   createIndexedDbPosLocalStorageAdapter,
   createPosLocalStore,
@@ -1978,6 +1979,10 @@ function collectRuntimeRelevantEvents(events: PosLocalEventRecord[]) {
 }
 
 function isRuntimeRelevantLocalEvent(event: PosLocalEventRecord) {
+  if (isNonBlockingRegisterLifecycleReviewEvent(event)) {
+    return false;
+  }
+
   return (
     isSyncablePosLocalEvent(event) ||
     event.type === "register.opened" ||

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -253,6 +253,7 @@ export interface RegisterDrawerGateState {
   canOpenCashControls?: boolean;
   cashControlsRegisterSessionId?: Id<"registerSession">;
   canOpenDrawer?: boolean;
+  hasSignedInStaff?: boolean;
   hasPendingCloseoutApproval?: boolean;
   notes?: string;
   errorMessage: string | null;

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -2479,7 +2479,7 @@ describe("useRegisterViewModel", () => {
     expect(onRetrySync).toHaveBeenCalled();
   });
 
-  it("blocks POS when the active drawer has a synced closeout review", async () => {
+  it("keeps POS usable when the active drawer has a closeout review conflict", async () => {
     mockRegisterState = {
       ...mockRegisterState!,
       activeRegisterSession: {
@@ -2502,7 +2502,26 @@ describe("useRegisterViewModel", () => {
           ],
         },
       },
+      activeSession: null,
     };
+    mockActiveSession = null;
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        buildLocalEvent({
+          sequence: 1,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-new",
+          payload: {
+            expectedCash: 5_000,
+            localRegisterSessionId: "local-register-new",
+            openingFloat: 5_000,
+            status: "open",
+          },
+          sync: { status: "pending", uploaded: false },
+        }),
+      ],
+    });
 
     const { useRegisterViewModel } = await import("./useRegisterViewModel");
     const { result } = renderHook(() => useRegisterViewModel());
@@ -2512,22 +2531,50 @@ describe("useRegisterViewModel", () => {
         buildStaffAuthenticationResult(),
       );
     });
+    await waitForLocalRegisterEffects(result);
 
-    expect(result.current.drawerGate).not.toBeNull();
-    expect(result.current.drawerGate?.mode).toBe("closeoutBlocked");
-    expect(result.current.drawerGate?.hasPendingCloseoutApproval).toBe(true);
-    expect(result.current.drawerGate?.expectedCash).toBe(5_000);
-    expect(result.current.drawerGate?.closeoutSubmittedCountedCash).toBe(4_500);
-    expect(result.current.drawerGate?.closeoutSubmittedVariance).toBe(-500);
-    expect(result.current.drawerGate?.cashControlsRegisterSessionId).toBe(
-      "drawer-1",
+    expect(result.current.drawerGate).toBeNull();
+    expect(result.current.productEntry.disabled).toBe(false);
+    expect(result.current.syncStatus).toEqual(
+      expect.objectContaining({
+        label: "Pending sync",
+        pendingEventCount: 1,
+        status: "pending_sync",
+      }),
     );
-    expect(result.current.drawerGate?.onReopenRegister).toBeUndefined();
-    expect(
-      result.current.drawerGate?.onCloseoutSecondaryAction,
-    ).toBeUndefined();
-    expect(result.current.productEntry.disabled).toBe(true);
     expect(mockStartSession).not.toHaveBeenCalled();
+
+    let added = false;
+    await act(async () => {
+      added = await result.current.productEntry.onAddProduct({
+        id: "sku-2",
+        name: "Deep Wave",
+        price: 100,
+        barcode: "1234567890123",
+        productId: "product-2" as Id<"product">,
+        skuId: "sku-2" as Id<"productSku">,
+        sku: "DW-18",
+        category: "Hair",
+        description: "Deep wave bundle",
+        image: null,
+        inStock: true,
+        quantityAvailable: 5,
+      });
+    });
+
+    expect(added).toBe(true);
+    expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        localRegisterSessionId: "local-register-new",
+        type: "session.started",
+      }),
+    );
+    expect(mockAppendLocalEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        localRegisterSessionId: "drawer-1",
+        type: "session.started",
+      }),
+    );
   });
 
   it("holds the active POS session before signing the cashier out when session data is present", async () => {
@@ -3206,7 +3253,7 @@ describe("useRegisterViewModel", () => {
     expect(result.current.cashierCard?.cashierName).toBe("Offline Manager");
   });
 
-  it("holds bootstrap on a closing drawer and exposes the closeout-blocked gate", async () => {
+  it("holds bootstrap on a closing drawer and exposes the opening drawer gate", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -3243,24 +3290,84 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(result.current.drawerGate).not.toBeNull();
-    expect(result.current.drawerGate?.mode).toBe("closeoutBlocked");
+    expect(result.current.drawerGate?.mode).toBe("initialSetup");
     expect(result.current.drawerGate?.registerNumber).toBe("1");
     expect(result.current.productEntry.disabled).toBe(true);
     expect(mockStartSession).not.toHaveBeenCalled();
     expect(mockOpenDrawer).not.toHaveBeenCalled();
-    expect(result.current.drawerGate).not.toHaveProperty("onSubmit");
+    expect(result.current.drawerGate?.onSubmit).toEqual(expect.any(Function));
     expect(result.current.drawerGate?.onSubmitCloseout).toBeUndefined();
-    expect(result.current.drawerGate?.closeoutSubmittedReason).toBe(
-      "manager_review",
-    );
-    expect(result.current.drawerGate?.expectedCash).toBe(5_000);
-    expect(result.current.drawerGate?.hasPendingCloseoutApproval).toBe(true);
-    expect(result.current.drawerGate?.canOpenCashControls).toBe(true);
-    expect(result.current.drawerGate?.cashControlsRegisterSessionId).toBe(
-      "drawer-1",
-    );
-    expect(result.current.drawerGate?.closeoutSubmittedCountedCash).toBe(4_500);
-    expect(result.current.drawerGate?.closeoutSubmittedVariance).toBe(-500);
+    expect(result.current.drawerGate?.closeoutSubmittedReason).toBeUndefined();
+    expect(result.current.drawerGate?.expectedCash).toBeUndefined();
+    expect(
+      result.current.drawerGate?.hasPendingCloseoutApproval,
+    ).toBeUndefined();
+    expect(
+      result.current.drawerGate?.cashControlsRegisterSessionId,
+    ).toBeUndefined();
+    expect(
+      result.current.drawerGate?.closeoutSubmittedCountedCash,
+    ).toBeUndefined();
+    expect(result.current.drawerGate?.closeoutSubmittedVariance).toBeUndefined();
+  });
+
+  it("allows a newer local drawer to sell while a different cloud closeout awaits manager review", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: {
+        _id: "staff-1",
+        firstName: "Ama",
+        lastName: "Kusi",
+        activeRoles: ["cashier"],
+      },
+      activeRegisterSession: {
+        _id: "drawer-pending-approval",
+        status: "closing",
+        countedCash: 4_600,
+        managerApprovalRequestId: "approval-1" as Id<"approvalRequest">,
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now() - 60_000,
+        variance: -400,
+      },
+      activeSession: null,
+      activeSessionConflict: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        buildLocalEvent({
+          sequence: 1,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-new",
+          payload: {
+            expectedCash: 5_000,
+            localRegisterSessionId: "local-register-new",
+            openingFloat: 5_000,
+            status: "open",
+          },
+          sync: { status: "pending", uploaded: false },
+        }),
+      ],
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult({ activeRoles: ["cashier"] }),
+      );
+    });
+    await waitForLocalRegisterEffects(result);
+
+    expect(result.current.drawerGate).toBeNull();
+    expect(result.current.productEntry.disabled).toBe(false);
   });
 
   it("submits closeout from the POS drawer gate with the current cashier", async () => {
@@ -3275,7 +3382,7 @@ describe("useRegisterViewModel", () => {
       },
       activeRegisterSession: {
         _id: "drawer-1",
-        status: "closing",
+        status: "open",
         terminalId: "terminal-1",
         registerNumber: "1",
         openingFloat: 5_000,
@@ -3294,6 +3401,10 @@ describe("useRegisterViewModel", () => {
       result.current.authDialog?.onAuthenticated(
         buildStaffAuthenticationResult(),
       );
+    });
+
+    act(() => {
+      result.current.closeoutControl?.onRequestCloseout();
     });
 
     act(() => {
@@ -3336,7 +3447,7 @@ describe("useRegisterViewModel", () => {
       },
       activeRegisterSession: {
         _id: "drawer-1",
-        status: "closing",
+        status: "open",
         terminalId: "terminal-1",
         registerNumber: "1",
         openingFloat: 5_000,
@@ -3365,6 +3476,10 @@ describe("useRegisterViewModel", () => {
       result.current.authDialog?.onAuthenticated(
         buildStaffAuthenticationResult(),
       );
+    });
+
+    act(() => {
+      result.current.closeoutControl?.onRequestCloseout();
     });
 
     act(() => {
@@ -3399,7 +3514,7 @@ describe("useRegisterViewModel", () => {
       cashier: { _id: "staff-1", firstName: "Ama", lastName: "Kusi" },
       activeRegisterSession: {
         _id: "drawer-1",
-        status: "closing",
+        status: "open",
         terminalId: "terminal-1",
         registerNumber: "1",
         openingFloat: 5_000,
@@ -3418,6 +3533,10 @@ describe("useRegisterViewModel", () => {
       result.current.authDialog?.onAuthenticated(
         buildStaffAuthenticationResult(),
       );
+    });
+
+    act(() => {
+      result.current.closeoutControl?.onRequestCloseout();
     });
 
     act(() => {
@@ -3441,7 +3560,7 @@ describe("useRegisterViewModel", () => {
         }),
       ),
     );
-    expect(result.current.drawerGate?.errorMessage).toBeNull();
+    expect(result.current.drawerGate?.errorMessage).toBeUndefined();
   });
 
   it("records closeout locally without waiting for a server approval response", async () => {
@@ -3456,7 +3575,7 @@ describe("useRegisterViewModel", () => {
       },
       activeRegisterSession: {
         _id: "drawer-1",
-        status: "closing",
+        status: "open",
         terminalId: "terminal-1",
         registerNumber: "1",
         openingFloat: 5_000,
@@ -3474,6 +3593,10 @@ describe("useRegisterViewModel", () => {
       result.current.authDialog?.onAuthenticated(
         buildStaffAuthenticationResult(),
       );
+    });
+
+    act(() => {
+      result.current.closeoutControl?.onRequestCloseout();
     });
 
     act(() => {
@@ -3511,7 +3634,7 @@ describe("useRegisterViewModel", () => {
       },
       activeRegisterSession: {
         _id: "drawer-1",
-        status: "closing",
+        status: "open",
         terminalId: "terminal-1",
         registerNumber: "1",
         openingFloat: 5_000,
@@ -3530,6 +3653,10 @@ describe("useRegisterViewModel", () => {
       result.current.authDialog?.onAuthenticated(
         buildStaffAuthenticationResult(),
       );
+    });
+
+    act(() => {
+      result.current.closeoutControl?.onRequestCloseout();
     });
 
     act(() => {
@@ -3871,7 +3998,7 @@ describe("useRegisterViewModel", () => {
     expect(toast.success).toHaveBeenCalledWith("Opening float corrected");
   });
 
-  it("reopens a closing register session from the POS drawer gate", async () => {
+  it("opens a fresh local drawer when the cloud register session is closing", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -3900,30 +4027,42 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
+    expect(result.current.drawerGate?.mode).toBe("initialSetup");
+
+    act(() => {
+      result.current.drawerGate?.onOpeningFloatChange?.("50.00");
+      result.current.drawerGate?.onNotesChange?.("Fresh drawer");
+    });
+
     await act(async () => {
-      await result.current.drawerGate?.onReopenRegister?.();
+      await result.current.drawerGate?.onSubmit?.();
     });
 
     expect(mockReopenRegisterSessionCloseout).not.toHaveBeenCalled();
+    expect(mockAppendLocalEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "register.reopened" }),
+    );
     await waitFor(() =>
       expect(mockAppendLocalEvent).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: "register.reopened",
-          localRegisterSessionId: "drawer-1",
+          type: "register.opened",
+          localRegisterSessionId: expect.not.stringMatching(/^drawer-1$/),
+          payload: expect.objectContaining({
+            notes: "Fresh drawer",
+            openingFloat: 5_000,
+          }),
         }),
       ),
     );
     expect(mockMarkLocalEventsSynced).not.toHaveBeenCalled();
-    expect(toast.success).toHaveBeenCalledWith(
-      "Register reopened. You can start selling.",
-    );
+    expect(toast.success).toHaveBeenCalledWith("Drawer open");
   });
 
-  it("does not expose local register reopen to non-manager cashiers", async () => {
+  it("does not expose local register reopen to non-manager cashiers for closing sessions", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -3956,7 +4095,7 @@ describe("useRegisterViewModel", () => {
       );
     });
 
-    expect(result.current.drawerGate?.mode).toBe("closeoutBlocked");
+    expect(result.current.drawerGate?.mode).toBe("initialSetup");
     expect(result.current.drawerGate?.onReopenRegister).toBeUndefined();
     expect(result.current.productEntry.disabled).toBe(true);
     expect(mockAppendLocalEvent).not.toHaveBeenCalledWith(
@@ -3964,7 +4103,7 @@ describe("useRegisterViewModel", () => {
     );
   });
 
-  it("keeps closeout blocked when local register reopen persistence fails", async () => {
+  it("keeps the opening drawer gate when fresh drawer persistence fails after a closing session", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -3988,7 +4127,7 @@ describe("useRegisterViewModel", () => {
     };
     mockActiveSession = null;
     mockAppendLocalEvent.mockImplementation(async (input: { type: string }) =>
-      input.type === "register.reopened"
+      input.type === "register.opened"
         ? {
             ok: false,
             error: {
@@ -4003,18 +4142,22 @@ describe("useRegisterViewModel", () => {
 
     await act(async () => {
       result.current.authDialog?.onAuthenticated(
-        "staff-1" as Id<"staffProfile">,
+        buildStaffAuthenticationResult(),
       );
     });
 
-    await act(async () => {
-      await result.current.drawerGate?.onReopenRegister?.();
+    act(() => {
+      result.current.drawerGate?.onOpeningFloatChange?.("50.00");
     });
 
-    expect(result.current.drawerGate?.mode).toBe("closeoutBlocked");
+    await act(async () => {
+      await result.current.drawerGate?.onSubmit?.();
+    });
+
+    expect(result.current.drawerGate?.mode).toBe("initialSetup");
     expect(result.current.productEntry.disabled).toBe(true);
     expect(result.current.drawerGate?.errorMessage).toBe(
-      "Unable to reopen this register. Try again.",
+      "Unable to open the drawer. Try again.",
     );
     expect(toast.success).not.toHaveBeenCalledWith(
       "Register reopened. You can start selling.",
@@ -4086,7 +4229,7 @@ describe("useRegisterViewModel", () => {
     );
   });
 
-  it("gates an active POS session assigned to a closing drawer with closeout guidance", async () => {
+  it("gates an active POS session assigned to a closing drawer with drawer recovery", async () => {
     mockRegisterState = {
       phase: "active",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -4114,16 +4257,14 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(result.current.drawerGate).not.toBeNull();
-    expect(result.current.drawerGate?.mode).toBe("closeoutBlocked");
-    expect(result.current.drawerGate?.isRecovery).toBe(true);
+    expect(result.current.drawerGate?.mode).toBe("recovery");
     expect(result.current.productEntry.disabled).toBe(true);
     expect(mockStartSession).not.toHaveBeenCalled();
     expect(mockBindSessionToRegisterSession).not.toHaveBeenCalled();
     expect(mockOpenDrawer).not.toHaveBeenCalled();
-    expect(result.current.drawerGate).not.toHaveProperty("onSubmit");
-    expect(result.current.drawerGate?.onSubmitCloseout).toEqual(
-      expect.any(Function),
-    );
+    expect(result.current.drawerGate?.onSubmit).toEqual(expect.any(Function));
+    expect(result.current.drawerGate?.onSubmitCloseout).toBeUndefined();
+    expect(result.current.drawerGate?.closeoutSubmittedReason).toBeUndefined();
   });
 
   it("gates an active POS session assigned to a different open drawer", async () => {
@@ -7497,6 +7638,51 @@ describe("useRegisterViewModel", () => {
     expect(result.current.customerPanel.customerInfo.name).toBe("Ama Serwa");
   });
 
+  it("keeps a preserved active POS session usable after opening a local drawer before cloud binding", async () => {
+    mockRegisterState = {
+      phase: "active",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "staff-1", firstName: "Ama", lastName: "Kusi" },
+      activeRegisterSession: null,
+      activeSession: { _id: "session-1", sessionNumber: "POS-0001" },
+      resumableSession: null,
+    };
+    mockActiveSession = {
+      ...mockActiveSession!,
+      registerSessionId: undefined,
+      cartItems: [],
+      payments: [{ method: "cash", amount: 120, timestamp: 1_000 }],
+    };
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult({ activeRoles: ["cashier"] }),
+      );
+    });
+
+    expect(result.current.drawerGate?.mode).toBe("recovery");
+
+    act(() => {
+      result.current.drawerGate?.onOpeningFloatChange?.("50.00");
+    });
+
+    await act(async () => {
+      await result.current.drawerGate?.onSubmit?.();
+    });
+
+    await waitFor(() => expect(result.current.drawerGate).toBeNull());
+    expect(result.current.productEntry.disabled).toBe(false);
+    expect(mockBindSessionToRegisterSession).not.toHaveBeenCalled();
+    expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "register.opened",
+      }),
+    );
+  });
+
   it("keeps a preserved sale gated when drawer recovery binding fails", async () => {
     mockRegisterState = {
       phase: "active",
@@ -7898,7 +8084,7 @@ describe("useRegisterViewModel", () => {
     expect(toast.success).not.toHaveBeenCalledWith("Terminal setup repaired");
   });
 
-  it("routes lifecycle drawer authority blocks to the open-drawer gate", async () => {
+  it("keeps the drawer usable when stale lifecycle authority exists locally", async () => {
     mockListLocalEvents.mockResolvedValue({
       ok: true,
       value: [
@@ -7942,12 +8128,8 @@ describe("useRegisterViewModel", () => {
       );
     });
 
-    await waitFor(() =>
-      expect(result.current.drawerGate?.mode).toBe("recovery"),
-    );
-    expect(result.current.drawerGate?.canOpenDrawer).toBe(true);
-    expect(result.current.drawerGate?.onSubmit).toBeTypeOf("function");
-    expect(result.current.drawerGate?.onRetrySync).toBeUndefined();
+    await waitFor(() => expect(result.current.drawerGate).toBeNull());
+    expect(result.current.productEntry.disabled).toBe(false);
   });
 
   it("routes closed drawer authority blocks to the open-drawer gate", async () => {
@@ -8001,7 +8183,7 @@ describe("useRegisterViewModel", () => {
     expect(result.current.drawerGate?.onRetrySync).toBeUndefined();
   });
 
-  it("persists drawer authority when a mapped cloud drawer is no longer usable", async () => {
+  it("does not persist drawer authority from the register view hot path", async () => {
     mockRegisterState = {
       ...mockRegisterState!,
       activeRegisterSession: {
@@ -8053,16 +8235,8 @@ describe("useRegisterViewModel", () => {
     const { useRegisterViewModel } = await import("./useRegisterViewModel");
     renderHook(() => useRegisterViewModel());
 
-    await waitFor(() =>
-      expect(mockWriteDrawerAuthorityState).toHaveBeenCalledWith(
-        expect.objectContaining({
-          cloudRegisterSessionId: "drawer-1",
-          localRegisterSessionId: "local-register-1",
-          reason: "cloud_closed",
-          status: "blocked",
-        }),
-      ),
-    );
+    await waitFor(() => expect(mockListLocalCloudMappings).toHaveBeenCalled());
+    expect(mockWriteDrawerAuthorityState).not.toHaveBeenCalled();
   });
 
   it("requires a provisioned local sync seed before changing checkout state", async () => {
@@ -9374,7 +9548,7 @@ describe("useRegisterViewModel", () => {
     expect(result.current.checkout.payments).toEqual([]);
   });
 
-  it("keeps a locally closed register blocked until it is reopened", async () => {
+  it("opens the drawer gate after a local closeout is submitted", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -9440,17 +9614,97 @@ describe("useRegisterViewModel", () => {
     });
 
     await waitFor(() =>
-      expect(result.current.drawerGate?.mode).toBe("closeoutBlocked"),
+      expect(result.current.drawerGate?.mode).toBe("initialSetup"),
     );
-    expect(result.current.drawerGate?.closeoutSubmittedReason).toBe(
-      "pending_sync",
-    );
-    expect(result.current.drawerGate?.closeoutSubmittedCountedCash).toBe(5_000);
-    expect(result.current.drawerGate?.closeoutSubmittedVariance).toBe(0);
+    expect(result.current.drawerGate?.closeoutSubmittedReason).toBeUndefined();
+    expect(
+      result.current.drawerGate?.closeoutSubmittedCountedCash,
+    ).toBeUndefined();
+    expect(
+      result.current.drawerGate?.closeoutSubmittedVariance,
+    ).toBeUndefined();
     expect(result.current.drawerGate?.onSubmitCloseout).toBeUndefined();
     expect(result.current.productEntry.disabled).toBe(true);
     expect(result.current.closeoutControl?.canCloseout).toBe(false);
-    expect(result.current.drawerGate?.onReopenRegister).toBeTypeOf("function");
+    expect(result.current.drawerGate?.onReopenRegister).toBeUndefined();
+  });
+
+  it("opens a new drawer when the cloud register closed before local closeout sync cleared", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: {
+        _id: "staff-1",
+        firstName: "Ama",
+        lastName: "Kusi",
+        activeRoles: ["manager"],
+      },
+      activeRegisterSession: {
+        _id: "drawer-1",
+        status: "closed",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now(),
+      },
+      activeSession: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        buildLocalEvent({
+          sequence: 1,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-1",
+          payload: {
+            expectedCash: 5_000,
+            localRegisterSessionId: "local-register-1",
+            openingFloat: 5_000,
+          },
+          sync: { status: "synced", uploaded: true },
+        }),
+        buildLocalEvent({
+          sequence: 2,
+          type: "register.closeout_started",
+          localRegisterSessionId: "local-register-1",
+          payload: {
+            countedCash: 5_000,
+            notes: null,
+          },
+          sync: { status: "pending", uploaded: false },
+        }),
+      ],
+    });
+    mockListLocalCloudMappings.mockResolvedValue({
+      ok: true,
+      value: [
+        {
+          entity: "registerSession",
+          localId: "local-register-1",
+          cloudId: "drawer-1",
+          mappedAt: 1_100,
+        },
+      ],
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+    await waitForLocalRegisterEffects(result);
+
+    expect(result.current.drawerGate).not.toBeNull();
+    expect(result.current.drawerGate?.mode).toBe("initialSetup");
+    expect(result.current.drawerGate?.closeoutSubmittedReason).toBeUndefined();
+    expect(result.current.drawerGate?.onSubmitCloseout).toBeUndefined();
+    expect(result.current.productEntry.disabled).toBe(true);
   });
 
   it("does not present a synced local closeout as pending sync or closeout in progress", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -49,7 +49,7 @@ import {
   useConvexRegisterServiceCatalog,
 } from "@/lib/pos/infrastructure/convex/catalogGateway";
 import { useConvexRegisterState } from "@/lib/pos/infrastructure/convex/registerGateway";
-import { isPosUsableRegisterSessionStatus } from "~/shared/registerSessionStatus";
+import { isRegisterSessionSaleUsable } from "~/shared/registerSessionLifecyclePolicy";
 import { userError, type CommandResult } from "~/shared/commandResult";
 import type { ApprovalRequirement } from "~/shared/approvalPolicy";
 import {
@@ -147,7 +147,6 @@ import {
   findRegisterCloseoutReviewItem,
   getCloseoutCloudRegisterSessionId,
   getCloseoutLocalRegisterSessionId,
-  getLatestLocalRegisterLifecycleEvent,
   isKnownCloudRegisterSessionBlockingLocalProjection,
   readLocalSyncStatus,
 } from "./registerDrawerPresentation";
@@ -327,6 +326,7 @@ function hasSyncedSaleLocalEventsForStaff(
 }
 
 type LocalOperableRegisterSession = {
+  cloudRegisterSessionId?: string;
   expectedCash: number;
   localRegisterSessionId: string;
   openedAt: number;
@@ -335,6 +335,28 @@ type LocalOperableRegisterSession = {
   storeId: Id<"store">;
   terminalId: Id<"posTerminal">;
 };
+
+type CloseoutBlockedRegisterSession = {
+  _id?: Id<"registerSession"> | string;
+  countedCash?: number;
+  expectedCash: number;
+  localRegisterSessionId?: string;
+  localSyncStatus?: {
+    pendingEventCount?: number;
+    status: string;
+  };
+  managerApprovalRequestId?: Id<"approvalRequest">;
+  openedAt: number;
+  openingFloat: number;
+  registerNumber: string;
+  status: "closing";
+  terminalId: Id<"posTerminal">;
+  variance?: number;
+};
+
+function selectPassiveCloseoutBlockedRegisterSession(): CloseoutBlockedRegisterSession | null {
+  return null;
+}
 
 type LocalOperablePosSession = {
   localPosSessionId: string;
@@ -529,7 +551,6 @@ export function useRegisterViewModel(): RegisterViewModel {
   const exactAddKeyRef = useRef<string | null>(null);
   const pendingSessionStartKeyRef = useRef<string | null>(null);
   const seededRegisterSessionIdsRef = useRef<Set<string>>(new Set());
-  const persistedDrawerAuthorityBlockRef = useRef<string | null>(null);
   const autoTerminalRepairAttemptRef = useRef<string | null>(null);
   const activeCartItemsRef = useRef<CartItem[]>([]);
   const localRegisterReadModelRef = useRef<PosLocalRegisterReadModel | null>(
@@ -716,7 +737,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   }, [activeSession?._id]);
   const usableActiveRegisterSession =
     registerState?.activeRegisterSession &&
-    isPosUsableRegisterSessionStatus(registerState.activeRegisterSession.status)
+    isRegisterSessionSaleUsable(registerState.activeRegisterSession)
       ? registerState.activeRegisterSession
       : null;
   const localStaffPendingUploadCount = countPendingSyncableLocalEventsForStaff(
@@ -731,11 +752,6 @@ export function useRegisterViewModel(): RegisterViewModel {
     localRegisterReadModel?.sourceEvents ?? [],
     staffProfileId,
   );
-  const latestLocalRegisterLifecycleEvent =
-    getLatestLocalRegisterLifecycleEvent(localRegisterReadModel);
-  const latestLocalCloseoutIsSynced =
-    latestLocalRegisterLifecycleEvent?.type === "register.closeout_started" &&
-    latestLocalRegisterLifecycleEvent.sync.status === "synced";
   const projectedLocalActiveSale = localRegisterReadModel?.activeSale ?? null;
   const projectedLocalActiveSaleStaffProfileId =
     projectedLocalActiveSale?.staffProfileId ?? null;
@@ -754,12 +770,12 @@ export function useRegisterViewModel(): RegisterViewModel {
     activeStoreId &&
     terminal?._id &&
     !cloudRegisterSessionBlocksLocalProjection &&
-    isPosUsableRegisterSessionStatus(
-      localRegisterReadModel.activeRegisterSession.status,
-    )
+    isRegisterSessionSaleUsable(localRegisterReadModel.activeRegisterSession)
       ? {
           expectedCash:
             localRegisterReadModel.activeRegisterSession.expectedCash,
+          cloudRegisterSessionId:
+            localRegisterReadModel.activeRegisterSession.cloudRegisterSessionId,
           localRegisterSessionId:
             localRegisterReadModel.activeRegisterSession.localRegisterSessionId,
           openedAt: localRegisterReadModel.activeRegisterSession.openedAt,
@@ -771,62 +787,6 @@ export function useRegisterViewModel(): RegisterViewModel {
           terminalId: terminal._id,
         }
       : null;
-  const projectedLocalCloseoutBlockedRegisterSession =
-    localRegisterReadModel?.activeRegisterSession?.status === "closing" &&
-    !latestLocalCloseoutIsSynced &&
-    activeStoreId &&
-    terminal?._id
-      ? {
-          localRegisterSessionId:
-            localRegisterReadModel.activeRegisterSession.localRegisterSessionId,
-          status: "closing" as const,
-          terminalId: terminal._id,
-          registerNumber:
-            localRegisterReadModel.activeRegisterSession.registerNumber ?? "",
-          openingFloat:
-            localRegisterReadModel.activeRegisterSession.openingFloat,
-          expectedCash:
-            localRegisterReadModel.activeRegisterSession.expectedCash,
-          countedCash: localRegisterReadModel.activeRegisterSession.countedCash,
-          managerApprovalRequestId: undefined,
-          openedAt: localRegisterReadModel.activeRegisterSession.openedAt,
-          variance:
-            localRegisterReadModel.activeRegisterSession.countedCash ===
-            undefined
-              ? undefined
-              : localRegisterReadModel.activeRegisterSession.countedCash -
-                localRegisterReadModel.activeRegisterSession.expectedCash,
-          localSyncStatus: {
-            status:
-              localRegisterReadModel.syncStatus.state === "synced"
-                ? "synced"
-                : localRegisterReadModel.syncStatus.state === "needs_review" ||
-                    localRegisterReadModel.syncStatus.state === "failed"
-                  ? "needs_review"
-                  : "locally_closed_pending_sync",
-            pendingEventCount: localStaffPendingUploadCount,
-          },
-        }
-      : null;
-  const activeRegisterCloseoutReviewItem = findRegisterCloseoutReviewItem(
-    usableActiveRegisterSession,
-  );
-  const syncedCloseoutReviewRegisterSession =
-    usableActiveRegisterSession && activeRegisterCloseoutReviewItem
-      ? {
-          ...usableActiveRegisterSession,
-          status: "closing" as const,
-          countedCash:
-            activeRegisterCloseoutReviewItem.countedCash ??
-            usableActiveRegisterSession.countedCash,
-          expectedCash:
-            activeRegisterCloseoutReviewItem.expectedCash ??
-            usableActiveRegisterSession.expectedCash,
-          variance:
-            activeRegisterCloseoutReviewItem.variance ??
-            usableActiveRegisterSession.variance,
-        }
-      : null;
   const locallyOperableRegisterSession =
     localOperableRegisterSession &&
     activeStoreId === localOperableRegisterSession.storeId &&
@@ -834,18 +794,22 @@ export function useRegisterViewModel(): RegisterViewModel {
       ? localOperableRegisterSession
       : projectedLocalRegisterSession;
   const closeoutBlockedRegisterSession =
-    registerState?.activeRegisterSession?.status === "closing"
-      ? registerState.activeRegisterSession
-      : syncedCloseoutReviewRegisterSession
-        ? syncedCloseoutReviewRegisterSession
-        : projectedLocalCloseoutBlockedRegisterSession;
+    selectPassiveCloseoutBlockedRegisterSession();
+  const activeCloudRegisterSessionHasCloseoutReview = Boolean(
+    findRegisterCloseoutReviewItem(usableActiveRegisterSession),
+  );
+  const saleUsableActiveRegisterSession =
+    usableActiveRegisterSession && !activeCloudRegisterSessionHasCloseoutReview
+      ? usableActiveRegisterSession
+      : null;
   const activeRegisterNumber =
     activeSession?.registerNumber ??
-    usableActiveRegisterSession?.registerNumber ??
+    locallyOperableRegisterSession?.registerNumber ??
+    saleUsableActiveRegisterSession?.registerNumber ??
     closeoutBlockedRegisterSession?.registerNumber ??
     registerState?.activeSession?.registerNumber ??
     registerState?.resumableSession?.registerNumber;
-  const activeRegisterSessionId = usableActiveRegisterSession?._id as
+  const activeRegisterSessionId = saleUsableActiveRegisterSession?._id as
     | Id<"registerSession">
     | undefined;
   const cloudRegisterSessionId = activeRegisterSessionId?.toString();
@@ -944,59 +908,6 @@ export function useRegisterViewModel(): RegisterViewModel {
     updateSession,
   } = useConvexSessionActions();
   const voidSessionRef = useRef<typeof voidSession>(voidSession);
-  useEffect(() => {
-    const localRegisterSession = localRegisterReadModel?.activeRegisterSession;
-    const cloudRegisterSessionId =
-      registerState?.activeRegisterSession?._id?.toString() ??
-      localRegisterSession?.cloudRegisterSessionId;
-    if (
-      !cloudRegisterSessionBlocksLocalProjection ||
-      !activeStoreId ||
-      !localRegisterSession ||
-      !cloudRegisterSessionId ||
-      localRegisterReadModel?.saleBlockReason === "drawer_authority"
-    ) {
-      return;
-    }
-    const blockKey = `${activeStoreId}:${localRegisterSession.localRegisterSessionId}:${cloudRegisterSessionId}`;
-    if (persistedDrawerAuthorityBlockRef.current === blockKey) {
-      return;
-    }
-
-    void localStore
-      .writeDrawerAuthorityState({
-        cloudRegisterSessionId,
-        localRegisterSessionId: localRegisterSession.localRegisterSessionId,
-        message:
-          "The drawer is already closed. Repair drawer setup before continuing.",
-        observedAt: Date.now(),
-        reason: "cloud_closed",
-        registerNumber: localRegisterSession.registerNumber,
-        status: "blocked",
-        storeId: activeStoreId,
-        terminalId:
-          localRegisterSession.terminalId ??
-          terminal?.localTerminalId ??
-          terminal?._id?.toString() ??
-          "",
-      })
-      .then((result) => {
-        if (result.ok) {
-          persistedDrawerAuthorityBlockRef.current = blockKey;
-          noteLocalRegisterEventChanged();
-        }
-      });
-  }, [
-    activeStoreId,
-    cloudRegisterSessionBlocksLocalProjection,
-    localRegisterReadModel?.activeRegisterSession,
-    localRegisterReadModel?.saleBlockReason,
-    localStore,
-    noteLocalRegisterEventChanged,
-    registerState?.activeRegisterSession?._id,
-    terminal?._id,
-    terminal?.localTerminalId,
-  ]);
   useEffect(() => {
     let cancelled = false;
 
@@ -1663,7 +1574,8 @@ export function useRegisterViewModel(): RegisterViewModel {
   );
   const activeSessionNeedsRegisterBinding = Boolean(
     isCloudOperableSession(operableActiveSession) &&
-    !operableActiveSession.registerSessionId,
+      !operableActiveSession.registerSessionId &&
+      !locallyOperableRegisterSession,
   );
   const activeSessionHasMismatchedRegisterBinding = Boolean(
     isCloudOperableSession(operableActiveSession) &&
@@ -1677,18 +1589,18 @@ export function useRegisterViewModel(): RegisterViewModel {
   const hasCloseoutBlockedDrawerState = Boolean(
     bootstrapState &&
     closeoutBlockedRegisterSession &&
-    (!usableActiveRegisterSession || syncedCloseoutReviewRegisterSession),
+    !saleUsableActiveRegisterSession,
   );
   const hasMissingDrawerStartupState = Boolean(
     bootstrapState &&
     (bootstrapState.phase === "readyToStart" ||
       bootstrapState.phase === "resumable") &&
-    !usableActiveRegisterSession &&
+    !saleUsableActiveRegisterSession &&
     !locallyOperableRegisterSession,
   );
   const hasMissingDrawerRecoveryState = Boolean(
     bootstrapState &&
-    !usableActiveRegisterSession &&
+    !saleUsableActiveRegisterSession &&
     !locallyOperableRegisterSession &&
     (bootstrapState.phase === "active" ||
       bootstrapState.phase === "resumable" ||
@@ -1696,7 +1608,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   );
   const hasDraftDrawerRecoveryState = Boolean(
     hasInProgressSaleDraft &&
-    !usableActiveRegisterSession &&
+    !saleUsableActiveRegisterSession &&
     !locallyOperableRegisterSession &&
     !localEventRegisterSessionId &&
     !isTransactionCompleted,
@@ -1758,7 +1670,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   const activeCloseoutRegisterSession =
     closeoutBlockedRegisterSession ??
     (isCloseoutRequested
-      ? (usableActiveRegisterSession ?? localCloseoutRegisterSession)
+      ? (localCloseoutRegisterSession ?? saleUsableActiveRegisterSession)
       : null);
   const activeCloseoutRegisterSessionHasSyncReview = Boolean(
     findRegisterCloseoutReviewItem(activeCloseoutRegisterSession),
@@ -5033,8 +4945,9 @@ export function useRegisterViewModel(): RegisterViewModel {
         }
       : null;
 
+  const hasSignedInStaff = Boolean(cashier || localAuthenticatedStaff);
   const cashierCard =
-    activeStoreId && terminal?._id && staffProfileId
+    activeStoreId && terminal?._id && staffProfileId && hasSignedInStaff
       ? {
           cashierName: cashier
             ? getCashierDisplayName(cashier)
@@ -5069,6 +4982,7 @@ export function useRegisterViewModel(): RegisterViewModel {
             expectedCash:
               activeOpeningFloatCorrectionRegisterSession?.expectedCash,
             errorMessage: drawerErrorMessage,
+            hasSignedInStaff,
             isCorrectingOpeningFloat,
             onCancelOpeningFloatCorrection: () => {
               setCorrectedOpeningFloat("");
@@ -5127,6 +5041,7 @@ export function useRegisterViewModel(): RegisterViewModel {
                 activeCloseoutRegisterSessionHasSyncReview,
               ),
               errorMessage: drawerErrorMessage,
+              hasSignedInStaff,
               isCloseoutSubmitting: isSubmittingCloseout,
               isReopeningCloseout,
               onCloseoutCountedCashChange: (value: string) => {
@@ -5160,6 +5075,7 @@ export function useRegisterViewModel(): RegisterViewModel {
                 (activeSessionHasMismatchedRegisterBinding
                   ? "Sale assigned to a different drawer. Open that drawer before continuing."
                   : null),
+              hasSignedInStaff,
               isSubmitting: isOpeningDrawer,
               isRepairingTerminalSetup,
               onOpeningFloatChange: (value: string) => {


### PR DESCRIPTION
## Summary
- Added a shared register lifecycle policy for browser-local POS and Convex projection decisions.
- Moved drawer-open, sale-blocking, closeout-review, and supersession invariants onto that shared policy while keeping repositories fact-only.
- Added coverage for direct and mapped register review facts, rejected variance closeout cleanup, and the POS/cash-control surfaces that consume the policy.

## Why
The POS register flow and projection layer had duplicated lifecycle rules for locally opened drawers, reviewed closeouts, and multi-session drawer continuity. Sharing the invariant logic prevents drift while preserving local cashier continuity and server projection integrity.

## Validation
- bun run pr:athena
- reviewer loop: testing APPROVED, data-integrity APPROVED; earlier correctness/architecture reviewers approved after fixes
- plan reviewer loop: feasibility/scope/architecture/coherence APPROVED

Linear: V26-836, V26-837, V26-838, V26-839, V26-840
