### PR TITLE
fix(store-ops): scope catalog and daily operations visibility

### DIFF
--- a/docs/solutions/architecture/athena-store-ops-catalog-visibility-boundaries-2026-06-24.md
+++ b/docs/solutions/architecture/athena-store-ops-catalog-visibility-boundaries-2026-06-24.md
@@ -1,0 +1,81 @@
+---
+title: "Athena Store Ops Catalog Visibility Boundaries"
+date: 2026-06-24
+category: architecture
+module: athena-webapp
+problem_type: store_ops_catalog_visibility
+component: daily-operations-pos
+resolution_type: boundary_scoped_visibility
+severity: medium
+tags:
+  - athena
+  - daily-operations
+  - pos
+  - inventory-import
+  - operations
+---
+
+# Athena Store Ops Catalog Visibility Boundaries
+
+## Problem
+
+Store operations surfaces share catalog, POS, automation, and workflow data, but
+each surface owns a different operator decision. If archived legacy import SKUs
+remain visible in POS, cashiers can sell products that operators already removed
+from active sale flow. If low-level scheduled-run evidence appears in Daily
+Operations, managers see backend execution detail in a workspace meant for store
+day decisions.
+
+Both failures come from the same boundary issue: using available data as the
+display contract instead of scoping the contract to the surface's job.
+
+## Solution
+
+Filter visibility at the query or composition boundary closest to the surface:
+
+- POS catalog snapshots and checkout completion must exclude archived legacy
+  import products and SKUs before they reach cashier-facing search, quick add,
+  or transaction flows.
+- Archived products remain available to archived-product management surfaces so
+  operators can audit or restore them without leaking them into active POS.
+- Daily Operations can surface workflow blockers, approvals, opening review
+  carry-forward, and EOD links because those are manager decisions.
+- Scheduled-run evidence remains a reusable component, but Daily Operations
+  should not render it unless the surface explicitly needs backend automation
+  diagnostics.
+
+## Implementation Notes
+
+- Keep legacy import filtering server-side for POS snapshot and transaction
+  validation. Client filtering is useful for polish, not enforcement.
+- Preserve explicit props for store-pulse labels such as `"Today's top items"`
+  instead of changing shared components globally.
+- Pass operating-date search params through workflow links so historical review
+  surfaces open on the same store day the manager was inspecting.
+- Paginate carried-forward Opening review evidence in the review workspace
+  rather than trimming or hiding it.
+
+## Prevention
+
+- When adding data to Daily Operations, identify the operator decision it
+  supports. If it is mainly diagnostic evidence, put it behind a deeper
+  workspace or reusable component instead.
+- Tests for POS catalog queries should cover archived legacy import SKUs at the
+  server boundary, not just the rendered search list.
+- Tests for Daily Operations composition should assert that advanced scheduled
+  run detail stays off the default workspace while workflow-status links remain
+  visible.
+- Shared UI components should accept scoped copy or visibility props when only
+  one surface needs different wording.
+
+## Validation
+
+Focused coverage should prove:
+
+- Archived legacy import SKUs do not appear in POS catalog snapshots.
+- Checkout completion rejects archived legacy import product lines.
+- Archived-product management still finds archived legacy import products.
+- Daily Operations omits scheduled-run evidence from the default workspace.
+- Daily Operations keeps day-scoped top items, payment mix, approval counts,
+  Opening Handoff links, and EOD Review links aligned with the selected
+  operating date.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7902 nodes · 9273 edges · 2037 communities detected
+- 7905 nodes · 9277 edges · 2037 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2124,11 +2124,11 @@ Nodes (34): annotateTerminalSyncEvidenceReviewTargets(), buildTerminalAppUpdateP
 
 ### Community 12 - "Community 12"
 Cohesion: 0.07
-Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
+Nodes (22): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+14 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.07
-Nodes (22): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+14 more)
+Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.08
@@ -2191,28 +2191,28 @@ Cohesion: 0.2
 Nodes (28): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftCreatedMessage(), buildCycleCountDraftSavedMessage(), buildCycleCountDraftSubmissionKey(), buildCycleCountDraftSubmittedMessage(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx() (+20 more)
 
 ### Community 29 - "Community 29"
+Cohesion: 0.13
+Nodes (21): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), formatPendingApprovalsLabel(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate() (+13 more)
+
+### Community 30 - "Community 30"
 Cohesion: 0.14
 Nodes (23): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+15 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.13
 Nodes (24): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildInventorySnapshotRowsForProductSkusWithCtx(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle() (+16 more)
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.2
 Nodes (27): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), isExpenseLocalSyncEvent(), isSyncablePosLocalEvent() (+19 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.13
 Nodes (23): automationErrorMessage(), automationIdempotencyKey(), eodAutoCompleteDecision(), eodAutoCompleteLocalTiming(), eodAutoCompletePolicyCronWindow(), eodDecision(), getLatestDailyOperationsAutomationStatusWithCtx(), getOpeningAutoStartPolicyForApi() (+15 more)
-
-### Community 34 - "Community 34"
-Cohesion: 0.14
-Nodes (19): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate(), getLocalOperatingDateRange() (+11 more)
 
 ### Community 35 - "Community 35"
 Cohesion: 0.09
@@ -2611,52 +2611,52 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 134 - "Community 134"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 135 - "Community 135"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 136 - "Community 136"
+### Community 135 - "Community 135"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 137 - "Community 137"
+### Community 136 - "Community 136"
 Cohesion: 0.2
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 138 - "Community 138"
+### Community 137 - "Community 137"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 139 - "Community 139"
+### Community 138 - "Community 138"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 140 - "Community 140"
+### Community 139 - "Community 139"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 141 - "Community 141"
+### Community 140 - "Community 140"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 142 - "Community 142"
+### Community 141 - "Community 141"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 143 - "Community 143"
+### Community 142 - "Community 142"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 144 - "Community 144"
+### Community 143 - "Community 143"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 145 - "Community 145"
+### Community 144 - "Community 144"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
+
+### Community 145 - "Community 145"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 146 - "Community 146"
 Cohesion: 0.18
@@ -2732,15 +2732,15 @@ Nodes (5): clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), r
 
 ### Community 164 - "Community 164"
 Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 165 - "Community 165"
 Cohesion: 0.39
-Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 166 - "Community 166"
 Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
 ### Community 167 - "Community 167"
 Cohesion: 0.39
@@ -2787,20 +2787,20 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 178 - "Community 178"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 179 - "Community 179"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 180 - "Community 180"
+### Community 179 - "Community 179"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 181 - "Community 181"
+### Community 180 - "Community 180"
 Cohesion: 0.22
 Nodes (0):
+
+### Community 181 - "Community 181"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 182 - "Community 182"
 Cohesion: 0.31
@@ -3267,8 +3267,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 298 - "Community 298"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 299 - "Community 299"
 Cohesion: 0.33
@@ -3283,72 +3283,72 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 302 - "Community 302"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 303 - "Community 303"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
+
+### Community 303 - "Community 303"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 304 - "Community 304"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 305 - "Community 305"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 306 - "Community 306"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 307 - "Community 307"
+### Community 306 - "Community 306"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 308 - "Community 308"
+### Community 307 - "Community 307"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 309 - "Community 309"
+### Community 308 - "Community 308"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 309 - "Community 309"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 310 - "Community 310"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 311 - "Community 311"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 312 - "Community 312"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 313 - "Community 313"
+### Community 312 - "Community 312"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 314 - "Community 314"
+### Community 313 - "Community 313"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 314 - "Community 314"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 315 - "Community 315"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 316 - "Community 316"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 317 - "Community 317"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 318 - "Community 318"
+### Community 317 - "Community 317"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 318 - "Community 318"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 319 - "Community 319"
 Cohesion: 0.53
@@ -3407,32 +3407,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 333 - "Community 333"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
-### Community 334 - "Community 334"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 335 - "Community 335"
+### Community 334 - "Community 334"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 336 - "Community 336"
+### Community 335 - "Community 335"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
+
+### Community 336 - "Community 336"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 337 - "Community 337"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 338 - "Community 338"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 339 - "Community 339"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+
+### Community 339 - "Community 339"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 340 - "Community 340"
 Cohesion: 0.4
@@ -3443,64 +3443,64 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 342 - "Community 342"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 343 - "Community 343"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 344 - "Community 344"
+### Community 343 - "Community 343"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 345 - "Community 345"
+### Community 344 - "Community 344"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 346 - "Community 346"
+### Community 345 - "Community 345"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 347 - "Community 347"
+### Community 346 - "Community 346"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 348 - "Community 348"
+### Community 347 - "Community 347"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 349 - "Community 349"
+### Community 348 - "Community 348"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 350 - "Community 350"
+### Community 349 - "Community 349"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 351 - "Community 351"
+### Community 350 - "Community 350"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
+
+### Community 351 - "Community 351"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 352 - "Community 352"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 353 - "Community 353"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 354 - "Community 354"
 Cohesion: 0.5
 Nodes (2): moveBestSeller(), saveOrder()
 
-### Community 355 - "Community 355"
+### Community 354 - "Community 354"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 356 - "Community 356"
+### Community 355 - "Community 355"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 356 - "Community 356"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 357 - "Community 357"
 Cohesion: 0.4
@@ -3511,20 +3511,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 359 - "Community 359"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 360 - "Community 360"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 361 - "Community 361"
+### Community 360 - "Community 360"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 362 - "Community 362"
+### Community 361 - "Community 361"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+
+### Community 362 - "Community 362"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 363 - "Community 363"
 Cohesion: 0.4
@@ -3551,48 +3551,48 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 369 - "Community 369"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 370 - "Community 370"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 371 - "Community 371"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.8
+Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
 ### Community 372 - "Community 372"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 373 - "Community 373"
-Cohesion: 0.8
-Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
-
-### Community 374 - "Community 374"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 375 - "Community 375"
 Cohesion: 0.5
 Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
-### Community 376 - "Community 376"
+### Community 374 - "Community 374"
 Cohesion: 0.5
 Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
-### Community 377 - "Community 377"
+### Community 375 - "Community 375"
 Cohesion: 0.5
 Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
 
-### Community 378 - "Community 378"
+### Community 376 - "Community 376"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 379 - "Community 379"
+### Community 377 - "Community 377"
 Cohesion: 0.4
 Nodes (1): MockImage
+
+### Community 378 - "Community 378"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 379 - "Community 379"
+Cohesion: 0.6
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 380 - "Community 380"
 Cohesion: 0.4
@@ -3600,35 +3600,35 @@ Nodes (0):
 
 ### Community 381 - "Community 381"
 Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
-
-### Community 382 - "Community 382"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 383 - "Community 383"
-Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 384 - "Community 384"
+### Community 382 - "Community 382"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 385 - "Community 385"
+### Community 383 - "Community 383"
 Cohesion: 0.6
 Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
-### Community 386 - "Community 386"
+### Community 384 - "Community 384"
 Cohesion: 0.6
 Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+
+### Community 385 - "Community 385"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 386 - "Community 386"
+Cohesion: 0.7
+Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 387 - "Community 387"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 388 - "Community 388"
-Cohesion: 0.7
-Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 389 - "Community 389"
 Cohesion: 0.4
@@ -3639,36 +3639,36 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 391 - "Community 391"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 392 - "Community 392"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 393 - "Community 393"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 394 - "Community 394"
+### Community 392 - "Community 392"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 395 - "Community 395"
+### Community 393 - "Community 393"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 396 - "Community 396"
+### Community 394 - "Community 394"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 397 - "Community 397"
+### Community 395 - "Community 395"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 398 - "Community 398"
+### Community 396 - "Community 396"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 397 - "Community 397"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 398 - "Community 398"
+Cohesion: 0.6
+Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
 ### Community 399 - "Community 399"
 Cohesion: 0.4
@@ -3676,87 +3676,87 @@ Nodes (0):
 
 ### Community 400 - "Community 400"
 Cohesion: 0.6
-Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 401 - "Community 401"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 402 - "Community 402"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+
+### Community 402 - "Community 402"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 403 - "Community 403"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 404 - "Community 404"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 405 - "Community 405"
 Cohesion: 0.6
 Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
 
-### Community 406 - "Community 406"
+### Community 405 - "Community 405"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 407 - "Community 407"
+### Community 406 - "Community 406"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 408 - "Community 408"
+### Community 407 - "Community 407"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 409 - "Community 409"
+### Community 408 - "Community 408"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 410 - "Community 410"
+### Community 409 - "Community 409"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 411 - "Community 411"
+### Community 410 - "Community 410"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 412 - "Community 412"
+### Community 411 - "Community 411"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 413 - "Community 413"
+### Community 412 - "Community 412"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 414 - "Community 414"
+### Community 413 - "Community 413"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
+
+### Community 414 - "Community 414"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 415 - "Community 415"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 416 - "Community 416"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 417 - "Community 417"
 Cohesion: 0.67
 Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
+
+### Community 417 - "Community 417"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 418 - "Community 418"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 419 - "Community 419"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 420 - "Community 420"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
+
+### Community 420 - "Community 420"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 421 - "Community 421"
 Cohesion: 0.5
@@ -3775,96 +3775,96 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 425 - "Community 425"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 426 - "Community 426"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 427 - "Community 427"
+### Community 426 - "Community 426"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 428 - "Community 428"
+### Community 427 - "Community 427"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 429 - "Community 429"
+### Community 428 - "Community 428"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 430 - "Community 430"
+### Community 429 - "Community 429"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 431 - "Community 431"
+### Community 430 - "Community 430"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 431 - "Community 431"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 432 - "Community 432"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 433 - "Community 433"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 434 - "Community 434"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 435 - "Community 435"
+### Community 434 - "Community 434"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 436 - "Community 436"
+### Community 435 - "Community 435"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 437 - "Community 437"
+### Community 436 - "Community 436"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 438 - "Community 438"
+### Community 437 - "Community 437"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 439 - "Community 439"
+### Community 438 - "Community 438"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 440 - "Community 440"
+### Community 439 - "Community 439"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 441 - "Community 441"
+### Community 440 - "Community 440"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+
+### Community 441 - "Community 441"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 442 - "Community 442"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 443 - "Community 443"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 444 - "Community 444"
 Cohesion: 0.67
 Nodes (2): buildCtx(), buildQueryCtx()
 
-### Community 445 - "Community 445"
+### Community 444 - "Community 444"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 446 - "Community 446"
+### Community 445 - "Community 445"
 Cohesion: 0.67
 Nodes (2): buildRepository(), buildSession()
 
-### Community 447 - "Community 447"
+### Community 446 - "Community 446"
 Cohesion: 0.67
 Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+
+### Community 447 - "Community 447"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 448 - "Community 448"
 Cohesion: 0.5
@@ -3879,36 +3879,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 451 - "Community 451"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 452 - "Community 452"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 453 - "Community 453"
+### Community 452 - "Community 452"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
+
+### Community 453 - "Community 453"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 454 - "Community 454"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 455 - "Community 455"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 456 - "Community 456"
 Cohesion: 0.83
 Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
-### Community 457 - "Community 457"
+### Community 456 - "Community 456"
 Cohesion: 0.83
 Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
-### Community 458 - "Community 458"
+### Community 457 - "Community 457"
 Cohesion: 0.83
 Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+
+### Community 458 - "Community 458"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 459 - "Community 459"
 Cohesion: 0.5
@@ -3919,32 +3919,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 461 - "Community 461"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 462 - "Community 462"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 463 - "Community 463"
+### Community 462 - "Community 462"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 464 - "Community 464"
+### Community 463 - "Community 463"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
-### Community 465 - "Community 465"
+### Community 464 - "Community 464"
 Cohesion: 0.67
 Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
-### Community 466 - "Community 466"
+### Community 465 - "Community 465"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
-### Community 467 - "Community 467"
+### Community 466 - "Community 466"
 Cohesion: 0.67
 Nodes (2): getPosRouteScope(), Login()
+
+### Community 467 - "Community 467"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 468 - "Community 468"
 Cohesion: 0.5
@@ -3975,12 +3975,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 475 - "Community 475"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 476 - "Community 476"
 Cohesion: 0.67
 Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+
+### Community 476 - "Community 476"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 477 - "Community 477"
 Cohesion: 0.5
@@ -3991,12 +3991,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 479 - "Community 479"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 480 - "Community 480"
 Cohesion: 1.0
 Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
+
+### Community 480 - "Community 480"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 481 - "Community 481"
 Cohesion: 0.5
@@ -4007,12 +4007,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 483 - "Community 483"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 484 - "Community 484"
 Cohesion: 0.67
 Nodes (2): applyCommandResult(), handleCreateCase()
+
+### Community 484 - "Community 484"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 485 - "Community 485"
 Cohesion: 0.5

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,15 +8,15 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2109
-- Graph nodes: 7902
-- Graph edges: 9273
+- Graph nodes: 7905
+- Graph edges: 9277
 - Communities: 2037
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (89 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `harness-inferential-review.ts` (85 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `dailyClose.ts` (74 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `dailyOperations.ts` (62 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `dailyOperations.ts` (63 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `projectLocalEvents.ts` (62 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 - `terminalHealthPresentation.ts` (53 edges, Community 6) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -19,7 +19,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 ## Graph Hotspots
 - `DailyCloseView.tsx` (89 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (74 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `dailyOperations.ts` (62 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `dailyOperations.ts` (63 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `projectLocalEvents.ts` (62 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 

--- a/packages/athena-webapp/convex/inventory/products.sku.test.ts
+++ b/packages/athena-webapp/convex/inventory/products.sku.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { Id } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { assertConformsToExportedReturns } from "../lib/returnValidatorContract";
 import { backfillUndefinedSkuVisibilityFromProducts } from "./productSku";
 import {
   archive,
   createSku,
+  generateUniqueBarcode,
   getAll,
   getByIdOrSlug,
   unarchive,
@@ -339,6 +341,17 @@ describe("product archiving", () => {
 });
 
 describe("product catalog visibility", () => {
+  it("keeps product mutation return contracts executable", () => {
+    assertConformsToExportedReturns(generateUniqueBarcode, {
+      success: true,
+      barcode: "123456789012",
+    });
+    assertConformsToExportedReturns(generateUniqueBarcode, {
+      success: false,
+      error: "Could not generate unique barcode after multiple attempts",
+    });
+  });
+
   it("excludes non-live products and hidden SKUs by default while preserving explicit archived queries", async () => {
     const seed = {
       product: [
@@ -355,7 +368,7 @@ describe("product catalog visibility", () => {
           _id: "product-archived",
           availability: "archived",
           categoryId: "category-1",
-          isVisible: true,
+          isVisible: false,
           name: "Archived Product",
           storeId: "storezzzz",
           subcategoryId: "subcategory-1",
@@ -393,6 +406,7 @@ describe("product catalog visibility", () => {
           _id: "sku-archived",
           images: ["archived.jpg"],
           inventoryCount: 1,
+          isVisible: false,
           price: 1000,
           productId: "product-archived",
           quantityAvailable: 1,
@@ -438,6 +452,11 @@ describe("product catalog visibility", () => {
 
     expect(archivedProducts.map((product: Row) => product._id)).toEqual([
       "product-archived",
+    ]);
+    expect(archivedProducts[0].skus).toEqual([
+      expect.objectContaining({
+        _id: "sku-archived",
+      }),
     ]);
 
     const draftHiddenCtx = createProductsQueryCtx(seed).ctx;

--- a/packages/athena-webapp/convex/inventory/products.ts
+++ b/packages/athena-webapp/convex/inventory/products.ts
@@ -208,6 +208,8 @@ export const getAll = query({
     }
 
     const requestedAvailability = args.availability;
+    const includeHiddenSkus =
+      args.isVisible === false || requestedAvailability === "archived";
 
     // Filter by category/subcategory in memory
     const products = allProducts.filter((product) => {
@@ -249,7 +251,7 @@ export const getAll = query({
 
     // Filter by color and length in memory
     const skus = allSkus.filter((sku) => {
-      if (args.isVisible !== false && sku.isVisible === false) {
+      if (!includeHiddenSkus && sku.isVisible === false) {
         return false;
       }
       if (args.color && args.length) {

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -2112,6 +2112,16 @@ describe("daily operations overview read model", () => {
             subjectId: "register-2",
             subjectType: "register_session",
           },
+          {
+            _id: "approval-other-day",
+            createdAt: Date.UTC(2026, 4, 9, 10),
+            reason: "Next day variance review",
+            requestType: "variance_review",
+            status: "pending",
+            storeId: "store-1",
+            subjectId: "register-next",
+            subjectType: "register_session",
+          },
         ],
         dailyClose: [priorClose],
         dailyOpening: [startedOpening],
@@ -2177,11 +2187,76 @@ describe("daily operations overview read model", () => {
     expect(snapshot.attentionItems.map((item) => item.id)).not.toContain(
       "operational_work_item:work-completed:completed",
     );
+    expect(snapshot.attentionItems.map((item) => item.id)).not.toContain(
+      "approval_request:approval-other-day:pending",
+    );
     expect(
       snapshot.attentionItems.filter(
         (item) => item.owner === "operations_queue",
       ),
     ).toHaveLength(3);
+  });
+
+  it("carries prior-day pending approvals into the current operating day", async () => {
+    vi.setSystemTime(new Date("2026-05-08T12:00:00.000Z"));
+
+    const snapshot = await buildDailyOperationsSnapshotWithCtx(
+      buildCtx({
+        approvalRequest: [
+          {
+            _id: "approval-prior-day",
+            createdAt: Date.UTC(2026, 4, 7, 20),
+            reason: "Prior day variance review",
+            requestType: "variance_review",
+            status: "pending",
+            storeId: "store-1",
+            subjectId: "register-prior",
+            subjectType: "register_session",
+          },
+          {
+            _id: "approval-current-day",
+            createdAt: Date.UTC(2026, 4, 8, 10),
+            reason: "Current day variance review",
+            requestType: "variance_review",
+            status: "pending",
+            storeId: "store-1",
+            subjectId: "register-current",
+            subjectType: "register_session",
+          },
+          {
+            _id: "approval-future-day",
+            createdAt: Date.UTC(2026, 4, 9, 10),
+            reason: "Future day variance review",
+            requestType: "variance_review",
+            status: "pending",
+            storeId: "store-1",
+            subjectId: "register-future",
+            subjectType: "register_session",
+          },
+        ],
+        dailyClose: [priorClose],
+        dailyOpening: [startedOpening],
+        store: [store],
+      }),
+      { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(
+      snapshot.lanes.find((lane) => lane.key === "approvals"),
+    ).toMatchObject({
+      count: 2,
+      countLabel: "2",
+      status: "blocked",
+    });
+    expect(snapshot.attentionItems.map((item) => item.id)).toEqual(
+      expect.arrayContaining([
+        "approval_request:approval-prior-day:pending",
+        "approval_request:approval-current-day:pending",
+      ]),
+    );
+    expect(snapshot.attentionItems.map((item) => item.id)).not.toContain(
+      "approval_request:approval-future-day:pending",
+    );
   });
 
   it("keeps a completed store day reviewable and scopes timeline events to the day", async () => {

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -272,6 +272,23 @@ function resolveRange(args: {
   return operatingDateRange(args.operatingDate);
 }
 
+function approvalRequestBelongsToOperationsDay(args: {
+  currentTime: number;
+  endAt: number;
+  request: Pick<Doc<"approvalRequest">, "createdAt">;
+  startAt: number;
+}) {
+  const isCurrentOperatingDay =
+    args.currentTime >= args.startAt && args.currentTime < args.endAt;
+  const requestIsBeforeDayEnd = args.request.createdAt < args.endAt;
+
+  if (isCurrentOperatingDay) {
+    return requestIsBeforeDayEnd;
+  }
+
+  return requestIsBeforeDayEnd && args.request.createdAt >= args.startAt;
+}
+
 function emptyCloseSummary(): DailyOperationsCloseSummary {
   return {
     adjustedSalesTotal: 0,
@@ -476,7 +493,11 @@ function openingNotStartedAttention(args: {
 
 async function listOpenQueueSnapshot(
   ctx: Pick<QueryCtx, "db">,
-  storeId: Id<"store">,
+  args: {
+    endAt: number;
+    startAt: number;
+    storeId: Id<"store">;
+  },
 ) {
   const [workItemBatches, pendingApprovalRequests] = await Promise.all([
     Promise.all(
@@ -484,7 +505,7 @@ async function listOpenQueueSnapshot(
         ctx.db
           .query("operationalWorkItem")
           .withIndex("by_storeId_status", (q) =>
-            q.eq("storeId", storeId).eq("status", status),
+            q.eq("storeId", args.storeId).eq("status", status),
           )
           .take(MAX_OPERATIONS_LOOKAHEAD_LIMIT),
       ),
@@ -492,7 +513,7 @@ async function listOpenQueueSnapshot(
     ctx.db
       .query("approvalRequest")
       .withIndex("by_storeId_status", (q) =>
-        q.eq("storeId", storeId).eq("status", "pending"),
+        q.eq("storeId", args.storeId).eq("status", "pending"),
       )
       .take(MAX_OPERATIONS_LOOKAHEAD_LIMIT),
   ]);
@@ -500,7 +521,16 @@ async function listOpenQueueSnapshot(
   const openWorkItems = workItemBatches
     .flatMap((batch) => batch)
     .slice(0, MAX_OPERATIONS_QUERY_LIMIT);
-  const approvalRequests = pendingApprovalRequests.slice(
+  const currentTime = Date.now();
+  const dayApprovalRequests = pendingApprovalRequests.filter(
+    (request) =>
+      approvalRequestBelongsToOperationsDay({
+        ...args,
+        currentTime,
+        request,
+      }),
+  );
+  const approvalRequests = dayApprovalRequests.slice(
     0,
     MAX_OPERATIONS_QUERY_LIMIT,
   );
@@ -511,7 +541,7 @@ async function listOpenQueueSnapshot(
     workItemBatches.reduce((total, batch) => total + batch.length, 0) >
       MAX_OPERATIONS_QUERY_LIMIT;
   const hasMoreApprovalRequests =
-    pendingApprovalRequests.length > MAX_OPERATIONS_QUERY_LIMIT;
+    dayApprovalRequests.length > MAX_OPERATIONS_QUERY_LIMIT;
 
   return {
     approvalRequests,
@@ -1997,7 +2027,10 @@ export async function buildDailyOperationsSnapshotWithCtx(
       buildDailyOpeningSnapshotWithCtx(ctx, args),
       buildDailyCloseSnapshotWithCtx(ctx, args),
       getDailyCloseRecordForDate(ctx, args),
-      listOpenQueueSnapshot(ctx, args.storeId),
+      listOpenQueueSnapshot(ctx, {
+        ...range,
+        storeId: args.storeId,
+      }),
       args.includeScheduledRunSummaries &&
       (args.includeManagerReviewEvidence ?? true)
         ? listDailyOperationsScheduledRunSummaries(ctx, {

--- a/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
@@ -1602,6 +1602,12 @@ export async function voidTransaction(
   }
 
   const reason = args.reason?.trim() || undefined;
+  if (!reason) {
+    return userError({
+      code: "validation_failed",
+      message: "Reason is required before voiding a completed sale.",
+    });
+  }
 
   const preconditions = await validateTransactionVoidPreconditions(
     ctx,

--- a/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
+++ b/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
@@ -382,7 +382,7 @@ describe("voidTransaction", () => {
     expect(ctx.runMutation).not.toHaveBeenCalled();
   });
 
-  it("returns approval_required without an operator reason", async () => {
+  it("requires an operator reason before creating a void approval request", async () => {
     const ctx = createVoidCtx();
 
     await expect(
@@ -391,18 +391,17 @@ describe("voidTransaction", () => {
         transactionId: "txn-1" as Id<"posTransaction">,
       }),
     ).resolves.toMatchObject({
-      kind: "approval_required",
-      approval: {
-        metadata: expect.not.objectContaining({
-          reason: expect.anything(),
-        }),
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message: "Reason is required before voiding a completed sale.",
       },
     });
 
-    const approvalRequestPayload = vi.mocked(ctx.db.insert).mock.calls.find(
-      ([tableName]) => tableName === "approvalRequest",
-    )?.[1];
-    expect(approvalRequestPayload).not.toHaveProperty("notes");
+    expect(ctx.db.insert).not.toHaveBeenCalledWith(
+      "approvalRequest",
+      expect.anything(),
+    );
     expectNoVoidBusinessSideEffects();
   });
 

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
@@ -564,6 +564,18 @@ describe("listRegisterCatalog", () => {
           importedPrice: 85000,
           importedQuantity: 12,
         },
+        {
+          _id: "provisional-archived",
+          storeId: "store-a",
+          status: "active",
+          productId: "product-archived",
+          productSkuId: "sku-archived",
+          importedProductName: "Archived Legacy Import",
+          importedSku: "ARCHIVED-LEGACY",
+          importedBarcode: "ARCHIVED123",
+          importedPrice: 85000,
+          importedQuantity: 12,
+        },
       ],
       product: [
         {
@@ -600,6 +612,15 @@ describe("listRegisterCatalog", () => {
           description: "Hidden anchor",
           name: "Hidden Anchor",
           availability: "draft",
+          isVisible: false,
+        },
+        {
+          _id: "product-archived",
+          storeId: "store-a",
+          categoryId: "category-store-a",
+          description: "Archived anchor",
+          name: "Archived Anchor",
+          availability: "archived",
           isVisible: false,
         },
       ],
@@ -648,6 +669,17 @@ describe("listRegisterCatalog", () => {
           price: 0,
           quantityAvailable: 0,
         },
+        {
+          _id: "sku-archived",
+          storeId: "store-a",
+          productId: "product-archived",
+          sku: "ARCHIVED-ANCHOR",
+          barcode: "",
+          images: [],
+          isVisible: false,
+          price: 0,
+          quantityAvailable: 0,
+        },
       ],
     });
 
@@ -678,9 +710,11 @@ describe("listRegisterCatalog", () => {
     await expect(
       listRegisterCatalogAvailability(ctx, {
         storeId: "store-a" as Id<"store">,
-        productSkuIds: ["sku-trusted", "sku-provisional"] as Array<
-          Id<"productSku">
-        >,
+        productSkuIds: [
+          "sku-trusted",
+          "sku-provisional",
+          "sku-archived",
+        ] as Array<Id<"productSku">>,
       }),
     ).resolves.toEqual([
       {
@@ -717,6 +751,17 @@ describe("listRegisterCatalog", () => {
           inventoryImportProvisionalSkuId: "provisional-sku-1",
           availabilityPolicy: "active_provisional_import",
           inStock: true,
+        }),
+      ]),
+    );
+    await expect(
+      listRegisterCatalogAvailabilitySnapshot(ctx, {
+        storeId: "store-a" as Id<"store">,
+      }),
+    ).resolves.not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          productSkuId: "sku-archived",
         }),
       ]),
     );

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
@@ -448,6 +448,7 @@ async function readActiveLegacyImportProvisionalPolicyRow(
   if (
     category?.slug !== "legacy-import" ||
     !product ||
+    product.availability === "archived" ||
     (product.availability !== "draft" &&
       product.isVisible !== false &&
       args.sku.isVisible !== false)
@@ -520,6 +521,7 @@ export async function listRegisterCatalog(
       !product ||
       !sku ||
       product.storeId !== args.storeId ||
+      product.availability === "archived" ||
       sku.storeId !== args.storeId ||
       sku.productId !== product._id ||
       trustedAvailableSkuIds.has(provisionalSku.productSkuId) ||
@@ -566,6 +568,15 @@ export async function listRegisterCatalogAvailability(
       continue;
     }
 
+    const product = await ctx.db.get("product", sku.productId);
+
+    if (
+      product &&
+      (product.storeId !== args.storeId || product.availability === "archived")
+    ) {
+      continue;
+    }
+
     const availability = await validateInventoryAvailability(
       ctx.db,
       sku._id,
@@ -609,7 +620,7 @@ export async function listRegisterCatalogAvailability(
       ctx,
       {
         storeId: args.storeId,
-        productId: sku.productId,
+        productId: product?._id ?? sku.productId,
         productSkuId: sku._id,
       },
     );
@@ -724,6 +735,13 @@ export async function listRegisterCatalogAvailabilitySnapshot(
 
     const sku = await ctx.db.get("productSku", provisionalSku.productSkuId);
     if (!sku || sku.storeId !== args.storeId) {
+      continue;
+    }
+    const product = await ctx.db.get("product", sku.productId);
+    if (
+      product &&
+      (product.storeId !== args.storeId || product.availability === "archived")
+    ) {
       continue;
     }
     provisionalRows.push({

--- a/packages/athena-webapp/convex/pos/public/transactions.test.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.test.ts
@@ -980,7 +980,7 @@ describe("voidTransaction public mutation", () => {
     ).not.toHaveProperty("staffProofToken");
   });
 
-  it("allows completed sale voids without an operator reason", async () => {
+  it("requires an operator reason before voiding completed sales", async () => {
     vi.mocked(completeTransactionCommands.voidTransaction).mockResolvedValue({
       approval: {
         action: {
@@ -1009,15 +1009,14 @@ describe("voidTransaction public mutation", () => {
         transactionId: "txn-1" as Id<"posTransaction">,
       }),
     ).resolves.toMatchObject({
-      kind: "approval_required",
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message: "Reason is required before voiding a completed sale.",
+      },
     });
 
-    expect(completeTransactionCommands.voidTransaction).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.not.objectContaining({
-        reason: expect.anything(),
-      }),
-    );
+    expect(completeTransactionCommands.voidTransaction).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/packages/athena-webapp/convex/pos/public/transactions.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.ts
@@ -696,11 +696,19 @@ export const voidTransaction = mutation({
   returns: voidTransactionResultValidator,
   handler: async (ctx, args) => {
     const actorStaffProfileId = args.actorStaffProfileId ?? args.staffProfileId;
+    const reason = args.reason?.trim();
 
     if (!actorStaffProfileId) {
       return userError({
         code: "authentication_failed",
         message: "Staff sign-in is required before voiding a completed sale.",
+      });
+    }
+
+    if (!reason) {
+      return userError({
+        code: "validation_failed",
+        message: "Reason is required before voiding a completed sale.",
       });
     }
 
@@ -792,6 +800,7 @@ export const voidTransaction = mutation({
       ...commandArgs,
       actorStaffProfileId,
       actorUserId: athenaUser._id,
+      reason,
     });
 
     if (result.kind === "approval_required") {

--- a/packages/athena-webapp/src/components/common/PageLevelHeader.test.tsx
+++ b/packages/athena-webapp/src/components/common/PageLevelHeader.test.tsx
@@ -80,7 +80,7 @@ describe("PageLevelHeader", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("27.7k of 27.7k units are available to sell."),
+      await screen.findByText("27.7k of 27.7k units are available to sell."),
     ).toBeInTheDocument();
   });
 

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
@@ -721,6 +721,76 @@ describe("DailyOpeningViewContent", () => {
     expect(screen.queryByRole("tab", { name: /blocked/i })).toBeNull();
   });
 
+  it("paginates automation review evidence at five items per page", async () => {
+    const user = userEvent.setup();
+    const reviewEvidence = Array.from({ length: 12 }, (_, index) => ({
+      category: "operational_work_item",
+      description: `Carry-forward work item ${index + 1} needs review.`,
+      id: `review-evidence-${index + 1}`,
+      key: `review-evidence-${index + 1}`,
+      link: {
+        label: "View open work",
+        to: "/$orgUrlSlug/store/$storeUrlSlug/operations/open-work",
+      },
+      statusLabel: "Needs manager review",
+      title: `Carry-forward review ${index + 1}`,
+    }));
+
+    renderContent({
+      ...blockedSnapshot,
+      automationStatus: {
+        id: "automation-opening-started-with-many-review-items",
+        outcome: "applied",
+        occurredAt: Date.UTC(2026, 4, 8, 8, 30),
+        reviewEvidence,
+      },
+      startedOpening: {
+        startedAt: Date.UTC(2026, 4, 8, 8, 30),
+      },
+      status: "started",
+    });
+
+    const openingReview = screen
+      .getByRole("heading", { name: "Opening review" })
+      .closest("section")!;
+
+    expect(within(openingReview).getByText("Showing 1-5 of 12")).toBeInTheDocument();
+    expect(within(openingReview).getByText("Page 1 of 3")).toBeInTheDocument();
+    expect(
+      within(openingReview).getByText("Carry-forward review 5"),
+    ).toBeInTheDocument();
+    expect(
+      within(openingReview).queryByText("Carry-forward review 6"),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      within(openingReview).getByRole("button", {
+        name: /go to next page/i,
+      }),
+    );
+
+    expect(within(openingReview).getByText("Showing 6-10 of 12")).toBeInTheDocument();
+    expect(within(openingReview).getByText("Page 2 of 3")).toBeInTheDocument();
+    expect(
+      within(openingReview).getByText("Carry-forward review 6"),
+    ).toBeInTheDocument();
+    expect(
+      within(openingReview).queryByText("Carry-forward review 5"),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      within(openingReview).getByRole("button", {
+        name: /go to last page/i,
+      }),
+    );
+
+    expect(within(openingReview).getByText("Showing 11-12 of 12")).toBeInTheDocument();
+    expect(within(openingReview).getByText("Page 3 of 3")).toBeInTheDocument();
+    expect(
+      within(openingReview).getByText("Carry-forward review 12"),
+    ).toBeInTheDocument();
+  });
+
   it("keeps started Opening Handoff primary over stale skipped automation decisions", () => {
     renderContent({
       ...readySnapshot,

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
@@ -32,6 +32,7 @@ import type { ApprovalRequirement } from "~/shared/approvalPolicy";
 import type { CommandResult } from "~/shared/commandResult";
 import View from "../View";
 import { FadeIn } from "../common/FadeIn";
+import { ListPagination } from "../common/ListPagination";
 import {
   PageLevelHeader,
   PageWorkspace,
@@ -188,6 +189,7 @@ const bucketTabValues: BucketStatus[] = [
   "carry-forward",
   "ready",
 ];
+const OPENING_REVIEW_ITEMS_PER_PAGE = 5;
 
 const statusCopy: Record<
   DailyOpeningStatus,
@@ -683,6 +685,20 @@ function OpeningAutomationReviewPanel({
   orgUrlSlug: string;
   storeUrlSlug: string;
 }) {
+  const [page, setPage] = useState(1);
+  const pageCount = Math.max(
+    Math.ceil(items.length / OPENING_REVIEW_ITEMS_PER_PAGE),
+    1,
+  );
+  const clampedPage = Math.min(page, pageCount);
+  const paginatedItems = items.slice(
+    (clampedPage - 1) * OPENING_REVIEW_ITEMS_PER_PAGE,
+    clampedPage * OPENING_REVIEW_ITEMS_PER_PAGE,
+  );
+  const handlePageChange = (nextPage: number) => {
+    setPage(Math.min(Math.max(nextPage, 1), pageCount));
+  };
+
   if (items.length === 0) return null;
 
   return (
@@ -710,7 +726,7 @@ function OpeningAutomationReviewPanel({
         </Badge>
       </div>
       <div className="mt-layout-md space-y-layout-xs">
-        {items.map((item) => (
+        {paginatedItems.map((item) => (
           <OpeningItemCard
             currency={currency}
             item={item}
@@ -721,6 +737,15 @@ function OpeningAutomationReviewPanel({
           />
         ))}
       </div>
+      {items.length > OPENING_REVIEW_ITEMS_PER_PAGE ? (
+        <ListPagination
+          onPageChange={handlePageChange}
+          page={clampedPage}
+          pageCount={pageCount}
+          pageSize={OPENING_REVIEW_ITEMS_PER_PAGE}
+          totalItems={items.length}
+        />
+      ) : null}
     </section>
   );
 }

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -74,13 +74,16 @@ vi.mock("recharts", () => ({
   AreaChart: ({
     children,
     data = [],
+    margin,
   }: {
     children?: React.ReactNode;
     data?: Array<{ displayDate?: string; displayLabel?: string }>;
+    margin?: { bottom?: number; left?: number; right?: number; top?: number };
   }) => (
     <svg
       data-display-dates={data.map((day) => day.displayDate).join("|")}
       data-display-labels={data.map((day) => day.displayLabel).join("|")}
+      data-margin-right={margin?.right ?? ""}
       data-testid="store-pulse-chart"
     >
       {children}
@@ -969,15 +972,13 @@ describe("DailyOperationsViewContent", () => {
       screen.getByRole("heading", { name: "Historical store-day view" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "This historical operating date is view-only. Workflow actions are available only on the current operating date.",
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Metrics and timeline remain available for this historical day.",
-      ),
-    ).toBeInTheDocument();
+      screen.getByRole("link", {
+        name: "Review EOD Review for Friday, May 8, 2026",
+      }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/operations/daily-close?o=%252Fwigclub%252Fstore%252Fosu%252Foperations&operatingDate=2026-05-08",
+    );
     expect(screen.queryByText("Workflow status")).not.toBeInTheDocument();
     expect(screen.queryByText("Current day only")).not.toBeInTheDocument();
     expect(screen.queryByText("Needs attention")).not.toBeInTheDocument();
@@ -1094,6 +1095,32 @@ describe("DailyOperationsViewContent", () => {
     expect(
       screen.getByRole("heading", { name: "Athena automation" }),
     ).toBeInTheDocument();
+    const automationHeading = screen.getByRole("heading", {
+      name: "Athena automation",
+    });
+    const automationPanel = automationHeading.closest("section");
+    const netSalesMetric = screen.getByText(/^(Today's net sales|Net sales)$/);
+
+    expect(automationPanel).toHaveClass("py-layout-sm", "rounded-md");
+    expect(automationHeading).toHaveClass(
+      "text-sm",
+      "font-medium",
+      "text-foreground",
+    );
+    expect(automationHeading.parentElement).toHaveClass("gap-layout-sm");
+    const automationTime = within(automationPanel!).getByText(/[48]:30 AM/);
+
+    expect(automationTime).toHaveClass("tabular-nums");
+    expect(automationTime.parentElement).toHaveClass("mt-1.5");
+    expect(
+      automationHeading.compareDocumentPosition(netSalesMetric) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      automationHeading.compareDocumentPosition(
+        screen.getByRole("heading", { name: "Week at a glance" }),
+      ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(screen.getByText("Athena started Opening Handoff.")).toBeInTheDocument();
     expect(
       screen.getByText("Athena prepared EOD Review for manager review."),
@@ -1150,20 +1177,18 @@ describe("DailyOperationsViewContent", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows compact scheduled-run evidence without backend details", () => {
+  it("keeps scheduled-run evidence off the daily operations workspace", () => {
     renderContent(scheduledRunsSnapshot);
 
     expect(
-      screen.getByRole("heading", { name: "Scheduled runs" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("heading", { name: "Scheduled runs" }),
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByText(
-        "Payment verification partially ran. 2 applied, 1 needs review.",
-      ),
-    ).toBeInTheDocument();
+      screen.queryByText(/Payment verification partially ran/i),
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByText("Checkout completion ran. No eligible work found."),
-    ).toBeInTheDocument();
+      screen.queryByText(/Checkout completion ran/i),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText(/provider|exception|stack/i)).not.toBeInTheDocument();
   });
 
@@ -1181,10 +1206,19 @@ describe("DailyOperationsViewContent", () => {
     );
 
     const storePulse = screen.getByRole("region", { name: "Store pulse" });
+    const chart = within(storePulse).getByTestId("store-pulse-chart");
 
     expect(within(storePulse).getByText("Sales trend")).toBeInTheDocument();
-    expect(within(storePulse).getByTestId("store-pulse-chart")).toBeInTheDocument();
+    expect(chart).toBeInTheDocument();
+    expect(chart).toHaveAttribute(
+      "data-display-labels",
+      "Sun, May 3|Mon, May 4|Tue, May 5|Wed, May 6|Thu, May 7|Fri, May 8",
+    );
+    expect(chart).toHaveAttribute("data-margin-right", "72");
     expect(within(storePulse).getByText("Braiding Hair")).toBeInTheDocument();
+    expect(
+      within(storePulse).getByText("Today's top items"),
+    ).toBeInTheDocument();
     expect(
       within(storePulse).getByLabelText("Total items sold: 3"),
     ).toBeInTheDocument();
@@ -1197,7 +1231,7 @@ describe("DailyOperationsViewContent", () => {
       screen.queryByText("POS sales activity for the selected reporting window."),
     ).not.toBeInTheDocument();
     expect(
-      within(storePulse).getByText("Today's completed POS sales."),
+      within(storePulse).getByText("This week's completed POS sales."),
     ).toBeInTheDocument();
   });
 
@@ -1251,6 +1285,22 @@ describe("DailyOperationsViewContent", () => {
     expect(openingReview?.parentElement).toBe(timeline.parentElement);
     expect(openingReview?.compareDocumentPosition(timeline)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
+  it("passes historical operating dates to Opening Handoff review links", () => {
+    renderContent({
+      ...automationReviewSnapshot,
+      operatingDate: "2026-05-08",
+    });
+
+    expect(
+      screen.getByRole("link", {
+        name: "Review all Opening Handoff review items",
+      }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/operations/opening?o=%252Fwigclub%252Fstore%252Fosu%252Foperations&operatingDate=2026-05-08",
     );
   });
 
@@ -1492,6 +1542,9 @@ describe("DailyOperationsViewContent", () => {
       screen.queryByRole("link", { name: "Start Opening Handoff" }),
     ).not.toBeInTheDocument();
     expect(
+      screen.queryByRole("link", { name: "Review EOD Review" }),
+    ).not.toBeInTheDocument();
+    expect(
       screen.getByRole("heading", { name: "Historical store-day view" }),
     ).toBeInTheDocument();
     expect(
@@ -1501,6 +1554,30 @@ describe("DailyOperationsViewContent", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText("Needs attention")).not.toBeInTheDocument();
     expect(screen.queryByText("Workflow status")).not.toBeInTheDocument();
+  });
+
+  it("links historical started store days to EOD Review even before close", () => {
+    renderContent(operatingSnapshot);
+
+    expect(
+      screen.getByRole("heading", { name: "Historical store-day view" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: "Review EOD Review for Friday, May 8, 2026",
+      }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/operations/daily-close?o=%252Fwigclub%252Fstore%252Fosu%252Foperations&operatingDate=2026-05-08",
+    );
+    expect(
+      screen.queryByRole("link", { name: "Review EOD Review" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This historical operating date is view-only. Workflow actions are available only on the current operating date.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("keeps current-day opening actions available", () => {
@@ -1515,6 +1592,52 @@ describe("DailyOperationsViewContent", () => {
       "href",
       "/wigclub/store/osu/operations/opening?o=%252Fwigclub%252Fstore%252Fosu%252Foperations",
     );
+  });
+
+  it("surfaces pending approval requests on the leading side of the action strip", () => {
+    renderContent({
+      ...blockedSnapshot,
+      lanes: [
+        ...blockedSnapshot.lanes,
+        {
+          count: 2,
+          countLabel: "2",
+          description: "2 approvals pending.",
+          key: "approvals",
+          label: "Approvals",
+          status: "blocked",
+          to: "/$orgUrlSlug/store/$storeUrlSlug/operations/approvals",
+        },
+      ],
+      operatingDate: getCurrentLocalOperatingDate(),
+    });
+
+    const approvalLink = screen.getByRole("link", {
+      name: "Open 2 pending approvals",
+    });
+    const operatingDateButton = screen.getByRole("button", {
+      name: /Change operating date/,
+    });
+
+    expect(approvalLink).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/operations/approvals?o=%252Fwigclub%252Fstore%252Fosu%252Foperations",
+    );
+    expect(approvalLink).toHaveClass("w-full", "sm:w-auto");
+    expect(within(approvalLink).getByText("2")).toHaveClass(
+      "font-semibold",
+      "tabular-nums",
+    );
+    expect(within(approvalLink).getByText("pending approvals")).toHaveClass(
+      "text-muted-foreground",
+    );
+    expect(
+      approvalLink.compareDocumentPosition(operatingDateButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Review close blockers" }),
+    ).toBeInTheDocument();
   });
 
   it("passes origin context to current-day blocker review actions", () => {
@@ -1875,7 +1998,7 @@ describe("DailyOperationsView", () => {
     );
   });
 
-  it("ignores store pulse search state and queries the today store pulse window", () => {
+  it("keeps the store pulse query scoped to the operating day", () => {
     mockedHooks.useSearch.mockReturnValue({
       storePulseWindow: "this_month",
     });
@@ -1905,7 +2028,7 @@ describe("DailyOperationsView", () => {
 
     expect(within(storePulse).queryByRole("tablist")).not.toBeInTheDocument();
     expect(
-      within(storePulse).getByText("Today's completed POS sales."),
+      within(storePulse).getByText("This week's completed POS sales."),
     ).toBeInTheDocument();
   });
 

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -58,6 +58,7 @@ import { formatOperationsMetricHelper } from "./operationsMetricFormatting";
 import {
   StorePulseSummaryView,
   type StorePulseSummary,
+  type StorePulseTrendDay,
   type StorePulseWindow,
 } from "../store-pulse/StorePulseSummaryView";
 
@@ -516,17 +517,37 @@ function shouldShowHistoricalEodReviewAction(
   snapshot: DailyOperationsSnapshot,
 ) {
   return (
-    snapshot.lifecycle.status === "closed" &&
+    snapshot.lifecycle.status !== "not_opened" &&
     isHistoricalOperatingDate(snapshot.operatingDate)
   );
 }
 
+function getPendingApprovalsLane(snapshot: DailyOperationsSnapshot) {
+  const approvalsLane = snapshot.lanes.find((lane) => lane.key === "approvals");
+
+  return approvalsLane && approvalsLane.count > 0 ? approvalsLane : null;
+}
+
+function getPendingApprovalsCountLabel(
+  lane: DailyOperationsSnapshot["lanes"][number],
+) {
+  return lane.countLabel ?? String(lane.count);
+}
+
+function formatPendingApprovalsLabel(
+  lane: DailyOperationsSnapshot["lanes"][number],
+) {
+  const countLabel = getPendingApprovalsCountLabel(lane);
+  return `${countLabel} pending approval${lane.count === 1 ? "" : "s"}`;
+}
+
 function getWorkflowSearch(to: string, operatingDate: string) {
+  const shouldCarryOperatingDate =
+    to.endsWith("/operations/daily-close") ||
+    to.endsWith("/operations/opening");
   const search = {
     o: getOrigin(),
-    ...(to.endsWith("/operations/daily-close")
-      ? buildDailyCloseSearch(operatingDate)
-      : {}),
+    ...(shouldCarryOperatingDate ? buildDailyCloseSearch(operatingDate) : {}),
   };
 
   return Object.keys(search).length > 0 ? search : undefined;
@@ -570,19 +591,12 @@ function TimelineMessage({
   const inlineLink =
     event.transactionLink ?? event.registerLink ?? event.productLink;
   const linkLabel = inlineLink?.label?.trim();
-  const matchLabel = event.transactionLink ? undefined : event.registerLink?.matchLabel;
-  const linkMatch = findTimelineLinkMatch(
-    event.message,
-    linkLabel,
-    matchLabel,
-  );
+  const matchLabel = event.transactionLink
+    ? undefined
+    : event.registerLink?.matchLabel;
+  const linkMatch = findTimelineLinkMatch(event.message, linkLabel, matchLabel);
 
-  if (
-    !inlineLink?.to ||
-    !inlineLink.params ||
-    !linkLabel ||
-    !linkMatch
-  ) {
+  if (!inlineLink?.to || !inlineLink.params || !linkLabel || !linkMatch) {
     return <>{formatTimelineMessage(event.message)}</>;
   }
 
@@ -702,7 +716,9 @@ function formatRegisterVarianceCount(value: number) {
   return `${value} register variances`;
 }
 
-function getOtherPaymentTotals(summary: DailyOperationsSnapshot["closeSummary"]) {
+function getOtherPaymentTotals(
+  summary: DailyOperationsSnapshot["closeSummary"],
+) {
   return (summary.paymentTotals ?? [])
     .filter((paymentTotal) => paymentTotal.method.toLowerCase() !== "cash")
     .sort((left, right) => right.amount - left.amount);
@@ -737,7 +753,9 @@ function getPreviousOperatingDate(operatingDate: string) {
 }
 
 function getPriorComparisonMetric(snapshot: DailyOperationsSnapshot) {
-  const previousOperatingDate = getPreviousOperatingDate(snapshot.operatingDate);
+  const previousOperatingDate = getPreviousOperatingDate(
+    snapshot.operatingDate,
+  );
 
   if (!previousOperatingDate) return undefined;
 
@@ -754,7 +772,9 @@ function getPriorWindowLabel(operatingDate: string) {
   return operatingDate === getLocalOperatingDate() ? "yesterday" : "prior day";
 }
 
-function shouldShowExpenseMetric(summary: DailyOperationsSnapshot["closeSummary"]) {
+function shouldShowExpenseMetric(
+  summary: DailyOperationsSnapshot["closeSummary"],
+) {
   if (summary.salesTotal <= 0) {
     return true;
   }
@@ -762,7 +782,9 @@ function shouldShowExpenseMetric(summary: DailyOperationsSnapshot["closeSummary"
   return summary.expenseTransactionCount > 0 || summary.expenseTotal !== 0;
 }
 
-function shouldShowVarianceMetric(summary: DailyOperationsSnapshot["closeSummary"]) {
+function shouldShowVarianceMetric(
+  summary: DailyOperationsSnapshot["closeSummary"],
+) {
   if (summary.salesTotal <= 0) {
     return true;
   }
@@ -1018,14 +1040,85 @@ function AutomationStatusPanel({
   orgUrlSlug,
   snapshot,
   storeUrlSlug,
+  variant = "default",
 }: {
   orgUrlSlug: string;
   snapshot: DailyOperationsSnapshot;
   storeUrlSlug: string;
+  variant?: "compact" | "default";
 }) {
   const statuses = getVisibleAutomationStatuses(snapshot);
 
   if (statuses.length === 0) return null;
+
+  if (variant === "compact") {
+    return (
+      <section className="rounded-md border border-border bg-surface-raised px-layout-md py-layout-sm shadow-surface">
+        <div className="flex flex-col gap-layout-sm">
+          <h3 className="flex shrink-0 items-center gap-layout-xs text-sm font-medium text-foreground">
+            <Bot aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
+            Athena automation
+          </h3>
+          <div className="flex min-w-0 flex-col gap-layout-xs">
+            {statuses.map((status) => {
+              const label = getAutomationLaneLabel(status.lane);
+              const link = status.sourceLink;
+
+              return (
+                <article
+                  className="flex min-w-0 flex-col gap-layout-xs"
+                  key={status.id}
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm text-foreground">
+                      {getAutomationStatusMessage(status)}
+                    </p>
+                    <div className="mt-1.5 flex flex-wrap items-center gap-layout-xs">
+                      {status.occurredAt ? (
+                        <p className="font-numeric text-xs tabular-nums text-muted-foreground">
+                          {formatEventTime(status.occurredAt)}
+                        </p>
+                      ) : null}
+                      {link?.to ? (
+                        <Button
+                          asChild
+                          className="h-7 shrink-0 px-2 text-xs"
+                          size="sm"
+                          variant="ghost"
+                        >
+                          <Link
+                            aria-label={`Open ${label} automation source`}
+                            params={buildParams(
+                              orgUrlSlug,
+                              storeUrlSlug,
+                              link.params,
+                            )}
+                            search={
+                              {
+                                o: getOrigin(),
+                                ...(link.search ?? {}),
+                              } as never
+                            }
+                            to={link.to}
+                          >
+                            Open
+                            <ArrowUpRight
+                              aria-hidden="true"
+                              className="h-3.5 w-3.5"
+                            />
+                          </Link>
+                        </Button>
+                      ) : null}
+                    </div>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className="rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface">
@@ -1062,11 +1155,7 @@ function AutomationStatusPanel({
                 >
                   <Link
                     aria-label={`Open ${label} automation source`}
-                    params={buildParams(
-                      orgUrlSlug,
-                      storeUrlSlug,
-                      link.params,
-                    )}
+                    params={buildParams(orgUrlSlug, storeUrlSlug, link.params)}
                     search={
                       {
                         o: getOrigin(),
@@ -1165,7 +1254,7 @@ function getScheduledRunMessage(run: DailyOperationsScheduledRunSummary) {
   return `${label} ran. ${run.succeededCount} applied.`;
 }
 
-function ScheduledRunEvidencePanel({
+export function ScheduledRunEvidencePanel({
   snapshot,
 }: {
   snapshot: DailyOperationsSnapshot;
@@ -1175,28 +1264,30 @@ function ScheduledRunEvidencePanel({
   if (runs.length === 0) return null;
 
   return (
-    <section className="rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface">
-      <h3 className="flex items-center gap-layout-xs text-base font-medium text-foreground">
-        <Clock3 aria-hidden="true" className="h-4 w-4" />
-        Scheduled runs
-      </h3>
-      <div className="mt-layout-sm space-y-layout-xs">
-        {runs.map((run) => (
-          <article
-            className="rounded-md border border-border/70 bg-background/60 px-layout-md py-layout-sm"
-            key={run.id}
-          >
-            <p className="text-sm text-foreground">
-              {getScheduledRunMessage(run)}
-            </p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              {formatEventTime(run.completedAt)}
-              {run.outcome === "partial_failure"
-                ? ` · ${run.processedCount} checked`
-                : null}
-            </p>
-          </article>
-        ))}
+    <section className="rounded-md border border-border bg-surface-raised px-layout-md py-layout-sm shadow-surface">
+      <div className="flex flex-col gap-layout-sm">
+        <h3 className="flex shrink-0 items-center gap-layout-xs text-sm font-medium text-foreground">
+          <Clock3 aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
+          Scheduled runs
+        </h3>
+        <div className="flex min-w-0 flex-col gap-layout-xs">
+          {runs.map((run) => (
+            <article
+              className="flex min-w-0 flex-col gap-layout-xs"
+              key={run.id}
+            >
+              <p className="text-sm text-foreground">
+                {getScheduledRunMessage(run)}
+              </p>
+              <p className="mt-1.5 font-numeric text-xs tabular-nums text-muted-foreground">
+                {formatEventTime(run.completedAt)}
+                {run.outcome === "partial_failure"
+                  ? ` · ${run.processedCount} checked`
+                  : null}
+              </p>
+            </article>
+          ))}
+        </div>
       </div>
     </section>
   );
@@ -1219,7 +1310,9 @@ function AutomationReviewEvidencePanel({
 
   if (evidenceItems.length === 0) return null;
 
-  const pendingCheckoutCount = evidenceItems.filter(isPendingCheckoutReview).length;
+  const pendingCheckoutCount = evidenceItems.filter(
+    isPendingCheckoutReview,
+  ).length;
   const otherReviewCount = evidenceItems.length - pendingCheckoutCount;
   const previewItems = evidenceItems.slice(0, REVIEW_EVIDENCE_PREVIEW_LIMIT);
   const hiddenItemCount = Math.max(
@@ -1269,10 +1362,7 @@ function AutomationReviewEvidencePanel({
 
       <div className="mt-layout-md divide-y divide-border/70 border-y border-border/70">
         {previewItems.map((item) => (
-          <article
-            className="py-layout-sm"
-            key={item.id}
-          >
+          <article className="py-layout-sm" key={item.id}>
             <div className="min-w-0">
               <p className="text-sm font-medium leading-5 text-foreground">
                 {getReviewEvidenceTitle(item)}
@@ -1295,7 +1385,12 @@ function AutomationReviewEvidencePanel({
           workflow.
         </p>
       ) : null}
-      <Button asChild className="mt-layout-md w-full" size="sm" variant="outline">
+      <Button
+        asChild
+        className="mt-layout-md w-full"
+        size="sm"
+        variant="outline"
+      >
         <Link
           aria-label="Review all Opening Handoff review items"
           params={buildParams(orgUrlSlug, storeUrlSlug)}
@@ -1433,17 +1528,20 @@ function DailyOperationsStorePulsePanel({
   hasFullAdminAccess: boolean;
   snapshot: DailyOperationsSnapshot;
 }) {
+  const storePulseSummary = buildWeekToDateStorePulseSummary(snapshot);
+
   return (
     <section className="space-y-layout-md">
-      {snapshot.storePulse ? (
+      {storePulseSummary ? (
         <StorePulseSummaryView
           canViewFinancialDetails={hasFullAdminAccess}
           currencyFormatter={currencyFormatter(currency)}
           onPulseWindowChange={() => undefined}
-          pulseWindow="today"
+          pulseWindow="this_week"
           showPulseWindowFilter={false}
           showSummaryMetrics={false}
-          summary={snapshot.storePulse}
+          summary={storePulseSummary}
+          topItemsTitle="Today's top items"
         />
       ) : (
         <div className="rounded-lg border border-border bg-surface p-layout-md shadow-surface">
@@ -1455,6 +1553,56 @@ function DailyOperationsStorePulsePanel({
       )}
     </section>
   );
+}
+
+function buildWeekToDateStorePulseSummary(
+  snapshot: DailyOperationsSnapshot,
+): StorePulseSummary | null | undefined {
+  const summary = snapshot.storePulse;
+  const operatorSnapshot = summary?.operatorSnapshot;
+
+  if (!summary || !operatorSnapshot) return summary;
+
+  const knownTrendByDate = new Map(
+    operatorSnapshot.trend.map((day) => [day.date, day]),
+  );
+  const weekToDateTrend = snapshot.weekMetrics
+    .filter((metric) => metric.operatingDate <= snapshot.operatingDate)
+    .map((metric): StorePulseTrendDay => {
+      const knownTrendDay = knownTrendByDate.get(metric.operatingDate);
+
+      return {
+        averageTransaction:
+          metric.transactionCount > 0
+            ? metric.salesTotal / metric.transactionCount
+            : 0,
+        date: metric.operatingDate,
+        hasKnownItemCount: knownTrendDay ? true : false,
+        label:
+          knownTrendDay?.label ?? formatOperatingDate(metric.operatingDate),
+        totalItemsSold: knownTrendDay?.totalItemsSold ?? 0,
+        totalSales: metric.salesTotal,
+        transactionCount: metric.transactionCount,
+      };
+    });
+
+  if (weekToDateTrend.length === 0) return summary;
+
+  return {
+    ...summary,
+    operatorSnapshot: {
+      ...operatorSnapshot,
+      historyDays: Math.max(
+        operatorSnapshot.historyDays,
+        weekToDateTrend.length,
+      ),
+      trend: weekToDateTrend,
+      usableHistoryDays: Math.max(
+        operatorSnapshot.usableHistoryDays,
+        weekToDateTrend.filter((day) => day.transactionCount > 0).length,
+      ),
+    },
+  };
 }
 
 function SupportingWorkspaceLinks({
@@ -1578,13 +1726,16 @@ function WeekMetricsStrip({
   storePulseWindow: StorePulseWindow;
   storeUrlSlug: string;
 }) {
-  const scrollSelectedDayIntoView = useCallback((element: HTMLElement | null) => {
-    element?.scrollIntoView({
-      behavior: "auto",
-      block: "nearest",
-      inline: "center",
-    });
-  }, []);
+  const scrollSelectedDayIntoView = useCallback(
+    (element: HTMLElement | null) => {
+      element?.scrollIntoView({
+        behavior: "auto",
+        block: "nearest",
+        inline: "center",
+      });
+    },
+    [],
+  );
 
   if (metrics.length === 0) return null;
 
@@ -1625,7 +1776,10 @@ function WeekMetricsStrip({
           <p className="flex items-baseline justify-between gap-2 text-sm text-muted-foreground sm:justify-start">
             <span>Week sales</span>
             <span className="font-numeric text-base font-semibold tabular-nums text-foreground">
-              <FinancialValue canView={hasFinancialDetailsAccess} label="Week sales">
+              <FinancialValue
+                canView={hasFinancialDetailsAccess}
+                label="Week sales"
+              >
                 {formatMoney(currency, weekSalesTotal)}
               </FinancialValue>
             </span>
@@ -1724,16 +1878,16 @@ function WeekMetricsStrip({
                   {formatWeekdayDate(metric.operatingDate)}
                 </p>
                 <p className="mt-layout-sm font-numeric text-lg tabular-nums text-foreground">
-                  {isFutureDate
-                    ? "-"
-                    : (
-                        <FinancialValue
-                          canView={hasFinancialDetailsAccess}
-                          label={`${formatOperatingDate(metric.operatingDate)} sales`}
-                        >
-                          {formatMoney(currency, metric.salesTotal)}
-                        </FinancialValue>
-                      )}
+                  {isFutureDate ? (
+                    "-"
+                  ) : (
+                    <FinancialValue
+                      canView={hasFinancialDetailsAccess}
+                      label={`${formatOperatingDate(metric.operatingDate)} sales`}
+                    >
+                      {formatMoney(currency, metric.salesTotal)}
+                    </FinancialValue>
+                  )}
                 </p>
                 <p className="mt-1 text-xs text-muted-foreground">
                   {isFutureDate
@@ -1749,9 +1903,13 @@ function WeekMetricsStrip({
                   aria-disabled="true"
                   aria-label={`${formatOperatingDate(metric.operatingDate)} operations unavailable`}
                   className={cardClassName}
-                  data-week-metric-selected={metric.isSelected ? "true" : undefined}
+                  data-week-metric-selected={
+                    metric.isSelected ? "true" : undefined
+                  }
                   key={metric.operatingDate}
-                  ref={metric.isSelected ? scrollSelectedDayIntoView : undefined}
+                  ref={
+                    metric.isSelected ? scrollSelectedDayIntoView : undefined
+                  }
                 >
                   {content}
                 </div>
@@ -1763,7 +1921,9 @@ function WeekMetricsStrip({
                 aria-current={metric.isSelected ? "date" : undefined}
                 aria-label={`View ${formatOperatingDate(metric.operatingDate)} operations`}
                 className={cardClassName}
-                data-week-metric-selected={metric.isSelected ? "true" : undefined}
+                data-week-metric-selected={
+                  metric.isSelected ? "true" : undefined
+                }
                 key={metric.operatingDate}
                 params={buildParams(orgUrlSlug, storeUrlSlug)}
                 ref={metric.isSelected ? scrollSelectedDayIntoView : undefined}
@@ -1837,6 +1997,9 @@ export function DailyOperationsViewContent({
   const isHistoricalDate = snapshot
     ? isHistoricalOperatingDate(snapshot.operatingDate)
     : false;
+  const pendingApprovalsLane = snapshot
+    ? getPendingApprovalsLane(snapshot)
+    : null;
   const actionableLanes = snapshot
     ? snapshot.lanes.filter(isActionableLane)
     : [];
@@ -1854,7 +2017,46 @@ export function DailyOperationsViewContent({
           {isLoadingSnapshot || !snapshot ? null : (
             <PageWorkspace>
               <section className="space-y-layout-2xl">
-                <div className="flex flex-col gap-layout-sm lg:flex-row lg:items-center lg:justify-end">
+                <div className="flex flex-col gap-layout-sm lg:flex-row lg:items-center lg:justify-between">
+                  {pendingApprovalsLane ? (
+                    <div className="flex flex-col gap-layout-sm sm:flex-row sm:items-center">
+                      <Button
+                        asChild
+                        className="w-full sm:w-auto"
+                        variant="outline"
+                      >
+                        <Link
+                          aria-label={`Open ${formatPendingApprovalsLabel(
+                            pendingApprovalsLane,
+                          )}`}
+                          params={buildParams(orgUrlSlug, storeUrlSlug)}
+                          search={
+                            getWorkflowSearch(
+                              pendingApprovalsLane.to,
+                              snapshot.operatingDate,
+                            ) as never
+                          }
+                          to={pendingApprovalsLane.to}
+                        >
+                          <span className="font-numeric font-semibold tabular-nums text-foreground">
+                            {getPendingApprovalsCountLabel(
+                              pendingApprovalsLane,
+                            )}
+                          </span>
+                          <span className="text-muted-foreground">
+                            pending approval
+                            {pendingApprovalsLane.count === 1 ? "" : "s"}
+                          </span>
+                          <ArrowUpRight
+                            aria-hidden="true"
+                            className="ml-2 h-4 w-4"
+                          />
+                        </Link>
+                      </Button>
+                    </div>
+                  ) : (
+                    <div className="hidden lg:block" />
+                  )}
                   <div className="flex flex-col gap-layout-sm sm:flex-row sm:items-center">
                     <OperatingDatePicker
                       operatingDate={snapshot.operatingDate}
@@ -1913,6 +2115,15 @@ export function DailyOperationsViewContent({
                     ) : null}
                   </div>
                 </div>
+
+                {!isHistoricalDate ? (
+                  <AutomationStatusPanel
+                    orgUrlSlug={orgUrlSlug}
+                    snapshot={snapshot}
+                    storeUrlSlug={storeUrlSlug}
+                    variant="compact"
+                  />
+                ) : null}
 
                 <div className="grid gap-layout-sm sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-5">
                   <OperationsSummaryMetric
@@ -2127,12 +2338,6 @@ export function DailyOperationsViewContent({
                     />
                   ) : (
                     <section className="space-y-layout-lg">
-                      <AutomationStatusPanel
-                        orgUrlSlug={orgUrlSlug}
-                        snapshot={snapshot}
-                        storeUrlSlug={storeUrlSlug}
-                      />
-                      <ScheduledRunEvidencePanel snapshot={snapshot} />
                       <div>
                         <h3 className="text-base font-medium text-foreground">
                           Workflow status

--- a/packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx
@@ -83,9 +83,8 @@ vi.mock("@/lib/pos/infrastructure/local/localPosEntryContext", () => ({
 }));
 
 vi.mock("@/lib/pos/infrastructure/convex/catalogGateway", () => ({
-  usePrewarmRegisterCatalogOfflineSnapshots: (
-    input: Record<string, unknown>,
-  ) => usePrewarmRegisterCatalogOfflineSnapshotsMock(input),
+  usePrewarmRegisterCatalogOfflineSnapshots: (input: Record<string, unknown>) =>
+    usePrewarmRegisterCatalogOfflineSnapshotsMock(input),
 }));
 
 vi.mock("~/src/hooks/usePermissions", () => ({
@@ -252,17 +251,6 @@ describe("PointOfSaleView", () => {
     });
   });
 
-  it("links managers to active POS session operations from the POS landing page", () => {
-    render(<PointOfSaleView />);
-
-    const link = screen.getByRole("link", { name: /Active Sessions/i });
-
-    expect(link).toHaveAttribute("href", "/acme/store/downtown/pos/sessions");
-    expect(
-      screen.getByText("Review active and held sales reserving inventory"),
-    ).toBeInTheDocument();
-  });
-
   it("embeds store pulse on the POS landing page instead of linking to a separate route", () => {
     render(<PointOfSaleView />);
 
@@ -276,7 +264,9 @@ describe("PointOfSaleView", () => {
       screen.queryByRole("link", { name: /Sales Reports/i }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText("Review store pulse trends and operator sales insights"),
+      screen.queryByText(
+        "Review store pulse trends and operator sales insights",
+      ),
     ).not.toBeInTheDocument();
     expect(screen.getByText("Sales trend")).toBeInTheDocument();
     expect(screen.getByTestId("store-pulse-chart")).toBeInTheDocument();
@@ -329,9 +319,7 @@ describe("PointOfSaleView", () => {
       "/acme/store/downtown/pos/transactions",
     );
     expect(screen.getByLabelText("Store pulse loading")).toBeInTheDocument();
-    expect(
-      screen.getAllByText("-").length,
-    ).toBeGreaterThanOrEqual(4);
+    expect(screen.getAllByText("-").length).toBeGreaterThanOrEqual(4);
   });
 
   it("links POS users to terminal health from the POS landing page", () => {
@@ -371,7 +359,6 @@ describe("PointOfSaleView", () => {
     const link = screen.getByRole("link", { name: /POS Settings/i });
 
     expect(link).toHaveAttribute("href", "/acme/store/downtown/pos/settings");
-    expect(screen.queryByRole("link", { name: /Active Sessions/i })).toBeNull();
   });
 
   it("renders the POS launcher from local entry context when live summary and store context are unavailable", () => {
@@ -405,9 +392,6 @@ describe("PointOfSaleView", () => {
       "href",
       "/acme/store/downtown/pos/register",
     );
-    expect(
-      screen.queryByRole("link", { name: /Active Sessions/i }),
-    ).not.toBeInTheDocument();
     expect(useQueryMock).toHaveBeenCalledWith(expect.anything(), {
       pulseWindow: "today",
       storeId: "store-1",

--- a/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
+++ b/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
@@ -19,7 +19,6 @@ import {
   Receipt,
   Search,
   HandCoins,
-  ClipboardList,
   MonitorCheck,
 } from "lucide-react";
 import { useGetActiveOrganization } from "@/hooks/useGetOrganizations";
@@ -152,24 +151,6 @@ export default function PointOfSaleView() {
       available: Boolean(liveLinkParams),
     },
     {
-      title: "Active Sessions",
-      description: "Review active and held sales reserving inventory",
-      icon: ClipboardList,
-      href: "/$orgUrlSlug/store/$storeUrlSlug/pos/sessions" as const,
-      params: liveLinkParams,
-      color: "bg-cyan-600",
-      available: hasFullAdminAccess && Boolean(liveLinkParams),
-    },
-    {
-      title: "Terminal Health",
-      description: "Review checkout station sync, staff authority, and support signals",
-      icon: MonitorCheck,
-      href: "/$orgUrlSlug/store/$storeUrlSlug/pos/terminals" as const,
-      params: liveLinkParams,
-      color: "bg-emerald-600",
-      available: canAccessPOS() && Boolean(liveLinkParams),
-    },
-    {
       title: "Expense Reports",
       description: "View expense reports",
       icon: Receipt,
@@ -177,6 +158,16 @@ export default function PointOfSaleView() {
       params: liveLinkParams,
       color: "bg-yellow-500",
       available: Boolean(liveLinkParams),
+    },
+    {
+      title: "Terminal Health",
+      description:
+        "Review checkout station sync, staff authority, and support signals",
+      icon: MonitorCheck,
+      href: "/$orgUrlSlug/store/$storeUrlSlug/pos/terminals" as const,
+      params: liveLinkParams,
+      color: "bg-emerald-600",
+      available: canAccessPOS() && Boolean(liveLinkParams),
     },
     {
       title: "Customers",

--- a/packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.test.tsx
@@ -133,6 +133,20 @@ describe("ExpenseReportsView", () => {
     vi.useRealTimers();
   });
 
+  it("keeps the workspace header visible while expense reports load", () => {
+    useQueryMock.mockReturnValue(undefined);
+
+    render(<ExpenseReportsView />);
+
+    expect(
+      screen.getByRole("heading", { name: "Expense Reports" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Today" })).toBeInTheDocument();
+    expect(
+      screen.queryByText("No expense reports today"),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders expense reports in the workspace frame with back navigation", () => {
     useQueryMock.mockReturnValue([
       {

--- a/packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx
+++ b/packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx
@@ -152,8 +152,9 @@ export function ExpenseReportsView() {
     return tableData.filter((t) => isToday(t.completedAt));
   }, [tableData, filter, operatingDateStartAt]);
 
-  if (!activeStore || !expenseTransactions || !formatter) return null;
+  if (!activeStore || !formatter) return null;
 
+  const isLoadingExpenseReports = expenseTransactions === undefined;
   const hasReports = filteredData.length > 0;
 
   return (
@@ -207,7 +208,7 @@ export function ExpenseReportsView() {
               </TabsList>
             </Tabs>
 
-            {hasReports ? (
+            {isLoadingExpenseReports ? null : hasReports ? (
               <>
                 <div className="grid gap-layout-sm md:hidden">
                   {filteredData.map((report) => (

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
@@ -1029,7 +1029,7 @@ describe("TransactionView", () => {
     ).toBeDisabled();
   });
 
-  it("uses terminal staff proof when submitting completed sale voids without a reason", async () => {
+  it("requires a reason before submitting completed sale voids", async () => {
     const user = userEvent.setup();
     const authMutation = vi.fn().mockResolvedValue({
       kind: "ok",
@@ -1069,28 +1069,13 @@ describe("TransactionView", () => {
 
     await user.click(screen.getByRole("button", { name: "Void sale" }));
     await user.click(screen.getByRole("button", { name: "Submit void" }));
-    await user.click(screen.getByRole("button", { name: "Confirm" }));
 
     expect(authMutation).not.toHaveBeenCalled();
-    expect(terminalAuthMutation).toHaveBeenCalledWith({
-      allowedRoles: ["cashier", "manager"],
-      allowActiveSessionsOnOtherTerminals: true,
-      pinHash: "hashed:1234",
-      storeId: "store_1",
-      terminalId: "terminal_1",
-      username: "manager",
-    });
-    expect(voidMutation).toHaveBeenCalledWith({
-      actorStaffProfileId: "staff_terminal",
-      approvalProofId: undefined,
-      approvalRequestId: undefined,
-      staffProofToken: "proof-token-void",
-      transactionId: "txn_void_terminal",
-    });
-    expect(voidMutation.mock.calls[0]?.[0]).not.toHaveProperty("reason");
+    expect(terminalAuthMutation).not.toHaveBeenCalled();
+    expect(voidMutation).not.toHaveBeenCalled();
     expect(
-      screen.queryByText("Staff sign-in is required before voiding this sale"),
-    ).not.toBeInTheDocument();
+      screen.getByText("Reason is required before voiding this sale"),
+    ).toBeInTheDocument();
   });
 
   it("queues completed sale voids when the approval response includes an async request", async () => {

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
@@ -1360,6 +1360,11 @@ export function TransactionView() {
   }
 
   function requestVoidSubmit() {
+    if (!voidReason.trim()) {
+      setVoidError("Reason is required before voiding this sale");
+      return;
+    }
+
     setVoidError(null);
     setPendingCorrection("void");
   }
@@ -1646,8 +1651,7 @@ export function TransactionView() {
                           Void completed sale
                         </h2>
                         <p className="text-sm leading-6 text-muted-foreground">
-                          Staff sign-in and manager approval are required. The
-                          original sale stays visible for audit.
+                          Staff sign-in and manager approval are required.
                         </p>
                       </div>
                     </div>
@@ -1656,9 +1660,11 @@ export function TransactionView() {
                   <div className="space-y-3 p-5">
                     <Textarea
                       aria-label="Void reason"
+                      aria-required="true"
                       className="min-h-[90px] border-input bg-background"
                       onChange={(event) => setVoidReason(event.target.value)}
-                      placeholder="Optional reason for voiding this completed sale."
+                      placeholder="Reason for voiding this completed sale."
+                      required
                       value={voidReason}
                     />
                     {voidError ? (

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx
@@ -144,6 +144,26 @@ describe("TransactionsView", () => {
     useSearchMock.mockReturnValue({});
   });
 
+  it("keeps the workspace header visible while completed transactions load", () => {
+    getActiveStoreMock.mockReturnValue({
+      activeStore: {
+        _id: "store-1",
+        currency: "GHS",
+      },
+    });
+    useQueryMock.mockReturnValue(undefined);
+
+    render(<TransactionsView />);
+
+    expect(
+      screen.getByRole("heading", { name: "Completed Transactions" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Today" })).toBeInTheDocument();
+    expect(
+      screen.queryByText("No completed transactions today"),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not render session traces on the completed transactions surface", () => {
     getActiveStoreMock.mockReturnValue({
       activeStore: {

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx
@@ -487,8 +487,9 @@ export function TransactionsView() {
     transactions,
   ]);
 
-  if (!activeStore || !transactions || !formatter) return null;
+  if (!activeStore || !formatter) return null;
 
+  const isLoadingTransactions = transactions === undefined;
   const hasTransactions = filteredData.length > 0;
 
   return (
@@ -508,7 +509,7 @@ export function TransactionsView() {
                 Showing {activeFilterSummary}
               </div>
             ) : null}
-            {isTransactionBatchFull ? (
+            {!isLoadingTransactions && isTransactionBatchFull ? (
               <div className="flex flex-col gap-layout-sm rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
                 <span>
                   Showing latest {loadedLimit.toLocaleString()} completed
@@ -542,7 +543,7 @@ export function TransactionsView() {
               </TabsList>
             </Tabs>
 
-            {hasTransactions ? (
+            {isLoadingTransactions ? null : hasTransactions ? (
               <>
                 <div className="grid gap-layout-sm md:hidden">
                   {filteredData.map((transaction) => (

--- a/packages/athena-webapp/src/components/store-pulse/StorePulseSummaryView.tsx
+++ b/packages/athena-webapp/src/components/store-pulse/StorePulseSummaryView.tsx
@@ -31,6 +31,7 @@ import { Tabs, TabsList, TabsTrigger } from "../ui/tabs";
 export type StorePulseTrendDay = {
   averageTransaction: number;
   date: string;
+  hasKnownItemCount?: boolean;
   label: string;
   totalItemsSold: number;
   totalSales: number;
@@ -138,6 +139,7 @@ const detailCardClassName =
   "overflow-hidden rounded-lg border border-border bg-surface-raised shadow-surface";
 const detailRowClassName = "px-layout-md py-layout-sm";
 const topItemsPageSize = 5;
+const salesTrendAxisInset = 72;
 const chartAxisDateFormatter = new Intl.DateTimeFormat("en-US", {
   day: "numeric",
   month: "short",
@@ -366,7 +368,7 @@ function StorePulseTimeline({
         >
           <AreaChart
             data={chartData}
-            margin={{ left: 0, right: 0, top: 0, bottom: 0 }}
+            margin={{ left: 0, right: salesTrendAxisInset, top: 0, bottom: 0 }}
           >
             <defs>
               <linearGradient
@@ -398,7 +400,7 @@ function StorePulseTimeline({
               ticks={xAxisTicks}
             />
             <YAxis
-              width={72}
+              width={salesTrendAxisInset}
               axisLine={false}
               tickLine={false}
               tickFormatter={(value) =>
@@ -439,8 +441,13 @@ function StorePulseTimeline({
                           {formatEntityCount(
                             day.transactionCount,
                             "transaction",
-                          )}{" "}
-                          · {formatEntityCount(day.totalItemsSold, "item")}
+                          )}
+                          {day.hasKnownItemCount === false ? null : (
+                            <>
+                              {" "}
+                              · {formatEntityCount(day.totalItemsSold, "item")}
+                            </>
+                          )}
                         </span>
                       </div>
                     );
@@ -470,10 +477,12 @@ function TopItemsPanel({
   canViewFinancialDetails,
   currencyFormatter,
   snapshot,
+  title = "Top items",
 }: {
   canViewFinancialDetails: boolean;
   currencyFormatter: Intl.NumberFormat;
   snapshot: StorePulseOperatorSnapshot;
+  title?: string;
 }) {
   const [page, setPage] = useState(1);
   const topItemCount = snapshot.topItems.length;
@@ -491,7 +500,7 @@ function TopItemsPanel({
     <section className="space-y-layout-md">
       <div className="flex flex-col gap-layout-xs sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h3 className="text-base font-medium text-foreground">Top items</h3>
+          <h3 className="text-base font-medium text-foreground">{title}</h3>
           <p className="mt-1 text-sm text-muted-foreground">
             Highest-volume items in the current history window.
           </p>
@@ -738,9 +747,11 @@ function StorePulseDetailSkeleton({
 function StorePulseSkeleton({
   showFinancialSalesCards,
   showSummaryMetrics,
+  topItemsTitle = "Top items",
 }: {
   showFinancialSalesCards: boolean;
   showSummaryMetrics: boolean;
+  topItemsTitle?: string;
 }) {
   const visibleLoadingMetrics = showFinancialSalesCards
     ? loadingMetrics
@@ -774,7 +785,7 @@ function StorePulseSkeleton({
             <StorePulseDetailSkeleton
               description="Highest-volume items in the current history window."
               rowCount={5}
-              title="Top items"
+              title={topItemsTitle}
             />
           </PageWorkspaceMain>
 
@@ -799,6 +810,7 @@ export function StorePulseSummaryView({
   showPulseWindowFilter = true,
   showSummaryMetrics = true,
   summary,
+  topItemsTitle = "Top items",
 }: {
   canViewFinancialDetails: boolean;
   currencyFormatter: Intl.NumberFormat;
@@ -807,6 +819,7 @@ export function StorePulseSummaryView({
   showPulseWindowFilter?: boolean;
   showSummaryMetrics?: boolean;
   summary: StorePulseSummary | undefined;
+  topItemsTitle?: string;
 }) {
   const snapshot = summary?.operatorSnapshot;
   const comparison = snapshot?.comparison;
@@ -860,6 +873,7 @@ export function StorePulseSummaryView({
         <StorePulseSkeleton
           showFinancialSalesCards={canViewFinancialDetails}
           showSummaryMetrics={showSummaryMetrics}
+          topItemsTitle={topItemsTitle}
         />
       ) : (
         <div className="min-w-0 space-y-layout-xl md:space-y-layout-2xl">
@@ -965,6 +979,7 @@ export function StorePulseSummaryView({
                   canViewFinancialDetails={canViewFinancialDetails}
                   currencyFormatter={currencyFormatter}
                   snapshot={snapshot}
+                  title={topItemsTitle}
                 />
               </PageWorkspaceMain>
 


### PR DESCRIPTION
## Summary
- exclude archived legacy import products and SKUs from POS/catalog sale flows while preserving archived management visibility
- refine Daily Operations workflow, approval, automation, loading, and store-pulse composition
- paginate Opening review carry-forward evidence and document the reusable visibility boundary

## Validation
- bun run pr:athena
- root pre-push validation suite passed before branch-protection rejection of direct main push

Browser validation left to Kwamina.