### PR TITLE
[V26-845/V26-846/V26-847/V26-848/V26-849/V26-850]: POS closeout review-only lifecycle

### DIFF
--- a/docs/plans/2026-06-24-001-fix-pos-closeout-rejected-lifecycle-plan.html
+++ b/docs/plans/2026-06-24-001-fix-pos-closeout-rejected-lifecycle-plan.html
@@ -1,0 +1,265 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>fix: Add POS Closeout Rejected Lifecycle</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fa;
+      --panel: #ffffff;
+      --text: #17202a;
+      --muted: #5d6975;
+      --line: #d9dee5;
+      --accent: #176b87;
+      --accent-soft: #e6f3f6;
+      --warn-soft: #fff5df;
+      --code: #eef1f4;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 32px 20px 56px;
+    }
+    header, nav, section {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 20px;
+      margin: 16px 0;
+    }
+    header { padding: 24px; margin-bottom: 18px; }
+    h1, h2, h3 { line-height: 1.2; margin: 0; }
+    h1 { font-size: 30px; }
+    h2 { font-size: 20px; margin-bottom: 12px; }
+    h3 { font-size: 16px; margin: 16px 0 8px; }
+    p { margin: 8px 0 0; }
+    a { color: var(--accent); }
+    code {
+      background: var(--code);
+      border-radius: 4px;
+      padding: 1px 5px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.92em;
+    }
+    nav ul { columns: 2; margin: 10px 0 0; padding-left: 20px; }
+    ul { margin: 8px 0 0; padding-left: 20px; }
+    li { margin: 5px 0; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 10px;
+      font-size: 14px;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 8px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: #f1f4f7; }
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 14px;
+    }
+    .pill {
+      background: var(--accent-soft);
+      color: #0f5068;
+      border-radius: 999px;
+      padding: 4px 10px;
+      font-size: 13px;
+      font-weight: 600;
+    }
+    .callout {
+      background: var(--warn-soft);
+      border: 1px solid #ead59e;
+      border-radius: 8px;
+      padding: 12px 14px;
+      margin-top: 10px;
+    }
+    .unit {
+      border-top: 1px solid var(--line);
+      padding-top: 14px;
+      margin-top: 14px;
+    }
+    .unit:first-child { border-top: 0; padding-top: 0; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 12px;
+    }
+    .card {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px;
+      background: #fbfcfd;
+    }
+    .muted { color: var(--muted); }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>fix: Add POS Closeout Rejected Lifecycle</h1>
+      <p>Add a distinct <code>closeout_rejected</code> state so rejected variance closeouts stay reviewable while POS opens future sales against a replacement register session.</p>
+      <div class="meta">
+        <span class="pill">type: fix</span>
+        <span class="pill">status: active</span>
+        <span class="pill">date: 2026-06-24</span>
+        <span class="pill">deepened: 2026-06-24</span>
+      </div>
+      <p class="muted">Canonical source: <a href="./2026-06-24-001-fix-pos-closeout-rejected-lifecycle-plan.md">2026-06-24-001-fix-pos-closeout-rejected-lifecycle-plan.md</a></p>
+    </header>
+
+    <nav aria-label="Table of contents">
+      <h2>Contents</h2>
+      <ul>
+        <li><a href="#problem">Problem</a></li>
+        <li><a href="#requirements">Requirements</a></li>
+        <li><a href="#decisions">Key Decisions</a></li>
+        <li><a href="#matrix">Lifecycle Matrix</a></li>
+        <li><a href="#units">Implementation Units</a></li>
+        <li><a href="#impact">System Impact</a></li>
+        <li><a href="#risks">Risks</a></li>
+      </ul>
+    </nav>
+
+    <section id="problem">
+      <h2>Problem</h2>
+      <p>Rejected variance closeouts currently have a path that patches the register session back to <code>active</code>, clearing counted-cash evidence and making the drawer look usable in POS.</p>
+      <div class="callout">
+        <strong>Scope note:</strong> this plan supersedes the earlier no-new-status assumption. It deliberately does not implement settlement commands; <code>closeout_rejected</code> blocks Daily Close until explicit follow-up resolves it.
+      </div>
+    </section>
+
+    <section id="requirements">
+      <h2>Requirements</h2>
+      <ul>
+        <li>Rejected variance closeouts enter <code>closeout_rejected</code>, not <code>active</code>.</li>
+        <li>Review-only sessions are never POS-sale-usable and cannot receive ordinary sale/session bindings.</li>
+        <li>Evidence remains visible in Cash Controls, Daily Close, Daily Operations, workflow traces, and POS review gates.</li>
+        <li>POS offers opening a replacement register session after closeout submission, including variance closeouts still in review; the old register-session id remains non-reusable for sales.</li>
+        <li>Schema, DTO, public API, local read-model, and terminal-runtime compatibility ships before mutations write the new state.</li>
+        <li>Historical repair starts as a read-only dry-run audit, not an automatic write.</li>
+      </ul>
+    </section>
+
+    <section id="decisions">
+      <h2>Key Decisions</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>Status Name</h3>
+          <p>Use <code>closeout_rejected</code> because it matches prior session context and existing trace language.</p>
+        </article>
+        <article class="card">
+          <h3>Sale Policy</h3>
+          <p>Only <code>open</code> and <code>active</code> remain sale-usable. Reviewed replay cannot create, bind, update, or cash-record sales against <code>closed</code> or <code>closeout_rejected</code>.</p>
+        </article>
+        <article class="card">
+          <h3>Replacement Drawer</h3>
+          <p>A submitted closeout in <code>closing</code> or a rejected closeout in <code>closeout_rejected</code> cannot sell, but a new register session may open for the same terminal/register.</p>
+        </article>
+        <article class="card">
+          <h3>Evidence</h3>
+          <p>Canonical evidence spans session status, approval decision, sync conflict/event, operational event, and trace context.</p>
+        </article>
+        <article class="card">
+          <h3>Synced Rejection</h3>
+          <p>General <code>active -> closeout_rejected</code> is invalid; the synced path requires scoped reviewed local closeout evidence.</p>
+        </article>
+        <article class="card">
+          <h3>Daily Close</h3>
+          <p><code>closeout_rejected</code> is an unresolved blocker, not active work or closed financial evidence.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="matrix">
+      <h2>Lifecycle Matrix</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Status</th>
+            <th>POS sale usable</th>
+            <th>Cash Controls visible</th>
+            <th>POS state visible</th>
+            <th>Blocks replacement drawer</th>
+            <th>Daily Close treatment</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td><code>open</code></td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Active register work</td></tr>
+          <tr><td><code>active</code></td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Active register work</td></tr>
+          <tr><td><code>closing</code></td><td>No</td><td>Yes</td><td>Yes</td><td>No after closeout submission; yes only before the closeout packet exists</td><td>Closeout in progress / pending review</td></tr>
+          <tr><td><code>closeout_rejected</code></td><td>No</td><td>Yes</td><td>Review-only gate</td><td>No for a new register session</td><td>Blocking unresolved review work</td></tr>
+          <tr><td><code>closed</code></td><td>No</td><td>Historical/detail</td><td>Recent context only</td><td>No</td><td>Closed register evidence</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="units">
+      <h2>Implementation Units</h2>
+      <article class="unit">
+        <h3>U1. Define Closeout-Rejected Status Policy</h3>
+        <p>Add status policy plus schema, DTO, local read-model, public terminal/register, and terminal-runtime compatibility before writes, with tests proving submitted <code>closing</code> closeouts and <code>closeout_rejected</code> do not block replacement.</p>
+      </article>
+      <article class="unit">
+        <h3>U2. Persist Rejected Variance Closeouts As Review-Only</h3>
+        <p>Move rejection paths to <code>closeout_rejected</code> atomically while preserving approval, sync, operational, and trace evidence.</p>
+      </article>
+      <article class="unit">
+        <h3>U3. Expose Review-Only Sessions In Cash Controls, Daily Close, And Daily Operations</h3>
+        <p>Show rejected closeouts as unresolved review work and Daily Close blockers, not active drawers or settled closed sessions.</p>
+      </article>
+      <article class="unit">
+        <h3>U4. Make POS Gate Review-Only Sessions And Offer Replacement Opening</h3>
+        <p>Select submitted <code>closing</code> and rejected review-only sessions for drawer gate context while sale ids attach only to the replacement sale-usable session.</p>
+      </article>
+      <article class="unit">
+        <h3>U5. Harden Sale Attachment And Sync Projection Boundaries</h3>
+        <p>Route direct, stale, and local/offline sale paths through shared POS usability policy, including pending checkout, payment correction, and reviewed replay against closed/rejected sessions.</p>
+      </article>
+      <article class="unit">
+        <h3>U6. Address Historical Repair And Operational Handoff</h3>
+        <p>Document forward-only behavior or produce a read-only repair audit before any migration decision; rebuild Graphify after code changes.</p>
+      </article>
+    </section>
+
+    <section id="impact">
+      <h2>System Impact</h2>
+      <ul>
+        <li>Status policy affects schema validators, Cash Controls, POS register state, local sync projection, sale commands, Daily Close, Daily Operations, terminal runtime status, and traces.</li>
+        <li>Manager rejection must settle source sync event, conflict row, session status, operational event, and trace consistently.</li>
+        <li>Runtime status remains evidence, not authority.</li>
+      </ul>
+    </section>
+
+    <section id="risks">
+      <h2>Risks</h2>
+      <table>
+        <thead>
+          <tr><th>Risk</th><th>Mitigation</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>DTO/schema misses the new status</td><td>U1 updates schemas, DTOs, local read models, public APIs, terminal runtime validators, and tests.</td></tr>
+          <tr><td>Writers deploy before readers</td><td>Compatibility-first sequencing is an explicit requirement and implementation unit constraint.</td></tr>
+          <tr><td>Review-only sessions disappear from review surfaces</td><td>U3 adds Cash Controls, Daily Close, and Daily Operations tests.</td></tr>
+          <tr><td>Stale clients attach sales to rejected drawers</td><td>U5 hardens command and sync projection boundaries, including pending checkout and payment correction.</td></tr>
+          <tr><td>Evidence or atomicity is lost during rejection</td><td>U2 requires preserved evidence and split-brain regression tests.</td></tr>
+          <tr><td>Daily Close treats the rejected closeout as closed evidence</td><td>U3 defines it as a blocker outside closed counts and settled cash totals.</td></tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-06-24-001-fix-pos-closeout-rejected-lifecycle-plan.md
+++ b/docs/plans/2026-06-24-001-fix-pos-closeout-rejected-lifecycle-plan.md
@@ -1,0 +1,459 @@
+---
+title: "fix: Add POS Closeout Rejected Lifecycle"
+type: fix
+status: active
+date: 2026-06-24
+deepened: 2026-06-24
+---
+
+# fix: Add POS Closeout Rejected Lifecycle
+
+## Summary
+
+Add a distinct `closeout_rejected` register-session lifecycle state for variance closeouts that a manager rejects. The rejected drawer remains reviewable in Cash Controls, Daily Close, Daily Operations, workflow traces, and POS review gates, while POS treats it as non-sale-usable and opens future sales against a replacement register session.
+
+---
+
+## Problem Frame
+
+Rejected variance closeouts currently have a path that patches the register session back to `active`, clearing counted-cash evidence and making the drawer look usable in POS. That creates two risks at once: operators lose the evidence behind the manager rejection, and stale clients can attach new sales to a drawer whose closeout was already submitted for review.
+
+---
+
+## Requirements
+
+- R1. Rejected variance closeouts must enter a persisted review-only lifecycle state, not `active`.
+- R2. `closeout_rejected` sessions must never be POS-sale-usable and must not receive new ordinary sale/session bindings.
+- R3. `closeout_rejected` sessions must remain visible in Cash Controls, Daily Close, Daily Operations, workflow traces, and POS review affordances.
+- R4. Rejection must preserve review evidence: counted cash, expected cash, variance, notes, approval/request context, local sync event context, operational event context, and trace context.
+- R5. POS must offer opening a new register session after closeout submission, including a variance closeout still awaiting review, instead of making the submitted/rejected session look reusable.
+- R6. A replacement drawer/session may open for the same terminal/register after a prior session has submitted a closeout, including a variance closeout still in `closing`, while the prior register-session id remains non-reusable for sales.
+- R7. Sale attachment protections must live at command/projection boundaries, not only in frontend gates.
+- R8. Daily Close must treat `closeout_rejected` as unresolved review work, not as an active drawer and not as a settled closed drawer.
+- R9. Historical repair/backfill must be explicit and conservative; do not infer old bad states unless reliable rejection evidence exists.
+- R10. Implementation must refresh Graphify after modifying code files.
+- R11. Compatibility must be deployed before writes: validators, DTOs, local read models, public APIs, and terminal runtime status surfaces must accept `closeout_rejected` before any mutation can persist it.
+
+---
+
+## Scope Boundaries
+
+- This plan does not redesign the manager approval model, staff proof consumption, or Cash Controls authority rules.
+- This plan supersedes only the earlier assumption in `docs/plans/2026-06-23-001-refactor-pos-register-lifecycle-policy-plan.md` that no new register-session status would be introduced.
+- This plan intentionally does not implement first-class settlement/correction commands. `closeout_rejected` blocks Daily Close completion until a later explicit settlement/correction action resolves it.
+- This plan does not make runtime terminal status authoritative for sales. Runtime status remains evidence and diagnostics.
+- This plan does not automatically backfill production sessions. Any repair must start with a read-only dry-run report and a separate decision.
+
+### Deferred Follow-Up Work
+
+- First-class settlement/correction commands that move `closeout_rejected` to a resolved state.
+- Broader POS hub copy for every terminal lifecycle state beyond this closeout-rejected path.
+- Production repair/backfill for historical wrongly-active rejected closeouts, unless reliable operational-event evidence makes a narrow repair safe during implementation.
+- Cleanup of status labels in terminal health and cash-control tables beyond labels touched by this behavior.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/shared/registerSessionStatus.ts` owns the durable status vocabulary and policy status sets.
+- `packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts` centralizes sale usability, drawer-authority blocking, replacement-drawer eligibility, and closeout-review conflict classification.
+- `packages/athena-webapp/convex/schemas/operations/registerSession.ts` validates persisted register-session statuses.
+- `packages/athena-webapp/convex/cashControls/deposits.ts` contains the synced closeout rejection path that currently patches `status: "active"` and clears closeout evidence.
+- `packages/athena-webapp/convex/cashControls/closeouts.ts` handles direct async variance closeout review and already records `closeout_rejected` trace/evidence.
+- `packages/athena-webapp/convex/operations/registerSessions.ts` owns status transitions, register-state lookup, open-drawer conflict detection, and register transaction cash recording.
+- `packages/athena-webapp/convex/operations/dailyClose.ts` treats `open | active | closing` as active operational work and separately summarizes closed register sessions.
+- `packages/athena-webapp/convex/operations/dailyOperations.ts` hard-codes daily operation register status grouping and must include the new review-only state.
+- `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts` already distinguishes sale-usable active register sessions from closeout/review gate state, but `selectPassiveCloseoutBlockedRegisterSession()` is a null stub.
+- `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts` already validates direct sale completion against POS-usable register status.
+- `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts` handles offline/local event projection, closed-register replay exceptions, duplicate closeout conflicts, and reviewed sale projection.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md`: keep drawer lifecycle decisions in a pure shared policy and distinguish reuse of the current drawer from opening a replacement drawer.
+- `docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md`: UI gates are not sufficient; drawer invariants must be enforced at Convex command boundaries.
+- `docs/solutions/logic-errors/athena-pos-register-sync-closeout-review-recovery-2026-05-23.md`: closeout review approval/rejection must settle the source local sync event, not only the review row, while preserving closeout evidence.
+- `docs/solutions/logic-errors/athena-pos-synced-closeout-readiness-2026-06-17.md`: do not clear history to unblock POS; preserve closeout evidence and interpret it correctly.
+- `docs/solutions/logic-errors/athena-cash-controls-closeout-review-ia-2026-06-08.md`: closeout review should be presented as a decision packet with expected cash, counted cash, variance direction, and staff note.
+- `docs/solutions/logic-errors/athena-pos-drawer-authority-replacement-recovery-2026-06-06.md`: drawer authority is local-register-session scoped; a replacement open can clear older recoverable blocks without making the old drawer sale-usable.
+- `docs/solutions/logic-errors/athena-daily-close-store-day-boundary-2026-05-07.md`: Daily Close must re-read readiness server-side and block unresolved register/POS work before completion.
+
+---
+
+## Key Technical Decisions
+
+- **Status name:** Use `closeout_rejected`, matching prior session discussion and existing trace vocabulary.
+- **Sale usability:** Only `open | active` remain POS-sale-usable. `closeout_rejected`, `closing`, and `closed` cannot receive ordinary sale/session attachments.
+- **Replacement eligibility:** A submitted closeout in `closing` and a rejected closeout in `closeout_rejected` do not conflict-block a replacement register session for the same terminal/register. The prior session remains review-visible, not sale-usable.
+- **Compatibility sequencing:** Ship schema, DTO, public API, local read-model, and terminal-runtime acceptance before any mutation writes the new status.
+- **Evidence preservation:** Do not clear `countedCash`, `expectedCash`, `variance`, `notes`, approval context, source sync event context, operational event context, or trace context.
+- **Canonical evidence shape:** Treat canonical rejection evidence as the tuple of register-session status, approval request/decision, source sync conflict/event, operational event, and register-session trace. A separate append-only closeout record may be added only if implementation finds an existing local pattern that makes it cheap and safer.
+- **Evidence-backed synced rejection transition:** General `active -> closeout_rejected` is invalid. The synced `register_closed` rejection path may move an `active` cloud session to `closeout_rejected` only through a narrow helper that requires scoped, reviewed local closeout evidence for that exact register session.
+- **Reviewed replay exception:** Manager-reviewed historical replay must never create, bind, or update any sale/register transaction against `closed` or `closeout_rejected`. It may only preserve conflict/review evidence linked to those sessions.
+- **Daily Close semantics:** `closeout_rejected` is an unresolved blocker. It is neither active register work nor closed-register evidence, and Daily Close cannot complete until explicit settlement/correction follow-up resolves it.
+- **Historical repair:** Base delivery is forward-only. A dry-run audit may report candidates; no write repair ships without reliable evidence and separate approval.
+
+---
+
+## Lifecycle Model
+
+```mermaid
+stateDiagram-v2
+  [*] --> open: drawer opened
+  open --> active: first sale/cash activity
+  open --> closing: closeout submitted
+  active --> closing: closeout submitted
+  active --> closeout_rejected: synced rejection with reviewed local closeout evidence only
+  closing --> closed: closeout approved/applied
+  closing --> closeout_rejected: variance closeout rejected
+  closed --> closing: explicit manager reopen for correction
+
+  note right of open
+    POS sale-usable
+  end note
+  note right of active
+    POS sale-usable
+  end note
+  note right of closing
+    Review-visible, no sales,
+    replacement drawer may open
+  end note
+  note right of closeout_rejected
+    Review-visible, no sales,
+    replacement drawer may open,
+    Daily Close blocker
+  end note
+  note right of closed
+    Historical, no sales
+  end note
+```
+
+### Lifecycle Policy Matrix
+
+| Status | POS sale usable | Cash Controls visible | Register-state visible in POS | Blocks replacement drawer | Daily Close treatment |
+| --- | --- | --- | --- | --- | --- |
+| `open` | Yes | Yes | Yes | Yes | Active register work |
+| `active` | Yes | Yes | Yes | Yes | Active register work |
+| `closing` | No | Yes | Yes | No after closeout submission; yes only before the closeout packet exists | Closeout in progress / pending review |
+| `closeout_rejected` | No | Yes | Yes as review-only gate | No for a new register session | Blocking unresolved review work |
+| `closed` | No | Historical/detail | Sometimes for recent context | No | Closed register evidence |
+
+---
+
+## Implementation Units
+
+### U1. Define Closeout-Rejected Status Policy
+
+**Goal:** Add the persisted `closeout_rejected` status and shared behavior policies that every caller can consume.
+
+**Requirements:** R1, R2, R3, R6, R11
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/shared/registerSessionStatus.ts`
+- Modify: `packages/athena-webapp/shared/registerSessionStatus.test.ts`
+- Modify: `packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts`
+- Modify: `packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts`
+- Modify: `packages/athena-webapp/convex/schemas/operations/registerSession.ts`
+- Modify: `packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts`
+- Modify: `packages/athena-webapp/convex/pos/domain/types.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/terminals.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/terminals.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/register.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/register.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/application/dto.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts`
+
+**Approach:**
+- Add `closeout_rejected` to the durable status vocabulary and schema validators.
+- Keep review-only submitted closeouts, including `closing` with a closeout packet and `closeout_rejected`, out of POS-usable statuses and open-drawer conflict-blocking statuses.
+- Add or update behavior-specific helpers for review visibility, Daily Close blocker visibility, and replacement drawer eligibility.
+- Update DTO/runtime validators before any mutation writes the new status.
+
+**Test scenarios:**
+- `open` and `active` remain POS-sale-usable.
+- `closeout_rejected` is valid, cash-control/review visible, and not POS-sale-usable.
+- `closing` with a submitted closeout packet and `closeout_rejected` do not conflict-block replacement drawer opening.
+- Unknown status strings still fail every schema/DTO/public-terminal validator.
+- Public terminal/register responses and local read models accept and preserve `closeout_rejected` while rejecting unknown statuses.
+
+**Verification:** Shared status, lifecycle-policy, public API, and local runtime/read-model tests prove the new status matrix before mutation or UI work depends on it.
+
+### U2. Persist Rejected Variance Closeouts As Review-Only
+
+**Goal:** Move rejected closeout paths to `closeout_rejected` while preserving counted-cash and variance evidence atomically.
+
+**Requirements:** R1, R3, R4, R11
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/registerSessions.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.ts`
+- Test: `packages/athena-webapp/convex/cashControls/registerSessions.test.ts`
+- Test: `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+- Test: `packages/athena-webapp/convex/cashControls/closeouts.test.ts`
+- Test: `packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts`
+
+**Approach:**
+- Add transition helpers for `closing -> closeout_rejected` and for the narrow evidence-backed synced rejection path from `active -> closeout_rejected`.
+- Update the synced closeout review rejection branch in `deposits.ts` so it no longer patches the session to `active` or clears evidence.
+- Update direct async variance closeout rejection in `closeouts.ts` to leave the session in the explicit rejected state rather than relying only on approval request status and trace evidence.
+- Keep duplicate closeout rejection semantics separate so duplicate evidence does not mutate unrelated already-closed sessions.
+- Make the manager rejection action atomic across approval decision, source sync event/conflict row, register-session status, operational event, and trace milestone.
+
+**Test scenarios:**
+- Rejecting a variance closeout review patches the session to `closeout_rejected`.
+- Rejecting a synced variance closeout keeps counted cash, expected cash, variance, notes, approval/sync context, and trace context.
+- Duplicate closeout evidence does not mutate an unrelated already-closed session to `closeout_rejected`.
+- General transition into `closeout_rejected` from `open`, ordinary `active`, or `closed` fails.
+- Evidence-backed `active -> closeout_rejected` succeeds only when scoped reviewed `register_closed` evidence exists.
+- Simulated failure paths do not leave split-brain state where review/sync rows are settled but the session remains sale-usable.
+- The existing "reopens drawers left closing by rejected variance closeout reviews" regression expects review-only evidence and replacement eligibility, not `active`; POS does not need to wait for rejection to open the replacement once the closeout packet exists.
+
+**Verification:** Cash-control backend tests prove rejected variance closeouts no longer return to `active`, no longer lose evidence, and cannot partially settle review metadata without session lifecycle alignment.
+
+### U3. Expose Review-Only Sessions In Cash Controls, Daily Close, And Daily Operations
+
+**Goal:** Keep `closeout_rejected` visible as unresolved review work without counting it as active sales work or completed closeout history.
+
+**Requirements:** R3, R4, R8
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.ts`
+- Modify: `packages/athena-webapp/convex/operations/dailyClose.ts`
+- Modify: `packages/athena-webapp/convex/operations/dailyOperations.ts`
+- Modify: `packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx`
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`
+- Modify: `packages/athena-webapp/src/components/cash-controls/registerSessionColumns.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/DailyCloseView.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/DailyOperationsView.tsx`
+- Test: `packages/athena-webapp/convex/cashControls/registerSessions.test.ts`
+- Test: `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyClose.test.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyOperations.test.ts`
+- Test: `packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx`
+- Test: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+- Test: `packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx`
+- Test: `packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx`
+
+**Approach:**
+- Update closeout snapshot queries/lists to include `closeout_rejected` in review/variance work surfaces.
+- Query `closeout_rejected` sessions directly for Daily Close readiness by store/day/status instead of relying on pending approval requests.
+- Define Daily Close summary treatment: rejected closeouts appear as unresolved blocker rows with counted/expected/variance evidence, do not increment closed register counts, do not contribute as settled `expectedCashTotal`, and should be called out separately from active drawer counts.
+- Update Daily Operations register-status grouping so the status is visible in timeline/operation context.
+- Keep completed Daily Close snapshots historical; do not recompute old completed snapshots just because the new status exists.
+
+**Test scenarios:**
+- Cash Controls dashboard shows a `closeout_rejected` session in unresolved variance/review work.
+- Register detail shows rejected closeout evidence, variance, counted cash, notes, and timeline context.
+- `closeout_rejected` does not appear as a live sellable drawer or as completed closeout history.
+- Daily Close readiness finds a `closeout_rejected` session even when the approval request is no longer pending.
+- Daily Close completion is blocked until settlement/correction follow-up resolves the status.
+- Daily Operations surfaces the rejected closeout as review work, not a healthy closed drawer.
+- Completed Daily Close snapshot history is not rewritten.
+
+**Verification:** Cash Controls, Daily Close, and Daily Operations tests prove review-only sessions are visible and correctly categorized.
+
+### U4. Make POS Gate Review-Only Sessions And Offer Replacement Opening
+
+**Goal:** Ensure POS shows the rejected drawer as review-only and routes continued selling through a newly opened register session.
+
+**Requirements:** R2, R3, R5, R6
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/registerSessions.ts`
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts`
+- Modify: `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx`
+- Test: `packages/athena-webapp/convex/pos/application/getRegisterState.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sessionCommands.test.ts`
+- Test: `packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx`
+
+**Approach:**
+- Keep open-register reuse paths limited to sale-usable sessions.
+- Update register-state/repository mapping so POS can see `closeout_rejected` as drawer context for review/gate presentation.
+- Replace the `selectPassiveCloseoutBlockedRegisterSession()` null stub with a selector that chooses non-sale-usable review sessions when they should drive the drawer gate.
+- Keep `activeRegisterSessionId` derived only from `saleUsableActiveRegisterSession`.
+- Ensure the drawer gate action makes opening a new drawer the primary path for continued sales while preserving compact review context for the rejected closeout.
+
+**Test scenarios:**
+- POS register state with `closeout_rejected` does not produce a sale-usable `activeRegisterSessionId`.
+- POS drawer gate presents a path to open a replacement drawer/session after a variance closeout is submitted, even while the prior session remains `closing` for review.
+- A newly opened replacement drawer becomes the sale-usable register session while the old `closing` or `closeout_rejected` drawer remains review-only context.
+- Full sequence: variance closeout submitted, old session becomes review-only `closing`, replacement drawer opens, pending checkout/session/sale uses replacement id, manager later rejects the old closeout into `closeout_rejected`, and the old session receives no sale mutation.
+- POS review chips/evidence remain visible enough to explain why the old drawer is paused.
+
+**Verification:** POS tests prove rejected/closed review-only sessions are visible as gate context but cannot become sale attachment targets.
+
+### U5. Harden Sale Attachment And Sync Projection Boundaries
+
+**Goal:** Prevent direct, stale, and offline/local sync paths from attaching ordinary sales to `closeout_rejected` or `closed` sessions.
+
+**Requirements:** R2, R6, R7
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/registerSessions.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/expenseSessionCommands.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/catalog.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/transactions.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sessionCommands.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/completeTransaction.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/adjustTransactionItems.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/correctTransaction.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/correctTransactionPaymentMethod.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.test.ts`
+- Test: `packages/athena-webapp/convex/pos/public/catalog.test.ts`
+- Test: `packages/athena-webapp/convex/pos/public/transactions.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts`
+
+**Approach:**
+- Replace ad hoc sale guards such as `status === "closing" || status === "closed"` or `status !== "open" && status !== "active"` with shared POS usability policy where the action is ordinary sale/session attachment.
+- Keep reviewed historical projection exceptions explicit and scoped to conflict evidence. Reviewed replay must never create, bind, or update any sale/register transaction against `closed` or `closeout_rejected`; those sessions may only receive conflict/review evidence.
+- Ensure `recordRegisterSessionTransaction` rejects sale adjustments on any non-POS-usable status.
+- Ensure item adjustment, payment correction, pending checkout, catalog readiness, and transaction public API paths either reject `closeout_rejected` or intentionally operate only on already-completed historical sales without mutating the rejected drawer as a live sale target.
+
+**Test scenarios:**
+- Ordinary sale completion still succeeds for `open` and `active`.
+- Ordinary sale completion with `closeout_rejected` returns a precondition failure.
+- POS session start/resume/bind rejects a preferred or existing `closeout_rejected` register session.
+- Pending checkout does not bind ordinary sale context to a rejected drawer.
+- `recordRegisterSessionTransaction` rejects sale cash recording for `closeout_rejected`.
+- Payment correction/adjustment paths that require an open drawer reject `closeout_rejected` through the same policy.
+- Local/offline `sale_completed` against a `closeout_rejected` drawer creates or preserves review work instead of projecting ordinary sale attachment.
+- Reviewed `sale_completed` replay against `closed` preserves conflict/review evidence only and does not create, bind, update, or cash-record a sale/register transaction against the closed session.
+- Reviewed `sale_completed` replay against `closeout_rejected` preserves conflict/review evidence only and does not create, bind, update, or cash-record a sale/register transaction against the rejected session.
+
+**Verification:** Backend command/projection tests prove stale clients and local sync cannot attach new sales to rejected or closed drawers.
+
+### U6. Address Historical Repair And Operational Handoff
+
+**Goal:** Make the rollout safe for existing data and ensure future implementers know whether backfill is required.
+
+**Requirements:** R4, R8, R9, R10
+
+**Dependencies:** U1, U2, U3, U4, U5
+
+**Files:**
+- Modify: `docs/solutions/logic-errors/athena-pos-register-sync-closeout-review-recovery-2026-05-23.md` if implementation changes the durable lesson.
+- Modify: `docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md` if the new status refines that policy boundary.
+- Modify: `scripts/harness-app-registry.ts` only if harness review reports missing validation coverage for touched surfaces.
+- Optional generate: read-only repair audit artifact/script if implementation finds reliable evidence.
+- Generate: `graphify-out/*` via `bun run graphify:rebuild` after code changes.
+
+**Approach:**
+- Inspect whether rejected-closeout operational events and sync event metadata can identify wrongly-active sessions safely.
+- If repair is plausible, first produce a dry-run report with candidate ids, evidence source, ambiguity reason, later sale/replacement checks, and proposed action. The default action is no write.
+- If repair is not safe, document why new behavior is forward-only.
+- Update durable learning docs only for substantive new policy decisions.
+- Follow package testing guidance for POS register/session write paths, Cash Controls, Daily Close, Convex audit, typecheck, build, and Graphify rebuild.
+
+**Test scenarios:**
+- No test expectation for documentation-only updates; behavioral validation is covered in U1-U5.
+- If a repair/backfill is added, it has fixtures for safe match, ambiguous later replacement session, missing evidence, later sale activity, and idempotent re-run.
+
+**Verification:** Implementation handoff states whether historical repair was included or deferred, and Graphify is rebuilt after code changes.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Register-session status flows through schema validators, Cash Controls mutations, POS register-state queries, local/offline sync projection, POS view-model gates, terminal runtime status, workflow traces, Daily Operations, and Daily Close readiness.
+- **Error propagation:** Stale sale attempts should fail with safe command-result/precondition messaging already used by POS drawer guards. Raw backend text should not surface in POS UI.
+- **State lifecycle risks:** The key partial-write risk is resolving sync/review rows without patching the register session into the same review-only state. Manager rejection must settle the source sync event, conflict row, session status, operational event, and trace together.
+- **API surface parity:** Public Convex validators and DTOs that serialize register-session status must accept `closeout_rejected`; browser code must still treat it as non-sale-usable.
+- **Integration coverage:** Unit tests alone are insufficient because the change crosses manager review, sync projection, POS state, Daily Close, and Daily Operations. At least one integration test must prove replacement drawer opening and subsequent sale attachment to the new session.
+- **Unchanged invariants:** `open | active` remain the only POS-sale-usable statuses. `closed` remains historical. Runtime status remains evidence, not authority.
+
+```mermaid
+flowchart TB
+  Status["shared status policy"] --> Cash["Cash Controls closeout/reject"]
+  Status --> POS["POS register state and drawer gate"]
+  Status --> Sync["Local sync projection"]
+  Status --> Commands["Sale/session command guards"]
+  Status --> Daily["Daily Close readiness"]
+  Status --> Ops["Daily Operations timeline"]
+
+  Cash --> Evidence["approval, sync, operational, trace evidence"]
+  Sync --> Evidence
+  Evidence --> Cash
+  Evidence --> Daily
+  Evidence --> Ops
+  POS --> NewDrawer["replacement register session"]
+  NewDrawer --> Commands
+```
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| A validator or DTO misses the new status and rejects live data | U1 ships compatibility first across schemas, DTOs, local read models, public terminal/register APIs, and terminal runtime validators. |
+| A mutation writes `closeout_rejected` before readers understand it | Sequence implementation/deploy so acceptance lands before writer changes, and keep tests proving serialization surfaces handle the state. |
+| Review-only sessions disappear from Cash Controls, Daily Close, or Daily Operations | U3 adds explicit queries and tests for all review surfaces. |
+| POS still cannot open a new drawer after closeout submission or rejection | U1/U4 keep review-only `closing` sessions with closeout packets and `closeout_rejected` out of conflict-blocking policy and add replacement flow tests. |
+| Stale clients attach sales to the rejected drawer | U5 hardens command and sync projection boundaries using shared POS usability policy. |
+| Evidence is lost during rejection | U2 requires preserving counted cash, variance, notes, approval, sync, operational, and trace context. |
+| Review/sync rows settle while the session remains sale-usable | U2 requires atomic mutation behavior and split-brain regression tests. |
+| Daily Close treats the rejected closeout as closed financial evidence | U3 defines it as a blocker that does not increment closed register counts or settled cash totals. |
+| Historical bad sessions remain active | U6 treats repair as read-only audit first and a separate write decision. |
+
+---
+
+## Documentation / Operational Notes
+
+- Implementation should update durable `docs/solutions/` guidance if the new `closeout_rejected` status changes the team's documented lifecycle policy.
+- After modifying code files, run `bun run graphify:rebuild` from the repo root per `AGENTS.md`.
+- If public Convex functions or generated client references change, refresh generated artifacts using the package guide: `bunx convex dev --once` from `packages/athena-webapp` when credentials are available.
+- Recommended validation follows the POS register/session write path, Cash Controls, Daily Close, Daily Operations, Convex audit, typecheck/build, and harness review.
+
+---
+
+## Sources & References
+
+- Related prior plan: `docs/plans/2026-06-23-001-refactor-pos-register-lifecycle-policy-plan.md`
+- Related learning: `docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md`
+- Related learning: `docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md`
+- Related learning: `docs/solutions/logic-errors/athena-pos-register-sync-closeout-review-recovery-2026-05-23.md`
+- Related learning: `docs/solutions/logic-errors/athena-pos-synced-closeout-readiness-2026-06-17.md`
+- Related learning: `docs/solutions/logic-errors/athena-cash-controls-closeout-review-ia-2026-06-08.md`
+- Related learning: `docs/solutions/logic-errors/athena-daily-close-store-day-boundary-2026-05-07.md`
+- Code: `packages/athena-webapp/shared/registerSessionStatus.ts`
+- Code: `packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts`
+- Code: `packages/athena-webapp/convex/cashControls/deposits.ts`
+- Code: `packages/athena-webapp/convex/cashControls/closeouts.ts`
+- Code: `packages/athena-webapp/convex/operations/registerSessions.ts`
+- Code: `packages/athena-webapp/convex/operations/dailyClose.ts`
+- Code: `packages/athena-webapp/convex/operations/dailyOperations.ts`
+- Code: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Code: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`

--- a/docs/solutions/logic-errors/athena-pos-closeout-review-only-lifecycle-2026-06-25.md
+++ b/docs/solutions/logic-errors/athena-pos-closeout-review-only-lifecycle-2026-06-25.md
@@ -1,0 +1,74 @@
+---
+title: Athena POS Closeout Review-Only Lifecycle
+date: 2026-06-25
+category: logic-errors
+module: athena-webapp
+problem_type: lifecycle_state_error
+component: pos
+symptoms:
+  - "A rejected register closeout with variance can make the POS drawer look active again"
+  - "POS can attach new sales to a session whose closeout is already submitted for review"
+  - "Opening a replacement drawer can be blocked by the previous variance closeout that should be review-only"
+root_cause: sale_usable_status_reused_for_reviewable_closeout_state
+resolution_type: code_fix
+severity: high
+tags:
+  - pos
+  - cash-controls
+  - register-session
+  - closeout
+  - lifecycle
+---
+
+# Athena POS Closeout Review-Only Lifecycle
+
+## Problem
+
+Register session status has to answer more than one question. `active` and
+`open` mean POS can sell against the session. A submitted or rejected variance
+closeout means managers still need review evidence, but cashiers should not
+continue selling against that same session.
+
+The bug pattern appears when rejection or variance review uses `active` as the
+escape hatch. That keeps the session easy to find in POS, but it also makes the
+drawer look sale-usable and can let future sales attach to closeout evidence
+that should already be frozen for review.
+
+## Solution
+
+Separate reviewability from sale usability:
+
+- Introduce a distinct review-only lifecycle status, such as
+  `closeout_rejected`, for rejected variance closeouts.
+- Keep POS sale-usable policy centralized in shared status helpers. Only `open`
+  and `active` should satisfy sale attachment.
+- Keep replacement-drawer conflict policy separate from sale usability. A
+  `closing` session with a submitted closeout, and a `closeout_rejected`
+  session, should not block opening a new register session.
+- Preserve closeout evidence when moving into review-only states. Counted cash,
+  variance, notes, closeout records, trace IDs, and review references are the
+  audit trail.
+- If managers reopen a rejected closeout for correction, move it back to
+  `closing`, not `active`, unless a separately reviewed policy explicitly allows
+  returning to sale-usable work.
+
+## Prevention
+
+- Add tests at every sale-attachment boundary: cloud commands, local event
+  projection, checkout completion, correction flows, and POS public register
+  queries.
+- Add cash-control and operations read-model tests that prove review-only
+  sessions remain visible to managers without counting as active drawers.
+- Add replacement-drawer tests that prove prior submitted variance closeouts do
+  not block opening the next drawer.
+- Add negative manager-review tests for reopen paths so missing or unauthorized
+  proof cannot move a rejected closeout forward.
+- Keep lifecycle helpers in `shared/registerSessionStatus.ts` and
+  `shared/registerSessionLifecyclePolicy.ts` as the single vocabulary for POS
+  usability, cash-control visibility, and replacement blocking.
+
+## Related
+
+- `docs/solutions/logic-errors/athena-pos-register-sync-closeout-review-recovery-2026-05-23.md`
+- `docs/solutions/logic-errors/athena-cash-controls-sale-sync-review-evidence-2026-06-18.md`
+- `docs/solutions/architecture/athena-pos-register-viewmodel-boundaries-2026-06-17.md`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2115 files · ~0 words
+- 2116 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7911 nodes · 9278 edges · 2043 communities detected
+- 7920 nodes · 9298 edges · 2044 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2053,10 +2053,11 @@
 - [[_COMMUNITY_Community 2040|Community 2040]]
 - [[_COMMUNITY_Community 2041|Community 2041]]
 - [[_COMMUNITY_Community 2042|Community 2042]]
+- [[_COMMUNITY_Community 2043|Community 2043]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
-2. `buildDailyCloseSnapshotWithCtx()` - 31 edges
+2. `buildDailyCloseSnapshotWithCtx()` - 33 edges
 3. `collectConvexQueryWriteBoundaryFindings()` - 28 edges
 4. `projectLocalRegisterReadModel()` - 26 edges
 5. `buildDailyOpeningSnapshotWithCtx()` - 17 edges
@@ -2089,8 +2090,8 @@ Cohesion: 0.06
 Nodes (84): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectConvexQueryWriteBoundaryFindings(), collectConvexReturnValidatorContractFindings(), collectHandlerDbAliases() (+76 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.06
-Nodes (65): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildApprovalRequestsById(), buildDailyCloseApprovalSubject() (+57 more)
+Cohesion: 0.05
+Nodes (67): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildApprovalRequestsById(), buildDailyCloseApprovalSubject() (+59 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.07
@@ -2233,80 +2234,80 @@ Cohesion: 0.12
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
 ### Community 38 - "Community 38"
+Cohesion: 0.15
+Nodes (21): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+13 more)
+
+### Community 39 - "Community 39"
 Cohesion: 0.16
 Nodes (19): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), pendingCheckoutItemMatchesLine(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding() (+11 more)
 
-### Community 39 - "Community 39"
+### Community 40 - "Community 40"
 Cohesion: 0.09
 Nodes (5): listCompletedTransactionsForDay(), listCompletedTransactionsForRange(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 41 - "Community 41"
+### Community 42 - "Community 42"
 Cohesion: 0.19
 Nodes (23): assertCompoundSolutionCheck(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSourceLineChanges(), countFileLines(), extractFrontmatter() (+15 more)
 
-### Community 42 - "Community 42"
+### Community 43 - "Community 43"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.21
 Nodes (23): buildCartChange(), buildLegacyContextPayload(), buildLegacyProductId(), compactPayload(), compileLegacyStorefrontAnalyticsRow(), compileLegacyStorefrontAnalyticsRows(), compileLegacyStorefrontAnalyticsRowsWithReport(), containsSensitiveText() (+15 more)
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.19
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
+Cohesion: 0.18
+Nodes (23): buildEventMessage(), buildNextEvidence(), buildNextSaleEvidence(), buildReviewPriority(), buildWorkItemPriority(), createOrReusePendingCheckoutItem(), createProvisionalCatalogAnchors(), findMatchingPendingCheckoutItem() (+15 more)
+
+### Community 47 - "Community 47"
 Cohesion: 0.22
 Nodes (21): assertRegisterNumberIsAvailable(), buildRuntimeDrawerAuthorityDirective(), cleanActiveRegisterSession(), cleanAppSessionRecovery(), cleanAppShell(), cleanAppUpdate(), cleanBrowserInfo(), cleanDiagnosticMessage() (+13 more)
 
-### Community 46 - "Community 46"
+### Community 48 - "Community 48"
 Cohesion: 0.12
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
 
-### Community 47 - "Community 47"
-Cohesion: 0.19
-Nodes (22): buildEventMessage(), buildNextEvidence(), buildNextSaleEvidence(), buildReviewPriority(), buildWorkItemPriority(), createOrReusePendingCheckoutItem(), createProvisionalCatalogAnchors(), findMatchingPendingCheckoutItem() (+14 more)
-
-### Community 48 - "Community 48"
+### Community 49 - "Community 49"
 Cohesion: 0.17
 Nodes (21): buildHomepageSnapshotV1(), hydrateCategory(), hydrateFeaturedItem(), hydrateProduct(), hydrateSubcategory(), hydrateTargetProducts(), isCustomerVisibleProduct(), isCustomerVisibleSku() (+13 more)
 
-### Community 49 - "Community 49"
+### Community 50 - "Community 50"
 Cohesion: 0.17
 Nodes (19): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady(), mapSyncStatus() (+11 more)
 
-### Community 50 - "Community 50"
+### Community 51 - "Community 51"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 51 - "Community 51"
+### Community 52 - "Community 52"
 Cohesion: 0.15
 Nodes (16): findLatestOpenOperatingDay(), getTodaySummary(), getTransactionById(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile() (+8 more)
 
-### Community 52 - "Community 52"
+### Community 53 - "Community 53"
 Cohesion: 0.21
 Nodes (21): detectFormat(), extractJsonRows(), flattenJsonRows(), inferProductName(), isRecord(), looksLikeLabel(), normalizeKey(), normalizeLegacyRow() (+13 more)
 
-### Community 53 - "Community 53"
+### Community 54 - "Community 54"
 Cohesion: 0.25
 Nodes (21): asRecord(), errorFor(), getLocalExpenseSessionId(), getOrCreateSession(), isExpenseEvent(), itemSource(), itemSourceKey(), numberField() (+13 more)
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.18
 Nodes (18): assertValidEodLocalCompletionWindowMinutes(), assertValidEodThreshold(), assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getEodAutoCompletePolicyConfigWithCtx() (+10 more)
-
-### Community 56 - "Community 56"
-Cohesion: 0.17
-Nodes (17): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+9 more)
 
 ### Community 57 - "Community 57"
 Cohesion: 0.18
@@ -2541,56 +2542,56 @@ Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
 ### Community 115 - "Community 115"
+Cohesion: 0.23
+Nodes (8): canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), getSaleBlockingDrawerAuthority(), isDrawerAuthoritySaleBlocking(), isRegisterSessionConflictBlocking(), isRegisterSessionReplacementBlocking(), isRegisterSessionSaleUsable(), isScopedRegisterSession()
+
+### Community 116 - "Community 116"
 Cohesion: 0.22
 Nodes (6): buildTrustedInventoryFinalizationPayload(), buildTrustedInventoryMoneyPayload(), getTrustedInventoryReviewValidationMessage(), isNonNegativeInteger(), parseVariantDisplayMoney(), resolveTrustedInventoryReviewState()
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.17
 Nodes (2): getNextTransactionPageSearch(), getNextTransactionTimeFilterSearch()
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.29
 Nodes (10): applyTheme(), emitThemeChange(), getStorage(), getStoredThemeMode(), getSystemTheme(), getThemeSnapshot(), initializeAthenaTheme(), isThemeMode() (+2 more)
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.29
 Nodes (9): buildAbusePartitionKey(), buildServerContextTrackingEnvelope(), derivePrimarySubject(), isAcceptedSyntheticContext(), isRecord(), readPayload(), readRequiredNumber(), readRequiredString() (+1 more)
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.2
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
-
-### Community 127 - "Community 127"
-Cohesion: 0.24
-Nodes (6): canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), getSaleBlockingDrawerAuthority(), isDrawerAuthoritySaleBlocking(), isRegisterSessionSaleUsable(), isScopedRegisterSession()
 
 ### Community 128 - "Community 128"
 Cohesion: 0.2
@@ -2617,52 +2618,52 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 134 - "Community 134"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 135 - "Community 135"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 136 - "Community 136"
+### Community 135 - "Community 135"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 137 - "Community 137"
+### Community 136 - "Community 136"
 Cohesion: 0.2
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 138 - "Community 138"
+### Community 137 - "Community 137"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 139 - "Community 139"
+### Community 138 - "Community 138"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 140 - "Community 140"
+### Community 139 - "Community 139"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 141 - "Community 141"
+### Community 140 - "Community 140"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 142 - "Community 142"
+### Community 141 - "Community 141"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 143 - "Community 143"
+### Community 142 - "Community 142"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 144 - "Community 144"
+### Community 143 - "Community 143"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 145 - "Community 145"
+### Community 144 - "Community 144"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
+
+### Community 145 - "Community 145"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 146 - "Community 146"
 Cohesion: 0.18
@@ -2742,15 +2743,15 @@ Nodes (5): clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), r
 
 ### Community 165 - "Community 165"
 Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 166 - "Community 166"
 Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
+Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
 ### Community 167 - "Community 167"
 Cohesion: 0.39
-Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 168 - "Community 168"
 Cohesion: 0.39
@@ -2797,20 +2798,20 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 179 - "Community 179"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 180 - "Community 180"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.22
 Nodes (0):
-
-### Community 182 - "Community 182"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 183 - "Community 183"
 Cohesion: 0.31
@@ -3413,32 +3414,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 333 - "Community 333"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
-### Community 334 - "Community 334"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 335 - "Community 335"
+### Community 334 - "Community 334"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 336 - "Community 336"
+### Community 335 - "Community 335"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
+
+### Community 336 - "Community 336"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 337 - "Community 337"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 338 - "Community 338"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 339 - "Community 339"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+
+### Community 339 - "Community 339"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 340 - "Community 340"
 Cohesion: 0.4
@@ -3449,44 +3450,44 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 342 - "Community 342"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 343 - "Community 343"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 344 - "Community 344"
+### Community 343 - "Community 343"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 345 - "Community 345"
+### Community 344 - "Community 344"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 346 - "Community 346"
+### Community 345 - "Community 345"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 347 - "Community 347"
+### Community 346 - "Community 346"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 348 - "Community 348"
+### Community 347 - "Community 347"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 349 - "Community 349"
+### Community 348 - "Community 348"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 350 - "Community 350"
+### Community 349 - "Community 349"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 351 - "Community 351"
+### Community 350 - "Community 350"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
+
+### Community 351 - "Community 351"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 352 - "Community 352"
 Cohesion: 0.4
@@ -3497,12 +3498,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 354 - "Community 354"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 355 - "Community 355"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 355 - "Community 355"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 356 - "Community 356"
 Cohesion: 0.4
@@ -3517,20 +3518,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 359 - "Community 359"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 360 - "Community 360"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 361 - "Community 361"
+### Community 360 - "Community 360"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 362 - "Community 362"
+### Community 361 - "Community 361"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+
+### Community 362 - "Community 362"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 363 - "Community 363"
 Cohesion: 0.4
@@ -3557,80 +3558,80 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 369 - "Community 369"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 370 - "Community 370"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 371 - "Community 371"
+### Community 370 - "Community 370"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 372 - "Community 372"
+### Community 371 - "Community 371"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 373 - "Community 373"
+### Community 372 - "Community 372"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 374 - "Community 374"
+### Community 373 - "Community 373"
 Cohesion: 0.5
 Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
-### Community 375 - "Community 375"
+### Community 374 - "Community 374"
 Cohesion: 0.5
 Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
-### Community 376 - "Community 376"
+### Community 375 - "Community 375"
 Cohesion: 0.5
 Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
 
-### Community 377 - "Community 377"
+### Community 376 - "Community 376"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 378 - "Community 378"
+### Community 377 - "Community 377"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 379 - "Community 379"
+### Community 378 - "Community 378"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 380 - "Community 380"
+### Community 379 - "Community 379"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 381 - "Community 381"
+### Community 380 - "Community 380"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 382 - "Community 382"
+### Community 381 - "Community 381"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 383 - "Community 383"
+### Community 382 - "Community 382"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 384 - "Community 384"
+### Community 383 - "Community 383"
 Cohesion: 0.6
 Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
-### Community 385 - "Community 385"
+### Community 384 - "Community 384"
 Cohesion: 0.6
 Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
-### Community 386 - "Community 386"
+### Community 385 - "Community 385"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 387 - "Community 387"
+### Community 386 - "Community 386"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
+
+### Community 387 - "Community 387"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 388 - "Community 388"
 Cohesion: 0.4
@@ -3645,44 +3646,44 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 391 - "Community 391"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 392 - "Community 392"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 393 - "Community 393"
+### Community 392 - "Community 392"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 394 - "Community 394"
+### Community 393 - "Community 393"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 395 - "Community 395"
+### Community 394 - "Community 394"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 396 - "Community 396"
+### Community 395 - "Community 395"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 397 - "Community 397"
+### Community 396 - "Community 396"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
-### Community 398 - "Community 398"
+### Community 397 - "Community 397"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 399 - "Community 399"
+### Community 398 - "Community 398"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 400 - "Community 400"
+### Community 399 - "Community 399"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 400 - "Community 400"
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 401 - "Community 401"
 Cohesion: 0.7
@@ -10252,6 +10253,10 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2043 - "Community 2043"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -11469,1461 +11474,1463 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1314`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `register.ts`
+- **Thin community `Community 1315`** (1 nodes): `register.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `sync.ts`
+- **Thin community `Community 1316`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1317`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1318`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1319`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `schema.ts`
+- **Thin community `Community 1320`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `automation.ts`
+- **Thin community `Community 1321`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1322`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1323`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `index.ts`
+- **Thin community `Community 1324`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1325`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1326`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1327`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1328`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1329`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1330`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `category.ts`
+- **Thin community `Community 1331`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `color.ts`
+- **Thin community `Community 1332`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1333`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1334`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `index.ts`
+- **Thin community `Community 1335`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1336`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1337`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1338`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1339`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `organization.ts`
+- **Thin community `Community 1340`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1341`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `product.ts`
+- **Thin community `Community 1342`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1343`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1344`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `store.ts`
+- **Thin community `Community 1345`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1346`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `index.ts`
+- **Thin community `Community 1347`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1348`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1349`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1350`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1351`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1352`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1353`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1354`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `index.ts`
+- **Thin community `Community 1355`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1356`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1357`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1358`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1359`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1360`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1361`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1362`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1363`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1364`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1365`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1366`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `customer.ts`
+- **Thin community `Community 1367`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1368`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1369`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1370`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1371`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `index.ts`
+- **Thin community `Community 1372`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1373`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1374`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1375`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1376`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1377`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1378`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1379`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1380`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1381`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1382`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1383`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1384`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1385`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1386`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1387`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1388`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1389`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1390`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1391`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `index.ts`
+- **Thin community `Community 1392`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1393`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1394`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `index.ts`
+- **Thin community `Community 1395`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1396`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1397`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1398`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1399`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1400`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1401`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `index.ts`
+- **Thin community `Community 1402`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1403`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1404`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1405`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1406`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1407`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1408`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `bag.ts`
+- **Thin community `Community 1409`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1410`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1411`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1412`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `guest.ts`
+- **Thin community `Community 1413`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `index.ts`
+- **Thin community `Community 1414`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `offer.ts`
+- **Thin community `Community 1415`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1416`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1417`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `review.ts`
+- **Thin community `Community 1418`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1419`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1420`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1421`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1422`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1423`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1424`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1425`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1426`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1427`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `bag.ts`
+- **Thin community `Community 1428`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1429`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `customer.ts`
+- **Thin community `Community 1430`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `guest.ts`
+- **Thin community `Community 1431`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1432`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1433`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1434`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1435`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1436`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1437`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1438`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `users.ts`
+- **Thin community `Community 1439`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `payment.ts`
+- **Thin community `Community 1440`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1441`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1442`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1443`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1444`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1445`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1446`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1447`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `index.ts`
+- **Thin community `Community 1448`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1449`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1450`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1451`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1452`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `auth.ts`
+- **Thin community `Community 1453`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1454`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1455`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1456`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1457`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1458`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1459`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1460`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `index.ts`
+- **Thin community `Community 1461`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1462`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1463`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1464`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1465`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1466`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1467`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1468`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1469`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1470`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1471`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1472`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1473`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1474`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1475`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1476`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1477`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1478`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1479`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1480`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1481`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1482`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `constants.ts`
+- **Thin community `Community 1483`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1484`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1485`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1486`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `types.ts`
+- **Thin community `Community 1487`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1488`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1489`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1490`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1491`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1492`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1493`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1494`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1495`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1496`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1497`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1498`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1499`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1500`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1501`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1502`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1503`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1504`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1505`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1506`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1507`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `constants.ts`
+- **Thin community `Community 1508`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1509`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1510`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1511`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `data.ts`
+- **Thin community `Community 1512`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1513`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1514`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1515`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1516`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1517`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1518`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1519`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1520`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1521`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `constants.ts`
+- **Thin community `Community 1522`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1523`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1524`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1525`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `data.ts`
+- **Thin community `Community 1526`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1527`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1528`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1529`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1530`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1531`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1532`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1533`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1534`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1535`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1536`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1537`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1538`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `constants.ts`
+- **Thin community `Community 1539`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1540`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1541`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1542`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1543`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1544`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1545`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1546`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1547`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1548`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1549`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1550`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1551`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1552`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1553`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1554`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1555`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1556`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1557`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1558`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1559`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1560`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1561`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1562`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1563`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1564`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1565`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1566`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1567`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1568`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1569`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1570`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1571`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1572`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1573`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `constants.ts`
+- **Thin community `Community 1574`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1575`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1576`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1577`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `data.ts`
+- **Thin community `Community 1578`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1579`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1580`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `constants.ts`
+- **Thin community `Community 1581`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1582`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1583`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1584`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1585`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `data.ts`
+- **Thin community `Community 1586`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1587`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `constants.ts`
+- **Thin community `Community 1588`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1589`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1590`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1591`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1592`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `data.ts`
+- **Thin community `Community 1593`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1594`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1595`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1596`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1597`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1598`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1599`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1600`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1601`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1602`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1603`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1604`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1605`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1606`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1607`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1608`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1609`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1610`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1611`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1612`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1613`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1614`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1615`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1616`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1617`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1618`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1619`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1620`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1621`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `types.ts`
+- **Thin community `Community 1622`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1623`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1624`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1625`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1626`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1627`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1628`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1629`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1630`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1631`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1632`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1633`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1634`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1635`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1636`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1637`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1638`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1639`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `data.ts`
+- **Thin community `Community 1640`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1641`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1642`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1643`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1644`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1645`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1646`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1647`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1648`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1649`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1650`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1651`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1652`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `constants.ts`
+- **Thin community `Community 1653`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1654`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1655`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1656`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `data.ts`
+- **Thin community `Community 1657`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `types.ts`
+- **Thin community `Community 1658`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1659`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1660`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1661`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1662`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1663`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `index.ts`
+- **Thin community `Community 1664`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1665`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1666`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1667`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1668`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `index.tsx`
+- **Thin community `Community 1669`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1670`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1671`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1672`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1673`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1674`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1675`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1676`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1677`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `index.tsx`
+- **Thin community `Community 1678`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1679`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1680`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1681`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `button.tsx`
+- **Thin community `Community 1682`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1683`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `card.tsx`
+- **Thin community `Community 1684`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1685`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1686`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `command.tsx`
+- **Thin community `Community 1687`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1688`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1689`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1690`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `form.tsx`
+- **Thin community `Community 1691`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1692`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1693`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `input.tsx`
+- **Thin community `Community 1694`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1695`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1696`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1697`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1698`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1699`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1700`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `select.tsx`
+- **Thin community `Community 1701`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1702`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1703`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1704`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1705`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `table.tsx`
+- **Thin community `Community 1706`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1707`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1708`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1709`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1710`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1711`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1712`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1713`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1714`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `constants.ts`
+- **Thin community `Community 1715`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1716`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1717`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1718`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `data.ts`
+- **Thin community `Community 1719`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1720`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1721`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1722`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1723`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1724`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1725`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1726`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1727`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1728`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1729`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `index.ts`
+- **Thin community `Community 1730`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1731`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1732`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1733`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 1734`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1735`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1736`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1737`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1738`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1739`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1740`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1741`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1742`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 1743`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 1744`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `index.ts`
+- **Thin community `Community 1745`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 1746`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `index.ts`
+- **Thin community `Community 1747`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 1748`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 1749`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `aws.ts`
+- **Thin community `Community 1750`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `constants.ts`
+- **Thin community `Community 1751`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `countries.ts`
+- **Thin community `Community 1752`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1753`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1754`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1755`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1756`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1757`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1758`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1759`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 1760`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `dto.ts`
+- **Thin community `Community 1761`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `ports.ts`
+- **Thin community `Community 1762`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `constants.ts`
+- **Thin community `Community 1763`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1764`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1765`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `index.ts`
+- **Thin community `Community 1766`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1767`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `types.ts`
+- **Thin community `Community 1768`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1769`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1770`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1771`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1772`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1773`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1774`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1775`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1776`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1777`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 1778`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 1779`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 1780`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 1781`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 1782`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1783`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1784`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1785`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1786`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `index.ts`
+- **Thin community `Community 1787`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1788`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `category.ts`
+- **Thin community `Community 1789`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `product.ts`
+- **Thin community `Community 1790`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `store.ts`
+- **Thin community `Community 1791`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1792`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `user.ts`
+- **Thin community `Community 1793`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1794`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1795`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1796`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1797`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1798`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `main.tsx`
+- **Thin community `Community 1799`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 1800`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1801`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1802`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1803`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1804`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1805`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `index.tsx`
+- **Thin community `Community 1806`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1807`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1808`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1809`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1810`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1811`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1812`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1813`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `index.tsx`
+- **Thin community `Community 1814`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1815`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1816`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1817`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `home.tsx`
+- **Thin community `Community 1818`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1819`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1820`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1821`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `index.tsx`
+- **Thin community `Community 1822`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `review.tsx`
+- **Thin community `Community 1823`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1824`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1825`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `index.tsx`
+- **Thin community `Community 1826`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1827`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1828`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1829`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `index.tsx`
+- **Thin community `Community 1830`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1831`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1832`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1833`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1834`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1835`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1836`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 1837`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `index.tsx`
+- **Thin community `Community 1838`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1839`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1840`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1841`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1842`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1843`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1844`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1845`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1846`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1847`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `index.tsx`
+- **Thin community `Community 1848`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1849`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `index.tsx`
+- **Thin community `Community 1850`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `new.tsx`
+- **Thin community `Community 1851`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `index.tsx`
+- **Thin community `Community 1852`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `new.tsx`
+- **Thin community `Community 1853`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1854`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1855`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `index.tsx`
+- **Thin community `Community 1856`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `new.tsx`
+- **Thin community `Community 1857`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `index.tsx`
+- **Thin community `Community 1858`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1859`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1860`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1861`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1862`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `index.tsx`
+- **Thin community `Community 1863`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1864`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1865`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1866`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `index.tsx`
+- **Thin community `Community 1867`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1868`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `_authed.tsx`
+- **Thin community `Community 1869`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1870`** (1 nodes): `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `index.tsx`
+- **Thin community `Community 1871`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1872`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1873`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1874`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 1875`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1876`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 1877`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1878`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 1879`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1880`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1881`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1882`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1883`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1884`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1885`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1886`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1887`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1888`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1889`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1890`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1891`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1892`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1893`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1894`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1895`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `setup.ts`
+- **Thin community `Community 1896`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1897`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `types.ts`
+- **Thin community `Community 1898`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1899`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1900`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1901`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1902`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1903`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1904`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1905`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `types.ts`
+- **Thin community `Community 1906`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1907`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1908`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1909`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1910`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1911`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1912`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1913`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1914`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `schema.ts`
+- **Thin community `Community 1915`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1916`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1917`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1918`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1919`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1920`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1921`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1922`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1923`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1924`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `types.ts`
+- **Thin community `Community 1925`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1926`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1927`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1928`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1929`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1930`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1931`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1932`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `constants.ts`
+- **Thin community `Community 1933`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1934`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `About.tsx`
+- **Thin community `Community 1935`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1936`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1937`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1938`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1939`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1940`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1941`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1942`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1943`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1944`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1945`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `types.ts`
+- **Thin community `Community 1946`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1947`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1948`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1949`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1950`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1951`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1952`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1953`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1954`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1955`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1956`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1957`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `button.tsx`
+- **Thin community `Community 1958`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `card.tsx`
+- **Thin community `Community 1959`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1960`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `command.tsx`
+- **Thin community `Community 1961`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1962`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1963`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1964`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `form.tsx`
+- **Thin community `Community 1965`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1966`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1967`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1968`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1969`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `input.tsx`
+- **Thin community `Community 1970`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `label.tsx`
+- **Thin community `Community 1971`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1972`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1973`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1974`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `index.ts`
+- **Thin community `Community 1975`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `types.ts`
+- **Thin community `Community 1976`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1977`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1978`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1979`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1980`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `select.tsx`
+- **Thin community `Community 1981`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1982`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1983`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `table.tsx`
+- **Thin community `Community 1984`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1985`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1986`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1987`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1988`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1989`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `config.ts`
+- **Thin community `Community 1990`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 1991`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1992`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1993`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1994`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1995`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `constants.ts`
+- **Thin community `Community 1996`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `countries.ts`
+- **Thin community `Community 1997`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1998`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1999`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2000`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2001`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `index.ts`
+- **Thin community `Community 2002`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2003`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `store.ts`
+- **Thin community `Community 2004`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `bag.ts`
+- **Thin community `Community 2005`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2006`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `category.ts`
+- **Thin community `Community 2007`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `organization.ts`
+- **Thin community `Community 2008`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `product.ts`
+- **Thin community `Community 2009`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `store.ts`
+- **Thin community `Community 2010`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2011`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `user.ts`
+- **Thin community `Community 2012`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `states.ts`
+- **Thin community `Community 2013`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2014`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2015`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2016`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2017`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2018`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2019`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2020`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2021`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `index.tsx`
+- **Thin community `Community 2022`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2023`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `index.tsx`
+- **Thin community `Community 2024`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2025`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2026`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2027`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2028`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2029`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `index.tsx`
+- **Thin community `Community 2030`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2031`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2032`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2033`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2034`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2035`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `index.js`
+- **Thin community `Community 2036`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2037`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2038`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2039`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2040`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2041`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2042`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2043`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -12936,7 +12943,7 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**
-  _Cohesion score 0.06 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.05 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**
   _Cohesion score 0.07 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,15 +7,15 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2115
-- Graph nodes: 7911
-- Graph edges: 9278
-- Communities: 2043
+- Code files discovered: 2116
+- Graph nodes: 7920
+- Graph edges: 9298
+- Communities: 2044
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (89 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `harness-inferential-review.ts` (85 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `dailyClose.ts` (74 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (76 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `dailyOperations.ts` (63 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `projectLocalEvents.ts` (62 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -18,7 +18,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (89 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `dailyClose.ts` (74 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (76 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `dailyOperations.ts` (63 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `projectLocalEvents.ts` (62 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,7 +19,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 54) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 55) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `storefrontContextEvents.ts` (17 edges, Community 76) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
 - `checkoutSession.ts` (14 edges, Community 89) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 

--- a/packages/athena-webapp/convex/cashControls/closeouts.test.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.test.ts
@@ -28,6 +28,17 @@ describe("cash control closeouts", () => {
         message: "Counted cash cannot be negative.",
       },
     };
+    const rejectedCloseoutResult = {
+      kind: "ok" as const,
+      data: {
+        action: "rejected" as const,
+        approvalRequest: null,
+        registerSession: {
+          _id: "session-1",
+          status: "closeout_rejected",
+        },
+      },
+    };
 
     assertConformsToExportedReturns(
       submitRegisterSessionCloseout,
@@ -44,6 +55,10 @@ describe("cash control closeouts", () => {
     assertConformsToExportedReturns(
       reviewRegisterSessionCloseout,
       validationError,
+    );
+    assertConformsToExportedReturns(
+      reviewRegisterSessionCloseout,
+      rejectedCloseoutResult,
     );
   });
 
@@ -277,6 +292,37 @@ describe("cash control closeouts", () => {
     expect(runMutation).not.toHaveBeenCalled();
   });
 
+  it("returns user_error when submitting a closeout already under rejected review", async () => {
+    const runMutation = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async () => ({
+          _id: "session-1",
+          expectedCash: 10000,
+          status: "closeout_rejected",
+          storeId: "store-1",
+        })),
+      },
+      runMutation,
+      runQuery: vi.fn(async () => ({ _id: "store-1" })),
+    };
+
+    const result = await getHandler(submitRegisterSessionCloseout)(ctx, {
+      countedCash: 9000,
+      registerSessionId: "session-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Register closeout is already under review.",
+      },
+    });
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
   it("returns user_error when reopening a non-closeout register session", async () => {
     const runMutation = vi.fn();
     const ctx = {
@@ -355,6 +401,238 @@ describe("cash control closeouts", () => {
       },
     });
     expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("reopens rejected closeouts for correction without making them sale-usable", async () => {
+    let registerSession = {
+      _id: "session-1",
+      closeoutRecords: [],
+      countedCash: 9000,
+      expectedCash: 10000,
+      notes: "Variance counted at lane 1.",
+      openedAt: 1,
+      openingFloat: 5000,
+      organizationId: "org-1",
+      registerNumber: "A1",
+      status: "closeout_rejected",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      variance: -1000,
+    };
+    const patch = vi.fn(async (table: string, id: string, updates: object) => {
+      if (table === "registerSession" && id === "session-1") {
+        registerSession = { ...registerSession, ...updates };
+      }
+    });
+    const insert = vi.fn(async () => "inserted");
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string) => {
+          if (table === "registerSession") return registerSession;
+          if (table === "approvalProof") {
+            return {
+              _id: "proof-1",
+              actionKey: "cash_controls.register_session.reopen_closeout",
+              approvedByStaffProfileId: "manager-1",
+              expiresAt: Date.now() + 60_000,
+              requestedByStaffProfileId: "staff-1",
+              requiredRole: "manager",
+              storeId: "store-1",
+              subjectId: "session-1",
+              subjectLabel: "A1",
+              subjectType: "register_session",
+            };
+          }
+          if (table === "store") return { _id: "store-1", currency: "GHS" };
+          if (table === "staffProfile") {
+            return {
+              _id: "manager-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+          return null;
+        }),
+        insert,
+        patch,
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({
+            collect: vi.fn(async () => []),
+            order: vi.fn(() => ({
+              first: vi.fn(async () => null),
+            })),
+            take: vi.fn(async () => [
+              {
+                organizationId: "org-1",
+                role: "manager",
+                staffProfileId: "manager-1",
+                status: "active",
+                storeId: "store-1",
+              },
+            ]),
+            unique: vi.fn(async () => null),
+          })),
+        })),
+      },
+      runMutation: vi.fn(),
+    };
+
+    const result = await getHandler(reopenRegisterSessionCloseout)(ctx, {
+      actorUserId: "manager-user-1",
+      approvalProofId: "proof-1",
+      registerSessionId: "session-1",
+      requestedByStaffProfileId: "staff-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: {
+        action: "reopened",
+        approvalRequest: null,
+        registerSession: expect.objectContaining({
+          _id: "session-1",
+          status: "closing",
+          countedCash: 9000,
+          closeoutRecords: [
+            expect.objectContaining({
+              actorStaffProfileId: "manager-1",
+              actorUserId: "manager-user-1",
+              countedCash: 9000,
+              expectedCash: 10000,
+              notes: "Variance counted at lane 1.",
+              occurredAt: expect.any(Number),
+              reason: "Correction needed after manager rejection.",
+              type: "reopened",
+              variance: -1000,
+            }),
+          ],
+          variance: -1000,
+        }),
+      },
+    });
+    expect(patch).toHaveBeenCalledWith(
+      "registerSession",
+      "session-1",
+      expect.objectContaining({
+        closeoutRecords: [
+          expect.objectContaining({
+            actorStaffProfileId: "manager-1",
+            actorUserId: "manager-user-1",
+            countedCash: 9000,
+            expectedCash: 10000,
+            notes: "Variance counted at lane 1.",
+            occurredAt: expect.any(Number),
+            reason: "Correction needed after manager rejection.",
+            type: "reopened",
+            variance: -1000,
+          }),
+        ],
+        managerApprovalRequestId: undefined,
+        status: "closing",
+      }),
+    );
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("requires manager approval before reopening a rejected closeout", async () => {
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async () => ({
+          _id: "session-1",
+          expectedCash: 10000,
+          organizationId: "org-1",
+          status: "closeout_rejected",
+          storeId: "store-1",
+        })),
+        patch,
+      },
+    };
+
+    const result = await getHandler(reopenRegisterSessionCloseout)(ctx, {
+      registerSessionId: "session-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "authentication_failed",
+        message: "Only managers can reopen a rejected register closeout.",
+      },
+    });
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("rejects rejected-closeout reopen approvals from staff without review permission", async () => {
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string) => {
+          if (table === "registerSession") {
+            return {
+              _id: "session-1",
+              expectedCash: 10000,
+              organizationId: "org-1",
+              registerNumber: "A1",
+              status: "closeout_rejected",
+              storeId: "store-1",
+            };
+          }
+          if (table === "approvalProof") {
+            return {
+              _id: "proof-1",
+              actionKey: "cash_controls.register_session.reopen_closeout",
+              approvedByStaffProfileId: "staff-1",
+              expiresAt: Date.now() + 60_000,
+              requestedByStaffProfileId: "staff-1",
+              requiredRole: "manager",
+              storeId: "store-1",
+              subjectId: "session-1",
+              subjectLabel: "A1",
+              subjectType: "register_session",
+            };
+          }
+          if (table === "staffProfile") {
+            return {
+              _id: "staff-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+          return null;
+        }),
+        patch,
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({
+            take: vi.fn(async () => []),
+          })),
+        })),
+      },
+    };
+
+    const result = await getHandler(reopenRegisterSessionCloseout)(ctx, {
+      approvalProofId: "proof-1",
+      registerSessionId: "session-1",
+      requestedByStaffProfileId: "staff-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "authorization_failed",
+        message: "Only managers can reopen a rejected register closeout.",
+      },
+    });
+    expect(patch).not.toHaveBeenCalledWith(
+      "registerSession",
+      "session-1",
+      expect.anything(),
+    );
   });
 
   it("requires the same manager to submit a reopened closeout correction", async () => {

--- a/packages/athena-webapp/convex/cashControls/closeouts.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.ts
@@ -9,6 +9,10 @@ import {
 } from "../operations/approvalActions";
 import { consumeApprovalProofWithCtx } from "../operations/approvalProofs";
 import { recordOperationalEventWithCtx } from "../operations/operationalEvents";
+import {
+  rejectRegisterSessionCloseoutWithCtx,
+  reopenRejectedRegisterSessionCloseoutWithCtx,
+} from "../operations/registerSessions";
 import { recordRegisterSessionTraceBestEffort } from "../operations/registerSessionTracing";
 import { commandResultValidator } from "../lib/commandResultValidators";
 import { toDisplayAmount } from "../lib/currency";
@@ -720,6 +724,13 @@ export const submitRegisterSessionCloseout = mutation({
       });
     }
 
+    if (registerSession.status === "closeout_rejected") {
+      return userError({
+        code: "precondition_failed",
+        message: "Register closeout is already under review.",
+      });
+    }
+
     const config = getCashControlsConfig(store);
     const closeoutReview = buildRegisterSessionCloseoutReview({
       countedCash: args.countedCash,
@@ -1153,6 +1164,104 @@ export const reopenRegisterSessionCloseout = mutation({
       });
     }
 
+    if (registerSession.status === "closeout_rejected") {
+      if (!registerSession.organizationId || !args.approvalProofId) {
+        return userError({
+          code: "authentication_failed",
+          message: "Only managers can reopen a rejected register closeout.",
+        });
+      }
+
+      const proof = await consumeCommandApprovalProofWithCtx(ctx, {
+        action: REGISTER_CLOSEOUT_REOPEN_ACTION,
+        approvalProofId: args.approvalProofId,
+        requiredRole: "manager",
+        requestedByStaffProfileId: args.requestedByStaffProfileId,
+        storeId: args.storeId,
+        subject: {
+          type: "register_session",
+          id: registerSession._id,
+          label: registerSession.registerNumber,
+        },
+      });
+
+      if (proof.kind !== "ok") {
+        return proof;
+      }
+
+      const canReopenRejectedCloseout = await staffProfileCanReviewCloseoutVariance(ctx, {
+        organizationId: registerSession.organizationId,
+        staffProfileId: proof.data.approvedByStaffProfileId,
+        storeId: args.storeId,
+      });
+
+      if (!canReopenRejectedCloseout) {
+        return userError({
+          code: "authorization_failed",
+          message: "Only managers can reopen a rejected register closeout.",
+        });
+      }
+
+      const previousCloseout = omitUndefined({
+        countedCash: registerSession.countedCash,
+        expectedCash: registerSession.expectedCash,
+        notes: registerSession.notes,
+        variance: registerSession.variance,
+      });
+      const reopenedSession = await reopenRejectedRegisterSessionCloseoutWithCtx(
+        ctx,
+        {
+          actorStaffProfileId: proof.data.approvedByStaffProfileId,
+          actorUserId: args.actorUserId,
+          registerSessionId: args.registerSessionId,
+          reason: "Correction needed after manager rejection.",
+        },
+      );
+      const reopenedAt = Date.now();
+
+      await recordOperationalEventWithCtx(ctx, {
+        actorStaffProfileId: proof.data.approvedByStaffProfileId,
+        actorUserId: args.actorUserId,
+        eventType: "register_session_closeout_reopened",
+        message: "Rejected register closeout reopened for correction.",
+        metadata: previousCloseout,
+        organizationId: registerSession.organizationId,
+        reason: "Correction needed after manager rejection.",
+        registerSessionId: registerSession._id,
+        storeId: args.storeId,
+        subjectId: registerSession._id,
+        subjectLabel: registerSession.registerNumber,
+        subjectType: "register_session",
+      });
+
+      const traceResult = await recordRegisterSessionTraceBestEffort(ctx, {
+        stage: "closeout_reopened",
+        session: reopenedSession ?? {
+          ...registerSession,
+          status: "closing",
+        },
+        occurredAt: reopenedAt,
+        actorStaffProfileId: proof.data.approvedByStaffProfileId,
+        actorUserId: args.actorUserId,
+        countedCash: registerSession.countedCash,
+        reason: "Correction needed after manager rejection.",
+        variance: registerSession.variance,
+      });
+
+      await persistRegisterSessionWorkflowTraceIdBestEffort(ctx, {
+        registerSessionId: registerSession._id,
+        traceCreated: traceResult.traceCreated,
+        traceId: traceResult.traceId,
+        workflowTraceId: reopenedSession?.workflowTraceId,
+      });
+
+      return ok({
+        action: "reopened",
+        approvalRequest: null,
+        registerSession: reopenedSession,
+      });
+    }
+
     if (registerSession.status !== "closing") {
       if (registerSession.status !== "closed") {
         return userError({
@@ -1497,6 +1606,13 @@ export const reviewRegisterSessionCloseout = mutation({
       });
     }
 
+    if (registerSession.status !== "closing") {
+      return userError({
+        code: "precondition_failed",
+        message: "Register session is not in closeout.",
+      });
+    }
+
     const proof = await consumeApprovalProofWithCtx(ctx, {
       actionKey: REGISTER_VARIANCE_REVIEW_ACTION_KEY,
       approvalProofId: args.approvalProofId,
@@ -1622,6 +1738,10 @@ export const reviewRegisterSessionCloseout = mutation({
       });
     }
 
+    const rejectedSession = await rejectRegisterSessionCloseoutWithCtx(ctx, {
+      registerSessionId: registerSession._id,
+    });
+
     await recordOperationalEventWithCtx(ctx, {
       actorStaffProfileId: reviewedByStaffProfileId,
       actorUserId: args.reviewedByUserId,
@@ -1645,7 +1765,6 @@ export const reviewRegisterSessionCloseout = mutation({
       subjectType: "register_session",
     });
 
-    const rejectedSession = await ctx.db.get("registerSession", registerSession._id);
     const rejectionOccurredAt = Date.now();
     const rejectionTraceResult = await recordRegisterSessionTraceBestEffort(ctx, {
       stage: "closeout_rejected",

--- a/packages/athena-webapp/convex/cashControls/deposits.test.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.test.ts
@@ -549,6 +549,18 @@ describe("cash control deposits", () => {
           storeId: "store_1" as Id<"store">,
           variance: 0,
         },
+        {
+          _id: "session_rejected" as Id<"registerSession">,
+          countedCash: 8800,
+          expectedCash: 9500,
+          openedAt: 15,
+          openingFloat: 5000,
+          registerNumber: "D4",
+          status: "closeout_rejected",
+          storeId: "store_1" as Id<"store">,
+          terminalId: "terminal_3" as Id<"posTerminal">,
+          variance: -700,
+        },
       ],
       staffNamesById: new Map(),
       terminalNamesById: new Map([
@@ -557,9 +569,10 @@ describe("cash control deposits", () => {
       ]),
     });
 
-    expect(snapshot.registerSessions).toHaveLength(3);
+    expect(snapshot.registerSessions).toHaveLength(4);
     expect(snapshot.registerSessions.map((session) => session._id)).toEqual([
       "session_closing",
+      "session_rejected",
       "session_open",
       "session_closed",
     ]);
@@ -572,7 +585,7 @@ describe("cash control deposits", () => {
       totalDeposited: 1200,
     });
 
-    expect(snapshot.pendingCloseouts).toHaveLength(1);
+    expect(snapshot.pendingCloseouts).toHaveLength(2);
     expect(snapshot.pendingCloseouts[0]).toMatchObject({
       _id: "session_closing",
       pendingApprovalRequest: {
@@ -582,6 +595,11 @@ describe("cash control deposits", () => {
       },
       terminalName: "Back counter",
       totalDeposited: 500,
+    });
+    expect(snapshot.pendingCloseouts[1]).toMatchObject({
+      _id: "session_rejected",
+      status: "closeout_rejected",
+      terminalName: null,
     });
 
     expect(snapshot.openSessions[0]).toMatchObject({
@@ -605,10 +623,14 @@ describe("cash control deposits", () => {
       },
     });
 
-    expect(snapshot.unresolvedVariances).toHaveLength(2);
+    expect(snapshot.unresolvedVariances).toHaveLength(3);
     expect(snapshot.unresolvedVariances[0]).toMatchObject({
       _id: "session_closing",
       variance: -500,
+    });
+    expect(snapshot.unresolvedVariances[1]).toMatchObject({
+      _id: "session_rejected",
+      variance: -700,
     });
 
     expect(snapshot.recentDeposits).toEqual([
@@ -913,7 +935,7 @@ describe("cash control deposits", () => {
           openingFloat: 10000,
           organizationId: "org_1",
           registerNumber: "1",
-          status: "closed",
+          status: "active",
           storeId: "store_1",
           terminalId: "terminal_1",
         },
@@ -1024,6 +1046,7 @@ describe("cash control deposits", () => {
       expect.objectContaining({
         _id: "session_open",
         expectedCash: 65000,
+        status: "active",
       }),
     ]);
     expect(ctx.tables.get("operationalEvent")).toEqual(
@@ -1132,7 +1155,7 @@ describe("cash control deposits", () => {
           openingFloat: 15500,
           organizationId: "org_1",
           registerNumber: "1",
-          status: "closed",
+          status: "active",
           storeId: "store_1",
           terminalId: "terminal_1",
         },
@@ -1387,7 +1410,7 @@ describe("cash control deposits", () => {
           openingFloat: 15500,
           organizationId: "org_1",
           registerNumber: "1",
-          status: "closed",
+          status: "active",
           storeId: "store_1",
           terminalId: "terminal_1",
         },
@@ -2331,7 +2354,7 @@ describe("cash control deposits", () => {
           openingFloat: 10000,
           organizationId: "org_1",
           registerNumber: "1",
-          status: "closed",
+          status: "active",
           storeId: "store_1",
           terminalId: "terminal_1",
         },
@@ -3577,7 +3600,7 @@ describe("cash control deposits", () => {
     );
   });
 
-  it("reopens drawers left closing by rejected variance closeout reviews", async () => {
+  it("persists rejected variance closeout reviews without clearing evidence", async () => {
     const ctx = createAuthorizedRegisterDepositCtx({
       operationalEvent: [],
       posLocalSyncConflict: [
@@ -3700,10 +3723,11 @@ describe("cash control deposits", () => {
     expect(ctx.tables.get("registerSession")).toEqual([
       expect.objectContaining({
         _id: "session_open",
-        countedCash: undefined,
-        notes: undefined,
-        status: "active",
-        variance: undefined,
+        countedCash: 45000,
+        expectedCash: 50000,
+        notes: "cash count issue",
+        status: "closeout_rejected",
+        variance: -5000,
       }),
     ]);
     expect(ctx.tables.get("posLocalSyncEvent")).toEqual([

--- a/packages/athena-webapp/convex/cashControls/deposits.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.ts
@@ -12,7 +12,10 @@ import {
 } from "./closeouts";
 import { recordOperationalEventWithCtx } from "../operations/operationalEvents";
 import { recordPaymentAllocationWithCtx } from "../operations/paymentAllocations";
-import { recordRegisterSessionDepositWithCtx } from "../operations/registerSessions";
+import {
+  recordRegisterSessionDepositWithCtx,
+  rejectRegisterSessionCloseoutWithCtx,
+} from "../operations/registerSessions";
 import { recordRegisterSessionTraceBestEffort } from "../operations/registerSessionTracing";
 import { toPesewas } from "../lib/currency";
 import {
@@ -560,7 +563,9 @@ export function buildCashControlsDashboardSnapshot(args: {
       isRegisterSessionSaleUsable(registerSession),
     ),
     pendingCloseouts: sessionSummaries.filter(
-      (registerSession) => registerSession.status === "closing",
+      (registerSession) =>
+        registerSession.status === "closing" ||
+        registerSession.status === "closeout_rejected",
     ),
     recentDeposits: [...args.deposits]
       .sort((left, right) => right.recordedAt - left.recordedAt)
@@ -587,6 +592,7 @@ export function buildCashControlsDashboardSnapshot(args: {
         registerSession.localSyncStatus?.status === "needs_review" ||
         (variance !== 0 &&
           (registerSession.status === "closing" ||
+            registerSession.status === "closeout_rejected" ||
             Boolean(registerSession.pendingApprovalRequest)))
       );
     }),
@@ -1363,6 +1369,37 @@ export const resolveRegisterSessionSyncReview = mutation({
           (syncEvent.status === "conflicted" ||
             syncEvent.status === "rejected")
         ) {
+          if (
+            syncEvent.eventType === "register_closed" &&
+            review.reviewKind === "register_closeout_variance" &&
+            !rejectedCloseoutLocalEventIds.has(syncEvent.localEventId)
+          ) {
+            const conflictDetails = conflict.details ?? {};
+            const syncPayload = recordDetail(syncEvent.payload);
+            const reviewedCountedCash =
+              numberDetail(conflictDetails, "countedCash") ??
+              numberDetail(syncPayload ?? undefined, "countedCash") ??
+              registerSession.countedCash;
+            const reviewedVariance =
+              numberDetail(conflictDetails, "variance") ??
+              (reviewedCountedCash !== undefined
+                ? reviewedCountedCash - registerSession.expectedCash
+                : registerSession.variance);
+            const reviewedNotes =
+              typeof conflictDetails.notes === "string"
+                ? conflictDetails.notes
+                : typeof syncPayload?.notes === "string"
+                  ? syncPayload.notes
+                  : undefined;
+
+            await rejectRegisterSessionCloseoutWithCtx(ctx, {
+              allowActiveReviewedCloseoutEvidence: true,
+              countedCash: reviewedCountedCash,
+              notes: reviewedNotes,
+              registerSessionId: args.registerSessionId,
+              variance: reviewedVariance,
+            });
+          }
           await localSyncRepository.patchEvent(syncEvent._id, {
             rejectionCode: "manager_rejected",
             rejectionMessage:
@@ -1381,14 +1418,6 @@ export const resolveRegisterSessionSyncReview = mutation({
         ) {
           const conflictDetails = conflict.details ?? {};
           rejectedCloseoutLocalEventIds.add(syncEvent.localEventId);
-          if (review.reviewKind === "register_closeout_variance") {
-            await ctx.db.patch("registerSession", args.registerSessionId, {
-              countedCash: undefined,
-              notes: undefined,
-              status: "active",
-              variance: undefined,
-            });
-          }
           await recordOperationalEventWithCtx(ctx, {
             ...(args.actorStaffProfileId
               ? { actorStaffProfileId: args.actorStaffProfileId }

--- a/packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts
+++ b/packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts
@@ -52,12 +52,14 @@ type RegisterSessionRecord = {
   countedCash?: number;
   expectedCash: number;
   managerApprovalRequestId?: Id<"approvalRequest">;
+  notes?: string;
   openedAt: number;
   organizationId?: Id<"organization">;
   registerNumber?: string;
-  status: "open" | "active" | "closing" | "closed";
+  status: "open" | "active" | "closing" | "closeout_rejected" | "closed";
   storeId: Id<"store">;
   terminalId?: Id<"posTerminal">;
+  variance?: number;
   workflowTraceId?: string;
 };
 
@@ -666,8 +668,11 @@ describe("register session trace lifecycle handlers", () => {
       registerSessions: [
         buildRegisterSession({
           countedCash: 16_050,
+          expectedCash: 10_000,
           managerApprovalRequestId: "approval-1" as Id<"approvalRequest">,
+          notes: "Counted after shift.",
           status: "closing",
+          variance: 6_050,
         }),
       ],
     });
@@ -686,9 +691,26 @@ describe("register session trace lifecycle handlers", () => {
         kind: "ok",
         data: expect.objectContaining({
           action: "rejected",
+          registerSession: expect.objectContaining({
+            countedCash: 16_050,
+            expectedCash: 10_000,
+            notes: "Counted after shift.",
+            status: "closeout_rejected",
+            variance: 6_050,
+          }),
         }),
       }),
     );
+    expect(ctx.registerSessions).toEqual([
+      expect.objectContaining({
+        countedCash: 16_050,
+        expectedCash: 10_000,
+        managerApprovalRequestId: undefined,
+        notes: "Counted after shift.",
+        status: "closeout_rejected",
+        variance: 6_050,
+      }),
+    ]);
     expect(mocks.traceRecord).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({

--- a/packages/athena-webapp/convex/cashControls/registerSessions.test.ts
+++ b/packages/athena-webapp/convex/cashControls/registerSessions.test.ts
@@ -8,10 +8,13 @@ import {
   buildRegisterSessionDepositPatch,
   buildRegisterSessionCloseoutPatch,
   buildRegisterSessionOpeningFloatCorrectionPatch,
+  buildRejectedRegisterSessionCloseoutPatch,
   buildReopenedRegisterSessionPatch,
   buildRegisterSession,
   buildRegisterSessionTransactionPatch,
+  openRegisterSession,
   calculateRegisterSessionCashDelta,
+  recordRegisterSessionDeposit,
   recordRegisterSessionTransaction,
 } from "../operations/registerSessions";
 import { recordRegisterSessionTraceBestEffort } from "../operations/registerSessionTracing";
@@ -211,6 +214,107 @@ describe("cash controls register sessions", () => {
     expect(recordRegisterSessionTraceBestEffort).not.toHaveBeenCalled();
   });
 
+  it("rejects sale writes against closeout-rejected sessions", async () => {
+    const session = {
+      ...buildRegisterSession({
+        storeId: "store_1" as Id<"store">,
+        openingFloat: 5000,
+        registerNumber: "A1",
+        terminalId: "terminal_1" as Id<"posTerminal">,
+      }),
+      _id: "register_session_1",
+      status: "closeout_rejected" as const,
+    };
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async () => session),
+        patch,
+      },
+    };
+
+    await expect(
+      getHandler(recordRegisterSessionTransaction)(ctx, {
+        adjustmentKind: "sale",
+        payments: [{ amount: 9000, method: "cash", timestamp: 1 }],
+        registerSessionId: "register_session_1",
+        storeId: "store_1",
+        terminalId: "terminal_1",
+      }),
+    ).rejects.toThrow("Register session is not accepting new transactions.");
+
+    expect(patch).not.toHaveBeenCalled();
+    expect(recordRegisterSessionTraceBestEffort).not.toHaveBeenCalled();
+  });
+
+  it("opens replacement sessions after submitted or rejected closeouts", async () => {
+    const existingSessions = [
+      {
+        _id: "register_session_closing",
+        countedCash: 4500,
+        expectedCash: 5000,
+        status: "closing",
+        storeId: "store_1",
+        terminalId: "terminal_1",
+        registerNumber: "A1",
+        variance: -500,
+      },
+      {
+        _id: "register_session_rejected",
+        countedCash: 4500,
+        expectedCash: 5000,
+        status: "closeout_rejected",
+        storeId: "store_1",
+        terminalId: "terminal_2",
+        registerNumber: "B2",
+        variance: -500,
+      },
+    ];
+    const insertedSessions: unknown[] = [];
+    const ctx = {
+      db: {
+        get: vi.fn(async (_table: string, id: string) =>
+          insertedSessions.find((session) => (session as { _id: string })._id === id) ??
+          null,
+        ),
+        insert: vi.fn(async (_table: string, value: unknown) => {
+          const id = `register_session_new_${insertedSessions.length + 1}`;
+          insertedSessions.push({ ...(value as object), _id: id });
+          return id;
+        }),
+        patch: vi.fn(),
+        query: vi.fn(() => ({
+          withIndex: vi.fn((indexName: string) => ({
+            order: vi.fn(() => ({
+              first: vi.fn(async () =>
+                indexName === "by_terminalId"
+                  ? existingSessions.shift() ?? null
+                  : null,
+              ),
+            })),
+          })),
+        })),
+      },
+    };
+
+    await expect(
+      getHandler(openRegisterSession)(ctx, {
+        storeId: "store_1",
+        terminalId: "terminal_1",
+        registerNumber: "A1",
+        openingFloat: 1000,
+      }),
+    ).resolves.toMatchObject({ status: "open" });
+    await expect(
+      getHandler(openRegisterSession)(ctx, {
+        storeId: "store_1",
+        terminalId: "terminal_2",
+        registerNumber: "B2",
+        openingFloat: 1000,
+      }),
+    ).resolves.toMatchObject({ status: "open" });
+  });
+
   it("computes closeout variance before final signoff", () => {
     const registerSession = buildRegisterSession({
       storeId: "store_1" as Id<"store">,
@@ -261,6 +365,47 @@ describe("cash controls register sessions", () => {
     });
   });
 
+  it("moves rejected closeout reviews into review-only state without clearing evidence", () => {
+    expect(
+      buildRejectedRegisterSessionCloseoutPatch({
+        countedCash: 45000,
+        expectedCash: 50000,
+        managerApprovalRequestId: "approval-1" as Id<"approvalRequest">,
+        notes: "cash count issue",
+        status: "closing",
+        variance: -5000,
+      }),
+    ).toEqual({
+      managerApprovalRequestId: undefined,
+      status: "closeout_rejected",
+    });
+
+    expect(() =>
+      buildRejectedRegisterSessionCloseoutPatch({
+        expectedCash: 50000,
+        status: "active",
+      }),
+    ).toThrow(
+      "Active register sessions require reviewed closeout evidence before rejection.",
+    );
+
+    expect(
+      buildRejectedRegisterSessionCloseoutPatch(
+        {
+          countedCash: 45000,
+          expectedCash: 50000,
+          notes: "cash count issue",
+          status: "active",
+          variance: -5000,
+        },
+        { allowActiveReviewedCloseoutEvidence: true },
+      ),
+    ).toEqual({
+      managerApprovalRequestId: undefined,
+      status: "closeout_rejected",
+    });
+  });
+
   it("subtracts recorded deposits from expected cash without letting the drawer go negative", () => {
     const registerSession = {
       ...buildRegisterSession({
@@ -287,6 +432,36 @@ describe("cash controls register sessions", () => {
         amount: 15000,
       })
     ).toThrow("Register session expected cash cannot be negative.");
+  });
+
+  it("rejects deposits against closeout-rejected sessions", async () => {
+    const session = {
+      ...buildRegisterSession({
+        storeId: "store_1" as Id<"store">,
+        openingFloat: 5000,
+        registerNumber: "A1",
+        terminalId: "terminal_1" as Id<"posTerminal">,
+      }),
+      _id: "register_session_1",
+      status: "closeout_rejected" as const,
+    };
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async () => session),
+        patch,
+      },
+    };
+
+    await expect(
+      getHandler(recordRegisterSessionDeposit)(ctx, {
+        amount: 2500,
+        registerSessionId: "register_session_1",
+      }),
+    ).rejects.toThrow(
+      "Cannot record a deposit for a closed register session.",
+    );
+    expect(patch).not.toHaveBeenCalled();
   });
 
   it("corrects opening float by applying only the float delta to expected cash", () => {

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -1073,6 +1073,116 @@ describe("end-of-day review backend foundation", () => {
     });
   });
 
+  it("surfaces review-only closeouts as blockers without active or closed totals", async () => {
+    const { db } = createDb({
+      approvalRequest: [
+        {
+          _id: "approval-submitted",
+          createdAt: Date.UTC(2026, 4, 7, 19),
+          metadata: {
+            countedCash: 9200,
+            expectedCash: 10000,
+            variance: -800,
+          },
+          reason:
+            "Register closeout variance requires manager review before synced closeout can be applied.",
+          registerSessionId: "register-submitted",
+          requestType: "variance_review",
+          status: "pending",
+          storeId: "store-1",
+          subjectId: "register-submitted",
+          subjectType: "register_session",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "register-rejected",
+          countedCash: 8500,
+          expectedCash: 10000,
+          openedAt: Date.UTC(2026, 4, 7, 9),
+          openingFloat: 10000,
+          registerNumber: "A1",
+          status: "closeout_rejected",
+          storeId: "store-1",
+          variance: -1500,
+        },
+        {
+          _id: "register-submitted",
+          countedCash: 9200,
+          expectedCash: 10000,
+          managerApprovalRequestId: "approval-submitted",
+          openedAt: Date.UTC(2026, 4, 7, 10),
+          openingFloat: 10000,
+          registerNumber: "A2",
+          status: "closing",
+          storeId: "store-1",
+          variance: -800,
+        },
+      ],
+      store: [store],
+    });
+
+    const snapshot = await buildDailyCloseSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      { operatingDate: "2026-05-07", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.readiness.status).toBe("blocked");
+    expect(snapshot.blockers.map((item) => item.key)).toEqual([
+      "approval_request:approval-submitted:pending",
+      "register_session:register-rejected:closeout_rejected",
+      "register_session:register-submitted:variance_review",
+    ]);
+    expect(snapshot.blockers.map((item) => item.key)).not.toContain(
+      "register_session:register-submitted:closing",
+    );
+    expect(
+      snapshot.blockers.find(
+        (item) =>
+          item.key === "register_session:register-rejected:closeout_rejected",
+      ),
+    ).toMatchObject({
+      message:
+        "Review or reopen the rejected register closeout before completing the end of day review.",
+      metadata: {
+        countedCash: 8500,
+        expectedCash: 10000,
+        status: "closeout_rejected",
+        variance: -1500,
+      },
+      title: "Register closeout needs review",
+    });
+    expect(
+      snapshot.blockers.find(
+        (item) =>
+          item.key === "register_session:register-submitted:variance_review",
+      ),
+    ).toMatchObject({
+      message:
+        "Resolve the submitted register closeout variance review before completing the end of day review.",
+      metadata: {
+        countedCash: 9200,
+        expectedCash: 10000,
+        status: "closing",
+        variance: -800,
+      },
+      title: "Register closeout variance needs review",
+    });
+    expect(snapshot.summary).toMatchObject({
+      closedRegisterSessionCount: 0,
+      expectedCashTotal: 0,
+      netCashVariance: 0,
+      registerCount: 0,
+      registerVarianceCount: 0,
+    });
+    expect(snapshot.readyItems.map((item) => item.key)).not.toContain(
+      "register_session:register-rejected:closed",
+    );
+    expect(snapshot.readyItems.map((item) => item.key)).not.toContain(
+      "register_session:register-submitted:closed",
+    );
+  });
+
   it("adds explicit applied item-adjustment settlement totals without changing original sale totals", async () => {
     const { db } = createDb({
       posTransaction: [

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -36,6 +36,7 @@ const DAILY_CLOSE_CARRY_FORWARD_TYPE = "daily_close_carry_forward";
 const TERMINAL_WORK_ITEM_STATUSES = new Set(["completed", "cancelled"]);
 const OPEN_OPERATIONAL_WORK_ITEM_STATUSES = ["open", "in_progress"] as const;
 const ACTIVE_REGISTER_STATUSES = ["open", "active", "closing"] as const;
+const REVIEW_ONLY_REGISTER_CLOSEOUT_STATUSES = ["closeout_rejected"] as const;
 const OPEN_POS_SESSION_STATUSES = ["active", "held"] as const;
 const DAILY_CLOSE_COMPLETION_ACTION = APPROVAL_ACTIONS.dailyCloseCompletion;
 const DAILY_CLOSE_REOPEN_ACTION = APPROVAL_ACTIONS.dailyCloseReopen;
@@ -545,13 +546,22 @@ function registerSessionCloseoutOperatingAt(
       record.type === "closed" && typeof record.occurredAt === "number",
   );
   const closeoutSubmittedAt =
-    session.status === "closing" &&
-    typeof session.countedCash === "number" &&
-    closeoutApproval?.requestType === "variance_review"
-      ? closeoutApproval.createdAt
+    isSubmittedVarianceCloseout(session, closeoutApproval)
+      ? closeoutApproval?.createdAt
       : undefined;
 
   return firstClosedRecord?.occurredAt ?? closeoutSubmittedAt ?? session.closedAt;
+}
+
+function isSubmittedVarianceCloseout(
+  session: RegisterSessionRangeCandidate,
+  closeoutApproval?: RegisterSessionCloseoutApproval,
+) {
+  return (
+    session.status === "closing" &&
+    typeof session.countedCash === "number" &&
+    closeoutApproval?.requestType === "variance_review"
+  );
 }
 
 function registerSessionLabel(
@@ -849,6 +859,24 @@ async function listActiveRegisterSessions(
 ) {
   const sessions = await Promise.all(
     ACTIVE_REGISTER_STATUSES.map((status) =>
+      ctx.db
+        .query("registerSession")
+        .withIndex("by_storeId_status", (q) =>
+          q.eq("storeId", storeId).eq("status", status),
+        )
+        .take(DAILY_CLOSE_QUERY_LIMIT),
+    ),
+  );
+
+  return sessions.flat();
+}
+
+async function listReviewOnlyRegisterCloseoutSessions(
+  ctx: Pick<QueryCtx, "db">,
+  storeId: Id<"store">,
+) {
+  const sessions = await Promise.all(
+    REVIEW_ONLY_REGISTER_CLOSEOUT_STATUSES.map((status) =>
       ctx.db
         .query("registerSession")
         .withIndex("by_storeId_status", (q) =>
@@ -1785,6 +1813,7 @@ export async function buildDailyCloseSnapshotWithCtx(
 
   const [
     activeRegisterSessionsForStore,
+    reviewOnlyRegisterCloseoutSessionsForStore,
     closedRegisterSessions,
     pendingApprovals,
     openPosSessions,
@@ -1797,6 +1826,7 @@ export async function buildDailyCloseSnapshotWithCtx(
     priorClose,
   ] = await Promise.all([
     listActiveRegisterSessions(ctx, args.storeId),
+    listReviewOnlyRegisterCloseoutSessions(ctx, args.storeId),
     listClosedRegisterSessionsForDay(ctx, { ...range, storeId: args.storeId }),
     listPendingCloseoutApprovals(ctx, { ...range, storeId: args.storeId }),
     listOpenPosSessions(ctx, { ...range, storeId: args.storeId }),
@@ -1820,11 +1850,55 @@ export async function buildDailyCloseSnapshotWithCtx(
     getPriorCompletedDailyClose(ctx, args),
   ]);
 
-  const activeRegisterSessions = await filterRegisterSessionsBelongingToRange(
+  const activeRegisterSessionsInRange =
+    await filterRegisterSessionsBelongingToRange(
+      ctx,
+      activeRegisterSessionsForStore,
+      range,
+    );
+  const reviewOnlyRegisterCloseoutSessionsInRange =
+    await filterRegisterSessionsBelongingToRange(
+      ctx,
+      reviewOnlyRegisterCloseoutSessionsForStore,
+      range,
+    );
+  const activeRegisterSessionApprovalsById = await buildApprovalRequestsById(
     ctx,
-    activeRegisterSessionsForStore,
-    range,
+    activeRegisterSessionsInRange.map(
+      (session) => session.managerApprovalRequestId,
+    ),
   );
+  const submittedVarianceCloseoutSessions = activeRegisterSessionsInRange.filter(
+    (session) =>
+      isSubmittedVarianceCloseout(
+        session,
+        closeoutApprovalForRegisterSession(
+          session,
+          activeRegisterSessionApprovalsById,
+        ),
+      ),
+  );
+  const activeRegisterSessions = activeRegisterSessionsInRange.filter(
+    (session) =>
+      !isSubmittedVarianceCloseout(
+        session,
+        closeoutApprovalForRegisterSession(
+          session,
+          activeRegisterSessionApprovalsById,
+        ),
+      ),
+  );
+  const reviewOnlyRegisterCloseoutSessions = [
+    ...reviewOnlyRegisterCloseoutSessionsInRange,
+    ...submittedVarianceCloseoutSessions,
+  ];
+  const reviewOnlyRegisterCloseoutApprovalsById =
+    await buildApprovalRequestsById(
+      ctx,
+      reviewOnlyRegisterCloseoutSessions.map(
+        (session) => session.managerApprovalRequestId,
+      ),
+    );
   const relevantRegisterSessions = [
     ...activeRegisterSessions,
     ...closedRegisterSessions,
@@ -1859,6 +1933,7 @@ export async function buildDailyCloseSnapshotWithCtx(
       : undefined;
   const terminalLabelsById = await buildTerminalLabelsById(ctx, [
     ...activeRegisterSessions.map((session) => session.terminalId),
+    ...reviewOnlyRegisterCloseoutSessions.map((session) => session.terminalId),
     ...closedRegisterSessions.map((session) => session.terminalId),
     ...approvalRegisterSessions.map((session) => session.terminalId),
     ...expenseSessions.map((session) => session.terminalId),
@@ -1869,6 +1944,12 @@ export async function buildDailyCloseSnapshotWithCtx(
   const staffNamesById = await buildStaffNamesById(ctx, [
     ...activeRegisterSessions.map((session) => session.openedByStaffProfileId),
     ...activeRegisterSessions.map((session) => session.closedByStaffProfileId),
+    ...reviewOnlyRegisterCloseoutSessions.map(
+      (session) => session.openedByStaffProfileId,
+    ),
+    ...reviewOnlyRegisterCloseoutSessions.map(
+      (session) => session.closedByStaffProfileId,
+    ),
     ...closedRegisterSessions.map((session) => session.openedByStaffProfileId),
     ...closedRegisterSessions.map((session) => session.closedByStaffProfileId),
     ...approvalRegisterSessions.map(
@@ -1951,6 +2032,80 @@ export async function buildDailyCloseSnapshotWithCtx(
           ? { closedAt: session.closedAt }
           : {}),
         ...(closedBy ? { closedBy } : {}),
+      },
+    });
+  });
+
+  reviewOnlyRegisterCloseoutSessions.forEach((session) => {
+    const terminalLabel = session.terminalId
+      ? terminalLabelsById.get(session.terminalId)
+      : undefined;
+    const registerLabel = trimOptional(session.registerNumber)
+      ? registerSessionLabel(session)
+      : undefined;
+    const registerMetadata = registerMetadataLabel(
+      terminalLabel,
+      registerLabel,
+    );
+    const openedBy = session.openedByStaffProfileId
+      ? staffNamesById.get(session.openedByStaffProfileId)
+      : undefined;
+    const closedBy = session.closedByStaffProfileId
+      ? staffNamesById.get(session.closedByStaffProfileId)
+      : undefined;
+    const isCarriedOver = session.openedAt < range.startAt;
+    const closeoutApproval = closeoutApprovalForRegisterSession(
+      session,
+      reviewOnlyRegisterCloseoutApprovalsById,
+    );
+    const isSubmittedVarianceReview = isSubmittedVarianceCloseout(
+      session,
+      closeoutApproval,
+    );
+
+    blockers.push({
+      key: `register_session:${session._id}:${
+        isSubmittedVarianceReview ? "variance_review" : session.status
+      }`,
+      severity: "blocker",
+      category: "register_session",
+      title: isSubmittedVarianceReview
+        ? "Register closeout variance needs review"
+        : "Register closeout needs review",
+      message: isSubmittedVarianceReview
+        ? "Resolve the submitted register closeout variance review before completing the end of day review."
+        : "Review or reopen the rejected register closeout before completing the end of day review.",
+      subject: {
+        type: "register_session",
+        id: session._id,
+        label: registerSessionLabel(session),
+      },
+      link: {
+        label: "View session",
+        params: { sessionId: session._id },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId",
+      },
+      metadata: {
+        ...(terminalLabel ? { terminal: terminalLabel } : {}),
+        ...(registerMetadata ? { register: registerMetadata } : {}),
+        operatingScope: isCarriedOver
+          ? "Carried over from prior day"
+          : "Opened today",
+        openedAt: session.openedAt,
+        ...(openedBy ? { openedBy } : {}),
+        expectedCash: session.expectedCash,
+        ...(typeof session.countedCash === "number"
+          ? { countedCash: session.countedCash }
+          : {}),
+        status: session.status,
+        ...nonZeroVarianceMetadata(session.variance),
+        ...(typeof session.closedAt === "number"
+          ? { closedAt: session.closedAt }
+          : {}),
+        ...(closedBy ? { closedBy } : {}),
+        ...(closeoutApproval
+          ? { reviewRequestedAt: closeoutApproval.createdAt }
+          : {}),
       },
     });
   });

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -2088,6 +2088,103 @@ describe("daily operations overview read model", () => {
     });
   });
 
+  it("surfaces review-only closeouts as close work instead of closed drawer health", async () => {
+    const snapshot = await buildDailyOperationsSnapshotWithCtx(
+      buildCtx({
+        approvalRequest: [
+          {
+            _id: "approval-submitted",
+            createdAt: Date.UTC(2026, 4, 8, 19),
+            metadata: {
+              countedCash: 9200,
+              expectedCash: 10000,
+              variance: -800,
+            },
+            reason:
+              "Register closeout variance requires manager review before synced closeout can be applied.",
+            registerSessionId: "register-submitted",
+            requestType: "variance_review",
+            status: "pending",
+            storeId: "store-1",
+            subjectId: "register-submitted",
+            subjectType: "register_session",
+          },
+        ],
+        dailyClose: [priorClose],
+        dailyOpening: [startedOpening],
+        registerSession: [
+          {
+            _id: "register-rejected",
+            countedCash: 8500,
+            expectedCash: 10000,
+            openedAt: Date.UTC(2026, 4, 8, 9),
+            openingFloat: 10000,
+            registerNumber: "1",
+            status: "closeout_rejected",
+            storeId: "store-1",
+            variance: -1500,
+          },
+          {
+            _id: "register-submitted",
+            countedCash: 9200,
+            expectedCash: 10000,
+            managerApprovalRequestId: "approval-submitted",
+            openedAt: Date.UTC(2026, 4, 8, 10),
+            openingFloat: 10000,
+            registerNumber: "2",
+            status: "closing",
+            storeId: "store-1",
+            variance: -800,
+          },
+        ],
+        store: [store],
+      }),
+      { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.lifecycle.status).toBe("close_blocked");
+    expect(snapshot.closeSummary).toMatchObject({
+      registerVarianceCount: 0,
+    });
+    expect(snapshot.lanes.find((lane) => lane.key === "close")).toMatchObject({
+      count: 3,
+      status: "blocked",
+    });
+    expect(
+      snapshot.lanes.find((lane) => lane.key === "registers"),
+    ).toMatchObject({
+      count: 2,
+      status: "blocked",
+    });
+    expect(snapshot.attentionItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "register_session:register-rejected:closeout_rejected",
+          label: "Register closeout needs review",
+          owner: "daily_close",
+          source: {
+            id: "register-rejected",
+            label: "Register 1",
+            type: "register_session",
+          },
+        }),
+        expect.objectContaining({
+          id: "register_session:register-submitted:variance_review",
+          label: "Register closeout variance needs review",
+          owner: "daily_close",
+          source: {
+            id: "register-submitted",
+            label: "Register 2",
+            type: "register_session",
+          },
+        }),
+      ]),
+    );
+    expect(snapshot.attentionItems.map((item) => item.id)).not.toContain(
+      "register_session:register-submitted:closing",
+    );
+  });
+
   it("surfaces open queue work and pending approvals without counting terminal work", async () => {
     const snapshot = await buildDailyOperationsSnapshotWithCtx(
       buildCtx({

--- a/packages/athena-webapp/convex/operations/registerSessionTracing.ts
+++ b/packages/athena-webapp/convex/operations/registerSessionTracing.ts
@@ -35,7 +35,7 @@ export type RegisterSessionTraceableSession = {
   organizationId?: Id<"organization">;
   terminalId?: Id<"posTerminal">;
   registerNumber?: string;
-  status: "open" | "active" | "closing" | "closed";
+  status: "open" | "active" | "closing" | "closeout_rejected" | "closed";
   openedByUserId?: Id<"athenaUser">;
   openedByStaffProfileId?: Id<"staffProfile">;
   openedAt: number;

--- a/packages/athena-webapp/convex/operations/registerSessions.ts
+++ b/packages/athena-webapp/convex/operations/registerSessions.ts
@@ -2,10 +2,12 @@ import { internalMutation, internalQuery, MutationCtx } from "../_generated/serv
 import { Id } from "../_generated/dataModel";
 import { v } from "convex/values";
 import {
+  isCashControlVisibleRegisterSessionStatus,
   isPosUsableRegisterSessionStatus,
   isRegisterSessionConflictBlockingStatus,
   type RegisterSessionStatus,
 } from "../../shared/registerSessionStatus";
+import { isRegisterSessionReplacementBlocking } from "../../shared/registerSessionLifecyclePolicy";
 import { recordRegisterSessionTraceBestEffort } from "./registerSessionTracing";
 
 const registerSessionStatusSet = (
@@ -14,8 +16,9 @@ const registerSessionStatusSet = (
 
 const REGISTER_SESSION_TRANSITIONS = {
   active: registerSessionStatusSet("closing"),
+  closeout_rejected: registerSessionStatusSet("closing"),
   closed: registerSessionStatusSet(),
-  closing: registerSessionStatusSet("active", "closed"),
+  closing: registerSessionStatusSet("active", "closeout_rejected", "closed"),
   open: registerSessionStatusSet("active", "closing"),
 } satisfies Record<RegisterSessionStatus, ReadonlySet<RegisterSessionStatus>>;
 type RegisterSessionIdentity = {
@@ -244,6 +247,119 @@ export function buildReopenedRegisterSessionPatch(session: {
   };
 }
 
+export function buildReopenedRejectedRegisterSessionCloseoutPatch(
+  session: {
+    closeoutRecords?: RegisterSessionCloseoutRecord[];
+    countedCash?: number;
+    expectedCash: number;
+    notes?: string;
+    status: RegisterSessionStatus;
+    variance?: number;
+  },
+  args: {
+    actorStaffProfileId?: Id<"staffProfile">;
+    actorUserId?: Id<"athenaUser">;
+    reason?: string;
+  } = {}
+) {
+  assertValidRegisterSessionTransition(session.status, "closing");
+  const occurredAt = Date.now();
+  const reason =
+    trimOptional(args.reason) ??
+    "Rejected register closeout reopened for correction.";
+
+  return {
+    closeoutRecords: [
+      ...(session.closeoutRecords ?? []),
+      omitUndefined({
+        actorStaffProfileId: args.actorStaffProfileId,
+        actorUserId: args.actorUserId,
+        countedCash: session.countedCash,
+        expectedCash: session.expectedCash,
+        notes: session.notes,
+        occurredAt,
+        reason,
+        type: "reopened" as const,
+        variance: session.variance,
+      }),
+    ],
+    managerApprovalRequestId: undefined,
+    status: "closing" as const,
+  };
+}
+
+export function buildRejectedRegisterSessionCloseoutPatch(
+  session: {
+    countedCash?: number;
+    expectedCash: number;
+    managerApprovalRequestId?: Id<"approvalRequest">;
+    notes?: string;
+    status: RegisterSessionStatus;
+    variance?: number;
+  },
+  args: {
+    allowActiveReviewedCloseoutEvidence?: boolean;
+    countedCash?: number;
+    notes?: string;
+    variance?: number;
+  } = {}
+) {
+  if (session.status === "active") {
+    if (!args.allowActiveReviewedCloseoutEvidence) {
+      throw new Error(
+        "Active register sessions require reviewed closeout evidence before rejection."
+      );
+    }
+
+    const evidenceCountedCash = args.countedCash ?? session.countedCash;
+    const evidenceVariance =
+      args.variance ??
+      (evidenceCountedCash !== undefined
+        ? evidenceCountedCash - session.expectedCash
+        : session.variance);
+
+    if (
+      evidenceCountedCash === undefined ||
+      evidenceVariance === undefined
+    ) {
+      throw new Error(
+        "Active register sessions require reviewed closeout evidence before rejection."
+      );
+    }
+  } else {
+    assertValidRegisterSessionTransition(
+      session.status,
+      "closeout_rejected"
+    );
+  }
+
+  const patch: {
+    countedCash?: number;
+    managerApprovalRequestId: undefined;
+    notes?: string;
+    status: "closeout_rejected";
+    variance?: number;
+  } = {
+    managerApprovalRequestId: undefined,
+    status: "closeout_rejected",
+  };
+
+  if (args.countedCash !== undefined) {
+    patch.countedCash = args.countedCash;
+  }
+
+  const notes = trimOptional(args.notes);
+  if (notes !== undefined) {
+    patch.notes = notes;
+  }
+
+  if (args.variance !== undefined) {
+    patch.variance = args.variance;
+  }
+
+  return patch;
+}
+
 export function buildReopenedClosedRegisterSessionPatch(
   session: {
     closedAt?: number;
@@ -418,6 +534,12 @@ async function findConflictingRegisterSession(
     registerNumber?: string;
   }
 ) {
+  const hasSubmittedCloseout = (
+    session: { countedCash?: number; managerApprovalRequestId?: Id<"approvalRequest">; variance?: number }
+  ) =>
+    session.countedCash !== undefined ||
+    session.variance !== undefined ||
+    session.managerApprovalRequestId !== undefined;
   const latestByTerminal = await ctx.db
     .query("registerSession")
     .withIndex("by_terminalId", (q) => q.eq("terminalId", args.terminalId))
@@ -426,7 +548,10 @@ async function findConflictingRegisterSession(
 
   if (
     latestByTerminal &&
-    isRegisterSessionConflictBlockingStatus(latestByTerminal.status)
+    isRegisterSessionReplacementBlocking({
+      hasSubmittedCloseout: hasSubmittedCloseout(latestByTerminal),
+      session: latestByTerminal,
+    })
   ) {
     throw new Error("A register session is already open for this terminal.");
   }
@@ -447,7 +572,10 @@ async function findConflictingRegisterSession(
 
   if (
     latestByRegisterNumber &&
-    isRegisterSessionConflictBlockingStatus(latestByRegisterNumber.status)
+    isRegisterSessionReplacementBlocking({
+      hasSubmittedCloseout: hasSubmittedCloseout(latestByRegisterNumber),
+      session: latestByRegisterNumber,
+    })
   ) {
     throw new Error("A register session is already open for this register number.");
   }
@@ -580,7 +708,10 @@ export const getRegisterSessionForRegisterState = internalQuery({
           return latestByRegisterNumber;
         }
 
-        if (latestByRegisterNumber.status === "closed") {
+        if (
+          latestByRegisterNumber.status === "closed" ||
+          latestByRegisterNumber.status === "closeout_rejected"
+        ) {
           return latestByRegisterNumber;
         }
       }
@@ -596,7 +727,10 @@ export const getRegisterSessionForRegisterState = internalQuery({
       return null;
     }
 
-    if (isRegisterSessionConflictBlockingStatus(latestByTerminal.status)) {
+    if (
+      isRegisterSessionConflictBlockingStatus(latestByTerminal.status) ||
+      isCashControlVisibleRegisterSessionStatus(latestByTerminal.status)
+    ) {
       return latestByTerminal;
     }
 
@@ -640,7 +774,7 @@ export const recordRegisterSessionTransaction = internalMutation({
 
     if (
       args.adjustmentKind === "sale" &&
-      (session.status === "closing" || session.status === "closed")
+      !isPosUsableRegisterSessionStatus(session.status)
     ) {
       throw new Error("Register session is not accepting new transactions.");
     }
@@ -750,6 +884,53 @@ export const reopenRegisterSession = internalMutation({
   },
 });
 
+export async function rejectRegisterSessionCloseoutWithCtx(
+  ctx: MutationCtx,
+  args: {
+    allowActiveReviewedCloseoutEvidence?: boolean;
+    countedCash?: number;
+    notes?: string;
+    registerSessionId: Id<"registerSession">;
+    variance?: number;
+  }
+) {
+  const session = await ctx.db.get("registerSession", args.registerSessionId);
+  if (!session) {
+    throw new Error("Register session not found.");
+  }
+
+  await ctx.db.patch(
+    "registerSession",
+    args.registerSessionId,
+    buildRejectedRegisterSessionCloseoutPatch(session, args)
+  );
+
+  return ctx.db.get("registerSession", args.registerSessionId);
+}
+
+export async function reopenRejectedRegisterSessionCloseoutWithCtx(
+  ctx: MutationCtx,
+  args: {
+    actorStaffProfileId?: Id<"staffProfile">;
+    actorUserId?: Id<"athenaUser">;
+    registerSessionId: Id<"registerSession">;
+    reason?: string;
+  }
+) {
+  const session = await ctx.db.get("registerSession", args.registerSessionId);
+  if (!session) {
+    throw new Error("Register session not found.");
+  }
+
+  await ctx.db.patch(
+    "registerSession",
+    args.registerSessionId,
+    buildReopenedRejectedRegisterSessionCloseoutPatch(session, args)
+  );
+
+  return ctx.db.get("registerSession", args.registerSessionId);
+}
+
 export const reopenClosedRegisterSessionCloseout = internalMutation({
   args: {
     actorStaffProfileId: v.optional(v.id("staffProfile")),
@@ -798,8 +979,10 @@ export async function recordRegisterSessionDepositWithCtx(
     throw new Error("Register session not found.");
   }
 
-  if (session.status === "closed") {
-    throw new Error("Cannot record a deposit for a closed register session.");
+  if (session.status === "closed" || session.status === "closeout_rejected") {
+    throw new Error(
+      "Cannot record a deposit for a closed register session."
+    );
   }
 
   await ctx.db.patch(

--- a/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
@@ -1759,7 +1759,7 @@ export async function resolveTransactionVoidApprovalDecisionWithCtx(
     ctx,
     transaction,
     {
-      requireUsableRegisterSession: registerSession?.status !== "closing",
+      requireUsableRegisterSession: true,
     },
   );
   if (preconditions.kind !== "ok") {

--- a/packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts
@@ -1,5 +1,6 @@
 import type { Id } from "../../../_generated/dataModel";
 import type { MutationCtx } from "../../../_generated/server";
+import { isPosUsableRegisterSessionStatus } from "../../../../shared/registerSessionStatus";
 import type { ApprovalRequirement } from "../../../../shared/approvalPolicy";
 import { buildApprovalRequest } from "../../../operations/approvalRequestHelpers";
 import {
@@ -199,7 +200,7 @@ async function requireRegisterSessionAllowsPaymentCorrection(
     throw new Error("Register session not found for this transaction.");
   }
 
-  if (registerSession.status === "closing") {
+  if (!isPosUsableRegisterSessionStatus(registerSession.status)) {
     throw new Error(CLOSING_REGISTER_PAYMENT_UPDATE_MESSAGE);
   }
 }
@@ -232,6 +233,10 @@ async function adjustRegisterSessionExpectedCashForPaymentCorrection(
 
   if (!registerSession || registerSession.storeId !== args.storeId) {
     throw new Error("Register session not found for this transaction.");
+  }
+
+  if (!isPosUsableRegisterSessionStatus(registerSession.status)) {
+    throw new Error(CLOSING_REGISTER_PAYMENT_UPDATE_MESSAGE);
   }
 
   const nextExpectedCash = registerSession.expectedCash + expectedCashDelta;

--- a/packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.test.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.test.ts
@@ -16,6 +16,7 @@ type TableName =
   | "posPendingCheckoutItem"
   | "product"
   | "productSku"
+  | "registerSession"
   | "store"
   | "subcategory";
 type Row = Record<string, unknown> & { _id: string };
@@ -33,6 +34,7 @@ function createPendingCheckoutCtx(seed?: Partial<Record<TableName, Row[]>>) {
     posPendingCheckoutItem: new Map(),
     product: new Map(),
     productSku: new Map(),
+    registerSession: new Map(),
     store: new Map(),
     subcategory: new Map(),
   };
@@ -44,6 +46,7 @@ function createPendingCheckoutCtx(seed?: Partial<Record<TableName, Row[]>>) {
     posPendingCheckoutItem: 0,
     product: 0,
     productSku: 0,
+    registerSession: 0,
     store: 0,
     subcategory: 0,
   };
@@ -158,6 +161,37 @@ const baseSeed = {
 };
 
 describe("createOrReusePendingCheckoutItem", () => {
+  it("rejects ordinary pending checkout sale context for review-only drawers", async () => {
+    const { ctx, tables } = createPendingCheckoutCtx({
+      ...baseSeed,
+      registerSession: [
+        {
+          _id: "register-session-1",
+          expectedCash: 5_000,
+          status: "closeout_rejected",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    await expect(
+      createOrReusePendingCheckoutItem(ctx, {
+        createdByUserId: "user0001" as Id<"athenaUser">,
+        lookupCode: "123456789012",
+        name: "Loose wave bundle",
+        price: 125000,
+        quantitySold: 1,
+        registerSessionId: "register-session-1" as Id<"registerSession">,
+        storeId: "storezzzz" as Id<"store">,
+        timestamp: 1_000,
+      }),
+    ).rejects.toThrow(
+      "Open a replacement drawer before selling this pending checkout item.",
+    );
+
+    expect(tables.posPendingCheckoutItem.size).toBe(0);
+  });
+
   it("creates a reviewable pending checkout item without creating trusted catalog stock", async () => {
     const { ctx, tables } = createPendingCheckoutCtx(baseSeed);
 
@@ -495,7 +529,17 @@ describe("createOrReusePendingCheckoutItem", () => {
   });
 
   it("records sold evidence only after a pending checkout line is committed", async () => {
-    const { ctx, tables } = createPendingCheckoutCtx(baseSeed);
+    const { ctx, tables } = createPendingCheckoutCtx({
+      ...baseSeed,
+      registerSession: [
+        {
+          _id: "register-session-1",
+          expectedCash: 5_000,
+          status: "active",
+          storeId: "storezzzz",
+        },
+      ],
+    });
 
     const result = await createOrReusePendingCheckoutItem(ctx, {
       createdByUserId: "user0001" as Id<"athenaUser">,

--- a/packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.ts
@@ -1,5 +1,6 @@
 import type { Doc, Id } from "../../../_generated/dataModel";
 import type { MutationCtx } from "../../../_generated/server";
+import { isPosUsableRegisterSessionStatus } from "../../../../shared/registerSessionStatus";
 import { recordOperationalEventWithCtx } from "../../../operations/operationalEvents";
 import { createOperationalWorkItemWithCtx } from "../../../operations/operationalWorkItems";
 import { toSlug } from "../../../utils";
@@ -131,6 +132,34 @@ async function findTrustedCatalogSkuForLookupCode(
   }
 
   return null;
+}
+
+async function requireOrdinarySaleUsableRegisterSession(
+  ctx: MutationCtx,
+  args: {
+    registerSessionId?: Id<"registerSession">;
+    source: "online" | "offline_sync";
+    storeId: Id<"store">;
+  },
+) {
+  if (!args.registerSessionId || args.source !== "online") {
+    return;
+  }
+
+  const registerSession = await ctx.db.get(
+    "registerSession",
+    args.registerSessionId,
+  );
+
+  if (
+    !registerSession ||
+    registerSession.storeId !== args.storeId ||
+    !isPosUsableRegisterSessionStatus(registerSession.status)
+  ) {
+    throw new Error(
+      "Open a replacement drawer before selling this pending checkout item.",
+    );
+  }
 }
 
 async function findOrCreatePendingCheckoutCategory(
@@ -708,6 +737,11 @@ export async function createOrReusePendingCheckoutItem(
   const normalizedLookupCode = normalizeLookupCode(lookupCode);
   const source = args.source ?? "online";
   const timestamp = args.timestamp ?? Date.now();
+  await requireOrdinarySaleUsableRegisterSession(ctx, {
+    registerSessionId: args.registerSessionId,
+    source,
+    storeId: args.storeId,
+  });
   const trustedCatalogSku = await findTrustedCatalogSkuForLookupCode(ctx, {
     lookupCode,
     storeId: args.storeId,

--- a/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
+++ b/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
@@ -851,7 +851,7 @@ describe("voidTransaction", () => {
     );
   });
 
-  it("applies a queued completed-sale void when the original drawer is closing", async () => {
+  it("blocks a queued completed-sale void when the original drawer is closing", async () => {
     vi.mocked(getRegisterSessionById).mockResolvedValue({
       _id: "register-1",
       status: "closing",
@@ -883,16 +883,9 @@ describe("voidTransaction", () => {
         reviewedByStaffProfileId: "manager-1" as Id<"staffProfile">,
         reviewedByUserId: "manager-user-1" as Id<"athenaUser">,
       }),
-    ).resolves.toMatchObject({
-      approvalRequestId: "approval-request-1",
-      transactionId: "txn-1",
-    });
-    expect(recordRetailVoidPaymentAllocations).toHaveBeenCalled();
-    expect(patchPosTransaction).toHaveBeenCalledWith(
-      expect.anything(),
-      "txn-1",
-      expect.objectContaining({ status: "void" }),
-    );
+    ).rejects.toThrow("Drawer closed. Open the drawer before voiding this sale.");
+    expect(recordRetailVoidPaymentAllocations).not.toHaveBeenCalled();
+    expect(patchPosTransaction).not.toHaveBeenCalled();
   });
 
   it("blocks a queued completed-sale void when the original drawer is closed", async () => {
@@ -3876,7 +3869,9 @@ describe("completeTransaction trace ordering", () => {
     expect(createPosTransaction).not.toHaveBeenCalled();
   });
 
-  it("fails safely when a session sale is bound to a closing drawer", async () => {
+  it.each(["closing", "closeout_rejected"] as const)(
+    "fails safely when a session sale is bound to a %s drawer",
+    async (status) => {
     const runMutation = vi.fn().mockResolvedValue(undefined);
     const ctx = {
       runMutation,
@@ -3898,7 +3893,7 @@ describe("completeTransaction trace ordering", () => {
     vi.mocked(getRegisterSessionById).mockResolvedValue({
       _id: "register-1",
       storeId: "store-1",
-      status: "closing",
+      status,
       terminalId: "terminal-1",
       registerNumber: "1",
     } as never);
@@ -3935,7 +3930,8 @@ describe("completeTransaction trace ordering", () => {
 
     expect(runMutation).not.toHaveBeenCalled();
     expectNoCompletionSideEffects();
-  });
+    },
+  );
 
   it("fails safely when a session sale drawer belongs to another store", async () => {
     const runMutation = vi.fn().mockResolvedValue(undefined);

--- a/packages/athena-webapp/convex/pos/application/correctTransactionPaymentMethod.test.ts
+++ b/packages/athena-webapp/convex/pos/application/correctTransactionPaymentMethod.test.ts
@@ -404,6 +404,7 @@ describe("correctTransactionPaymentMethod", () => {
       _id: "register-session-1",
       countedCash: 9000,
       expectedCash: 7000,
+      status: "active",
       storeId: "store-1",
     } as never);
     vi.mocked(getPosTransactionById).mockResolvedValue({
@@ -463,6 +464,7 @@ describe("correctTransactionPaymentMethod", () => {
     vi.mocked(ctx.db.get).mockResolvedValue({
       _id: "register-session-1",
       expectedCash: 7000,
+      status: "active",
       storeId: "store-1",
     } as never);
     vi.mocked(getPosTransactionById).mockResolvedValue({
@@ -508,40 +510,45 @@ describe("correctTransactionPaymentMethod", () => {
     );
   });
 
-  it("rejects payment method corrections while the register session is closing", async () => {
-    const ctx = createMutationCtx();
-    vi.mocked(ctx.db.get).mockResolvedValue({
-      _id: "register-session-1",
-      expectedCash: 7000,
-      status: "closing",
-      storeId: "store-1",
-    } as never);
-    vi.mocked(getPosTransactionById).mockResolvedValue({
-      _id: "txn-1" as Id<"posTransaction">,
-      registerSessionId: "register-session-1" as Id<"registerSession">,
-      storeId: "store-1" as Id<"store">,
-      transactionNumber: "POS-111111",
-      status: "completed",
-      total: 1000,
-      totalPaid: 1000,
-      paymentMethod: "card",
-      payments: [{ method: "card", amount: 1000, timestamp: 1 }],
-    } as never);
+  it.each(["closing", "closeout_rejected"] as const)(
+    "rejects payment method corrections while the register session is %s",
+    async (status) => {
+      const ctx = createMutationCtx();
+      vi.mocked(ctx.db.get).mockResolvedValue({
+        _id: "register-session-1",
+        expectedCash: 7000,
+        status,
+        storeId: "store-1",
+      } as never);
+      vi.mocked(getPosTransactionById).mockResolvedValue({
+        _id: "txn-1" as Id<"posTransaction">,
+        registerSessionId: "register-session-1" as Id<"registerSession">,
+        storeId: "store-1" as Id<"store">,
+        transactionNumber: "POS-111111",
+        status: "completed",
+        total: 1000,
+        totalPaid: 1000,
+        paymentMethod: "card",
+        payments: [{ method: "card", amount: 1000, timestamp: 1 }],
+      } as never);
 
-    await expect(
-      correctTransactionPaymentMethod(ctx as never, {
-        approvalProofId: "proof-1" as Id<"approvalProof">,
-        transactionId: "txn-1" as Id<"posTransaction">,
-        paymentMethod: "cash",
-        reason: "Till entry correction",
-      }),
-    ).rejects.toThrow(
-      "Register closeout is under review. Reopen the register before updating payment details.",
-    );
-    expect(correctSameAmountSinglePaymentAllocationWithCtx).not.toHaveBeenCalled();
-    expect(patchPosTransaction).not.toHaveBeenCalled();
-    expect(ctx.db.patch).not.toHaveBeenCalled();
-  });
+      await expect(
+        correctTransactionPaymentMethod(ctx as never, {
+          approvalProofId: "proof-1" as Id<"approvalProof">,
+          transactionId: "txn-1" as Id<"posTransaction">,
+          paymentMethod: "cash",
+          reason: "Till entry correction",
+        }),
+      ).rejects.toThrow(
+        "Register closeout is under review. Reopen the register before updating payment details.",
+      );
+      expect(
+        correctSameAmountSinglePaymentAllocationWithCtx,
+      ).not.toHaveBeenCalled();
+      expect(patchPosTransaction).not.toHaveBeenCalled();
+      expect(ctx.db.patch).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects split payments", async () => {
     vi.mocked(getPosTransactionById).mockResolvedValue({

--- a/packages/athena-webapp/convex/pos/application/getRegisterState.test.ts
+++ b/packages/athena-webapp/convex/pos/application/getRegisterState.test.ts
@@ -141,4 +141,27 @@ describe("buildRegisterState", () => {
     expect(result.activeRegisterSession?.status).toBe("closing");
     expect(result.resumableSession?._id).toBe("session-2");
   });
+
+  it("keeps a rejected closeout drawer visible without making it sale-active", () => {
+    const result = buildRegisterState({
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "cashier-1", firstName: "Ama", lastName: "K" },
+      activeRegisterSession: {
+        _id: "drawer-1" as Id<"registerSession">,
+        countedCash: 4_500,
+        expectedCash: 5_000,
+        openedAt: 1710000000000,
+        openingFloat: 5_000,
+        registerNumber: "A1",
+        status: "closeout_rejected",
+        variance: -500,
+      },
+      activeSession: null,
+      heldSessions: [],
+    });
+
+    expect(result.phase).toBe("readyToStart");
+    expect(result.activeRegisterSession?.status).toBe("closeout_rejected");
+    expect(result.activeSession).toBeNull();
+  });
 });

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -2638,7 +2638,7 @@ describe("projectLocalSyncEvent", () => {
     ]);
   });
 
-  it("projects an existing reviewed sale mapping and opens inventory work for the selected conflict", async () => {
+  it("keeps existing reviewed sale mappings against closed drawers as conflict evidence", async () => {
     const repository = createProjectionRepository({
       registerSession: {
         _id: "register-session-1",
@@ -2717,58 +2717,19 @@ describe("projectLocalSyncEvent", () => {
       },
     });
 
-    expect(result.status).toBe("projected");
-    expect(result.conflicts).toEqual([]);
+    expect(result.status).toBe("conflicted");
+    expect(result.conflicts).toEqual([
+      expect.objectContaining({
+        conflictType: "permission",
+        summary: "Register was not open before this sale synced.",
+        details: expect.objectContaining({ status: "closed" }),
+      }),
+    ]);
     expect(repository.createdTransactions).toEqual([]);
     expect(repository.createdTransactionItems).toEqual([]);
     expect(repository.productPatches).toEqual([]);
     expect(repository.recordedSaleInventoryMovements).toEqual([]);
-    expect(repository.createdServiceWorkItems).toEqual([
-      expect.objectContaining({
-        metadata: expect.objectContaining({
-          receiptNumber: "LR-001",
-          registerSessionId: "register-session-1",
-          skippedMutationItems: [
-            expect.objectContaining({
-              productSkuId: "sku-1",
-              reason: "stock_shortfall",
-              requestedQuantity: 1,
-            }),
-          ],
-          sourceId: "transaction-1",
-          sourceType: "posTransaction",
-        }),
-        type: "synced_sale_inventory_review",
-      }),
-    ]);
-
-    const retryResult = await projectLocalSyncEvent(repository, {
-      storeId: "store-1" as never,
-      terminalId: "terminal-1" as never,
-      event: buildSaleCompletedEvent(),
-      syncEventId: "sync-event-1-retry",
-      submittedByUserId: "athena-user-1" as never,
-      now: 101,
-      options: {
-        allowClosedRegisterSaleProjection: true,
-        allowReviewedInventorySaleProjection: true,
-        reviewedConflictIds: ["conflict-reviewed-inventory"],
-      },
-    });
-
-    expect(retryResult.status).toBe("projected");
-    expect(repository.createdTransactions).toEqual([]);
-    expect(repository.createdServiceWorkItems).toHaveLength(1);
-    expect(repository.mappings).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          cloudId: "service-work-item-1",
-          cloudTable: "operationalWorkItem",
-          localId: "local-txn-1:inventory-review",
-          localIdKind: "inventoryReviewWorkItem",
-        }),
-      ]),
-    );
+    expect(repository.createdServiceWorkItems).toEqual([]);
   });
 
   it("does not duplicate-conflict an already projected inventory review sale replay", async () => {
@@ -4263,72 +4224,14 @@ describe("projectLocalSyncEvent", () => {
     ]);
   });
 
-  it("projects a manager-reviewed sale against a closed register session", async () => {
+  it("applies the expected total for manager-reviewed non-cash overpayment against an active drawer", async () => {
     const repository = createProjectionRepository({
       registerSession: {
         _id: "register-session-1",
-        expectedCash: 100,
         closeoutRecords: [],
-        countedCash: 100,
-        registerNumber: "1",
-        status: "closed",
-        variance: 0,
-      },
-    });
-
-    const result = await projectLocalSyncEvent(repository, {
-      storeId: "store-1" as never,
-      terminalId: "terminal-1" as never,
-      event: {
-        ...buildSaleCompletedEvent(),
-        staffProofToken: undefined,
-      },
-      syncEventId: "sync-event-1",
-      now: 100,
-      options: {
-        allowClosedRegisterSaleProjection: true,
-        trustStoredStaffProof: true,
-      },
-    });
-
-    expect(result.status).toBe("projected");
-    expect(repository.createdTransactions).toEqual([
-      expect.objectContaining({
-        registerSessionId: "register-session-1",
-        total: 25,
-      }),
-    ]);
-    expect(repository.registerSessionPatches).toEqual(
-      expect.arrayContaining([
-        {
-          registerSessionId: "register-session-1",
-          patch: expect.objectContaining({
-            expectedCash: 125,
-            variance: -25,
-          }),
-        },
-      ]),
-    );
-    expect(result.mappings).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          cloudTable: "posTransaction",
-          localId: "local-txn-1",
-        }),
-      ]),
-    );
-  });
-
-  it("applies the expected total for manager-reviewed non-cash overpayment", async () => {
-    const repository = createProjectionRepository({
-      registerSession: {
-        _id: "register-session-1",
         expectedCash: 100,
-        closeoutRecords: [],
-        countedCash: 100,
         registerNumber: "1",
-        status: "closed",
-        variance: 0,
+        status: "active",
       },
     });
     const baseSale = buildSaleCompletedEvent();
@@ -4353,7 +4256,6 @@ describe("projectLocalSyncEvent", () => {
       syncEventId: "sync-event-1",
       now: 100,
       options: {
-        allowClosedRegisterSaleProjection: true,
         applyExpectedTotalForReviewedNonCashOverpayment: true,
         trustStoredStaffProof: true,
       },
@@ -4392,173 +4294,53 @@ describe("projectLocalSyncEvent", () => {
     );
   });
 
-  it("keeps reviewed mixed-tender non-cash overpayment out of expected cash", async () => {
-    const repository = createProjectionRepository({
-      registerSession: {
-        _id: "register-session-1",
-        expectedCash: 100,
-        closeoutRecords: [],
-        countedCash: 100,
-        registerNumber: "1",
-        status: "closed",
-        variance: 0,
-      },
-    });
-    const baseSale = buildSaleCompletedEvent();
-
-    const result = await projectLocalSyncEvent(repository, {
-      storeId: "store-1" as never,
-      terminalId: "terminal-1" as never,
-      event: buildSaleCompletedEvent({
-        payload: {
-          ...baseSale.payload,
-          payments: [
-            {
-              localPaymentId: "local-payment-cash",
-              method: "cash",
-              amount: 25,
-              timestamp: 20,
-            },
-            {
-              localPaymentId: "local-payment-mobile",
-              method: "mobile_money",
-              amount: 50,
-              timestamp: 21,
-            },
-          ],
+  it.each(["closed", "closeout_rejected"] as const)(
+    "keeps reviewed sale replay against a %s register session as review evidence only",
+    async (status) => {
+      const repository = createProjectionRepository({
+        registerSession: {
+          _id: "register-session-1",
+          expectedCash: 100,
+          closeoutRecords: [],
+          countedCash: 100,
+          registerNumber: "1",
+          status,
+          variance: 0,
         },
-        staffProofToken: undefined,
-      }),
-      syncEventId: "sync-event-1",
-      now: 100,
-      options: {
-        allowClosedRegisterSaleProjection: true,
-        applyExpectedTotalForReviewedNonCashOverpayment: true,
-        trustStoredStaffProof: true,
-      },
-    });
+      });
 
-    expect(result.status).toBe("projected");
-    expect(result.conflicts).toEqual([]);
-    expect(repository.createdTransactions).toEqual([
-      expect.objectContaining({
-        payments: [
-          expect.objectContaining({
-            amount: 25,
-            method: "mobile_money",
-          }),
-        ],
-        total: 25,
-        totalPaid: 25,
-      }),
-    ]);
-    expect(repository.createdPaymentAllocations).toEqual([
-      expect.objectContaining({
-        amount: 25,
-        externalReference: "local-payment-mobile",
-        method: "mobile_money",
-        targetType: "pos_transaction",
-      }),
-    ]);
-    expect(repository.registerSessionPatches).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          patch: expect.objectContaining({
-            expectedCash: expect.any(Number),
-          }),
-        }),
-      ]),
-    );
-  });
-
-  it("keeps mixed-tender cash change when non-cash is within the sale total", async () => {
-    const repository = createProjectionRepository({
-      registerSession: {
-        _id: "register-session-1",
-        expectedCash: 100,
-        closeoutRecords: [],
-        countedCash: 100,
-        registerNumber: "1",
-        status: "closed",
-        variance: 0,
-      },
-    });
-    const baseSale = buildSaleCompletedEvent();
-
-    const result = await projectLocalSyncEvent(repository, {
-      storeId: "store-1" as never,
-      terminalId: "terminal-1" as never,
-      event: buildSaleCompletedEvent({
-        payload: {
-          ...baseSale.payload,
-          payments: [
-            {
-              localPaymentId: "local-payment-mobile",
-              method: "mobile_money",
-              amount: 20,
-              timestamp: 20,
-            },
-            {
-              localPaymentId: "local-payment-cash",
-              method: "cash",
-              amount: 10,
-              timestamp: 21,
-            },
-          ],
+      const result = await projectLocalSyncEvent(repository, {
+        storeId: "store-1" as never,
+        terminalId: "terminal-1" as never,
+        event: {
+          ...buildSaleCompletedEvent(),
+          staffProofToken: undefined,
         },
-        staffProofToken: undefined,
-      }),
-      syncEventId: "sync-event-1",
-      now: 100,
-      options: {
-        allowClosedRegisterSaleProjection: true,
-        applyExpectedTotalForReviewedNonCashOverpayment: true,
-        trustStoredStaffProof: true,
-      },
-    });
+        syncEventId: "sync-event-1",
+        now: 100,
+        options: {
+          allowClosedRegisterSaleProjection: true,
+          trustStoredStaffProof: true,
+        },
+      });
 
-    expect(result.status).toBe("projected");
-    expect(result.conflicts).toEqual([]);
-    expect(repository.createdTransactions).toEqual([
-      expect.objectContaining({
-        payments: [
-          expect.objectContaining({
-            amount: 20,
-            method: "mobile_money",
-          }),
-          expect.objectContaining({
-            amount: 10,
-            method: "cash",
-          }),
-        ],
-        total: 25,
-        totalPaid: 30,
-      }),
-    ]);
-    expect(repository.createdPaymentAllocations).toEqual([
-      expect.objectContaining({
-        amount: 20,
-        externalReference: "local-payment-mobile",
-        method: "mobile_money",
-        targetType: "pos_transaction",
-      }),
-      expect.objectContaining({
-        amount: 5,
-        externalReference: "local-payment-cash",
-        method: "cash",
-        targetType: "pos_transaction",
-      }),
-    ]);
-    expect(repository.registerSessionPatches).toEqual(
-      expect.arrayContaining([
+      expect(result.status).toBe("conflicted");
+      expect(result.mappings).toEqual([]);
+      expect(repository.createdPosSessions).toEqual([]);
+      expect(repository.createdTransactions).toEqual([]);
+      expect(repository.createdTransactionItems).toEqual([]);
+      expect(repository.createdPaymentAllocations).toEqual([]);
+      expect(repository.posSessionPatches).toEqual([]);
+      expect(repository.registerSessionPatches).toEqual([]);
+      expect(result.conflicts).toEqual([
         expect.objectContaining({
-          patch: expect.objectContaining({
-            expectedCash: 105,
-          }),
+          conflictType: "permission",
+          summary: "Register was not open before this sale synced.",
+          details: expect.objectContaining({ status }),
         }),
-      ]),
-    );
-  });
+      ]);
+    },
+  );
 
   it("projects a synced closeout as idempotent when the register was already closed with the same count", async () => {
     const repository = createProjectionRepository({

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -1458,22 +1458,6 @@ async function resolveSaleRegisterAndSession(
   }
 
   if (!isRegisterSessionSaleUsable(registerSession)) {
-    if (
-      args.options?.allowClosedRegisterSaleProjection === true &&
-      registerSession.status === "closed"
-    ) {
-      return {
-        registerSession,
-        existingPosSession: null,
-        existingPosSessionMapping: null,
-        resolvedRegisterNumber:
-          payload.registerNumber ??
-          registerSession.registerNumber ??
-          terminal?.registerNumber ??
-          "",
-      };
-    }
-
     const conflict = await createConflict(repository, args, {
       conflictType: "permission",
       summary: "Register was not open before this sale synced.",
@@ -2506,7 +2490,10 @@ async function persistPaymentAllocations(
     }
   }
 
-  if (payments.expectedCashDelta > 0) {
+  if (
+    payments.expectedCashDelta > 0 &&
+    isRegisterSessionSaleUsable(session.registerSession)
+  ) {
     const expectedCash =
       session.registerSession.expectedCash + payments.expectedCashDelta;
     const variance =

--- a/packages/athena-webapp/convex/pos/domain/types.ts
+++ b/packages/athena-webapp/convex/pos/domain/types.ts
@@ -55,7 +55,7 @@ export interface PosActiveSessionConflict {
 
 export interface PosCashDrawerSummary {
   _id: Id<"registerSession">;
-  status: "open" | "active" | "closing" | "closed";
+  status: "open" | "active" | "closing" | "closeout_rejected" | "closed";
   terminalId?: Id<"posTerminal">;
   registerNumber?: string;
   openingFloat: number;

--- a/packages/athena-webapp/convex/pos/public/register.test.ts
+++ b/packages/athena-webapp/convex/pos/public/register.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from "vitest";
+
+import { assertConformsToExportedReturns } from "../../lib/returnValidatorContract";
+import { openDrawer } from "./register";
+
+describe("pos public register contracts", () => {
+  it("accepts review-only closeout register-session statuses in command results", () => {
+    assertConformsToExportedReturns(openDrawer as never, {
+      kind: "ok",
+      data: {
+        _id: "register-session-1",
+        status: "closeout_rejected",
+        terminalId: "terminal-1",
+        registerNumber: "8",
+        openingFloat: 100,
+        expectedCash: 100,
+        openedAt: 1_000,
+        notes: "Manager rejected variance closeout.",
+        workflowTraceId: "trace-register-session-1",
+      },
+    });
+  });
+});

--- a/packages/athena-webapp/convex/pos/public/register.ts
+++ b/packages/athena-webapp/convex/pos/public/register.ts
@@ -10,6 +10,7 @@ const registerSessionSummaryValidator = v.object({
     v.literal("open"),
     v.literal("active"),
     v.literal("closing"),
+    v.literal("closeout_rejected"),
     v.literal("closed"),
   ),
   terminalId: v.optional(v.id("posTerminal")),

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -187,7 +187,7 @@ function buildTerminalHealthSummaryResult() {
     },
     registerSessionLink: {
       registerSessionId: "register-session-1",
-      status: "open",
+      status: "closeout_rejected",
     },
     syncEvidence: {
       latestEvent: {

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -420,6 +420,9 @@ const terminalHealthSummaryReturnValidator = v.object({
       status: v.union(
         v.literal("open"),
         v.literal("active"),
+        v.literal("closing"),
+        v.literal("closeout_rejected"),
+        v.literal("closed"),
       ),
     }),
     v.null(),

--- a/packages/athena-webapp/convex/schemas/operations/registerSession.ts
+++ b/packages/athena-webapp/convex/schemas/operations/registerSession.ts
@@ -11,6 +11,7 @@ export const registerSessionSchema = v.object({
     v.literal("open"),
     v.literal("active"),
     v.literal("closing"),
+    v.literal("closeout_rejected"),
     v.literal("closed")
   ),
   openedByUserId: v.optional(v.id("athenaUser")),

--- a/packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts
@@ -185,6 +185,7 @@ export const posTerminalRuntimeActiveRegisterSessionValidator = v.object({
     v.literal("open"),
     v.literal("active"),
     v.literal("closing"),
+    v.literal("closeout_rejected"),
     v.literal("closed"),
   ),
 });

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 16 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, cycleCountDrafts.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 8 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCaseTracing.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 19 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 588 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 589 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 9 file(s); key children: README.md, SUMMARY.md, pos, prod.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -138,6 +138,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/pos/infrastructure/repositories/transactionRepository.test.ts`](../../convex/pos/infrastructure/repositories/transactionRepository.test.ts)
 - [`convex/pos/public/catalog.test.ts`](../../convex/pos/public/catalog.test.ts)
 - [`convex/pos/public/posRecoveryCodes.test.ts`](../../convex/pos/public/posRecoveryCodes.test.ts)
+- [`convex/pos/public/register.test.ts`](../../convex/pos/public/register.test.ts)
 - [`convex/pos/public/sync.test.ts`](../../convex/pos/public/sync.test.ts)
 - [`convex/pos/public/terminalAppSessions.test.ts`](../../convex/pos/public/terminalAppSessions.test.ts)
 - [`convex/pos/public/terminals.test.ts`](../../convex/pos/public/terminals.test.ts)

--- a/packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts
+++ b/packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts
@@ -7,6 +7,7 @@ import {
   getSaleBlockingDrawerAuthority,
   isNonBlockingRegisterLifecycleReviewEvent,
   isRegisterCloseoutReviewConflict,
+  isRegisterSessionReplacementBlocking,
   isRegisterSessionSaleUsable,
   REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY,
 } from "./registerSessionLifecyclePolicy";
@@ -16,7 +17,37 @@ describe("registerSessionLifecyclePolicy", () => {
     expect(isRegisterSessionSaleUsable({ status: "open" })).toBe(true);
     expect(isRegisterSessionSaleUsable({ status: "active" })).toBe(true);
     expect(isRegisterSessionSaleUsable({ status: "closing" })).toBe(false);
+    expect(isRegisterSessionSaleUsable({ status: "closeout_rejected" })).toBe(
+      false,
+    );
     expect(isRegisterSessionSaleUsable({ status: "closed" })).toBe(false);
+  });
+
+  it("allows replacement for submitted closeouts without making them sale usable", () => {
+    expect(
+      isRegisterSessionReplacementBlocking({
+        hasSubmittedCloseout: false,
+        session: { status: "closing" },
+      }),
+    ).toBe(true);
+    expect(
+      isRegisterSessionReplacementBlocking({
+        hasSubmittedCloseout: true,
+        session: { status: "closing" },
+      }),
+    ).toBe(false);
+    expect(
+      isRegisterSessionReplacementBlocking({
+        hasSubmittedCloseout: true,
+        session: { status: "closeout_rejected" },
+      }),
+    ).toBe(false);
+    expect(
+      isRegisterSessionReplacementBlocking({
+        hasSubmittedCloseout: true,
+        session: { status: "active" },
+      }),
+    ).toBe(true);
   });
 
   it("treats same-drawer lifecycle rejection as recoverable for local sale blocking", () => {
@@ -130,6 +161,22 @@ describe("registerSessionLifecyclePolicy", () => {
         registerSession: {
           localRegisterSessionId: "reviewed-local-drawer",
           status: "closing",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        },
+        reviewSequence: 10,
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toBe(true);
+    expect(
+      canSupersedeReviewedRegisterSessionForLocalOpen({
+        hasOpenRegisterCloseoutReview: true,
+        replacementLocalRegisterSessionId: "replacement-local-drawer",
+        replacementSequence: 12,
+        registerSession: {
+          localRegisterSessionId: "reviewed-local-drawer",
+          status: "closeout_rejected",
           storeId: "store-1",
           terminalId: "terminal-1",
         },

--- a/packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts
+++ b/packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts
@@ -71,6 +71,19 @@ export function isRegisterSessionConflictBlocking(
   return isRegisterSessionConflictBlockingStatus(session?.status);
 }
 
+export function isRegisterSessionReplacementBlocking(input: {
+  hasSubmittedCloseout?: boolean;
+  session: Pick<RegisterSessionLifecycleScopedSession, "status"> | null | undefined;
+}) {
+  if (!input.session) return false;
+  if (input.session.status === "closeout_rejected") return false;
+  if (input.session.status === "closing" && input.hasSubmittedCloseout) {
+    return false;
+  }
+
+  return isRegisterSessionConflictBlocking(input.session);
+}
+
 export function getSaleBlockingDrawerAuthority<
   Authority extends RegisterSessionLifecycleDrawerAuthority,
 >(input: {
@@ -135,7 +148,8 @@ export function canSupersedeReviewedRegisterSessionForLocalOpen(input: {
     isDistinctReplacement &&
     isNewerThanReview &&
     (isRegisterSessionSaleUsable(input.registerSession) ||
-      input.registerSession?.status === "closing") &&
+      input.registerSession?.status === "closing" ||
+      input.registerSession?.status === "closeout_rejected") &&
     input.hasOpenRegisterCloseoutReview
   );
 }

--- a/packages/athena-webapp/shared/registerSessionStatus.test.ts
+++ b/packages/athena-webapp/shared/registerSessionStatus.test.ts
@@ -11,6 +11,7 @@ describe("register session status policies", () => {
     ["open", true],
     ["active", true],
     ["closing", false],
+    ["closeout_rejected", false],
     ["closed", false],
   ] as const)("classifies %s POS usability as %s", (status, expected) => {
     expect(isPosUsableRegisterSessionStatus(status)).toBe(expected);
@@ -20,6 +21,7 @@ describe("register session status policies", () => {
     ["open", true],
     ["active", true],
     ["closing", true],
+    ["closeout_rejected", false],
     ["closed", false],
   ] as const)("classifies %s duplicate-drawer blocking as %s", (status, expected) => {
     expect(isRegisterSessionConflictBlockingStatus(status)).toBe(expected);
@@ -29,6 +31,7 @@ describe("register session status policies", () => {
     ["open", true],
     ["active", true],
     ["closing", true],
+    ["closeout_rejected", true],
     ["closed", false],
   ] as const)("classifies %s cash-control visibility as %s", (status, expected) => {
     expect(isCashControlVisibleRegisterSessionStatus(status)).toBe(expected);

--- a/packages/athena-webapp/shared/registerSessionStatus.ts
+++ b/packages/athena-webapp/shared/registerSessionStatus.ts
@@ -2,6 +2,7 @@ export const REGISTER_SESSION_STATUSES = [
   "open",
   "active",
   "closing",
+  "closeout_rejected",
   "closed",
 ] as const;
 
@@ -18,8 +19,12 @@ export const REGISTER_SESSION_CONFLICT_BLOCKING_STATUSES = [
   "closing",
 ] as const satisfies readonly RegisterSessionStatus[];
 
-export const CASH_CONTROL_VISIBLE_REGISTER_SESSION_STATUSES =
-  REGISTER_SESSION_CONFLICT_BLOCKING_STATUSES;
+export const CASH_CONTROL_VISIBLE_REGISTER_SESSION_STATUSES = [
+  "open",
+  "active",
+  "closing",
+  "closeout_rejected",
+] as const satisfies readonly RegisterSessionStatus[];
 
 export function isRegisterSessionStatus(
   status: unknown,

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx
@@ -722,6 +722,38 @@ describe("CashControlsDashboardContent", () => {
     expect(screen.getByText("Closed session history")).toBeInTheDocument();
   });
 
+  it("keeps rejected closeouts in the cashroom attention lane", () => {
+    render(
+      <CashControlsDashboardContent
+        currency="USD"
+        dashboardSnapshot={{
+          ...baseSnapshot,
+          registerSessions: [
+            {
+              _id: "session-rejected-register-2",
+              countedCash: 9000,
+              expectedCash: 10000,
+              openedAt: new Date("2026-04-29T07:40:00.000Z").getTime(),
+              openingFloat: 4000,
+              registerNumber: "Register 2",
+              status: "closeout_rejected",
+              totalDeposited: 0,
+              variance: -1000,
+            },
+          ],
+        }}
+        isLoading={false}
+        orgUrlSlug="v26"
+        storeUrlSlug="east-legon"
+      />,
+    );
+
+    expect(screen.getByText("Register 2")).toBeInTheDocument();
+    expect(screen.getByText("Needs action")).toBeInTheDocument();
+    expect(screen.queryByText("Live drawers")).not.toBeInTheDocument();
+    expect(screen.queryByText("Closed session history")).not.toBeInTheDocument();
+  });
+
   it("separates pending sync from reconciliation issues", () => {
     render(
       <CashControlsDashboardContent

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
@@ -1088,6 +1088,7 @@ function CashroomWorkflow({
   const needsAttention = sessions.filter(
     (session) =>
       session.status === "closing" ||
+      session.status === "closeout_rejected" ||
       Boolean(session.pendingApprovalRequest) ||
       getSessionSyncStatus(session).status !== "synced",
   );

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
@@ -91,6 +91,30 @@ describe("RegisterDrawerGate", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("offers replacement drawer opening for submitted review-only closeouts", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderGate({
+      closeoutSecondaryActionLabel: "Open replacement drawer",
+      closeoutSubmittedCountedCash: 12500,
+      closeoutSubmittedVariance: 2500,
+      expectedCash: 10000,
+      hasPendingCloseoutApproval: true,
+      mode: "closeoutBlocked",
+      onReopenRegister: undefined,
+      onSubmit,
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Open replacement drawer" }),
+    );
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(
+      screen.queryByRole("button", { name: "Reopen register" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("hides submitted closeout sign-out when no staff is signed in", () => {
     renderGate({
       closeoutSubmittedCountedCash: 780_000,

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -108,6 +108,12 @@ export function RegisterDrawerGate({
     }
     void drawerGate.onSubmit?.();
   };
+  const handleSubmitButtonClick = () => {
+    if (drawerGate.canOpenDrawer === false) {
+      return;
+    }
+    void drawerGate.onSubmit?.();
+  };
   const handleCloseoutSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     void drawerGate.onSubmitCloseout?.();
@@ -378,6 +384,23 @@ export function RegisterDrawerGate({
             </div>
 
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              {drawerGate.onSubmit ? (
+                <LoadingButton
+                  className="w-full sm:w-auto"
+                  disabled={
+                    drawerGate.canOpenDrawer === false ||
+                    Boolean(drawerGate.isSubmitting)
+                  }
+                  isLoading={Boolean(drawerGate.isSubmitting)}
+                  onClick={handleSubmitButtonClick}
+                  type="button"
+                  variant="default"
+                >
+                  {drawerGate.closeoutSecondaryActionLabel ??
+                    "Open replacement drawer"}
+                </LoadingButton>
+              ) : null}
+
               {drawerGate.canOpenCashControls ? (
                 <CashControlsButton
                   className="w-full sm:w-auto"

--- a/packages/athena-webapp/src/lib/pos/application/dto.ts
+++ b/packages/athena-webapp/src/lib/pos/application/dto.ts
@@ -63,7 +63,7 @@ export interface PosCashierDto {
 
 export interface PosCashDrawerDto {
   _id: Id<"registerSession">;
-  status: "open" | "active" | "closing" | "closed";
+  status: "open" | "active" | "closing" | "closeout_rejected" | "closed";
   terminalId?: Id<"posTerminal">;
   registerNumber?: string;
   openingFloat: number;

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
@@ -4,10 +4,78 @@ import type { PosLocalEventRecord } from "./posLocalStore";
 import {
   hasSettledRegisterCloseout,
   projectLocalRegisterReadModel,
+  type PosLocalCashDrawerReadModel,
   type PosLocalRegisterReadModelError,
 } from "./registerReadModel";
 
 describe("projectLocalRegisterReadModel", () => {
+  it("accepts review-only closeout status in local register drawer snapshots", () => {
+    const drawer = {
+      localRegisterSessionId: "local-register-1",
+      cloudRegisterSessionId: "cloud-register-1",
+      status: "closeout_rejected",
+      openingFloat: 100,
+      expectedCash: 100,
+      countedCash: 90,
+      openedAt: 1_000,
+      notes: "Manager rejected variance closeout.",
+    } satisfies PosLocalCashDrawerReadModel;
+
+    expect(drawer.status).toBe("closeout_rejected");
+  });
+
+  it("keeps closeout-rejected local drawers review-only during event replay", () => {
+    const model = projectLocalRegisterReadModel({
+      events: [
+        event({
+          sequence: 1,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-1",
+          payload: {
+            localRegisterSessionId: "local-register-1",
+            openingFloat: 100,
+            expectedCash: 100,
+            status: "closeout_rejected",
+          },
+        }),
+        event({
+          sequence: 2,
+          type: "session.started",
+          localRegisterSessionId: "local-register-1",
+          localPosSessionId: "local-sale-1",
+          payload: { localPosSessionId: "local-sale-1", status: "active" },
+        }),
+        event({
+          sequence: 3,
+          type: "cart.item_added",
+          localRegisterSessionId: "local-register-1",
+          localPosSessionId: "local-sale-1",
+          payload: {
+            localItemId: "local-item-1",
+            productId: "product-1",
+            productSkuId: "sku-1",
+            productSku: "SKU-1",
+            productName: "Lace Front",
+            price: 75,
+            quantity: 1,
+          },
+        }),
+      ],
+      isOnline: true,
+    });
+
+    expect(model.activeRegisterSession).toMatchObject({
+      localRegisterSessionId: "local-register-1",
+      status: "closeout_rejected",
+    });
+    expect(model.canSell).toBe(false);
+    expect(model.activeSale).toBeNull();
+    expect(errorCodes(model.errors)).toEqual([
+      "register_closed",
+      "register_closed",
+    ]);
+  });
+
   it("replays a local drawer, sale, cart, payment, and receipt history", () => {
     const model = projectLocalRegisterReadModel({
       events: [

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
@@ -106,7 +106,7 @@ export interface PosLocalCompletedSaleReadModel {
 export interface PosLocalCashDrawerReadModel {
   localRegisterSessionId: string;
   cloudRegisterSessionId?: string;
-  status: "open" | "active" | "closing" | "closed";
+  status: "open" | "active" | "closing" | "closeout_rejected" | "closed";
   terminalId?: string;
   registerNumber?: string;
   openingFloat: number;
@@ -274,7 +274,7 @@ export function projectLocalRegisterReadModel(input: {
       continue;
     }
 
-    if (activeRegisterSession.status === "closing") {
+    if (!isRegisterSessionSaleUsable(activeRegisterSession)) {
       errors.push(errorFor(event, "register_closed"));
       continue;
     }
@@ -1002,6 +1002,7 @@ function registerStatus(
   return value === "open" ||
     value === "active" ||
     value === "closing" ||
+    value === "closeout_rejected" ||
     value === "closed"
     ? value
     : undefined;

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts
@@ -583,6 +583,38 @@ describe("terminalRuntimeStatus", () => {
     );
   });
 
+  it("preserves review-only closeout register-session status in runtime evidence", () => {
+    const status = buildPosTerminalRuntimeStatus({
+      activeRegisterSession: {
+        cloudRegisterSessionId: "cloud-register-1",
+        localRegisterSessionId: "local-register-1",
+        openedAt: 1_000,
+        registerNumber: "8",
+        status: "closeout_rejected",
+      },
+      clock: () => 2_000,
+      events: [],
+      source: "register",
+      staffAuthorityStatus: "ready",
+      terminalSeed: {
+        cloudTerminalId: "terminal-cloud-1",
+        displayName: "Front register",
+        provisionedAt: 1_000,
+        schemaVersion: 5,
+        storeId: "store-1",
+        syncSecretHash: "sync-secret-hash",
+        terminalId: "local-terminal-1",
+      },
+    });
+
+    expect(status.activeRegisterSession).toMatchObject({
+      cloudRegisterSessionId: "cloud-register-1",
+      localRegisterSessionId: "local-register-1",
+      observedAt: 2_000,
+      status: "closeout_rejected",
+    });
+  });
+
   it("reports uncertainty metadata as support-safe counts without exposing payload details", () => {
     const input = {
       clock: () => 2_000,

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
@@ -109,7 +109,7 @@ export type PosTerminalRuntimeActiveRegisterSessionInput = {
   localRegisterSessionId: string;
   openedAt?: number;
   registerNumber?: string;
-  status: "open" | "active" | "closing" | "closed";
+  status: "open" | "active" | "closing" | "closeout_rejected" | "closed";
 };
 
 export type PosTerminalRuntimeActiveRegisterSessionDiagnostics =

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -84,7 +84,7 @@ let mockRegisterState:
       } | null;
       activeRegisterSession: {
         _id: string;
-        status: "open" | "active" | "closing" | "closed";
+        status: "open" | "active" | "closing" | "closeout_rejected" | "closed";
         terminalId?: string;
         registerNumber?: string;
         openingFloat: number;
@@ -3253,7 +3253,7 @@ describe("useRegisterViewModel", () => {
     expect(result.current.cashierCard?.cashierName).toBe("Offline Manager");
   });
 
-  it("holds bootstrap on a closing drawer and exposes the opening drawer gate", async () => {
+  it("holds submitted closing drawer as review-only and exposes replacement opening", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -3290,25 +3290,79 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(result.current.drawerGate).not.toBeNull();
-    expect(result.current.drawerGate?.mode).toBe("initialSetup");
+    expect(result.current.drawerGate?.mode).toBe("closeoutBlocked");
     expect(result.current.drawerGate?.registerNumber).toBe("1");
     expect(result.current.productEntry.disabled).toBe(true);
     expect(mockStartSession).not.toHaveBeenCalled();
     expect(mockOpenDrawer).not.toHaveBeenCalled();
     expect(result.current.drawerGate?.onSubmit).toEqual(expect.any(Function));
+    expect(result.current.drawerGate?.closeoutSecondaryActionLabel).toBe(
+      "Open replacement drawer",
+    );
     expect(result.current.drawerGate?.onSubmitCloseout).toBeUndefined();
-    expect(result.current.drawerGate?.closeoutSubmittedReason).toBeUndefined();
-    expect(result.current.drawerGate?.expectedCash).toBeUndefined();
+    expect(result.current.drawerGate?.onReopenRegister).toBeUndefined();
+    expect(result.current.drawerGate?.closeoutSubmittedReason).toBe(
+      "manager_review",
+    );
+    expect(result.current.drawerGate?.expectedCash).toBe(5_000);
     expect(
       result.current.drawerGate?.hasPendingCloseoutApproval,
-    ).toBeUndefined();
+    ).toBe(true);
     expect(
       result.current.drawerGate?.cashControlsRegisterSessionId,
-    ).toBeUndefined();
+    ).toBe("drawer-1");
     expect(
       result.current.drawerGate?.closeoutSubmittedCountedCash,
-    ).toBeUndefined();
-    expect(result.current.drawerGate?.closeoutSubmittedVariance).toBeUndefined();
+    ).toBe(4_500);
+    expect(result.current.drawerGate?.closeoutSubmittedVariance).toBe(-500);
+  });
+
+  it("holds rejected closeout drawers as review-only replacement context", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: {
+        _id: "staff-1",
+        firstName: "Ama",
+        lastName: "Kusi",
+        activeRoles: ["manager"],
+      },
+      activeRegisterSession: {
+        _id: "drawer-1",
+        status: "closeout_rejected",
+        countedCash: 4_500,
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now(),
+        variance: -500,
+      },
+      activeSession: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+
+    expect(result.current.drawerGate?.mode).toBe("closeoutBlocked");
+    expect(result.current.drawerGate?.onSubmit).toEqual(expect.any(Function));
+    expect(result.current.drawerGate?.onReopenRegister).toBeUndefined();
+    expect(result.current.drawerGate?.closeoutSubmittedReason).toBe(
+      "manager_review",
+    );
+    expect(result.current.drawerGate?.closeoutSecondaryActionLabel).toBe(
+      "Open replacement drawer",
+    );
+    expect(result.current.productEntry.disabled).toBe(true);
+    expect(mockStartSession).not.toHaveBeenCalled();
   });
 
   it("allows a newer local drawer to sell while a different cloud closeout awaits manager review", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -368,13 +368,61 @@ type CloseoutBlockedRegisterSession = {
   openedAt: number;
   openingFloat: number;
   registerNumber: string;
-  status: "closing";
+  status: "closing" | "closeout_rejected";
   terminalId: Id<"posTerminal">;
   variance?: number;
 };
 
-function selectPassiveCloseoutBlockedRegisterSession(): CloseoutBlockedRegisterSession | null {
-  return null;
+function selectPassiveCloseoutBlockedRegisterSession(
+  session:
+    | {
+        _id?: Id<"registerSession"> | string;
+        countedCash?: number;
+        expectedCash?: number;
+        localSyncStatus?: CloseoutBlockedRegisterSession["localSyncStatus"] | null;
+        managerApprovalRequestId?: Id<"approvalRequest">;
+        openedAt?: number;
+        openingFloat?: number;
+        registerNumber?: string;
+        status?: string;
+        terminalId?: Id<"posTerminal">;
+        variance?: number;
+      }
+    | null
+    | undefined,
+): CloseoutBlockedRegisterSession | null {
+  if (
+    !session ||
+    (session.status !== "closing" && session.status !== "closeout_rejected") ||
+    !session.terminalId ||
+    session.expectedCash === undefined ||
+    session.openedAt === undefined ||
+    session.openingFloat === undefined
+  ) {
+    return null;
+  }
+  const hasSubmittedCloseoutEvidence =
+    session.status === "closeout_rejected" ||
+    session.countedCash !== undefined ||
+    Boolean(session.managerApprovalRequestId) ||
+    session.localSyncStatus?.status === "needs_review";
+  if (!hasSubmittedCloseoutEvidence) {
+    return null;
+  }
+
+  return {
+    _id: session._id,
+    countedCash: session.countedCash,
+    expectedCash: session.expectedCash,
+    localSyncStatus: session.localSyncStatus ?? undefined,
+    managerApprovalRequestId: session.managerApprovalRequestId,
+    openedAt: session.openedAt,
+    openingFloat: session.openingFloat,
+    registerNumber: session.registerNumber ?? "",
+    status: session.status,
+    terminalId: session.terminalId,
+    variance: session.variance,
+  };
 }
 
 type LocalOperablePosSession = {
@@ -818,7 +866,11 @@ export function useRegisterViewModel(): RegisterViewModel {
       ? localOperableRegisterSession
       : projectedLocalRegisterSession;
   const closeoutBlockedRegisterSession =
-    selectPassiveCloseoutBlockedRegisterSession();
+    locallyOperableRegisterSession === null
+      ? selectPassiveCloseoutBlockedRegisterSession(
+          registerState?.activeRegisterSession,
+        )
+      : null;
   const activeCloudRegisterSessionHasCloseoutReview = Boolean(
     findRegisterCloseoutReviewItem(usableActiveRegisterSession),
   );
@@ -1729,6 +1781,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     | "pending_sync"
     | undefined =
     activeCloseoutRegisterSessionHasSyncReview ||
+    activeCloseoutRegisterSession?.status === "closeout_rejected" ||
     Boolean(activeCloseoutRegisterSession?.managerApprovalRequestId)
       ? "manager_review"
       : activeCloseoutRegisterSessionHasSubmittedCount &&
@@ -5159,15 +5212,11 @@ export function useRegisterViewModel(): RegisterViewModel {
               closeoutNotes,
               closeoutSubmittedReason: activeCloseoutSubmittedReason,
               closeoutSecondaryActionLabel: closeoutBlockedRegisterSession
-                ? "Reopen register"
+                ? "Open replacement drawer"
                 : "Return to sale",
               registerSessionCode: activeCloseoutRegisterSessionCode,
               onCloseoutSecondaryAction: closeoutBlockedRegisterSession
-                ? isCashierManager
-                  ? activeCloseoutRegisterSessionHasSyncReview
-                    ? undefined
-                    : handleReopenRegisterCloseout
-                  : undefined
+                ? undefined
                 : handleCancelRegisterCloseout,
               expectedCash: activeCloseoutRegisterSession?.expectedCash,
               canOpenCashControls: isCashierManager,
@@ -5176,14 +5225,19 @@ export function useRegisterViewModel(): RegisterViewModel {
                 (activeCloseoutCloudRegisterSessionCode as
                   | Id<"registerSession">
                   | undefined),
+              canOpenDrawer: closeoutBlockedRegisterSession
+                ? canSignedInStaffOpenDrawer
+                : undefined,
               hasPendingCloseoutApproval: Boolean(
                 activeCloseoutRegisterSession?.managerApprovalRequestId ||
-                activeCloseoutRegisterSessionHasSyncReview,
+                activeCloseoutRegisterSessionHasSyncReview ||
+                activeCloseoutRegisterSession?.status === "closeout_rejected",
               ),
               errorMessage: drawerErrorMessage,
               hasSignedInStaff,
               isCloseoutSubmitting: isSubmittingCloseout,
               isReopeningCloseout,
+              isSubmitting: isOpeningDrawer,
               onCloseoutCountedCashChange: (value: string) => {
                 setCloseoutCountedCash(value);
                 setDrawerErrorMessage(null);
@@ -5192,11 +5246,15 @@ export function useRegisterViewModel(): RegisterViewModel {
                 setCloseoutNotes(value);
                 setDrawerErrorMessage(null);
               },
+              onSubmit: closeoutBlockedRegisterSession
+                ? handleOpenDrawer
+                : undefined,
               onSubmitCloseout: activeCloseoutSubmittedReason
                 ? undefined
                 : handleSubmitRegisterCloseout,
-              onReopenRegister:
-                isCashierManager && !activeCloseoutRegisterSessionHasSyncReview
+              onReopenRegister: closeoutBlockedRegisterSession
+                ? undefined
+                : isCashierManager && !activeCloseoutRegisterSessionHasSyncReview
                   ? handleReopenRegisterCloseout
                   : undefined,
               onSignOut: handleCashierSignOut,


### PR DESCRIPTION
## Summary
- Add a distinct review-only `closeout_rejected` register-session lifecycle for rejected variance closeouts.
- Keep POS sale attachment limited to sale-usable sessions while allowing replacement drawer opens after submitted/rejected variance closeouts.
- Surface review-only sessions through cash controls/operations, preserve closeout evidence on rejection/reopen paths, and document the lifecycle pattern.

## Why
Rejected variance closeouts were previously patched back to `active`, which made the drawer look usable and could let new POS work attach to a session whose closeout evidence should be frozen for review. The new policy separates sale usability, review visibility, and replacement blocking.

## Validation
- Unanimous reviewer subagent approval: project standards, testing, correctness, TypeScript, and data integrity.
- `bun run --filter '@athena/webapp' test -- shared/registerSessionStatus.test.ts shared/registerSessionLifecyclePolicy.test.ts convex/cashControls/closeouts.test.ts convex/cashControls/registerSessions.test.ts convex/cashControls/registerSessionTraceLifecycle.test.ts convex/cashControls/deposits.test.ts convex/operations/dailyClose.test.ts convex/operations/dailyOperations.test.ts convex/pos/application/getRegisterState.test.ts convex/pos/application/commands/createOrReusePendingCheckoutItem.test.ts convex/pos/application/correctTransactionPaymentMethod.test.ts convex/pos/application/completeTransaction.test.ts convex/pos/application/sync/projectLocalEvents.test.ts convex/pos/public/register.test.ts convex/pos/public/terminals.test.ts src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts src/lib/pos/infrastructure/local/registerReadModel.test.ts src/components/cash-controls/CashControlsDashboard.test.tsx src/components/pos/register/RegisterDrawerGate.test.tsx src/lib/pos/presentation/register/useRegisterViewModel.test.ts`\n- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`\n- `bun run --filter '@athena/webapp' lint:convex:changed`\n- `bun run --filter '@athena/webapp' lint:frontend:changed`\n- `bun run --filter '@athena/webapp' audit:convex`\n- `bun run --filter '@athena/webapp' build`\n- `bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts src/tests/pos/offlineSalesContinuity.spec.ts`\n- `bun run pre-commit:generated-artifacts && bun run graphify:rebuild`\n- `bun run pr:athena`\n\nLinear: https://linear.app/v26-labs/issue/V26-845, https://linear.app/v26-labs/issue/V26-846, https://linear.app/v26-labs/issue/V26-847, https://linear.app/v26-labs/issue/V26-848, https://linear.app/v26-labs/issue/V26-849, https://linear.app/v26-labs/issue/V26-850