### PR TITLE
Paginate stock operations inventory snapshots

### DIFF
--- a/docs/solutions/architecture/athena-pos-offline-inventory-snapshot-2026-05-15.md
+++ b/docs/solutions/architecture/athena-pos-offline-inventory-snapshot-2026-05-15.md
@@ -55,6 +55,7 @@ Clearing or removing an uncompleted cart line restores that terminal-local avail
 Keep tests at the boundaries where this contract can drift:
 
 - Server query tests must prove the full snapshot uses the same register catalog scope as metadata and subtracts active inventory holds.
+- Full availability snapshot queries should avoid hydrating display metadata such as category names or color names. Normal live SKUs only need the trusted SKU, product ownership/status, holds, pending-checkout rows, and active provisional rows. Read category documents only for draft/hidden operational-category exceptions such as `pos-pending-checkout` and `legacy-import`.
 - Local store tests must keep catalog metadata and availability snapshots in separate tables so metadata never becomes accidental stock proof.
 - Gateway tests must cover online live-overlay precedence, offline full-snapshot fallback, and missing snapshot rows remaining unselectable.
 - Register view-model tests must cover terminal-local cart decrements, readiness messaging, and barcode/direct-add rejection for unknown availability.

--- a/docs/solutions/architecture/athena-product-page-single-sku-provisional-trusted-finalization-2026-06-23.md
+++ b/docs/solutions/architecture/athena-product-page-single-sku-provisional-trusted-finalization-2026-06-23.md
@@ -59,6 +59,19 @@ must set the provisional row to `status: "finalized"` and
 `posExposureStatus: "hidden"` so register catalog, availability reads, and local
 snapshots use `trusted_inventory`.
 
+Do not make POS visibility depend on customer storefront visibility for
+legacy-import cleanup anchors. Finalized legacy-import products can remain
+`draft` and hidden from the storefront while POS still needs to find the trusted
+SKU. POS catalog and search paths should treat `legacy-import` as a staff
+operational category after the active provisional row closes, while continuing
+to suppress the trusted row when an active provisional row still owns the sale
+policy.
+
+Do not require `netPrice` for POS search when register catalog rows already use
+`price` as the fallback. Finalized import SKUs created from product edit may
+only have `price`, and POS search, barcode lookup, and register snapshots must
+agree on the sellable price rule.
+
 Do not rely only on operational events for support review. Stock-affecting trust
 transitions need SKU activity evidence even when the trusted stock delta is zero
 and no inventory movement is written.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7876 nodes · 9231 edges · 2032 communities detected
+- 7887 nodes · 9254 edges · 2032 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2194,20 +2194,20 @@ Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
 ### Community 31 - "Community 31"
+Cohesion: 0.13
+Nodes (24): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildInventorySnapshotRowsForProductSkusWithCtx(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle() (+16 more)
+
+### Community 32 - "Community 32"
 Cohesion: 0.2
 Nodes (27): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), isExpenseLocalSyncEvent(), isSyncablePosLocalEvent() (+19 more)
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.13
 Nodes (23): automationErrorMessage(), automationIdempotencyKey(), eodAutoCompleteDecision(), eodAutoCompleteLocalTiming(), eodAutoCompletePolicyCronWindow(), eodDecision(), getLatestDailyOperationsAutomationStatusWithCtx(), getOpeningAutoStartPolicyForApi() (+15 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.14
 Nodes (19): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate(), getLocalOperatingDateRange() (+11 more)
-
-### Community 34 - "Community 34"
-Cohesion: 0.15
-Nodes (23): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), formatSignedQuantity() (+15 more)
 
 ### Community 35 - "Community 35"
 Cohesion: 0.09
@@ -2354,124 +2354,124 @@ Cohesion: 0.17
 Nodes (13): buildProviderRegistry(), createIntelligenceRun(), defaultFakeOutput(), failedGenerationResult(), getStoreInsightsSnapshotFallback(), isActivityTrend(), isDeviceDistribution(), isInsightGenerationInProgressError() (+5 more)
 
 ### Community 71 - "Community 71"
+Cohesion: 0.25
+Nodes (17): getRegisterCatalogPrice(), isActiveProvisionalImportSkuForStore(), isDraftAllowedInTrustedRegisterCatalog(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailability(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogAvailabilitySkus() (+9 more)
+
+### Community 72 - "Community 72"
 Cohesion: 0.12
 Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.22
 Nodes (15): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+7 more)
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.14
 Nodes (7): formatLocalStartTime(), formatLocalStartTimeFromParts(), getLocalStartTimeParts(), handleSave(), parseLocalStartMinutes(), updateLocalCompletionWindowPart(), updateLocalStartTimePart()
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.25
 Nodes (16): buildStorefrontContextEvent(), buildStorefrontIdempotencyKey(), compactScalarPayload(), createStorefrontContextTrackingEnvelope(), createStorefrontRouteViewedContextEvent(), getCartChange(), getCartContextEventInput(), getCheckoutBlocker() (+8 more)
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.22
 Nodes (14): assertActorMatchesStore(), buildCompiledContextBundle(), buildStoreInsightsContextBundleFromContextEvents(), buildUserInsightsContextBundleFromContextEvents(), compileContextEvent(), compileContextEventsWithReport(), getDataWindow(), getStoreFrontActorById() (+6 more)
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.13
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
+Cohesion: 0.15
+Nodes (5): buildMissingDraftResult(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
+
+### Community 82 - "Community 82"
 Cohesion: 0.14
 Nodes (5): getBlockedPosTerminalShellCopy(), getPosHubRouteParams(), getRouteParamsForPattern(), getStoreWorkspaceRouteParams(), PosTerminalBlockedShell()
 
-### Community 81 - "Community 81"
+### Community 83 - "Community 83"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 82 - "Community 82"
+### Community 84 - "Community 84"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 83 - "Community 83"
+### Community 85 - "Community 85"
 Cohesion: 0.19
 Nodes (10): buildLatestRunDebugPayload(), getBoundedDebugRunsByCapability(), getLatestDebugRunByCapability(), getLatestDebugRunBySubject(), isActiveRunStale(), isActiveRunStatus(), selectLatestDebugRunFromCandidates(), shouldRecoverActiveRun() (+2 more)
 
-### Community 84 - "Community 84"
+### Community 86 - "Community 86"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 85 - "Community 85"
+### Community 87 - "Community 87"
 Cohesion: 0.13
 Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
 
-### Community 86 - "Community 86"
+### Community 88 - "Community 88"
 Cohesion: 0.24
 Nodes (15): buildGeneratedControlId(), captureRemoteAssistCoBrowseFrame(), collectSanitizedSurface(), collectSensitiveRegions(), collectVisibleText(), getControlId(), getControlPriority(), getElementLabel() (+7 more)
 
-### Community 87 - "Community 87"
+### Community 89 - "Community 89"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 88 - "Community 88"
+### Community 90 - "Community 90"
 Cohesion: 0.22
 Nodes (11): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), getInvalidationNodes(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline() (+3 more)
 
-### Community 89 - "Community 89"
+### Community 91 - "Community 91"
 Cohesion: 0.23
 Nodes (13): collectConvexReturnValidatorContractFindings(), escapeRegExp(), extractConvexPublicFunctionsWithReturns(), fileExists(), findMatchingDefinitionEnd(), hasConvexReturnContractProofForExport(), isConvexReturnContractSourcePath(), isRelevantConvexContractProofPath() (+5 more)
 
-### Community 90 - "Community 90"
+### Community 92 - "Community 92"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 91 - "Community 91"
+### Community 93 - "Community 93"
 Cohesion: 0.22
 Nodes (9): buildHistoricalContextEventAppendArgs(), buildHistoricalImportIdempotencyKey(), buildPrimarySubject(), buildStoppedReport(), countOmittedFields(), createEmptyReport(), increment(), planHistoricalStorefrontContextImport() (+1 more)
 
-### Community 92 - "Community 92"
+### Community 94 - "Community 94"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 93 - "Community 93"
-Cohesion: 0.28
-Nodes (14): getRegisterCatalogPrice(), isActiveProvisionalImportSkuForStore(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailability(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow() (+6 more)
-
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.32
 Nodes (14): buildPosOperatorSnapshot(), buildRecentDayBuckets(), buildSummaryTrendBucket(), buildTransactionDateBuckets(), calculateDeltaPercent(), formatHourLabel(), formatPaymentMethodLabel(), formatShortDate() (+6 more)
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.26
 Nodes (11): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), classifyRegisterSessionSyncReview(), findTransactionIdForSyncEvent(), hasInventoryReviewWorkItemForProjectedSale(), listOpenLocalSyncConflictsByRegisterSession(), numberDetail() (+3 more)
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.28
 Nodes (14): buildActorRefs(), buildReturnExchangeTraceEvent(), buildReturnExchangeTraceRecord(), buildTraceEvent(), buildTraceRecord(), compactDetails(), recordOnlineOrderReturnExchangeTraceBestEffort(), recordOnlineOrderTraceBestEffort() (+6 more)
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.14
 Nodes (2): formatSessionCode(), formatSessionIdentifier()
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.15
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
-
-### Community 100 - "Community 100"
-Cohesion: 0.17
-Nodes (5): buildMissingDraftResult(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
 
 ### Community 101 - "Community 101"
 Cohesion: 0.18
@@ -2618,68 +2618,68 @@ Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
 ### Community 137 - "Community 137"
+Cohesion: 0.2
+Nodes (2): listProductSkusByProductId(), readAllQueryResults()
+
+### Community 138 - "Community 138"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.33
 Nodes (7): createAthenaProviderError(), createProviderFailureResult(), getProviderFailureDiagnostic(), invokeStructuredTextProvider(), isJsonObject(), isJsonValue(), sanitizeDiagnostic()
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
-
-### Community 152 - "Community 152"
-Cohesion: 0.22
-Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
 ### Community 153 - "Community 153"
 Cohesion: 0.29
@@ -2782,24 +2782,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 178 - "Community 178"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 179 - "Community 179"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 181 - "Community 181"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
 ### Community 182 - "Community 182"
 Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 183 - "Community 183"
 Cohesion: 0.22
@@ -2846,420 +2846,420 @@ Cohesion: 0.25
 Nodes (0):
 
 ### Community 194 - "Community 194"
+Cohesion: 0.5
+Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
+
+### Community 195 - "Community 195"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.36
 Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.29
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.29
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 204 - "Community 204"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 205 - "Community 205"
 Cohesion: 0.39
-Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 206 - "Community 206"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.39
+Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
 
 ### Community 207 - "Community 207"
-Cohesion: 0.29
-Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 208 - "Community 208"
 Cohesion: 0.29
-Nodes (2): findRegisterCloseoutReviewItem(), readLocalSyncStatus()
+Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
 
 ### Community 209 - "Community 209"
-Cohesion: 0.46
-Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
+Cohesion: 0.29
+Nodes (2): findRegisterCloseoutReviewItem(), readLocalSyncStatus()
 
 ### Community 210 - "Community 210"
 Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
 ### Community 211 - "Community 211"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 212 - "Community 212"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 213 - "Community 213"
+### Community 214 - "Community 214"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 214 - "Community 214"
+### Community 215 - "Community 215"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 215 - "Community 215"
+### Community 216 - "Community 216"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 216 - "Community 216"
+### Community 217 - "Community 217"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 222 - "Community 222"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 223 - "Community 223"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 224 - "Community 224"
-Cohesion: 0.48
-Nodes (6): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), isDuplicateRegisterOpenConflict(), skipped()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 225 - "Community 225"
 Cohesion: 0.48
-Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
+Nodes (6): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), isDuplicateRegisterOpenConflict(), skipped()
 
 ### Community 226 - "Community 226"
+Cohesion: 0.48
+Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
+
+### Community 227 - "Community 227"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.33
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
-
-### Community 239 - "Community 239"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 240 - "Community 240"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 241 - "Community 241"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 242 - "Community 242"
 Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 243 - "Community 243"
 Cohesion: 0.33
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 244 - "Community 244"
+Cohesion: 0.33
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+
+### Community 245 - "Community 245"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 246 - "Community 246"
+### Community 247 - "Community 247"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 248 - "Community 248"
-Cohesion: 0.52
-Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 249 - "Community 249"
 Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 250 - "Community 250"
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+
+### Community 251 - "Community 251"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.38
 Nodes (3): getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusSignature()
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.33
 Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
-
-### Community 254 - "Community 254"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 255 - "Community 255"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 256 - "Community 256"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 257 - "Community 257"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 262 - "Community 262"
+### Community 263 - "Community 263"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 263 - "Community 263"
+### Community 264 - "Community 264"
 Cohesion: 0.47
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 264 - "Community 264"
+### Community 265 - "Community 265"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 265 - "Community 265"
+### Community 266 - "Community 266"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 266 - "Community 266"
+### Community 267 - "Community 267"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.4
 Nodes (2): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository()
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 270 - "Community 270"
+### Community 271 - "Community 271"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 271 - "Community 271"
+### Community 272 - "Community 272"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 272 - "Community 272"
+### Community 273 - "Community 273"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.6
 Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 280 - "Community 280"
+### Community 281 - "Community 281"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 0.4
 Nodes (2): moveFeaturedItem(), saveOrder()
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
-
-### Community 284 - "Community 284"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 285 - "Community 285"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 286 - "Community 286"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 287 - "Community 287"
 Cohesion: 0.4
 Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
-### Community 287 - "Community 287"
+### Community 288 - "Community 288"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
-
-### Community 288 - "Community 288"
-Cohesion: 0.4
-Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 289 - "Community 289"
 Cohesion: 0.4
-Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
+Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 290 - "Community 290"
+Cohesion: 0.4
+Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
+
+### Community 291 - "Community 291"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 291 - "Community 291"
+### Community 292 - "Community 292"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 292 - "Community 292"
+### Community 293 - "Community 293"
 Cohesion: 0.47
 Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
 
-### Community 293 - "Community 293"
+### Community 294 - "Community 294"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 294 - "Community 294"
+### Community 295 - "Community 295"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 295 - "Community 295"
+### Community 296 - "Community 296"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 296 - "Community 296"
+### Community 297 - "Community 297"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
-
-### Community 297 - "Community 297"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 298 - "Community 298"
 Cohesion: 0.33
@@ -3274,160 +3274,160 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 301 - "Community 301"
-Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
-
-### Community 302 - "Community 302"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 302 - "Community 302"
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 303 - "Community 303"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 304 - "Community 304"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 305 - "Community 305"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 306 - "Community 306"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 307 - "Community 307"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 305 - "Community 305"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 306 - "Community 306"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 307 - "Community 307"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
 ### Community 308 - "Community 308"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 309 - "Community 309"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 310 - "Community 310"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 311 - "Community 311"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 312 - "Community 312"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 313 - "Community 313"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 314 - "Community 314"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 315 - "Community 315"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 316 - "Community 316"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 316 - "Community 316"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 317 - "Community 317"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 318 - "Community 318"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 321 - "Community 321"
+### Community 322 - "Community 322"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 322 - "Community 322"
+### Community 323 - "Community 323"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 323 - "Community 323"
+### Community 324 - "Community 324"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 324 - "Community 324"
+### Community 325 - "Community 325"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 325 - "Community 325"
+### Community 326 - "Community 326"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
-### Community 326 - "Community 326"
+### Community 327 - "Community 327"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 327 - "Community 327"
+### Community 328 - "Community 328"
 Cohesion: 0.6
 Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
-### Community 328 - "Community 328"
+### Community 329 - "Community 329"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 329 - "Community 329"
-Cohesion: 0.5
-Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 330 - "Community 330"
 Cohesion: 0.5
-Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
+Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 331 - "Community 331"
+Cohesion: 0.5
+Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
+
+### Community 332 - "Community 332"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 332 - "Community 332"
+### Community 333 - "Community 333"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 333 - "Community 333"
+### Community 334 - "Community 334"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 334 - "Community 334"
+### Community 335 - "Community 335"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 335 - "Community 335"
+### Community 336 - "Community 336"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
-
-### Community 336 - "Community 336"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 337 - "Community 337"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 338 - "Community 338"
-Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 339 - "Community 339"
-Cohesion: 0.6
-Nodes (3): isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 340 - "Community 340"
 Cohesion: 0.4

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2104
-- Graph nodes: 7876
-- Graph edges: 9231
+- Graph nodes: 7887
+- Graph edges: 9254
 - Communities: 2032
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,8 +20,8 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 54) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `storefrontContextEvents.ts` (17 edges, Community 75) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
-- `checkoutSession.ts` (14 edges, Community 87) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `storefrontContextEvents.ts` (17 edges, Community 76) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
+- `checkoutSession.ts` (14 edges, Community 89) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (15 edges, Community 88) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (15 edges, Community 90) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `app.test.js` (6 edges, Community 183) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 88) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossCluster()` (4 edges, Community 88) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossClusterWithPipeline()` (4 edges, Community 88) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisClient()` (4 edges, Community 90) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossCluster()` (4 edges, Community 90) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossClusterWithPipeline()` (4 edges, Community 90) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
@@ -26,6 +26,19 @@ function createRegisterCatalogCtx(
   seed: Partial<Record<TableName, Row[]>>,
   options: { asyncIteratorLimit?: number; failOnPaginate?: boolean } = {},
 ) {
+  const readCounts = Object.fromEntries(
+    (
+      [
+        "category",
+        "color",
+        "inventoryHold",
+        "inventoryImportProvisionalSku",
+        "posPendingCheckoutItem",
+        "product",
+        "productSku",
+      ] as TableName[]
+    ).map((table) => [table, 0]),
+  ) as Record<TableName, number>;
   const tables: Record<TableName, Map<string, Row>> = {
     category: new Map(),
     color: new Map(),
@@ -49,6 +62,10 @@ function createRegisterCatalogCtx(
     );
   }
 
+  function countRead(table: TableName, count = 1) {
+    readCounts[table] += count;
+  }
+
   function createIndexedQuery(table: TableName, filters: IndexedFilter[]) {
     const matches = Array.from(tables[table].values()).filter((row) =>
       filters.every((filter) => filter.matches(row[filter.field])),
@@ -57,11 +74,19 @@ function createRegisterCatalogCtx(
     return {
       async *[Symbol.asyncIterator]() {
         for (const row of matches.slice(0, options.asyncIteratorLimit)) {
+          countRead(table);
           yield row;
         }
       },
-      collect: async () => matches,
-      first: async () => matches[0] ?? null,
+      collect: async () => {
+        countRead(table, matches.length);
+        return matches;
+      },
+      first: async () => {
+        const row = matches[0] ?? null;
+        if (row) countRead(table);
+        return row;
+      },
       paginate: async ({
         cursor,
         numItems,
@@ -74,6 +99,7 @@ function createRegisterCatalogCtx(
         }
         const offset = cursor ? Number(cursor) : 0;
         const page = matches.slice(offset, offset + numItems);
+        countRead(table, page.length);
         const nextOffset = offset + page.length;
         const isDone = nextOffset >= matches.length;
 
@@ -83,7 +109,11 @@ function createRegisterCatalogCtx(
           continueCursor: isDone ? "" : String(nextOffset),
         };
       },
-      take: async (limit: number) => matches.slice(0, limit),
+      take: async (limit: number) => {
+        const rows = matches.slice(0, limit);
+        countRead(table, rows.length);
+        return rows;
+      },
     };
   }
 
@@ -91,12 +121,17 @@ function createRegisterCatalogCtx(
     db: {
       async get(tableOrId: TableName | string, maybeId?: string) {
         if (maybeId !== undefined && tableOrId in tables) {
-          return tables[tableOrId as TableName].get(maybeId) ?? null;
+          const row = tables[tableOrId as TableName].get(maybeId) ?? null;
+          if (row) countRead(tableOrId as TableName);
+          return row;
         }
 
-        for (const table of Object.values(tables)) {
+        for (const [tableName, table] of Object.entries(tables) as Array<
+          [TableName, Map<string, Row>]
+        >) {
           const row = table.get(tableOrId);
           if (row) {
+            countRead(tableName);
             return row;
           }
         }
@@ -145,7 +180,7 @@ function createRegisterCatalogCtx(
     },
   } as unknown as QueryCtx;
 
-  return { ctx, tables };
+  return { ctx, readCounts, tables };
 }
 
 describe("listRegisterCatalog", () => {
@@ -475,6 +510,7 @@ describe("listRegisterCatalog", () => {
           _id: "category-store-a",
           storeId: "store-a",
           name: "Imports",
+          slug: "legacy-import",
         },
       ],
       inventoryImportProvisionalSku: [
@@ -586,9 +622,9 @@ describe("listRegisterCatalog", () => {
           sku: "ATHENA-PROVISIONAL-CLOSURE",
           barcode: "",
           images: [],
-          isVisible: false,
-          price: 0,
-          quantityAvailable: 0,
+          isVisible: true,
+          price: 85000,
+          quantityAvailable: 12,
         },
         {
           _id: "sku-finalized",
@@ -692,8 +728,8 @@ describe("listRegisterCatalog", () => {
         {
           _id: "category-store-a",
           storeId: "store-a",
-          name: "Imports",
-          slug: "imports",
+          name: "Legacy import",
+          slug: "legacy-import",
         },
       ],
       inventoryImportProvisionalSku: [
@@ -720,8 +756,8 @@ describe("listRegisterCatalog", () => {
           categoryId: "category-store-a",
           description: "Reviewed import anchor",
           name: "Reviewed Closure",
-          availability: "live",
-          isVisible: true,
+          availability: "draft",
+          isVisible: false,
         },
       ],
       productSku: [
@@ -767,7 +803,9 @@ describe("listRegisterCatalog", () => {
         availabilityPolicy: "trusted_inventory",
       },
     ]);
-    expect(availability[0]).not.toHaveProperty("inventoryImportProvisionalSkuId");
+    expect(availability[0]).not.toHaveProperty(
+      "inventoryImportProvisionalSkuId",
+    );
 
     const snapshot = await listRegisterCatalogAvailabilitySnapshot(ctx, {
       storeId: "store-a" as Id<"store">,
@@ -1157,5 +1195,45 @@ describe("listRegisterCatalog", () => {
       ]),
     );
     expect(rows).toHaveLength(4);
+  });
+
+  it("does not read category metadata for normal live SKUs in the full availability snapshot", async () => {
+    const productCount = 1_000;
+    const products = Array.from({ length: productCount }, (_, index) => ({
+      _id: `product-${index}`,
+      storeId: "store-a",
+      categoryId: "category-store-a",
+      name: `Product ${index}`,
+    }));
+    const productSkus = products.map((product, index) => ({
+      _id: `sku-${index}`,
+      storeId: "store-a",
+      productId: product._id,
+      sku: `SKU-${index}`,
+      price: 100,
+      quantityAvailable: 3,
+    }));
+    const { ctx, readCounts } = createRegisterCatalogCtx({
+      category: [
+        {
+          _id: "category-store-a",
+          storeId: "store-a",
+          name: "General",
+          slug: "general",
+        },
+      ],
+      product: products,
+      productSku: productSkus,
+    });
+
+    const rows = await listRegisterCatalogAvailabilitySnapshot(ctx, {
+      storeId: "store-a" as Id<"store">,
+    });
+
+    expect(rows).toHaveLength(productCount);
+    expect(readCounts.category).toBe(0);
+    expect(
+      Object.values(readCounts).reduce((total, count) => total + count, 0),
+    ).toBeLessThan(2_050);
   });
 });

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
@@ -66,9 +66,16 @@ type PosPendingCheckoutItem = Pick<
 export const REGISTER_CATALOG_AVAILABILITY_LIMIT = 50;
 const REGISTER_CATALOG_PROVISIONAL_IMPORT_LIMIT = 5_000;
 const POS_OPERATIONAL_CATEGORY_SLUGS = new Set([
+  "legacy-import",
   "pos-pending-checkout",
   "pos-quick-add",
 ]);
+
+function isDraftAllowedInTrustedRegisterCatalog(categorySlug?: string) {
+  return (
+    categorySlug === "legacy-import" || categorySlug === "pos-pending-checkout"
+  );
+}
 
 async function readCategoryName(
   ctx: QueryCtx,
@@ -161,14 +168,15 @@ export function isTrustedRegisterCatalogSku(args: {
   const isReservedPosOperationalProduct = args.category?.slug
     ? POS_OPERATIONAL_CATEGORY_SLUGS.has(args.category.slug)
     : false;
-  const isPendingCheckoutProduct =
-    args.category?.slug === "pos-pending-checkout";
+  const isDraftAllowed = isDraftAllowedInTrustedRegisterCatalog(
+    args.category?.slug,
+  );
 
   return (
     args.product.availability !== "archived" &&
-    (args.product.availability !== "draft" || isPendingCheckoutProduct) &&
+    (args.product.availability !== "draft" || isDraftAllowed) &&
     (args.product.isVisible !== false || isReservedPosOperationalProduct) &&
-    (args.sku.isVisible !== false || isPendingCheckoutProduct)
+    (args.sku.isVisible !== false || isDraftAllowed)
   );
 }
 
@@ -199,12 +207,23 @@ async function listScopedRegisterCatalogSkus(
       continue;
     }
 
-    const category =
-      product.isVisible === false
-        ? await ctx.db.get("category", product.categoryId)
-        : null;
+    const category = await ctx.db.get("category", product.categoryId);
 
     if (!isTrustedRegisterCatalogSku({ product, sku, category })) {
+      continue;
+    }
+
+    if (
+      category?.slug === "legacy-import" &&
+      (product.availability === "draft" ||
+        product.isVisible === false ||
+        sku.isVisible === false) &&
+      (await readActiveProvisionalImportSkuForStoreSku(ctx, {
+        storeId: args.storeId,
+        productId: product._id,
+        productSkuId: sku._id,
+      }))
+    ) {
       continue;
     }
 
@@ -213,6 +232,63 @@ async function listScopedRegisterCatalogSkus(
     }
 
     rows.push({ product, sku });
+  }
+
+  return rows;
+}
+
+async function listScopedRegisterCatalogAvailabilitySkus(
+  ctx: QueryCtx,
+  args: {
+    activeProvisionalProductSkuIds: Set<Id<"productSku">>;
+    storeId: Id<"store">;
+  },
+) {
+  const rows: Array<Doc<"productSku">> = [];
+  const productCache = new Map<Id<"product">, Doc<"product"> | null>();
+  // Convex allows only one paginated query per function; this POS snapshot must read the store catalog in one query.
+  // eslint-disable-next-line @convex-dev/no-collect-in-query
+  const skus = await ctx.db
+    .query("productSku")
+    .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
+    .collect();
+
+  for (const sku of skus) {
+    if (getRegisterCatalogPrice(sku) <= 0) {
+      continue;
+    }
+
+    let product = productCache.get(sku.productId);
+
+    if (product === undefined) {
+      product = (await ctx.db.get("product", sku.productId)) ?? null;
+      productCache.set(sku.productId, product);
+    }
+
+    if (!product || product.storeId !== args.storeId) {
+      continue;
+    }
+
+    const needsOperationalCategoryCheck =
+      product.availability === "draft" ||
+      product.isVisible === false ||
+      sku.isVisible === false;
+    const category = needsOperationalCategoryCheck
+      ? await ctx.db.get("category", product.categoryId)
+      : null;
+
+    if (!isTrustedRegisterCatalogSku({ product, sku, category })) {
+      continue;
+    }
+
+    if (
+      category?.slug === "legacy-import" &&
+      args.activeProvisionalProductSkuIds.has(sku._id)
+    ) {
+      continue;
+    }
+
+    rows.push(sku);
   }
 
   return rows;
@@ -356,6 +432,36 @@ async function readActivePendingCheckoutItemForStoreSku(
     : null;
 }
 
+async function readActiveLegacyImportProvisionalPolicyRow(
+  ctx: QueryCtx,
+  args: {
+    storeId: Id<"store">;
+    sku: Doc<"productSku">;
+  },
+) {
+  const product = await ctx.db.get("product", args.sku.productId);
+  const category =
+    product?.storeId === args.storeId
+      ? await ctx.db.get("category", product.categoryId)
+      : null;
+
+  if (
+    category?.slug !== "legacy-import" ||
+    !product ||
+    (product.availability !== "draft" &&
+      product.isVisible !== false &&
+      args.sku.isVisible !== false)
+  ) {
+    return null;
+  }
+
+  return readActiveProvisionalImportSkuForStoreSku(ctx, {
+    storeId: args.storeId,
+    productId: product._id,
+    productSkuId: args.sku._id,
+  });
+}
+
 type ProvisionalIndexBuilder<TField extends string> = {
   eq(field: TField, value: unknown): ProvisionalIndexBuilder<TField>;
 };
@@ -470,6 +576,24 @@ export async function listRegisterCatalogAvailability(
     );
     const quantityAvailable = availability.available ?? 0;
 
+    const activeLegacyImportProvisionalPolicy =
+      await readActiveLegacyImportProvisionalPolicyRow(ctx, {
+        storeId: args.storeId,
+        sku,
+      });
+    if (activeLegacyImportProvisionalPolicy) {
+      rows.push({
+        productSkuId: sku._id,
+        skuId: sku._id,
+        inventoryImportProvisionalSkuId:
+          activeLegacyImportProvisionalPolicy._id,
+        inStock: true,
+        quantityAvailable: 0,
+        availabilityPolicy: "active_provisional_import",
+      });
+      continue;
+    }
+
     if (quantityAvailable > 0) {
       rows.push({
         productSkuId: sku._id,
@@ -537,10 +661,20 @@ export async function listRegisterCatalogAvailabilitySnapshot(
     storeId: Id<"store">;
   },
 ) {
-  const catalogSkus = await listScopedRegisterCatalogSkus(ctx, args);
+  const activeProvisionalSkus = await queryActiveProvisionalImportSkusForStore(
+    ctx,
+    args,
+  );
+  const activeProvisionalProductSkuIds = new Set(
+    activeProvisionalSkus.map((row) => row.productSkuId),
+  );
+  const catalogSkus = await listScopedRegisterCatalogAvailabilitySkus(ctx, {
+    activeProvisionalProductSkuIds,
+    storeId: args.storeId,
+  });
   const heldQuantities = await readActiveHeldQuantitiesForStoreSkus(ctx.db, {
     storeId: args.storeId,
-    skuIds: catalogSkus.map(({ sku }) => sku._id),
+    skuIds: catalogSkus.map((sku) => sku._id),
   });
   const pendingCheckoutItemsBySkuId = new Map(
     (await queryActivePendingCheckoutItemsForStore(ctx, args)).flatMap(
@@ -550,38 +684,32 @@ export async function listRegisterCatalogAvailabilitySnapshot(
           : [],
     ),
   );
-  const activeProvisionalSkus = await queryActiveProvisionalImportSkusForStore(
-    ctx,
-    args,
-  );
 
-  const trustedRows = catalogSkus.map(
-    ({ sku }): RegisterCatalogAvailabilityRow => {
-      const pendingCheckoutItem = pendingCheckoutItemsBySkuId.get(sku._id);
-      if (pendingCheckoutItem) {
-        return {
-          productSkuId: sku._id,
-          skuId: sku._id,
-          inStock: true,
-          quantityAvailable: 0,
-          availabilityPolicy: "pending_checkout",
-        };
-      }
-
-      const quantityAvailable = Math.max(
-        0,
-        sku.quantityAvailable - (heldQuantities.get(sku._id) ?? 0),
-      );
-
+  const trustedRows = catalogSkus.map((sku): RegisterCatalogAvailabilityRow => {
+    const pendingCheckoutItem = pendingCheckoutItemsBySkuId.get(sku._id);
+    if (pendingCheckoutItem) {
       return {
         productSkuId: sku._id,
         skuId: sku._id,
-        inStock: quantityAvailable > 0,
-        quantityAvailable,
-        availabilityPolicy: "trusted_inventory",
+        inStock: true,
+        quantityAvailable: 0,
+        availabilityPolicy: "pending_checkout",
       };
-    },
-  );
+    }
+
+    const quantityAvailable = Math.max(
+      0,
+      sku.quantityAvailable - (heldQuantities.get(sku._id) ?? 0),
+    );
+
+    return {
+      productSkuId: sku._id,
+      skuId: sku._id,
+      inStock: quantityAvailable > 0,
+      quantityAvailable,
+      availabilityPolicy: "trusted_inventory",
+    };
+  });
 
   const trustedAvailableSkuIds = new Set(
     trustedRows

--- a/packages/athena-webapp/convex/pos/application/queries/searchCatalog.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/searchCatalog.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "../../../_generated/dataModel";
 
 const mocks = vi.hoisted(() => ({
+  findActiveProvisionalImportSkuForStoreSku: vi.fn(),
   findStoreSkuByBarcode: vi.fn(),
   findStoreSkuBySku: vi.fn(),
   getCategoryById: vi.fn(),
@@ -14,6 +15,8 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../infrastructure/repositories/catalogRepository", () => ({
+  findActiveProvisionalImportSkuForStoreSku:
+    mocks.findActiveProvisionalImportSkuForStoreSku,
   findStoreSkuByBarcode: mocks.findStoreSkuByBarcode,
   findStoreSkuBySku: mocks.findStoreSkuBySku,
   getCategoryById: mocks.getCategoryById,
@@ -40,6 +43,7 @@ describe("searchCatalog", () => {
     mocks.isConvexProductId.mockReturnValue(false);
     mocks.findStoreSkuByBarcode.mockResolvedValue(null);
     mocks.findStoreSkuBySku.mockResolvedValue(null);
+    mocks.findActiveProvisionalImportSkuForStoreSku.mockResolvedValue(null);
     mocks.getProductById.mockImplementation(
       async (_ctx, productId) =>
         productById[productId as keyof typeof productById] ?? null,
@@ -47,6 +51,12 @@ describe("searchCatalog", () => {
   });
 
   it("excludes draft products, hidden products, and hidden SKUs from text search", async () => {
+    mocks.findActiveProvisionalImportSkuForStoreSku.mockImplementation(
+      async (_ctx, args) =>
+        args.productSkuId === "sku-active-legacy-import"
+          ? { _id: "provisional-active" }
+          : null,
+    );
     mocks.listMatchingStoreSkus.mockResolvedValue([
       { product: productById["product-live"], sku: skuById["sku-live"] },
       { product: productById["product-draft"], sku: skuById["sku-draft"] },
@@ -61,6 +71,14 @@ describe("searchCatalog", () => {
       {
         product: productById["product-pos-pending-checkout"],
         sku: skuById["sku-pos-pending-checkout"],
+      },
+      {
+        product: productById["product-finalized-legacy-import"],
+        sku: skuById["sku-finalized-legacy-import"],
+      },
+      {
+        product: productById["product-active-legacy-import"],
+        sku: skuById["sku-active-legacy-import"],
       },
       {
         product: productById["product-hidden-sku"],
@@ -86,7 +104,19 @@ describe("searchCatalog", () => {
         productId: "product-pos-pending-checkout",
         skuId: "sku-pos-pending-checkout",
       }),
+      expect.objectContaining({
+        id: "sku-finalized-legacy-import",
+        productId: "product-finalized-legacy-import",
+        skuId: "sku-finalized-legacy-import",
+        price: 4000,
+      }),
     ]);
+    expect(
+      mocks.findActiveProvisionalImportSkuForStoreSku,
+    ).toHaveBeenCalledWith(ctx, {
+      storeId,
+      productSkuId: "sku-active-legacy-import",
+    });
   });
 
   it("excludes hidden and draft rows from barcode and SKU lookup", async () => {
@@ -132,6 +162,36 @@ describe("searchCatalog", () => {
         productId: "product-pos-pending-checkout",
       }),
     );
+  });
+
+  it("includes finalized legacy-import rows in exact lookup after the provisional row closes", async () => {
+    mocks.findStoreSkuBySku.mockResolvedValueOnce(
+      skuById["sku-finalized-legacy-import"],
+    );
+
+    await expect(
+      lookupByBarcode(ctx, { storeId, barcode: "FINAL-LEGACY" }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        id: "sku-finalized-legacy-import",
+        category: "Legacy import",
+        productId: "product-finalized-legacy-import",
+        price: 4000,
+      }),
+    );
+  });
+
+  it("keeps active legacy-import trusted rows suppressed until provisional finalization closes", async () => {
+    mocks.findStoreSkuBySku.mockResolvedValueOnce(
+      skuById["sku-active-legacy-import"],
+    );
+    mocks.findActiveProvisionalImportSkuForStoreSku.mockResolvedValueOnce({
+      _id: "provisional-active",
+    });
+
+    await expect(
+      lookupByBarcode(ctx, { storeId, barcode: "ACTIVE-LEGACY" }),
+    ).resolves.toBeNull();
   });
 
   it("excludes hidden SKUs from exact product-id lookup", async () => {
@@ -198,6 +258,24 @@ const productById = {
     availability: "draft",
     isVisible: false,
   },
+  "product-finalized-legacy-import": {
+    _id: "product-finalized-legacy-import",
+    storeId,
+    categoryId: "category-legacy-import",
+    name: "Finalized Legacy Import",
+    description: "",
+    availability: "draft",
+    isVisible: false,
+  },
+  "product-active-legacy-import": {
+    _id: "product-active-legacy-import",
+    storeId,
+    categoryId: "category-legacy-import",
+    name: "Active Legacy Import",
+    description: "",
+    availability: "draft",
+    isVisible: false,
+  },
   "product-hidden-sku": {
     _id: "product-hidden-sku",
     storeId,
@@ -222,6 +300,11 @@ const categoryById = {
     _id: "category-pos-pending-checkout",
     name: "POS pending checkout",
     slug: "pos-pending-checkout",
+  },
+  "category-legacy-import": {
+    _id: "category-legacy-import",
+    name: "Legacy import",
+    slug: "legacy-import",
   },
 };
 
@@ -280,6 +363,28 @@ const skuById = {
     netPrice: 1000,
     price: 1000,
     quantityAvailable: 0,
+  },
+  "sku-finalized-legacy-import": {
+    _id: "sku-finalized-legacy-import",
+    storeId,
+    productId: "product-finalized-legacy-import",
+    sku: "FINAL-LEGACY",
+    barcode: "",
+    images: [],
+    isVisible: true,
+    price: 4000,
+    quantityAvailable: 20,
+  },
+  "sku-active-legacy-import": {
+    _id: "sku-active-legacy-import",
+    storeId,
+    productId: "product-active-legacy-import",
+    sku: "ACTIVE-LEGACY",
+    barcode: "",
+    images: [],
+    isVisible: true,
+    price: 4000,
+    quantityAvailable: 20,
   },
   "sku-hidden": {
     _id: "sku-hidden",

--- a/packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts
@@ -2,6 +2,7 @@ import type { Doc, Id } from "../../../_generated/dataModel";
 import type { QueryCtx } from "../../../_generated/server";
 
 import {
+  findActiveProvisionalImportSkuForStoreSku,
   findStoreSkuByBarcode,
   findStoreSkuBySku,
   getCategoryById,
@@ -32,9 +33,16 @@ type CatalogResult = {
 };
 
 const POS_OPERATIONAL_CATEGORY_SLUGS = new Set([
+  "legacy-import",
   "pos-pending-checkout",
   "pos-quick-add",
 ]);
+
+function isDraftAllowedInTrustedCatalog(categorySlug?: string) {
+  return (
+    categorySlug === "legacy-import" || categorySlug === "pos-pending-checkout"
+  );
+}
 
 function isTrustedCatalogResult(args: {
   product: NonNullable<Awaited<ReturnType<typeof getProductById>>>;
@@ -44,14 +52,40 @@ function isTrustedCatalogResult(args: {
   const isReservedPosOperationalProduct = args.category?.slug
     ? POS_OPERATIONAL_CATEGORY_SLUGS.has(args.category.slug)
     : false;
-  const isPendingCheckoutProduct =
-    args.category?.slug === "pos-pending-checkout";
+  const isDraftAllowed = isDraftAllowedInTrustedCatalog(args.category?.slug);
 
   return (
     args.product.availability !== "archived" &&
-    (args.product.availability !== "draft" || isPendingCheckoutProduct) &&
+    (args.product.availability !== "draft" || isDraftAllowed) &&
     (args.product.isVisible !== false || isReservedPosOperationalProduct) &&
-    (args.sku.isVisible !== false || isPendingCheckoutProduct)
+    (args.sku.isVisible !== false || isDraftAllowed)
+  );
+}
+
+function getTrustedCatalogPrice(sku: Doc<"productSku">) {
+  return sku.netPrice ?? sku.price;
+}
+
+async function isSuppressedByActiveLegacyImportProvisionalRow(
+  ctx: QueryCtx,
+  args: {
+    category?: Awaited<ReturnType<typeof getCategoryById>>;
+    product: NonNullable<Awaited<ReturnType<typeof getProductById>>>;
+    sku: Doc<"productSku">;
+    storeId: Id<"store">;
+  },
+) {
+  return (
+    args.category?.slug === "legacy-import" &&
+    (args.product.availability === "draft" ||
+      args.product.isVisible === false ||
+      args.sku.isVisible === false) &&
+    Boolean(
+      await findActiveProvisionalImportSkuForStoreSku(ctx, {
+        storeId: args.storeId,
+        productSkuId: args.sku._id,
+      }),
+    )
   );
 }
 
@@ -75,7 +109,7 @@ async function mapSkuToCatalogResult(
       sku: args.sku,
       category,
     }) ||
-    !args.sku.netPrice
+    getTrustedCatalogPrice(args.sku) <= 0
   ) {
     return null;
   }
@@ -88,7 +122,7 @@ async function mapSkuToCatalogResult(
     name: args.product.name,
     sku: args.sku.sku || "",
     barcode: args.sku.barcode || "",
-    price: args.sku.netPrice || args.sku.price,
+    price: getTrustedCatalogPrice(args.sku),
     category: categoryName,
     description: args.product.description || "",
     inStock: args.sku.quantityAvailable > 0,
@@ -127,20 +161,27 @@ export async function searchProducts(
       product?.storeId === args.storeId &&
       product.availability !== "archived" &&
       (product.availability !== "draft" ||
-        category?.slug === "pos-pending-checkout") &&
+        isDraftAllowedInTrustedCatalog(category?.slug)) &&
       (product.isVisible !== false ||
         POS_OPERATIONAL_CATEGORY_SLUGS.has(category?.slug ?? ""))
     ) {
       const productSkus = await listProductSkusByProductId(ctx, product._id);
       const categoryName = category?.name || "";
       const results = await Promise.all(
-        productSkus.map((sku) =>
-          mapSkuToCatalogResult(ctx, {
+        productSkus.map(async (sku) =>
+          (await isSuppressedByActiveLegacyImportProvisionalRow(ctx, {
+            category,
             product,
             sku,
-            category,
-            categoryName,
-          }),
+            storeId: args.storeId,
+          }))
+            ? null
+            : mapSkuToCatalogResult(ctx, {
+                product,
+                sku,
+                category,
+                categoryName,
+              }),
         ),
       );
 
@@ -155,12 +196,29 @@ export async function searchProducts(
     searchQuery: query,
   });
   const results = await Promise.all(
-    matchingSkus.map(({ product, sku }) =>
-      mapSkuToCatalogResult(ctx, {
+    matchingSkus.map(async ({ product, sku }) => {
+      const category =
+        product?.storeId === args.storeId
+          ? await getCategoryById(ctx, product.categoryId)
+          : null;
+
+      if (
+        await isSuppressedByActiveLegacyImportProvisionalRow(ctx, {
+          category,
+          product,
+          sku,
+          storeId: args.storeId,
+        })
+      ) {
+        return null;
+      }
+
+      return mapSkuToCatalogResult(ctx, {
         product,
         sku,
-      }),
-    ),
+        category,
+      });
+    }),
   );
 
   return results.filter((result): result is CatalogResult => result !== null);
@@ -199,20 +257,27 @@ export async function lookupByBarcode(
       product?.storeId === args.storeId &&
       product.availability !== "archived" &&
       (product.availability !== "draft" ||
-        category?.slug === "pos-pending-checkout") &&
+        isDraftAllowedInTrustedCatalog(category?.slug)) &&
       (product.isVisible !== false ||
         POS_OPERATIONAL_CATEGORY_SLUGS.has(category?.slug ?? ""))
     ) {
       const allSkus = await listProductSkusByProductId(ctx, product._id);
       const categoryName = category?.name || "";
       const results = await Promise.all(
-        allSkus.map((productSku) =>
-          mapSkuToCatalogResult(ctx, {
+        allSkus.map(async (productSku) =>
+          (await isSuppressedByActiveLegacyImportProvisionalRow(ctx, {
+            category,
             product,
             sku: productSku,
-            category,
-            categoryName,
-          }),
+            storeId: args.storeId,
+          }))
+            ? null
+            : mapSkuToCatalogResult(ctx, {
+                product,
+                sku: productSku,
+                category,
+                categoryName,
+              }),
         ),
       );
 
@@ -235,9 +300,20 @@ export async function lookupByBarcode(
     !product ||
     product.availability === "archived" ||
     (product.availability === "draft" &&
-      category?.slug !== "pos-pending-checkout") ||
+      !isDraftAllowedInTrustedCatalog(category?.slug)) ||
     (product.isVisible === false &&
       !POS_OPERATIONAL_CATEGORY_SLUGS.has(category?.slug ?? ""))
+  ) {
+    return null;
+  }
+
+  if (
+    await isSuppressedByActiveLegacyImportProvisionalRow(ctx, {
+      category,
+      product,
+      sku,
+      storeId: args.storeId,
+    })
   ) {
     return null;
   }

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts
@@ -89,6 +89,26 @@ export async function findStoreSkuBySku(
     .first();
 }
 
+export async function findActiveProvisionalImportSkuForStoreSku(
+  ctx: QueryCtx,
+  args: {
+    storeId: Id<"store">;
+    productSkuId: Id<"productSku">;
+  },
+) {
+  const row = await ctx.db
+    .query("inventoryImportProvisionalSku")
+    .withIndex("by_storeId_productSkuId_status", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("productSkuId", args.productSkuId)
+        .eq("status", "active"),
+    )
+    .first();
+
+  return row?.posExposureStatus === "available" ? row : null;
+}
+
 export async function listMatchingStoreSkus(
   ctx: QueryCtx,
   args: {
@@ -119,9 +139,12 @@ export async function listMatchingStoreSkus(
 
     const barcodeMatches =
       sku.barcode?.toLowerCase().includes(args.searchQuery) ?? false;
-    const skuMatches = sku.sku?.toLowerCase().includes(args.searchQuery) ?? false;
+    const skuMatches =
+      sku.sku?.toLowerCase().includes(args.searchQuery) ?? false;
     const nameMatches = product.name.toLowerCase().includes(args.searchQuery);
-    const productIdMatches = product._id.toLowerCase().includes(args.searchQuery);
+    const productIdMatches = product._id
+      .toLowerCase()
+      .includes(args.searchQuery);
     const descriptionMatches =
       product.description?.toLowerCase().includes(args.searchQuery) ?? false;
 

--- a/packages/athena-webapp/convex/stockOps/adjustments.test.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.test.ts
@@ -2,6 +2,8 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
+import { ok } from "../../shared/commandResult";
+import { assertConformsToExportedReturns } from "../lib/returnValidatorContract";
 
 const mockedAuthServer = vi.hoisted(() => ({
   getAuthUserId: vi.fn(),
@@ -16,11 +18,13 @@ import {
   assertDistinctStockAdjustmentLineItems,
   assertStockAdjustmentReasonCode,
   calculateCycleCountQuantityDelta,
+  getInventoryUnitSummaryWithCtx,
   hasHighStockAdjustmentVariance,
   listInventorySnapshotWithCtx,
   requiresStockAdjustmentApproval,
   resolveStockAdjustmentApprovalDecisionWithCtx,
   resolveStockAdjustmentQuantityDelta,
+  submitStockAdjustmentBatch,
   submitStockAdjustmentBatchCommandWithCtx,
   submitStockAdjustmentBatchWithCtx,
   summarizeStockAdjustmentLineItems,
@@ -580,6 +584,36 @@ function createSubmissionMutationCtx(args: {
 }
 
 describe("stock ops adjustments", () => {
+  it("accepts representative stock adjustment command return contracts", () => {
+    assertConformsToExportedReturns(
+      submitStockAdjustmentBatch,
+      ok({
+        _id: "stock-adjustment-batch-1",
+        adjustmentType: "manual",
+        approvalRequired: false,
+        createdAt: 1_700_000_000_000,
+        createdByUserId: "user-1",
+        lineItemCount: 1,
+        lineItems: [
+          {
+            inventoryAfter: 11,
+            inventoryBefore: 10,
+            productSkuId: "sku-1",
+            quantityDelta: 1,
+          },
+        ],
+        largestAbsoluteDelta: 1,
+        netQuantityDelta: 1,
+        organizationId: "org-1",
+        reasonCode: "manual_correction",
+        status: "applied",
+        storeId: "store-1",
+        submissionKey: "submission-1",
+        varianceThreshold: STOCK_ADJUSTMENT_APPROVAL_THRESHOLD,
+      }),
+    );
+  });
+
   it("returns hold-adjusted sellable availability while preserving durable SKU availability", async () => {
     const { ctx } = createInventorySnapshotQueryCtx();
 
@@ -600,6 +634,43 @@ describe("stock ops adjustments", () => {
         size: "Large",
       }),
     ]);
+  });
+
+  it("summarizes store-level inventory units without hydrating snapshot rows", async () => {
+    const { ctx, tables } = createInventorySnapshotQueryCtx();
+
+    tables.productSku.set("sku-2", {
+      _id: "sku-2",
+      images: [],
+      inventoryCount: 4,
+      productId: "product-1",
+      quantityAvailable: 1,
+      sku: "CW-20",
+      storeId: "store-1",
+    });
+    tables.productSku.set("other-store-sku", {
+      _id: "other-store-sku",
+      images: [],
+      inventoryCount: 100,
+      productId: "product-1",
+      quantityAvailable: 100,
+      sku: "OTHER",
+      storeId: "store-2",
+    });
+
+    const summary = await getInventoryUnitSummaryWithCtx(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(summary).toEqual({
+      availableUnits: 9,
+      hasMoreSkus: false,
+      onHandUnits: 14,
+      reservedUnits: 5,
+      skuCount: 2,
+      unavailableSkuCount: 2,
+      unavailableUnits: 5,
+    });
   });
 
   it("labels active checkout reservations without double subtracting availability", async () => {
@@ -704,12 +775,9 @@ describe("stock ops adjustments", () => {
       storeId: "store-1" as Id<"store">,
     });
 
-    expect(rows).toEqual([
-      expect.objectContaining({
-        stockAdjustmentBlockedMessage: null,
-        stockAdjustmentBlockedReason: null,
-      }),
-    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).not.toHaveProperty("stockAdjustmentBlockedMessage");
+    expect(rows[0]).not.toHaveProperty("stockAdjustmentBlockedReason");
   });
 
   it("marks unresolved POS pending checkout SKUs as blocked for stock adjustments", async () => {
@@ -782,6 +850,59 @@ describe("stock ops adjustments", () => {
         "Legacy import SKUs must be finalized before stock adjustments can update them.",
       stockAdjustmentBlockedReason: "provisional_import",
     });
+  });
+
+  it("keeps inventory snapshot rows bounded and sparse to stay below Convex response limits", async () => {
+    const { ctx, tables } = createInventorySnapshotQueryCtx();
+
+    tables.inventoryHold.clear();
+    tables.productSku.set("sku-1", {
+      ...(tables.productSku.get("sku-1") ?? {}),
+      images: [],
+      quantityAvailable: 10,
+      inventoryCount: 10,
+      netPrice: null,
+      barcode: null,
+      color: null,
+      length: null,
+      size: null,
+      sku: null,
+    });
+
+    for (let index = 2; index <= 1_000; index += 1) {
+      tables.productSku.set(`sku-${index}`, {
+        _id: `sku-${index}`,
+        barcode: null,
+        color: null,
+        images: [],
+        inventoryCount: 10,
+        length: null,
+        netPrice: null,
+        price: 1000,
+        productId: "product-1",
+        quantityAvailable: 10,
+        size: null,
+        sku: null,
+        storeId: "store-1",
+      });
+    }
+
+    const rows = await listInventorySnapshotWithCtx(ctx, {
+      limit: 1_000,
+      now: 1_000,
+      storeId: "store-1" as Id<"store">,
+    });
+    const firstRow = rows[0] as Record<string, unknown>;
+
+    expect(rows).toHaveLength(750);
+    expect(firstRow).not.toHaveProperty("barcode");
+    expect(firstRow).not.toHaveProperty("checkoutReservedQuantity");
+    expect(firstRow).not.toHaveProperty("durableQuantityAvailable");
+    expect(firstRow).not.toHaveProperty("imageUrl");
+    expect(firstRow).not.toHaveProperty("posReservedQuantity");
+    expect(firstRow).not.toHaveProperty("reservedQuantity");
+    expect(firstRow).not.toHaveProperty("stockAdjustmentBlockedMessage");
+    expect(JSON.stringify(rows).length).toBeLessThan(130_000);
   });
 
   it("calculates cycle-count deltas from the system quantity", () => {

--- a/packages/athena-webapp/convex/stockOps/adjustments.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.ts
@@ -5,6 +5,7 @@ import {
   type QueryCtx,
 } from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
+import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 import {
   requireAuthenticatedAthenaUserWithCtx,
@@ -73,6 +74,9 @@ const ACTIVE_CHECKOUT_ITEM_SUM_LIMIT = 5000;
 const STOCK_ADJUSTMENT_BLOCKER_POINT_LOOKUP_LIMIT = 50;
 const ACTIVE_PROVISIONAL_IMPORT_BLOCKER_SCAN_LIMIT = 1500;
 const ACTIVE_PENDING_CHECKOUT_BLOCKER_SCAN_LIMIT = 2000;
+const INVENTORY_SNAPSHOT_DEFAULT_LIMIT = 500;
+const INVENTORY_SNAPSHOT_MAX_LIMIT = 750;
+const INVENTORY_SUMMARY_SKU_LIMIT = 5000;
 const LEGACY_IMPORT_STOCK_ADJUSTMENT_BLOCK_MESSAGE =
   "Legacy import SKUs must be finalized before stock adjustments can update them.";
 const POS_PENDING_CHECKOUT_STOCK_ADJUSTMENT_BLOCK_MESSAGE =
@@ -708,16 +712,92 @@ async function readActiveCheckoutReservedQuantitiesForStockOpsSnapshot(
 export async function listInventorySnapshotWithCtx(
   ctx: QueryCtx,
   args: {
+    limit?: number;
     now?: number;
     storeId: Id<"store">;
   },
 ) {
   const now = args.now ?? Date.now();
-  // eslint-disable-next-line @convex-dev/no-collect-in-query -- This workspace needs the full store SKU snapshot so operators can reconcile counts across the entire catalog in one pass.
+  const limit = Math.min(
+    Math.max(1, Math.floor(args.limit ?? INVENTORY_SNAPSHOT_DEFAULT_LIMIT)),
+    INVENTORY_SNAPSHOT_MAX_LIMIT,
+  );
   const productSkus = await ctx.db
     .query("productSku")
     .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
-    .collect();
+    .take(limit);
+
+  return buildInventorySnapshotRowsForProductSkusWithCtx(ctx, {
+    now,
+    productSkus,
+    storeId: args.storeId,
+  });
+}
+
+export async function getInventoryUnitSummaryWithCtx(
+  ctx: QueryCtx,
+  args: {
+    storeId: Id<"store">;
+  },
+) {
+  const productSkus = await ctx.db
+    .query("productSku")
+    .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
+    .take(INVENTORY_SUMMARY_SKU_LIMIT);
+
+  return productSkus.reduce(
+    (summary, productSku) => {
+      const onHandUnits = Math.max(0, productSku.inventoryCount);
+      const availableUnits = Math.max(0, productSku.quantityAvailable);
+      const reservedUnits = Math.max(0, onHandUnits - availableUnits);
+
+      return {
+        availableUnits: summary.availableUnits + availableUnits,
+        hasMoreSkus:
+          summary.hasMoreSkus || productSkus.length === INVENTORY_SUMMARY_SKU_LIMIT,
+        onHandUnits: summary.onHandUnits + onHandUnits,
+        reservedUnits: summary.reservedUnits + reservedUnits,
+        skuCount: summary.skuCount + 1,
+        unavailableSkuCount:
+          summary.unavailableSkuCount + (reservedUnits > 0 ? 1 : 0),
+        unavailableUnits: summary.unavailableUnits + reservedUnits,
+      };
+    },
+    {
+      availableUnits: 0,
+      hasMoreSkus: false,
+      onHandUnits: 0,
+      reservedUnits: 0,
+      skuCount: 0,
+      unavailableSkuCount: 0,
+      unavailableUnits: 0,
+    },
+  );
+}
+
+async function buildInventorySnapshotRowsForProductSkusWithCtx(
+  ctx: QueryCtx,
+  args: {
+    now: number;
+    productSkus: Array<{
+      _id: Id<"productSku">;
+      barcode?: string;
+      color?: Id<"color">;
+      images: string[];
+      inventoryCount: number;
+      length?: number;
+      netPrice?: number | null;
+      price?: number | null;
+      productId: Id<"product">;
+      productName?: string;
+      quantityAvailable: number;
+      size?: string;
+      sku?: string;
+    }>;
+    storeId: Id<"store">;
+  },
+) {
+  const { now, productSkus } = args;
   const heldQuantities = await readActiveHeldQuantitiesForStockOpsSnapshot(
     ctx,
     {
@@ -830,34 +910,42 @@ export async function listInventorySnapshotWithCtx(
 
       return {
         _id: productSku._id,
-        barcode: productSku.barcode ?? null,
-        colorName: color?.name ?? null,
-        durableQuantityAvailable,
-        imageUrl: productSku.images[0] ?? null,
+        ...(productSku.barcode ? { barcode: productSku.barcode } : {}),
+        ...(color?.name ? { colorName: color.name } : {}),
+        ...(durableQuantityAvailable !== quantityAvailable
+          ? { durableQuantityAvailable }
+          : {}),
+        ...(productSku.images[0] ? { imageUrl: productSku.images[0] } : {}),
         inventoryCount: productSku.inventoryCount,
-        length: productSku.length ?? null,
-        netPrice: productSku.netPrice,
-        price: productSku.price,
-        productCategoryId: product?.categoryId ?? null,
-        productCategory: category?.name ?? null,
-        productCategorySlug: category?.slug ?? null,
+        ...(productSku.length !== undefined && productSku.length !== null
+          ? { length: productSku.length }
+          : {}),
+        ...(productSku.netPrice !== undefined && productSku.netPrice !== null
+          ? { netPrice: productSku.netPrice }
+          : {}),
+        ...(productSku.price !== undefined && productSku.price !== null
+          ? { price: productSku.price }
+          : {}),
+        ...(category?.name ? { productCategory: category.name } : {}),
         productId: productSku.productId,
         productName:
           product?.name ??
           productSku.productName ??
           productSku.sku ??
           String(productSku._id),
-        productSubcategoryId: product?.subcategoryId ?? null,
-        productSubcategory: subcategory?.name ?? null,
-        productSubcategorySlug: subcategory?.slug ?? null,
-        stockAdjustmentBlockedReason: blockedStatus?.reason ?? null,
-        stockAdjustmentBlockedMessage: blockedStatus?.message ?? null,
-        checkoutReservedQuantity,
-        posReservedQuantity,
+        ...(subcategory?.name ? { productSubcategory: subcategory.name } : {}),
+        ...(blockedStatus
+          ? {
+              stockAdjustmentBlockedMessage: blockedStatus.message,
+              stockAdjustmentBlockedReason: blockedStatus.reason,
+            }
+          : {}),
+        ...(checkoutReservedQuantity > 0 ? { checkoutReservedQuantity } : {}),
+        ...(posReservedQuantity > 0 ? { posReservedQuantity } : {}),
         quantityAvailable,
-        reservedQuantity,
-        size: productSku.size ?? null,
-        sku: productSku.sku ?? null,
+        ...(reservedQuantity > 0 ? { reservedQuantity } : {}),
+        ...(productSku.size ? { size: productSku.size } : {}),
+        ...(productSku.sku ? { sku: productSku.sku } : {}),
       };
     }),
   );
@@ -874,10 +962,45 @@ export async function listInventorySnapshotWithCtx(
 
 export const listInventorySnapshot = query({
   args: {
+    limit: v.optional(v.number()),
     storeId: v.id("store"),
   },
   handler: async (ctx, args) => {
     return listInventorySnapshotWithCtx(ctx, args);
+  },
+});
+
+export const getInventoryUnitSummary = query({
+  args: {
+    storeId: v.id("store"),
+  },
+  handler: async (ctx, args) => {
+    return getInventoryUnitSummaryWithCtx(ctx, args);
+  },
+});
+
+export const listInventorySnapshotPage = query({
+  args: {
+    paginationOpts: paginationOptsValidator,
+    storeId: v.id("store"),
+  },
+  handler: async (ctx, args) => {
+    const productSkuPage = await ctx.db
+      .query("productSku")
+      .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
+      .paginate({
+        ...args.paginationOpts,
+        numItems: Math.min(args.paginationOpts.numItems, 100),
+      });
+
+    return {
+      ...productSkuPage,
+      page: await buildInventorySnapshotRowsForProductSkusWithCtx(ctx, {
+        now: Date.now(),
+        productSkus: productSkuPage.page,
+        storeId: args.storeId,
+      }),
+    };
   },
 });
 

--- a/packages/athena-webapp/src/components/add-product/ProductStock.tsx
+++ b/packages/athena-webapp/src/components/add-product/ProductStock.tsx
@@ -432,6 +432,7 @@ function LegacyImportTrustPreview({
     ? "Refresh review"
     : reviewState.ctaLabel;
   const isCtaDisabled = requiresReviewRefresh ? false : reviewState.disabled;
+  const isFinalized = reviewState.status === "success";
 
   return (
     <TableRow
@@ -441,9 +442,9 @@ function LegacyImportTrustPreview({
     >
       <TableCell colSpan={8} className="px-4 py-3">
         <div
-          className={`flex flex-col gap-3 rounded-md border px-3 py-3 sm:flex-row sm:items-center sm:justify-between ${
-            reviewState.status === "success"
-              ? "border-emerald-200 bg-emerald-50/50"
+          className={`flex flex-col gap-3 rounded-md border bg-background px-3 py-3 transition-[border-color,box-shadow] duration-150 ease-out sm:flex-row sm:items-center sm:justify-between ${
+            isFinalized
+              ? "border-action-workflow-border shadow-sm"
               : "border-border"
           }`}
         >
@@ -459,6 +460,15 @@ function LegacyImportTrustPreview({
               >
                 Provisional SKU
               </Badge>
+              {isFinalized ? (
+                <Badge
+                  variant="outline"
+                  className="gap-1.5 border-action-workflow-border bg-background text-action-workflow"
+                >
+                  <Check className="h-3.5 w-3.5" />
+                  Finalized
+                </Badge>
+              ) : null}
             </div>
             <p
               className="max-w-3xl text-pretty text-xs leading-5 text-muted-foreground"
@@ -478,16 +488,27 @@ function LegacyImportTrustPreview({
           </div>
 
           <div className="flex flex-wrap items-center gap-2 sm:justify-end">
-            <Button
-              type="button"
-              size="sm"
-              variant="workflow-soft"
-              className="min-h-10 active:scale-[0.96] transition-transform"
-              disabled={isCtaDisabled}
-              onClick={handleClick}
-            >
-              {ctaLabel}
-            </Button>
+            {isFinalized ? (
+              <div
+                className="inline-flex min-h-10 items-center gap-2 rounded-md px-3 text-xs font-medium text-muted-foreground"
+                role="status"
+                aria-live="polite"
+              >
+                <Check className="h-3.5 w-3.5 text-action-workflow" />
+                Trusted SKU ready
+              </div>
+            ) : (
+              <Button
+                type="button"
+                size="sm"
+                variant="workflow-soft"
+                className="min-h-10 active:scale-[0.96] transition-transform"
+                disabled={isCtaDisabled}
+                onClick={handleClick}
+              >
+                {ctaLabel}
+              </Button>
+            )}
           </div>
         </div>
       </TableCell>

--- a/packages/athena-webapp/src/components/base/table/data-table.tsx
+++ b/packages/athena-webapp/src/components/base/table/data-table.tsx
@@ -24,7 +24,6 @@ import {
   TableRow,
 } from "../../ui/table";
 
-import { DataTableToolbar } from "./data-table-toolbar";
 import { DataTablePagination } from "./data-table-pagination";
 import { usePaginationPersistence } from "~/src/hooks/use-pagination-persistence";
 import { cn } from "@/lib/utils";
@@ -35,6 +34,7 @@ interface DataTableProps<TData, TValue> {
   data: TData[];
   getRowClassName?: (row: Row<TData>) => string | undefined;
   pageIndex?: number;
+  onLoadMore?: () => void;
   onPageIndexChange?: (pageIndex: number) => void;
   onRowClick?: (row: Row<TData>) => void;
   paginationRangeItemLabel?: string;
@@ -48,6 +48,7 @@ export function GenericDataTable<TData, TValue>({
   data,
   getRowClassName,
   pageIndex,
+  onLoadMore,
   onPageIndexChange,
   onRowClick,
   paginationRangeItemLabel,
@@ -154,6 +155,7 @@ export function GenericDataTable<TData, TValue>({
         </Table>
       </div>
       <DataTablePagination
+        onLoadMore={onLoadMore}
         rangeItemLabel={paginationRangeItemLabel}
         rangeItemPluralLabel={paginationRangeItemPluralLabel}
         table={table}

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.auth.test.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.auth.test.tsx
@@ -7,6 +7,7 @@ import { OperationsQueueView } from "./OperationsQueueView";
 const mockedHooks = vi.hoisted(() => ({
   useAuth: vi.fn(),
   useMutation: vi.fn(),
+  usePaginatedQuery: vi.fn(),
   useProtectedAdminPageState: vi.fn(),
   usePermissions: vi.fn(),
   useQuery: vi.fn(),
@@ -14,6 +15,7 @@ const mockedHooks = vi.hoisted(() => ({
 
 vi.mock("convex/react", () => ({
   useMutation: mockedHooks.useMutation,
+  usePaginatedQuery: mockedHooks.usePaginatedQuery,
   useQuery: mockedHooks.useQuery,
 }));
 
@@ -42,6 +44,7 @@ vi.mock("@tanstack/react-router", () => ({
     orgUrlSlug: "wigclub",
     storeUrlSlug: "wigclub",
   }),
+  useNavigate: () => vi.fn(),
   useSearch: () => ({}),
 }));
 
@@ -71,6 +74,12 @@ describe("OperationsQueueView auth readiness", () => {
     });
     mockedHooks.useProtectedAdminPageState.mockReturnValue(readyProtectedState);
     mockedHooks.useMutation.mockReturnValue(vi.fn());
+    mockedHooks.usePaginatedQuery.mockReturnValue({
+      isLoading: false,
+      loadMore: vi.fn(),
+      results: [],
+      status: "Exhausted",
+    });
     mockedHooks.useQuery.mockReturnValue(undefined);
   });
 
@@ -92,6 +101,7 @@ describe("OperationsQueueView auth readiness", () => {
       "skip",
       "skip",
     ]);
+    expect(mockedHooks.usePaginatedQuery.mock.calls[0]?.[1]).toBe("skip");
   });
 
   it("renders a sign-in fallback instead of subscribing when Convex auth is missing", () => {
@@ -110,6 +120,7 @@ describe("OperationsQueueView auth readiness", () => {
       "skip",
       "skip",
     ]);
+    expect(mockedHooks.usePaginatedQuery.mock.calls[0]?.[1]).toBe("skip");
   });
 
   it("subscribes to protected queries once the shared admin gate is ready", () => {
@@ -125,5 +136,45 @@ describe("OperationsQueueView auth readiness", () => {
       "skip",
       { storeId: "store-1" },
     ]);
+    expect(mockedHooks.usePaginatedQuery.mock.calls[0]?.[1]).toEqual({
+      storeId: "store-1",
+    });
+    expect(mockedHooks.usePaginatedQuery.mock.calls[0]?.[2]).toEqual({
+      initialNumItems: 100,
+    });
+  });
+
+  it("skips stock snapshot subscriptions on the open-work route", () => {
+    mockedHooks.useQuery.mockReturnValueOnce({
+      approvalRequests: [],
+      workItems: [],
+    });
+
+    render(<OperationsQueueView activeWorkflow="queue" />);
+
+    expect(mockedHooks.useQuery.mock.calls.map(([, args]) => args).slice(0, 4))
+      .toEqual([{ storeId: "store-1" }, "skip", "skip", "skip"]);
+    expect(mockedHooks.usePaginatedQuery.mock.calls[0]?.[1]).toBe("skip");
+  });
+
+  it("keeps stock snapshot subscriptions on the stock adjustments route", () => {
+    mockedHooks.useQuery
+      .mockReturnValueOnce({
+        approvalRequests: [],
+        workItems: [],
+      })
+      .mockReturnValueOnce(undefined);
+
+    render(<OperationsQueueView activeWorkflow="stock" />);
+
+    expect(mockedHooks.useQuery.mock.calls.map(([, args]) => args)).toEqual([
+      { storeId: "store-1" },
+      { storeId: "store-1" },
+      "skip",
+      { storeId: "store-1" },
+    ]);
+    expect(mockedHooks.usePaginatedQuery.mock.calls[0]?.[1]).toEqual({
+      storeId: "store-1",
+    });
   });
 });

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
@@ -15,6 +15,7 @@ const mockedHooks = vi.hoisted(() => ({
   useGetAuthedUser: vi.fn(),
   useGetActiveStore: vi.fn(),
   useMutation: vi.fn(),
+  usePaginatedQuery: vi.fn(),
   usePermissions: vi.fn(),
   useQuery: vi.fn(),
 }));
@@ -56,6 +57,7 @@ vi.mock("@tanstack/react-router", () => ({
 vi.mock("convex/react", () => ({
   useConvexAuth: mockedHooks.useConvexAuth,
   useMutation: mockedHooks.useMutation,
+  usePaginatedQuery: mockedHooks.usePaginatedQuery,
   useQuery: mockedHooks.useQuery,
 }));
 
@@ -238,6 +240,12 @@ describe("OperationsQueueViewContent", () => {
       unobserve() {}
     };
     vi.clearAllMocks();
+    mockedHooks.usePaginatedQuery.mockReturnValue({
+      isLoading: false,
+      loadMore: vi.fn(),
+      results: [],
+      status: "Exhausted",
+    });
     mockedToast.error.mockReset();
     mockedToast.success.mockReset();
     mockedHooks.useAuth.mockReturnValue({
@@ -263,12 +271,11 @@ describe("OperationsQueueViewContent", () => {
       approvalRequests: [],
       workItems: [],
     };
-    const inventorySnapshot: typeof baseProps.inventoryItems = [];
     let queryCallIndex = 0;
     mockedHooks.useQuery.mockImplementation(() => {
       queryCallIndex += 1;
 
-      return queryCallIndex % 2 === 1 ? queueSnapshot : inventorySnapshot;
+      return queryCallIndex === 1 ? queueSnapshot : undefined;
     });
   });
 
@@ -297,12 +304,56 @@ describe("OperationsQueueViewContent", () => {
     );
 
     expect(screen.queryByText("Operations lanes")).not.toBeInTheDocument();
+    expect(screen.getByText("0 open work items")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Service intake and stock review work that still needs progress or completion.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText("No open work items")).toBeInTheDocument();
     expect(
       screen.getByText(
         "New service intakes and approval-driven stock reviews will appear here",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("uses the open work count in the loaded route header", () => {
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        activeWorkflow="queue"
+        workItems={[
+          {
+            _id: "work-item-1" as Id<"operationalWorkItem">,
+            approvalState: "pending",
+            createdAt: Date.now() - 5 * 60 * 1000,
+            priority: "normal",
+            status: "open",
+            title: "Review pending checkout item",
+            type: "pos_pending_checkout_item_review",
+          },
+          {
+            _id: "work-item-2" as Id<"operationalWorkItem">,
+            approvalState: "pending",
+            createdAt: Date.now() - 10 * 60 * 1000,
+            priority: "high",
+            status: "open",
+            title: "Follow up service intake",
+            type: "service_case",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("2 open work items")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Service intake and stock review work that still needs progress or completion.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Review pending checkout item")).toBeInTheDocument();
+    expect(screen.getByText("Follow up service intake")).toBeInTheDocument();
   });
 
   it("shows only the open work header while the queue is loading", () => {
@@ -382,6 +433,72 @@ describe("OperationsQueueViewContent", () => {
     expect(
       screen.getByRole("tab", { name: /cycle count/i }),
     ).toBeInTheDocument();
+  });
+
+  it("shows the approvals header while approval data is loading", () => {
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        activeWorkflow="approvals"
+        isLoadingQueue
+      />,
+    );
+
+    expect(screen.getByText("Pending approvals")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Review manager approval requests before queued stock and payment changes are applied.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("No pending approvals")).not.toBeInTheDocument();
+  });
+
+  it("uses natural copy for the empty approvals header", () => {
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        activeWorkflow="approvals"
+        approvalRequests={[]}
+      />,
+    );
+
+    expect(screen.getAllByText("No pending approvals")).toHaveLength(1);
+    expect(screen.queryByText("0 pending approvals")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("High-variance deposits and stock reviews will surface here."),
+    ).toBeInTheDocument();
+  });
+
+  it("uses the pending approval count in the loaded approvals header", () => {
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        activeWorkflow="approvals"
+        approvalRequests={[
+          {
+            _id: "approval-1" as Id<"approvalRequest">,
+            requestType: "inventory_adjustment_review",
+            status: "pending",
+            workItemTitle: "Cycle count review · 1 SKU",
+          },
+          {
+            _id: "approval-2" as Id<"approvalRequest">,
+            requestType: "service_deposit",
+            status: "pending",
+            workItemTitle: "Service deposit review",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("2 pending approvals")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Review manager approval requests before queued stock and payment changes are applied.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Cycle count review · 1 SKU")).toBeInTheDocument();
+    expect(screen.getByText("Service deposit review")).toBeInTheDocument();
   });
 
   it("separates open work items from pending approvals", () => {
@@ -1093,7 +1210,7 @@ describe("OperationsQueueViewContent", () => {
   });
 
   it("renders the live operations page without the register closeout surface", () => {
-    render(<OperationsQueueView />);
+    render(<OperationsQueueView activeWorkflow="stock" />);
 
     expect(screen.getByText("No inventory loaded.")).toBeInTheDocument();
     expect(
@@ -1127,21 +1244,19 @@ describe("OperationsQueueViewContent", () => {
 
     mockedHooks.useMutation.mockReset();
     mockedHooks.useQuery.mockReset();
-    const mutationOrder = [
-      submitStockBatch,
-      decideApprovalRequest,
-      vi.fn(),
-      authenticateStaffCredential,
-      authenticateStaffCredentialForApproval,
-      vi.fn(),
-      vi.fn(),
-      vi.fn(),
-      vi.fn(),
-      vi.fn(),
-    ];
-    let mutationCallIndex = 0;
     mockedHooks.useMutation.mockImplementation(
-      () => mutationOrder[mutationCallIndex++ % mutationOrder.length],
+      () => async (args: Record<string, unknown>) => {
+        if ("actionKey" in args) {
+          return authenticateStaffCredentialForApproval(args);
+        }
+        if ("approvalRequestId" in args) {
+          return decideApprovalRequest(args);
+        }
+        if ("username" in args) {
+          return authenticateStaffCredential(args);
+        }
+        return submitStockBatch(args);
+      },
     );
     const queueSnapshot = {
       approvalRequests: [
@@ -1232,8 +1347,14 @@ describe("OperationsQueueViewContent", () => {
         approvalRequests: [],
         workItems: [],
       })
-      .mockReturnValueOnce(baseProps.inventoryItems)
+      .mockReturnValueOnce(undefined)
       .mockReturnValueOnce(null);
+    mockedHooks.usePaginatedQuery.mockReturnValue({
+      isLoading: false,
+      loadMore: vi.fn(),
+      results: baseProps.inventoryItems,
+      status: "Exhausted",
+    });
 
     render(
       <OperationsQueueView
@@ -1285,8 +1406,14 @@ describe("OperationsQueueViewContent", () => {
         approvalRequests: [],
         workItems: [],
       })
-      .mockReturnValueOnce(inventoryItems)
+      .mockReturnValueOnce(undefined)
       .mockReturnValueOnce(null);
+    mockedHooks.usePaginatedQuery.mockReturnValue({
+      isLoading: false,
+      loadMore: vi.fn(),
+      results: inventoryItems,
+      status: "Exhausted",
+    });
 
     render(
       <OperationsQueueView
@@ -1319,8 +1446,13 @@ describe("OperationsQueueViewContent", () => {
         approvalRequests: [],
         workItems: [],
       })
-      .mockReturnValueOnce(baseProps.inventoryItems)
       .mockReturnValueOnce(undefined);
+    mockedHooks.usePaginatedQuery.mockReturnValue({
+      isLoading: false,
+      loadMore: vi.fn(),
+      results: baseProps.inventoryItems,
+      status: "Exhausted",
+    });
 
     render(
       <OperationsQueueView
@@ -1363,21 +1495,19 @@ describe("OperationsQueueViewContent", () => {
 
     mockedHooks.useMutation.mockReset();
     mockedHooks.useQuery.mockReset();
-    const mutationOrder = [
-      submitStockBatch,
-      decideApprovalRequest,
-      vi.fn(),
-      authenticateStaffCredential,
-      authenticateStaffCredentialForApproval,
-      vi.fn(),
-      vi.fn(),
-      vi.fn(),
-      vi.fn(),
-      vi.fn(),
-    ];
-    let mutationCallIndex = 0;
     mockedHooks.useMutation.mockImplementation(
-      () => mutationOrder[mutationCallIndex++ % mutationOrder.length],
+      () => async (args: Record<string, unknown>) => {
+        if ("actionKey" in args) {
+          return authenticateStaffCredentialForApproval(args);
+        }
+        if ("approvalRequestId" in args) {
+          return decideApprovalRequest(args);
+        }
+        if ("username" in args) {
+          return authenticateStaffCredential(args);
+        }
+        return submitStockBatch(args);
+      },
     );
     const queueSnapshot = {
       approvalRequests: [
@@ -1399,7 +1529,7 @@ describe("OperationsQueueViewContent", () => {
         : baseProps.inventoryItems;
     });
 
-    render(<OperationsQueueView />);
+    render(<OperationsQueueView activeWorkflow="approvals" />);
 
     await user.click(screen.getByRole("button", { name: /unlock approvals/i }));
     await user.click(
@@ -1450,21 +1580,19 @@ describe("OperationsQueueViewContent", () => {
 
     mockedHooks.useMutation.mockReset();
     mockedHooks.useQuery.mockReset();
-    const mutationOrder = [
-      submitStockBatch,
-      decideApprovalRequest,
-      vi.fn(),
-      authenticateStaffCredential,
-      authenticateStaffCredentialForApproval,
-      vi.fn(),
-      vi.fn(),
-      vi.fn(),
-      vi.fn(),
-      vi.fn(),
-    ];
-    let mutationCallIndex = 0;
     mockedHooks.useMutation.mockImplementation(
-      () => mutationOrder[mutationCallIndex++ % mutationOrder.length],
+      () => async (args: Record<string, unknown>) => {
+        if ("actionKey" in args) {
+          return authenticateStaffCredentialForApproval(args);
+        }
+        if ("approvalRequestId" in args) {
+          return decideApprovalRequest(args);
+        }
+        if ("username" in args) {
+          return authenticateStaffCredential(args);
+        }
+        return submitStockBatch(args);
+      },
     );
     const queueSnapshot = {
       approvalRequests: [
@@ -1486,7 +1614,7 @@ describe("OperationsQueueViewContent", () => {
         : baseProps.inventoryItems;
     });
 
-    render(<OperationsQueueView />);
+    render(<OperationsQueueView activeWorkflow="approvals" />);
 
     await user.click(screen.getByRole("button", { name: /unlock approvals/i }));
     await user.click(

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useParams, useSearch } from "@tanstack/react-router";
-import { useMutation, useQuery } from "convex/react";
+import { useMutation, usePaginatedQuery, useQuery } from "convex/react";
 import {
   ArrowUpRight,
   ClipboardCheck,
@@ -44,6 +44,7 @@ import type {
   CycleCountDraftSummary,
   CycleCountDraftState,
   InventorySnapshotItem,
+  InventoryUnitSummary,
   StockAdjustmentSearchPatch,
   StockAdjustmentSearchState,
   SubmitStockAdjustmentArgs,
@@ -159,6 +160,16 @@ function getDefaultWorkflow(args: {
   if (args.approvalRequests.length > 0) return "approvals";
   if (args.workItems.length > 0) return "queue";
   return "stock";
+}
+
+function formatOpenWorkHeaderTitle(count: number) {
+  return `${count.toLocaleString()} open work ${count === 1 ? "item" : "items"}`;
+}
+
+function formatApprovalsHeaderTitle(count: number) {
+  if (count === 0) return "No pending approvals";
+
+  return `${count.toLocaleString()} pending ${count === 1 ? "approval" : "approvals"}`;
 }
 
 function formatQueueWorkItemValue(value: string) {
@@ -582,12 +593,15 @@ type OperationsQueueViewContentProps = {
   approvalDecisionUnlockRequired?: boolean;
   approvalDecisionUnlocked?: boolean;
   approvalRequests: QueueApprovalRequest[];
+  canLoadMoreInventoryItems?: boolean;
   cycleCountDraft?: CycleCountDraftState | null;
   cycleCountDraftSummary?: CycleCountDraftSummary | null;
   hasFullAdminAccess: boolean;
   inventoryItems: InventorySnapshotItem[];
+  inventoryUnitSummary?: InventoryUnitSummary | null;
   isCycleCountDraftSaving?: boolean;
   isDecidingApprovalRequestId?: string | null;
+  isLoadingMoreInventoryItems?: boolean;
   isLoadingPermissions: boolean;
   isLoadingQueue: boolean;
   isLoadingStock?: boolean;
@@ -599,6 +613,7 @@ type OperationsQueueViewContentProps = {
     requestType?: string;
   }) => Promise<void>;
   onLockApprovalDecisions?: () => void;
+  onLoadMoreInventoryItems?: () => void;
   onRequestApprovalDecisionUnlock?: () => void;
   onDiscardCycleCountDraft?: () => Promise<NormalizedCommandResult<unknown>>;
   onRefreshCycleCountDraftLineBaseline?: (args: {
@@ -629,12 +644,15 @@ export function OperationsQueueViewContent({
   approvalDecisionUnlockRequired = false,
   approvalDecisionUnlocked = true,
   approvalRequests,
+  canLoadMoreInventoryItems = false,
   cycleCountDraft,
   cycleCountDraftSummary,
   hasFullAdminAccess,
   inventoryItems,
+  inventoryUnitSummary,
   isCycleCountDraftSaving,
   isDecidingApprovalRequestId,
+  isLoadingMoreInventoryItems = false,
   isLoadingPermissions,
   isLoadingQueue,
   isLoadingStock = isLoadingQueue,
@@ -642,6 +660,7 @@ export function OperationsQueueViewContent({
   onDecideApprovalRequest,
   onDiscardCycleCountDraft,
   onLockApprovalDecisions,
+  onLoadMoreInventoryItems,
   onRequestApprovalDecisionUnlock,
   onRefreshCycleCountDraftLineBaseline,
   onSaveCycleCountDraftLine,
@@ -669,6 +688,40 @@ export function OperationsQueueViewContent({
     openWorkPageStart,
     openWorkPageStart + OPEN_WORK_ITEMS_PER_PAGE,
   );
+  const openWorkCount = workItems.length;
+  const openWorkHeaderTitle = isLoadingQueue
+    ? "Open work"
+    : formatOpenWorkHeaderTitle(openWorkCount);
+  const openWorkHeaderDescription =
+    "Service intake and stock review work that still needs progress or completion.";
+  const openWorkHeaderContentKey = isLoadingQueue
+    ? "open-work-loading"
+    : `open-work-${openWorkCount}`;
+  const hasRenderedOpenWorkLoadingHeaderRef = useRef(false);
+
+  if (resolvedWorkflow === "queue" && isLoadingQueue) {
+    hasRenderedOpenWorkLoadingHeaderRef.current = true;
+  }
+
+  const shouldAnimateOpenWorkHeader =
+    isLoadingQueue || hasRenderedOpenWorkLoadingHeaderRef.current;
+  const approvalCount = approvalRequests.length;
+  const approvalsHeaderTitle = isLoadingQueue
+    ? "Pending approvals"
+    : formatApprovalsHeaderTitle(approvalCount);
+  const approvalsHeaderDescription =
+    "Review manager approval requests before queued stock and payment changes are applied.";
+  const approvalsHeaderContentKey = isLoadingQueue
+    ? "approvals-loading"
+    : `approvals-${approvalCount}`;
+  const hasRenderedApprovalsLoadingHeaderRef = useRef(false);
+
+  if (resolvedWorkflow === "approvals" && isLoadingQueue) {
+    hasRenderedApprovalsLoadingHeaderRef.current = true;
+  }
+
+  const shouldAnimateApprovalsHeader =
+    isLoadingQueue || hasRenderedApprovalsLoadingHeaderRef.current;
 
   useEffect(() => {
     setOpenWorkPage(1);
@@ -688,10 +741,6 @@ export function OperationsQueueViewContent({
     return <NoPermissionView />;
   }
 
-  if (isLoadingQueue && resolvedWorkflow === "approvals") {
-    return null;
-  }
-
   if (!storeId) {
     return (
       <div className="container mx-auto py-8">
@@ -708,13 +757,17 @@ export function OperationsQueueViewContent({
       <PageWorkspace>
         {resolvedWorkflow === "stock" ? (
           <StockAdjustmentWorkspaceContent
+            canLoadMoreInventoryItems={canLoadMoreInventoryItems}
             cycleCountDraft={cycleCountDraft}
             cycleCountDraftSummary={cycleCountDraftSummary}
             inventoryItems={inventoryItems}
+            inventoryUnitSummary={inventoryUnitSummary}
             isCycleCountDraftSaving={isCycleCountDraftSaving}
+            isLoadingMoreInventoryItems={isLoadingMoreInventoryItems}
             isLoading={isLoadingStock}
             isSubmitting={isSubmittingStockBatch}
             onDiscardCycleCountDraft={onDiscardCycleCountDraft}
+            onLoadMoreInventoryItems={onLoadMoreInventoryItems}
             onRefreshCycleCountDraftLineBaseline={
               onRefreshCycleCountDraftLineBaseline
             }
@@ -730,9 +783,11 @@ export function OperationsQueueViewContent({
         {resolvedWorkflow === "queue" ? (
           <PageWorkspace>
             <PageLevelHeader
+              animateContent={shouldAnimateOpenWorkHeader}
+              contentKey={openWorkHeaderContentKey}
               eyebrow="Store Ops"
-              title="Open work"
-              description="Service intake and stock review work that still needs progress or completion."
+              title={openWorkHeaderTitle}
+              description={openWorkHeaderDescription}
               showBackButton
             />
 
@@ -801,19 +856,18 @@ export function OperationsQueueViewContent({
         {resolvedWorkflow === "approvals" ? (
           <PageWorkspace>
             <PageLevelHeader
+              animateContent={shouldAnimateApprovalsHeader}
+              contentKey={approvalsHeaderContentKey}
               eyebrow="Store Ops"
-              title="Pending approvals"
-              description="Review manager approval requests before queued stock and payment changes are applied."
+              title={approvalsHeaderTitle}
+              description={approvalsHeaderDescription}
               showBackButton={showBackButton}
             />
 
-            {approvalRequests.length === 0 ? (
+            {isLoadingQueue ? null : approvalRequests.length === 0 ? (
               <div className="flex min-h-[34rem] items-center justify-center">
                 <div className="max-w-md text-center">
-                  <p className="font-display text-2xl font-medium tracking-tight text-foreground">
-                    No pending approvals
-                  </p>
-                  <p className="mt-layout-sm text-sm leading-6 text-muted-foreground">
+                  <p className="text-sm leading-6 text-muted-foreground">
                     High-variance deposits and stock reviews will surface here.
                   </p>
                 </div>
@@ -1818,13 +1872,37 @@ export function OperationsQueueView({
         workItems: QueueWorkItem[];
       }
     | undefined;
-  const inventoryItems = useQuery(
-    stockOpsApi.adjustments.listInventorySnapshot,
-    canQueryProtectedData ? { storeId: activeStore!._id } : "skip",
-  ) as InventorySnapshotItem[] | undefined;
+  const shouldLoadStockWorkspace =
+    canQueryProtectedData &&
+    Boolean(activeStore?._id) &&
+    activeWorkflow !== "queue" &&
+    activeWorkflow !== "approvals";
+  const inventorySnapshotPage = usePaginatedQuery(
+    stockOpsApi.adjustments.listInventorySnapshotPage,
+    shouldLoadStockWorkspace
+      ? { storeId: activeStore!._id }
+      : "skip",
+    { initialNumItems: 100 },
+  );
+  const inventoryItems =
+    inventorySnapshotPage.results as InventorySnapshotItem[];
+  const inventoryUnitSummary = useQuery(
+    stockOpsApi.adjustments.getInventoryUnitSummary,
+    shouldLoadStockWorkspace
+      ? {
+          storeId: activeStore!._id,
+        }
+      : "skip",
+  ) as InventoryUnitSummary | undefined;
+  const isInventorySnapshotLoadingFirstPage =
+    shouldLoadStockWorkspace &&
+    inventorySnapshotPage.status === "LoadingFirstPage";
+  const isInventorySnapshotLoadingMore =
+    shouldLoadStockWorkspace && inventorySnapshotPage.status === "LoadingMore";
+  const canLoadMoreInventoryItems =
+    shouldLoadStockWorkspace && inventorySnapshotPage.status === "CanLoadMore";
   const selectedCycleCountScopeKey = useMemo(() => {
     if (stockAdjustmentSearch?.mode === "manual") return undefined;
-    if (!inventoryItems) return undefined;
 
     const selectedItem =
       stockAdjustmentSearch?.sku !== undefined
@@ -1858,9 +1936,9 @@ export function OperationsQueueView({
     | undefined;
   const activeCycleCountDraftSummary = useQuery(
     stockOpsApi.cycleCountDrafts.getActiveCycleCountDraftSummary,
-    canQueryProtectedData && activeStore?._id
+    shouldLoadStockWorkspace
       ? {
-          storeId: activeStore._id,
+          storeId: activeStore!._id,
         }
       : "skip",
   ) as CycleCountDraftSummary | undefined;
@@ -2233,17 +2311,21 @@ export function OperationsQueueView({
         approvalDecisionUnlockRequired
         approvalDecisionUnlocked={Boolean(activeApprovalDecisionUnlock)}
         approvalRequests={queue?.approvalRequests ?? []}
+        canLoadMoreInventoryItems={canLoadMoreInventoryItems}
         cycleCountDraft={cycleCountDraft}
         cycleCountDraftSummary={activeCycleCountDraftSummary ?? null}
         hasFullAdminAccess={canAccessSurface}
-        inventoryItems={inventoryItems ?? []}
+        inventoryItems={inventoryItems}
+        inventoryUnitSummary={inventoryUnitSummary ?? null}
         isCycleCountDraftSaving={isSavingCycleCountDraft}
         isDecidingApprovalRequestId={decisioningApprovalRequestId}
+        isLoadingMoreInventoryItems={isInventorySnapshotLoadingMore}
         isLoadingPermissions={false}
-        isLoadingQueue={queue === undefined || inventoryItems === undefined}
-        isLoadingStock={inventoryItems === undefined}
+        isLoadingQueue={queue === undefined || isInventorySnapshotLoadingFirstPage}
+        isLoadingStock={isInventorySnapshotLoadingFirstPage}
         onDiscardCycleCountDraft={handleDiscardCycleCountDraft}
         onDecideApprovalRequest={handleDecideApprovalRequest}
+        onLoadMoreInventoryItems={() => inventorySnapshotPage.loadMore(100)}
         onLockApprovalDecisions={() => setApprovalDecisionUnlock(null)}
         onRefreshCycleCountDraftLineBaseline={
           handleRefreshCycleCountDraftLineBaseline

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
@@ -966,6 +966,31 @@ describe("StockAdjustmentWorkspaceContent", () => {
     expect(screen.getByText("Reserved")).toBeInTheDocument();
   });
 
+  it("uses the store-level inventory summary for header unit totals", () => {
+    renderStockAdjustmentWorkspace({
+      inventoryUnitSummary: {
+        availableUnits: 19,
+        onHandUnits: 24,
+        reservedUnits: 5,
+        skuCount: 12,
+        unavailableSkuCount: 3,
+        unavailableUnits: 5,
+      },
+    });
+
+    expect(
+      screen.getByRole("heading", {
+        name: "3 SKUs have reserved units.",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/19 of 24 units are available to sell\. 5 reserved\./i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("24")).toBeInTheDocument();
+    expect(screen.getByText("19")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
   it("shows POS reserved units as reducing sellable availability", () => {
     renderStockAdjustmentWorkspace({
       inventoryItems: [
@@ -2047,6 +2072,20 @@ describe("StockAdjustmentWorkspaceContent", () => {
     await user.click(within(table).getByText("Inventory Item 11"));
 
     expect(screen.getByText("Showing 11-11 of 11 SKUs")).toBeInTheDocument();
+  });
+
+  it("loads more inventory rows from the paginated stock snapshot", async () => {
+    const user = userEvent.setup();
+    const onLoadMoreInventoryItems = vi.fn();
+
+    renderStockAdjustmentWorkspace({
+      canLoadMoreInventoryItems: true,
+      onLoadMoreInventoryItems,
+    });
+
+    await user.click(screen.getByRole("button", { name: /load more/i }));
+
+    expect(onLoadMoreInventoryItems).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the current stock row page when a counted quantity changes", async () => {

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
@@ -114,6 +114,19 @@ export type InventorySnapshotItem = {
     | null;
 };
 
+export type InventoryUnitSummary = {
+  availableUnits: number;
+  checkoutReservedUnits?: number;
+  fallbackReservedUnits?: number;
+  hasMoreSkus?: boolean;
+  onHandUnits: number;
+  posReservedUnits?: number;
+  reservedUnits: number;
+  skuCount: number;
+  unavailableSkuCount: number;
+  unavailableUnits: number;
+};
+
 export type SubmitStockAdjustmentArgs = {
   adjustmentType: "manual" | "cycle_count";
   lineItems: Array<
@@ -191,9 +204,12 @@ type SaveCycleCountDraftLineArgs = {
 type StockAdjustmentWorkspaceContentProps = {
   cycleCountDraft?: CycleCountDraftState | null;
   cycleCountDraftSummary?: CycleCountDraftSummary | null;
+  canLoadMoreInventoryItems?: boolean;
   inventoryItems: InventorySnapshotItem[];
+  inventoryUnitSummary?: InventoryUnitSummary | null;
   isCycleCountDraftSaving?: boolean;
   isLoading?: boolean;
+  isLoadingMoreInventoryItems?: boolean;
   isSubmitting: boolean;
   onDiscardCycleCountDraft?: () => Promise<NormalizedCommandResult<unknown>>;
   onSearchStateChange?: (patch: StockAdjustmentSearchPatch) => void;
@@ -203,6 +219,7 @@ type StockAdjustmentWorkspaceContentProps = {
   onRefreshCycleCountDraftLineBaseline?: (args: {
     productSkuId: Id<"productSku">;
   }) => Promise<NormalizedCommandResult<unknown>>;
+  onLoadMoreInventoryItems?: () => void;
   onSubmitBatch: (
     args: SubmitStockAdjustmentArgs,
   ) => Promise<NormalizedCommandResult<unknown>>;
@@ -1693,12 +1710,16 @@ function StockAdjustmentBarcodeScannerDialog({
 export function StockAdjustmentWorkspaceContent({
   cycleCountDraft,
   cycleCountDraftSummary,
+  canLoadMoreInventoryItems = false,
   inventoryItems,
+  inventoryUnitSummary,
   isCycleCountDraftSaving = false,
   isLoading = false,
+  isLoadingMoreInventoryItems = false,
   isSubmitting,
   onDiscardCycleCountDraft,
   onRefreshCycleCountDraftLineBaseline,
+  onLoadMoreInventoryItems,
   onSearchStateChange,
   onSaveCycleCountDraftLine,
   onSubmitBatch,
@@ -2120,7 +2141,7 @@ export function StockAdjustmentWorkspaceContent({
     inventoryItems[0] ??
     null;
   const inventoryState = useMemo(() => {
-    const totals = inventoryItems.reduce(
+    const loadedTotals = inventoryItems.reduce(
       (current, item) => {
         const unavailableUnits = Math.max(
           0,
@@ -2146,6 +2167,7 @@ export function StockAdjustmentWorkspaceContent({
           onHandUnits: current.onHandUnits + item.inventoryCount,
           posReservedUnits: current.posReservedUnits + posReservedUnits,
           reservedUnits: current.reservedUnits + reservedUnits,
+          skuCount: current.skuCount + 1,
           unavailableSkuCount:
             current.unavailableSkuCount + (unavailableUnits > 0 ? 1 : 0),
           unavailableUnits: current.unavailableUnits + unavailableUnits,
@@ -2158,12 +2180,23 @@ export function StockAdjustmentWorkspaceContent({
         onHandUnits: 0,
         posReservedUnits: 0,
         reservedUnits: 0,
+        skuCount: 0,
         unavailableSkuCount: 0,
         unavailableUnits: 0,
       },
     );
 
-    const itemCount = inventoryItems.length;
+    const totals = inventoryUnitSummary
+      ? {
+          ...inventoryUnitSummary,
+          checkoutReservedUnits: inventoryUnitSummary.checkoutReservedUnits ?? 0,
+          fallbackReservedUnits:
+            inventoryUnitSummary.fallbackReservedUnits ??
+            inventoryUnitSummary.reservedUnits,
+          posReservedUnits: inventoryUnitSummary.posReservedUnits ?? 0,
+        }
+      : loadedTotals;
+    const itemCount = totals.skuCount;
     const hasUnavailableUnits = totals.unavailableUnits > 0;
     const reservationSummary = formatReservationSourceSummary(totals);
 
@@ -2193,7 +2226,7 @@ export function StockAdjustmentWorkspaceContent({
               } reserved units.`
             : "All inventory is available.",
     };
-  }, [inventoryItems]);
+  }, [inventoryItems, inventoryUnitSummary]);
   const totalDraftChangedLineCount =
     cycleCountDraftSummary?.changedLineCount ??
     cycleCountDraft?.changedLineCount ??
@@ -3103,6 +3136,11 @@ export function StockAdjustmentWorkspaceContent({
               }
               onRowClick={(row) =>
                 handleSelectInventoryItem(row.original.inventoryItem._id)
+              }
+              onLoadMore={
+                canLoadMoreInventoryItems && !isLoadingMoreInventoryItems
+                  ? onLoadMoreInventoryItems
+                  : undefined
               }
               pageIndex={
                 searchState?.page === undefined


### PR DESCRIPTION
## Summary
- paginate the stock operations inventory snapshot query and load additional rows from the workspace table
- add a separate store inventory unit summary query for headline totals
- keep POS catalog visibility aligned for operational categories and provisional SKU review flows

## Validation
- bun run --filter @athena/webapp test -- convex/stockOps/adjustments.test.ts src/components/operations/StockAdjustmentWorkspace.test.tsx src/components/operations/OperationsQueueView.test.tsx src/components/operations/OperationsQueueView.auth.test.tsx
- bun run --filter @athena/webapp lint:convex:changed
- bun run --filter @athena/webapp lint:frontend:changed
- git diff --check
- bun run pr:athena
