### PR TITLE
fix: harden POS register recovery

### DIFF
--- a/docs/solutions/logic-errors/athena-pos-closeout-replacement-self-heal-2026-06-25.md
+++ b/docs/solutions/logic-errors/athena-pos-closeout-replacement-self-heal-2026-06-25.md
@@ -1,0 +1,78 @@
+---
+title: Athena POS Closeout Replacement Self-Heal
+date: 2026-06-25
+category: logic-errors
+module: athena-webapp
+problem_type: local_sync_recovery_conflict
+component: pos-register
+symptoms:
+  - "A terminal with a submitted closeout can open a new local register session but fail to project it to cloud"
+  - "POS can show the closeout review gate before switching to the open-drawer gate"
+  - "Retrying terminal repair can resurrect an older duplicate register-open conflict"
+root_cause: replacement_register_open_recovery_was_not_sequence_scoped_or_idempotent
+resolution_type: code_fix
+severity: high
+tags:
+  - pos
+  - register-session
+  - local-first
+  - sync
+  - closeout
+  - recovery
+---
+
+# Athena POS Closeout Replacement Self-Heal
+
+## Problem
+
+Terminals are allowed to open a replacement register session while the previous
+session is closing or waiting on closeout review. That invariant protects store
+operations: a manager review should pause the old drawer, not strand the
+terminal.
+
+The failure mode appears when local-first POS records the replacement
+`register.opened` event but cloud projection treats the previous reviewed
+drawer as a hard duplicate-open conflict. The UI can briefly present the old
+closeout-review gate, then the open-drawer gate, and a manual repair can replay
+duplicate conflicts out of order.
+
+## Solution
+
+Keep replacement recovery tied to the event that is actually being projected:
+
+- Allow superseding reviewed or closing register sessions only when the
+  replacement local session is in the same store and terminal scope.
+- Compare the replacement event sequence against the latest review sequence.
+  Unknown sequence data must use an explicit compatibility path; production
+  projection and repair should pass real sequence values.
+- Let POS local sync retry uploaded review events that are specifically
+  register-open replacement candidates, so the terminal can self-heal without
+  operator data surgery.
+- During cloud repair, choose one deterministic latest safe duplicate
+  register-open conflict, project it once, and mark older safe duplicate-open
+  conflicts obsolete. This keeps repeat repair idempotent instead of reopening
+  stale drawers.
+- Show the operator the next useful gate. If the main action is opening the
+  replacement drawer, route directly to the open-drawer gate instead of
+  presenting an extra closeout-review stop.
+
+## Prevention
+
+- Cover stale and fresh sequence comparisons in
+  `shared/registerSessionLifecyclePolicy.test.ts`.
+- Add projection tests for closing or reviewed sessions that should allow a new
+  local register open, plus stale sequence cases that must still block.
+- Add terminal repair tests that run repair twice and prove only one active
+  register session remains.
+- Keep UI gate tests focused on intent: replacement drawer CTAs should reveal
+  the open-drawer workflow, not call the open action before the operator enters
+  required drawer data.
+- Keep local session labels and cloud session labels visibly distinct in
+  operator-facing diagnostics so support can tell which side of sync is being
+  inspected.
+
+## Related
+
+- [Athena POS Closeout Review-Only Lifecycle](./athena-pos-closeout-review-only-lifecycle-2026-06-25.md)
+- [Athena POS Drawer Authority Replacement Recovery](./athena-pos-drawer-authority-replacement-recovery-2026-06-06.md)
+- [Athena POS Register Lifecycle Policy](../architecture/athena-pos-register-lifecycle-policy-2026-06-23.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7940 nodes · 9321 edges · 2047 communities detected
+- 7950 nodes · 9339 edges · 2047 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2126,11 +2126,11 @@ Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestSta
 
 ### Community 10 - "Community 10"
 Cohesion: 0.06
-Nodes (22): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+14 more)
+Nodes (21): assertPosLocalStoreOk(), buildRuntimeAppUpdateInput(), clearAcceptedTerminalIntegrityState(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus() (+13 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.06
-Nodes (21): assertPosLocalStoreOk(), buildRuntimeAppUpdateInput(), clearAcceptedTerminalIntegrityState(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus() (+13 more)
+Nodes (22): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+14 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.09
@@ -2625,100 +2625,100 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 135 - "Community 135"
-Cohesion: 0.36
-Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
-
-### Community 136 - "Community 136"
-Cohesion: 0.36
-Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
-
-### Community 137 - "Community 137"
-Cohesion: 0.2
-Nodes (2): listProductSkusByProductId(), readAllQueryResults()
-
-### Community 138 - "Community 138"
-Cohesion: 0.18
-Nodes (0):
-
-### Community 139 - "Community 139"
-Cohesion: 0.33
-Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
-
-### Community 140 - "Community 140"
-Cohesion: 0.24
-Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
-
-### Community 141 - "Community 141"
-Cohesion: 0.31
-Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
-
-### Community 142 - "Community 142"
-Cohesion: 0.35
-Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
-
-### Community 143 - "Community 143"
-Cohesion: 0.2
-Nodes (2): runSharedRecovery(), runWithTimeout()
-
-### Community 144 - "Community 144"
-Cohesion: 0.18
-Nodes (0):
-
-### Community 145 - "Community 145"
-Cohesion: 0.24
-Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
-
-### Community 146 - "Community 146"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
-### Community 147 - "Community 147"
+### Community 136 - "Community 136"
+Cohesion: 0.36
+Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
+
+### Community 137 - "Community 137"
+Cohesion: 0.36
+Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
+
+### Community 138 - "Community 138"
+Cohesion: 0.2
+Nodes (2): listProductSkusByProductId(), readAllQueryResults()
+
+### Community 139 - "Community 139"
 Cohesion: 0.18
 Nodes (0):
 
+### Community 140 - "Community 140"
+Cohesion: 0.33
+Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
+
+### Community 141 - "Community 141"
+Cohesion: 0.24
+Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
+
+### Community 142 - "Community 142"
+Cohesion: 0.31
+Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
+
+### Community 143 - "Community 143"
+Cohesion: 0.35
+Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
+
+### Community 144 - "Community 144"
+Cohesion: 0.2
+Nodes (2): runSharedRecovery(), runWithTimeout()
+
+### Community 145 - "Community 145"
+Cohesion: 0.25
+Nodes (7): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus()
+
+### Community 146 - "Community 146"
+Cohesion: 0.18
+Nodes (0):
+
+### Community 147 - "Community 147"
+Cohesion: 0.24
+Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
+
 ### Community 148 - "Community 148"
+Cohesion: 0.18
+Nodes (0):
+
+### Community 149 - "Community 149"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.33
 Nodes (7): createAthenaProviderError(), createProviderFailureResult(), getProviderFailureDiagnostic(), invokeStructuredTextProvider(), isJsonObject(), isJsonValue(), sanitizeDiagnostic()
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
-
-### Community 158 - "Community 158"
-Cohesion: 0.27
-Nodes (5): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), readLocalSyncStatus()
 
 ### Community 159 - "Community 159"
 Cohesion: 0.22
@@ -2805,24 +2805,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 180 - "Community 180"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 181 - "Community 181"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 182 - "Community 182"
+### Community 181 - "Community 181"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 183 - "Community 183"
+### Community 182 - "Community 182"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 184 - "Community 184"
+### Community 183 - "Community 183"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 184 - "Community 184"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 185 - "Community 185"
 Cohesion: 0.22
@@ -2878,427 +2878,427 @@ Nodes (0):
 
 ### Community 198 - "Community 198"
 Cohesion: 0.36
-Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
 
 ### Community 199 - "Community 199"
+Cohesion: 0.36
+Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+
+### Community 200 - "Community 200"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.29
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 205 - "Community 205"
+### Community 206 - "Community 206"
 Cohesion: 0.29
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 207 - "Community 207"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 208 - "Community 208"
 Cohesion: 0.39
-Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 209 - "Community 209"
+Cohesion: 0.39
+Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+
+### Community 210 - "Community 210"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.29
 Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 213 - "Community 213"
+### Community 214 - "Community 214"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 214 - "Community 214"
+### Community 215 - "Community 215"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 215 - "Community 215"
+### Community 216 - "Community 216"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 216 - "Community 216"
+### Community 217 - "Community 217"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 224 - "Community 224"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 225 - "Community 225"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 226 - "Community 226"
-Cohesion: 0.48
-Nodes (6): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), isDuplicateRegisterOpenConflict(), skipped()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 227 - "Community 227"
 Cohesion: 0.48
-Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
+Nodes (6): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), isDuplicateRegisterOpenConflict(), skipped()
 
 ### Community 228 - "Community 228"
-Cohesion: 0.29
-Nodes (0):
+Cohesion: 0.48
+Nodes (5): canRepairProjectRegisterOpen(), getRepairOpenRegisterCloseoutReviewState(), normalizeRepairString(), resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 229 - "Community 229"
-Cohesion: 0.33
-Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
+Cohesion: 0.48
+Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
 ### Community 230 - "Community 230"
-Cohesion: 0.52
-Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 231 - "Community 231"
 Cohesion: 0.33
-Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
+Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
 ### Community 232 - "Community 232"
+Cohesion: 0.52
+Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
+
+### Community 233 - "Community 233"
+Cohesion: 0.33
+Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
+
+### Community 234 - "Community 234"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 233 - "Community 233"
+### Community 235 - "Community 235"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 234 - "Community 234"
+### Community 236 - "Community 236"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 235 - "Community 235"
+### Community 237 - "Community 237"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 236 - "Community 236"
+### Community 238 - "Community 238"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 237 - "Community 237"
+### Community 239 - "Community 239"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 238 - "Community 238"
+### Community 240 - "Community 240"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 239 - "Community 239"
+### Community 241 - "Community 241"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 240 - "Community 240"
+### Community 242 - "Community 242"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 241 - "Community 241"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 242 - "Community 242"
-Cohesion: 0.29
-Nodes (0):
-
 ### Community 243 - "Community 243"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 244 - "Community 244"
-Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 245 - "Community 245"
 Cohesion: 0.33
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 246 - "Community 246"
+Cohesion: 0.33
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
+
+### Community 247 - "Community 247"
+Cohesion: 0.33
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+
+### Community 248 - "Community 248"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
-### Community 247 - "Community 247"
+### Community 249 - "Community 249"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 248 - "Community 248"
+### Community 250 - "Community 250"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 249 - "Community 249"
+### Community 251 - "Community 251"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 250 - "Community 250"
+### Community 252 - "Community 252"
 Cohesion: 0.52
 Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
-### Community 251 - "Community 251"
+### Community 253 - "Community 253"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 252 - "Community 252"
+### Community 254 - "Community 254"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 253 - "Community 253"
+### Community 255 - "Community 255"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 254 - "Community 254"
+### Community 256 - "Community 256"
 Cohesion: 0.38
 Nodes (3): getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusSignature()
 
-### Community 255 - "Community 255"
+### Community 257 - "Community 257"
 Cohesion: 0.33
 Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 256 - "Community 256"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 257 - "Community 257"
-Cohesion: 0.29
-Nodes (0):
-
 ### Community 258 - "Community 258"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 259 - "Community 259"
-Cohesion: 0.43
-Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 260 - "Community 260"
 Cohesion: 0.52
-Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
 ### Community 261 - "Community 261"
+Cohesion: 0.43
+Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
+
+### Community 262 - "Community 262"
+Cohesion: 0.52
+Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
+
+### Community 263 - "Community 263"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 262 - "Community 262"
+### Community 264 - "Community 264"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 263 - "Community 263"
+### Community 265 - "Community 265"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 264 - "Community 264"
+### Community 266 - "Community 266"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 265 - "Community 265"
+### Community 267 - "Community 267"
 Cohesion: 0.47
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 266 - "Community 266"
+### Community 268 - "Community 268"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 267 - "Community 267"
+### Community 269 - "Community 269"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 268 - "Community 268"
+### Community 270 - "Community 270"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
-
-### Community 269 - "Community 269"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 270 - "Community 270"
-Cohesion: 0.4
-Nodes (2): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository()
 
 ### Community 271 - "Community 271"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 272 - "Community 272"
+Cohesion: 0.4
+Nodes (2): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository()
+
+### Community 273 - "Community 273"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 274 - "Community 274"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 273 - "Community 273"
+### Community 275 - "Community 275"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 274 - "Community 274"
+### Community 276 - "Community 276"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 275 - "Community 275"
+### Community 277 - "Community 277"
 Cohesion: 0.6
 Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
-### Community 276 - "Community 276"
+### Community 278 - "Community 278"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 277 - "Community 277"
+### Community 279 - "Community 279"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 278 - "Community 278"
+### Community 280 - "Community 280"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 279 - "Community 279"
+### Community 281 - "Community 281"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 280 - "Community 280"
+### Community 282 - "Community 282"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 281 - "Community 281"
+### Community 283 - "Community 283"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 282 - "Community 282"
+### Community 284 - "Community 284"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 283 - "Community 283"
+### Community 285 - "Community 285"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 284 - "Community 284"
+### Community 286 - "Community 286"
 Cohesion: 0.4
 Nodes (2): moveBestSeller(), saveOrder()
 
-### Community 285 - "Community 285"
+### Community 287 - "Community 287"
 Cohesion: 0.4
 Nodes (2): moveFeaturedItem(), saveOrder()
 
-### Community 286 - "Community 286"
+### Community 288 - "Community 288"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 287 - "Community 287"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 288 - "Community 288"
-Cohesion: 0.4
-Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
-
 ### Community 289 - "Community 289"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 290 - "Community 290"
 Cohesion: 0.4
-Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
+Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
 ### Community 291 - "Community 291"
-Cohesion: 0.4
-Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
-
-### Community 292 - "Community 292"
-Cohesion: 0.47
-Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 293 - "Community 293"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 294 - "Community 294"
-Cohesion: 0.47
-Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
-
-### Community 295 - "Community 295"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 296 - "Community 296"
+### Community 292 - "Community 292"
+Cohesion: 0.4
+Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
+
+### Community 293 - "Community 293"
+Cohesion: 0.4
+Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
+
+### Community 294 - "Community 294"
+Cohesion: 0.47
+Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
+
+### Community 295 - "Community 295"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 296 - "Community 296"
+Cohesion: 0.47
+Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
+
 ### Community 297 - "Community 297"
+Cohesion: 0.33
+Nodes (1): ResizeObserverStub
+
+### Community 298 - "Community 298"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 299 - "Community 299"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 298 - "Community 298"
+### Community 300 - "Community 300"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 299 - "Community 299"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 300 - "Community 300"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 301 - "Community 301"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 302 - "Community 302"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 303 - "Community 303"
-Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 304 - "Community 304"
 Cohesion: 0.33
@@ -3309,148 +3309,148 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 306 - "Community 306"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 307 - "Community 307"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 308 - "Community 308"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 309 - "Community 309"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 308 - "Community 308"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 309 - "Community 309"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
 ### Community 310 - "Community 310"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
 ### Community 311 - "Community 311"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (1): MemoryCache
 
 ### Community 312 - "Community 312"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 313 - "Community 313"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 314 - "Community 314"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 315 - "Community 315"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 316 - "Community 316"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 317 - "Community 317"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 318 - "Community 318"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 319 - "Community 319"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 320 - "Community 320"
-Cohesion: 0.53
-Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 321 - "Community 321"
-Cohesion: 0.47
-Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 322 - "Community 322"
 Cohesion: 0.53
-Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
 ### Community 323 - "Community 323"
+Cohesion: 0.47
+Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+
+### Community 324 - "Community 324"
+Cohesion: 0.53
+Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+
+### Community 325 - "Community 325"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 324 - "Community 324"
+### Community 326 - "Community 326"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 325 - "Community 325"
+### Community 327 - "Community 327"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 326 - "Community 326"
+### Community 328 - "Community 328"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 327 - "Community 327"
-Cohesion: 0.6
-Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 328 - "Community 328"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 329 - "Community 329"
 Cohesion: 0.6
-Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
+Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 330 - "Community 330"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 331 - "Community 331"
+Cohesion: 0.6
+Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
+
+### Community 332 - "Community 332"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 333 - "Community 333"
 Cohesion: 0.5
 Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
-### Community 332 - "Community 332"
+### Community 334 - "Community 334"
 Cohesion: 0.5
 Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
-### Community 333 - "Community 333"
+### Community 335 - "Community 335"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 334 - "Community 334"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
-### Community 335 - "Community 335"
+### Community 336 - "Community 336"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 336 - "Community 336"
+### Community 337 - "Community 337"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 337 - "Community 337"
+### Community 338 - "Community 338"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
-
-### Community 338 - "Community 338"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 339 - "Community 339"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 340 - "Community 340"
-Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
-
-### Community 341 - "Community 341"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 341 - "Community 341"
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 342 - "Community 342"
 Cohesion: 0.4
@@ -3693,84 +3693,84 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 402 - "Community 402"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 403 - "Community 403"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 404 - "Community 404"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 405 - "Community 405"
-Cohesion: 0.6
-Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
-
-### Community 406 - "Community 406"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 406 - "Community 406"
+Cohesion: 0.6
+Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
+
 ### Community 407 - "Community 407"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 408 - "Community 408"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 408 - "Community 408"
+### Community 409 - "Community 409"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 409 - "Community 409"
+### Community 410 - "Community 410"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 410 - "Community 410"
+### Community 411 - "Community 411"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 411 - "Community 411"
+### Community 412 - "Community 412"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 412 - "Community 412"
+### Community 413 - "Community 413"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 413 - "Community 413"
+### Community 414 - "Community 414"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 414 - "Community 414"
+### Community 415 - "Community 415"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 415 - "Community 415"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 416 - "Community 416"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 417 - "Community 417"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
-
-### Community 418 - "Community 418"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 418 - "Community 418"
+Cohesion: 0.67
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 419 - "Community 419"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 420 - "Community 420"
-Cohesion: 0.67
-Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
-
-### Community 421 - "Community 421"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 421 - "Community 421"
+Cohesion: 0.67
+Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
 ### Community 422 - "Community 422"
 Cohesion: 0.5
@@ -3789,100 +3789,100 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 426 - "Community 426"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 427 - "Community 427"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 427 - "Community 427"
+### Community 428 - "Community 428"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 428 - "Community 428"
+### Community 429 - "Community 429"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 429 - "Community 429"
+### Community 430 - "Community 430"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 430 - "Community 430"
+### Community 431 - "Community 431"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 431 - "Community 431"
+### Community 432 - "Community 432"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 432 - "Community 432"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 433 - "Community 433"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 434 - "Community 434"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 435 - "Community 435"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 436 - "Community 436"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 436 - "Community 436"
+### Community 437 - "Community 437"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 437 - "Community 437"
+### Community 438 - "Community 438"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 438 - "Community 438"
+### Community 439 - "Community 439"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 439 - "Community 439"
+### Community 440 - "Community 440"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 440 - "Community 440"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 441 - "Community 441"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 442 - "Community 442"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 443 - "Community 443"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 444 - "Community 444"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 445 - "Community 445"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 446 - "Community 446"
 Cohesion: 0.67
 Nodes (2): buildCtx(), buildQueryCtx()
 
-### Community 446 - "Community 446"
+### Community 447 - "Community 447"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 447 - "Community 447"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
 
 ### Community 448 - "Community 448"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 449 - "Community 449"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 450 - "Community 450"
 Cohesion: 0.5
@@ -3897,36 +3897,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 453 - "Community 453"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 454 - "Community 454"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 454 - "Community 454"
+### Community 455 - "Community 455"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 455 - "Community 455"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 456 - "Community 456"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 457 - "Community 457"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 458 - "Community 458"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 459 - "Community 459"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 460 - "Community 460"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 461 - "Community 461"
 Cohesion: 0.5
@@ -3937,32 +3937,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 463 - "Community 463"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 464 - "Community 464"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 464 - "Community 464"
+### Community 465 - "Community 465"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 465 - "Community 465"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 466 - "Community 466"
 Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 467 - "Community 467"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 468 - "Community 468"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 469 - "Community 469"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 470 - "Community 470"
 Cohesion: 0.5
@@ -3993,12 +3993,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 477 - "Community 477"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
-
-### Community 478 - "Community 478"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 478 - "Community 478"
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 479 - "Community 479"
 Cohesion: 0.5
@@ -4009,12 +4009,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 481 - "Community 481"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 482 - "Community 482"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 482 - "Community 482"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 483 - "Community 483"
 Cohesion: 0.5
@@ -4025,124 +4025,124 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 485 - "Community 485"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 486 - "Community 486"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 486 - "Community 486"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 487 - "Community 487"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 488 - "Community 488"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 489 - "Community 489"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 490 - "Community 490"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 491 - "Community 491"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 492 - "Community 492"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 492 - "Community 492"
+### Community 493 - "Community 493"
 Cohesion: 0.67
 Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
-### Community 493 - "Community 493"
+### Community 494 - "Community 494"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 494 - "Community 494"
+### Community 495 - "Community 495"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 495 - "Community 495"
+### Community 496 - "Community 496"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 496 - "Community 496"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 497 - "Community 497"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 498 - "Community 498"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 499 - "Community 499"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 500 - "Community 500"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 501 - "Community 501"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 501 - "Community 501"
+### Community 502 - "Community 502"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 502 - "Community 502"
+### Community 503 - "Community 503"
 Cohesion: 0.83
 Nodes (3): completedEvent(), event(), item()
 
-### Community 503 - "Community 503"
+### Community 504 - "Community 504"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 504 - "Community 504"
+### Community 505 - "Community 505"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 505 - "Community 505"
+### Community 506 - "Community 506"
 Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
-### Community 506 - "Community 506"
+### Community 507 - "Community 507"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
-
-### Community 507 - "Community 507"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 508 - "Community 508"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 509 - "Community 509"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 510 - "Community 510"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 510 - "Community 510"
+### Community 511 - "Community 511"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 511 - "Community 511"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 512 - "Community 512"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 513 - "Community 513"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 514 - "Community 514"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 515 - "Community 515"
 Cohesion: 0.5
@@ -4173,63 +4173,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 522 - "Community 522"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 523 - "Community 523"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 524 - "Community 524"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 525 - "Community 525"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 525 - "Community 525"
+### Community 526 - "Community 526"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 526 - "Community 526"
+### Community 527 - "Community 527"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 527 - "Community 527"
+### Community 528 - "Community 528"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 528 - "Community 528"
+### Community 529 - "Community 529"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 529 - "Community 529"
+### Community 530 - "Community 530"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 530 - "Community 530"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 531 - "Community 531"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 532 - "Community 532"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 533 - "Community 533"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 533 - "Community 533"
+### Community 534 - "Community 534"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 534 - "Community 534"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 535 - "Community 535"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 536 - "Community 536"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 537 - "Community 537"
@@ -4241,12 +4241,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 539 - "Community 539"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 540 - "Community 540"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 540 - "Community 540"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 541 - "Community 541"
 Cohesion: 0.67
@@ -4301,28 +4301,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 554 - "Community 554"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 555 - "Community 555"
 Cohesion: 1.0
 Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
-### Community 555 - "Community 555"
+### Community 556 - "Community 556"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 556 - "Community 556"
+### Community 557 - "Community 557"
 Cohesion: 1.0
 Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
-### Community 557 - "Community 557"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 558 - "Community 558"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 559 - "Community 559"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 560 - "Community 560"
 Cohesion: 0.67
@@ -4337,12 +4337,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 563 - "Community 563"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 564 - "Community 564"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 564 - "Community 564"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 565 - "Community 565"
 Cohesion: 0.67
@@ -4365,12 +4365,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 570 - "Community 570"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 571 - "Community 571"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 571 - "Community 571"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 572 - "Community 572"
 Cohesion: 0.67
@@ -4385,12 +4385,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 575 - "Community 575"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
-
-### Community 576 - "Community 576"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 576 - "Community 576"
+Cohesion: 1.0
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 577 - "Community 577"
 Cohesion: 0.67
@@ -4401,28 +4401,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 579 - "Community 579"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 580 - "Community 580"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 581 - "Community 581"
 Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 582 - "Community 582"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 583 - "Community 583"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 584 - "Community 584"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 584 - "Community 584"
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 585 - "Community 585"
 Cohesion: 0.67
@@ -4430,11 +4430,11 @@ Nodes (0):
 
 ### Community 586 - "Community 586"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 587 - "Community 587"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 588 - "Community 588"
 Cohesion: 0.67
@@ -4449,12 +4449,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 591 - "Community 591"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 592 - "Community 592"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 592 - "Community 592"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 593 - "Community 593"
 Cohesion: 0.67
@@ -4473,40 +4473,40 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 597 - "Community 597"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 598 - "Community 598"
 Cohesion: 1.0
 Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
-### Community 598 - "Community 598"
-Cohesion: 0.67
-Nodes (1): FadeIn()
-
 ### Community 599 - "Community 599"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 600 - "Community 600"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 601 - "Community 601"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 602 - "Community 602"
 Cohesion: 1.0
 Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
-### Community 602 - "Community 602"
+### Community 603 - "Community 603"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 603 - "Community 603"
+### Community 604 - "Community 604"
 Cohesion: 0.67
 Nodes (1): VideoPlayer()
 
-### Community 604 - "Community 604"
+### Community 605 - "Community 605"
 Cohesion: 1.0
 Nodes (2): handleRefundOrder(), toast()
-
-### Community 605 - "Community 605"
-Cohesion: 0.67
-Nodes (0):
 
 ### Community 606 - "Community 606"
 Cohesion: 0.67
@@ -4517,16 +4517,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 608 - "Community 608"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 609 - "Community 609"
 Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 610 - "Community 610"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 611 - "Community 611"
 Cohesion: 0.67
@@ -4561,12 +4561,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 619 - "Community 619"
-Cohesion: 1.0
-Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
-
-### Community 620 - "Community 620"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 620 - "Community 620"
+Cohesion: 1.0
+Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
 
 ### Community 621 - "Community 621"
 Cohesion: 0.67
@@ -4586,79 +4586,79 @@ Nodes (0):
 
 ### Community 625 - "Community 625"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 626 - "Community 626"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 627 - "Community 627"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 628 - "Community 628"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 629 - "Community 629"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 630 - "Community 630"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 631 - "Community 631"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 632 - "Community 632"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 633 - "Community 633"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 633 - "Community 633"
+### Community 634 - "Community 634"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 634 - "Community 634"
+### Community 635 - "Community 635"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 635 - "Community 635"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 636 - "Community 636"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 637 - "Community 637"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 638 - "Community 638"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 639 - "Community 639"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 640 - "Community 640"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 641 - "Community 641"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 642 - "Community 642"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 643 - "Community 643"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 644 - "Community 644"
 Cohesion: 0.67
@@ -4690,11 +4690,11 @@ Nodes (0):
 
 ### Community 651 - "Community 651"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 652 - "Community 652"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 653 - "Community 653"
 Cohesion: 0.67
@@ -4721,44 +4721,44 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 659 - "Community 659"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 660 - "Community 660"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 660 - "Community 660"
+### Community 661 - "Community 661"
 Cohesion: 0.67
 Nodes (1): isInMaintenanceMode()
 
-### Community 661 - "Community 661"
+### Community 662 - "Community 662"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 662 - "Community 662"
+### Community 663 - "Community 663"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 663 - "Community 663"
+### Community 664 - "Community 664"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 664 - "Community 664"
-Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 665 - "Community 665"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 666 - "Community 666"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 667 - "Community 667"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 668 - "Community 668"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 668 - "Community 668"
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 669 - "Community 669"
 Cohesion: 0.67
@@ -4785,76 +4785,76 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 675 - "Community 675"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 676 - "Community 676"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 677 - "Community 677"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 678 - "Community 678"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 679 - "Community 679"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 680 - "Community 680"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 681 - "Community 681"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 682 - "Community 682"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 683 - "Community 683"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 684 - "Community 684"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 685 - "Community 685"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 686 - "Community 686"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 687 - "Community 687"
 Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 688 - "Community 688"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 689 - "Community 689"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 690 - "Community 690"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 691 - "Community 691"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 692 - "Community 692"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 693 - "Community 693"
 Cohesion: 0.67
@@ -4869,12 +4869,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 696 - "Community 696"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 697 - "Community 697"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 697 - "Community 697"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 698 - "Community 698"
 Cohesion: 0.67
@@ -4885,12 +4885,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 700 - "Community 700"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 701 - "Community 701"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 701 - "Community 701"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 702 - "Community 702"
 Cohesion: 0.67
@@ -4957,16 +4957,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 718 - "Community 718"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 719 - "Community 719"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 720 - "Community 720"
+### Community 719 - "Community 719"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 720 - "Community 720"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 721 - "Community 721"
 Cohesion: 1.0
@@ -4981,20 +4981,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 724 - "Community 724"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 725 - "Community 725"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 726 - "Community 726"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 727 - "Community 727"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 728 - "Community 728"
 Cohesion: 1.0
@@ -10275,111 +10275,109 @@ Nodes (0):
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 727`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 728`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 729`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 730`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 731`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 732`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 733`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 734`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 735`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 736`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 737`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 738`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 739`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 740`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 741`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 742`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 743`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 744`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 745`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 746`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 747`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 748`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 749`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 750`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 751`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 752`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 753`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 754`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 755`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 756`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 757`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 758`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 759`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 760`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 761`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 762`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 763`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 764`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 765`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 766`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 767`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 768`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 769`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 770`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 771`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 772`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 773`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 774`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 775`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 776`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 777`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 778`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `resolveTerminalCloudRepair.ts`, `resolveTerminalCloudRepair()`
+- **Thin community `Community 779`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 780`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2119
-- Graph nodes: 7940
-- Graph edges: 9321
+- Graph nodes: 7950
+- Graph edges: 9339
 - Communities: 2047
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -41,7 +41,6 @@ describe("projectLocalSyncEvent", () => {
       submittedByUserId: "athena-user-1" as never,
       now: 100,
     });
-
     expect(result.status).toBe("projected");
     expect(repository.createdPendingCheckoutItems).toEqual([
       expect.objectContaining({
@@ -1868,7 +1867,7 @@ describe("projectLocalSyncEvent", () => {
       event: {
         localEventId: "event-register-opened-cashier",
         localRegisterSessionId: "local-register-cashier",
-        sequence: 1,
+        sequence: 4,
         eventType: "register_opened",
         occurredAt: 20,
         staffProfileId: "staff-1" as never,
@@ -1909,7 +1908,7 @@ describe("projectLocalSyncEvent", () => {
       event: {
         localEventId: "event-register-opened-proof",
         localRegisterSessionId: "local-register-proof",
-        sequence: 1,
+        sequence: 4,
         eventType: "register_opened",
         occurredAt: 20,
         staffProfileId: "staff-1" as never,
@@ -1958,7 +1957,7 @@ describe("projectLocalSyncEvent", () => {
       event: {
         localEventId: "event-register-opened-seed",
         localRegisterSessionId: "register-session-1",
-        sequence: 1,
+        sequence: 2,
         eventType: "register_opened",
         occurredAt: 20,
         staffProfileId: "staff-1" as never,
@@ -3592,7 +3591,7 @@ describe("projectLocalSyncEvent", () => {
       event: {
         localEventId: "event-register-opened-2",
         localRegisterSessionId: "local-register-2",
-        sequence: 1,
+        sequence: 4,
         eventType: "register_opened",
         occurredAt: 10,
         staffProfileId: "staff-1" as never,
@@ -3661,7 +3660,7 @@ describe("projectLocalSyncEvent", () => {
     ]);
   });
 
-  it("creates a new register open when the active drawer has a closeout review", async () => {
+  it("conflicts a stale register open when the active drawer has a newer closeout review", async () => {
     const repository = createProjectionRepository({
       blockingRegisterSession: {
         _id: "register-session-reviewed",
@@ -3683,7 +3682,7 @@ describe("projectLocalSyncEvent", () => {
       event: {
         localEventId: "event-register-opened-2",
         localRegisterSessionId: "local-register-2",
-        sequence: 1,
+        sequence: 2,
         eventType: "register_opened",
         occurredAt: 10,
         staffProfileId: "staff-1" as never,
@@ -3697,23 +3696,14 @@ describe("projectLocalSyncEvent", () => {
       now: 100,
     });
 
-    expect(result.status).toBe("projected");
-    expect(result.conflicts).toEqual([]);
-    expect(result.mappings).toEqual([
+    expect(result.status).toBe("conflicted");
+    expect(result.conflicts).toEqual([
       expect.objectContaining({
-        localIdKind: "registerSession",
-        localId: "local-register-2",
-        cloudTable: "registerSession",
-        cloudId: "register-session-1",
+        summary: "A register session is already open for this terminal.",
       }),
     ]);
-    expect(repository.createdRegisterSessions).toEqual([
-      expect.objectContaining({
-        expectedCash: 250,
-        openingFloat: 250,
-        registerNumber: "1",
-      }),
-    ]);
+    expect(result.mappings).toEqual([]);
+    expect(repository.createdRegisterSessions).toEqual([]);
   });
 
   it("creates a new register open when the closing drawer has a closeout review", async () => {
@@ -3738,7 +3728,7 @@ describe("projectLocalSyncEvent", () => {
       event: {
         localEventId: "event-register-opened-closing-review",
         localRegisterSessionId: "local-register-2",
-        sequence: 1,
+        sequence: 4,
         eventType: "register_opened",
         occurredAt: 10,
         staffProfileId: "staff-1" as never,
@@ -6016,7 +6006,7 @@ function createProjectionRepository(
             },
             localEventId: `review-event-${registerSessionId}`,
             localRegisterSessionId: registerSessionId,
-            sequence: 0,
+            sequence: 3,
             status: "needs_review" as const,
             storeId: args.storeId,
             summary:

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -836,7 +836,7 @@ async function canSupersedeReviewedRegisterSessionForLocalOpen(
     replacementLocalRegisterSessionId: args.event.localRegisterSessionId,
     replacementSequence: args.event.sequence,
     registerSession,
-    reviewSequence: hasOpenRegisterCloseoutReview.latestReviewSequence,
+    reviewSequence: hasOpenRegisterCloseoutReview.latestReviewSequence ?? null,
     storeId: args.storeId,
     terminalId: args.terminalId,
   });
@@ -860,10 +860,11 @@ async function getOpenRegisterCloseoutReviewState(
 
   return {
     hasOpenRegisterCloseoutReview: closeoutReviewConflicts.length > 0,
-    latestReviewSequence: closeoutReviewConflicts
-      .map((conflict) => conflict.sequence)
-      .sort((left, right) => right - left)
-      .at(0),
+    latestReviewSequence: closeoutReviewConflicts.reduce<number | undefined>(
+      (latest, conflict) =>
+        latest === undefined ? conflict.sequence : Math.max(latest, conflict.sequence),
+      undefined,
+    ),
   };
 }
 

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { Doc, Id } from "../../../_generated/dataModel";
+import { REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY } from "../../../../shared/registerSessionLifecyclePolicy";
 import { buildTerminalCloudRepairPreconditionHash } from "./cloudRepairPolicy";
 import { resolveTerminalCloudRepair } from "./resolveTerminalCloudRepair";
 
@@ -27,7 +28,6 @@ describe("resolveTerminalCloudRepair", () => {
       storeId,
       terminalId,
     });
-
     expect(result).toEqual({
       kind: "ok",
       data: {
@@ -42,6 +42,309 @@ describe("resolveTerminalCloudRepair", () => {
       resolvedByUserId: "user-1",
       status: "resolved",
     });
+    expect(ctx.db.patch).toHaveBeenCalledWith("posLocalSyncEvent", "event-1-id", {
+      projectedAt: now,
+      status: "projected",
+    });
+    expect(ctx.tables.posLocalSyncMapping).toContainEqual(
+      expect.objectContaining({
+        localEventId: "event-1",
+        localId: "register-1",
+        localIdKind: "registerSession",
+      }),
+    );
+  });
+
+  it("projects the replacement drawer without resolving the prior closeout variance conflict", async () => {
+    const duplicateOpenConflict = buildConflict({
+      _id: "duplicate-open-conflict" as Id<"posLocalSyncConflict">,
+      localEventId: "event-open-replacement",
+      localRegisterSessionId: "register-replacement",
+      sequence: 3,
+    });
+    const closeoutVarianceConflict = buildConflict({
+      _id: "closeout-conflict" as Id<"posLocalSyncConflict">,
+      conflictType: "permission",
+      details: {
+        countedCash: 95,
+        expectedCash: 100,
+        variance: -5,
+      },
+      localEventId: "event-register-closed",
+      localRegisterSessionId: "registerSession-prior",
+      sequence: 2,
+      summary: REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY,
+    });
+    const ctx = buildCtx({
+      posLocalSyncConflict: [closeoutVarianceConflict, duplicateOpenConflict],
+      posLocalSyncEvent: [
+        buildEvent({
+          _id: "event-open-replacement-id" as Id<"posLocalSyncEvent">,
+          localEventId: "event-open-replacement",
+          localRegisterSessionId: "register-replacement",
+          sequence: 3,
+        }),
+      ],
+      registerSession: [
+        {
+          _id: "registerSession-prior" as Id<"registerSession">,
+          _creationTime: now - 30 * 60 * 1000,
+          storeId,
+          terminalId,
+          registerNumber: "A1",
+          status: "closing",
+          openedByStaffProfileId: "staff-1" as Id<"staffProfile">,
+          openedAt: now - 40 * 60 * 1000,
+          openingFloat: 100,
+          expectedCash: 100,
+        } as Doc<"registerSession">,
+      ],
+    });
+
+    const result = await resolveTerminalCloudRepair(ctx as never, {
+      expectedPreconditionHash: buildTerminalCloudRepairPreconditionHash({
+        safeConflictIds: [duplicateOpenConflict._id],
+        storeId,
+        terminalId,
+      }),
+      now,
+      resolvedByUserId: "user-1" as Id<"athenaUser">,
+      storeId,
+      terminalId,
+    });
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        resolvedConflictIds: [duplicateOpenConflict._id],
+        skippedConflictIds: [closeoutVarianceConflict._id],
+      },
+    });
+    expect(ctx.tables.registerSession).toContainEqual(
+      expect.objectContaining({
+        _id: expect.not.stringMatching(/^registerSession-prior$/),
+        registerNumber: "A1",
+        status: "active",
+        terminalId,
+      }),
+    );
+    const replacementSession = ctx.tables.registerSession.find(
+      (session) => session._id !== "registerSession-prior",
+    );
+    expect(replacementSession).toBeTruthy();
+    expect(ctx.tables.posLocalSyncMapping).toContainEqual(
+      expect.objectContaining({
+        cloudId: replacementSession?._id,
+        cloudTable: "registerSession",
+        localEventId: "event-open-replacement",
+        localId: "register-replacement",
+        localIdKind: "registerSession",
+      }),
+    );
+    expect(ctx.tables.posLocalSyncEvent).toContainEqual(
+      expect.objectContaining({
+        _id: "event-open-replacement-id",
+        projectedAt: now,
+        status: "projected",
+      }),
+    );
+    expect(ctx.tables.posLocalSyncConflict).toContainEqual(
+      expect.objectContaining({
+        _id: duplicateOpenConflict._id,
+        status: "resolved",
+      }),
+    );
+    expect(ctx.tables.posLocalSyncConflict).toContainEqual(
+      expect.objectContaining({
+        _id: closeoutVarianceConflict._id,
+        status: "needs_review",
+      }),
+    );
+  });
+
+  it("repairs only the latest safe duplicate register-open conflict", async () => {
+    const olderConflict = buildConflict({
+      _id: "older-conflict" as Id<"posLocalSyncConflict">,
+      localEventId: "event-open-older",
+      localRegisterSessionId: "register-older",
+      sequence: 2,
+    });
+    const latestConflict = buildConflict({
+      _id: "latest-conflict" as Id<"posLocalSyncConflict">,
+      localEventId: "event-open-latest",
+      localRegisterSessionId: "register-latest",
+      sequence: 3,
+    });
+    const ctx = buildCtx({
+      posLocalSyncConflict: [olderConflict, latestConflict],
+      posLocalSyncEvent: [
+        buildEvent({
+          _id: "event-open-older-id" as Id<"posLocalSyncEvent">,
+          localEventId: "event-open-older",
+          localRegisterSessionId: "register-older",
+          sequence: 2,
+        }),
+        buildEvent({
+          _id: "event-open-latest-id" as Id<"posLocalSyncEvent">,
+          localEventId: "event-open-latest",
+          localRegisterSessionId: "register-latest",
+          sequence: 3,
+        }),
+      ],
+    });
+
+    const result = await resolveTerminalCloudRepair(ctx as never, {
+      expectedPreconditionHash: buildTerminalCloudRepairPreconditionHash({
+        safeConflictIds: [latestConflict._id, olderConflict._id],
+        storeId,
+        terminalId,
+      }),
+      now,
+      resolvedByUserId: "user-1" as Id<"athenaUser">,
+      storeId,
+      terminalId,
+    });
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        resolvedConflictIds: [latestConflict._id, olderConflict._id],
+        skippedConflictIds: [],
+      },
+    });
+    expect(ctx.tables.posLocalSyncEvent).toContainEqual(
+      expect.objectContaining({
+        _id: "event-open-latest-id",
+        status: "projected",
+      }),
+    );
+    expect(ctx.tables.posLocalSyncEvent).toContainEqual(
+      expect.objectContaining({
+        _id: "event-open-older-id",
+        status: "conflicted",
+      }),
+    );
+    expect(ctx.tables.posLocalSyncConflict).toContainEqual(
+      expect.objectContaining({
+        _id: olderConflict._id,
+        status: "resolved",
+      }),
+    );
+
+    const repeat = await resolveTerminalCloudRepair(ctx as never, {
+      expectedPreconditionHash: buildTerminalCloudRepairPreconditionHash({
+        safeConflictIds: [],
+        storeId,
+        terminalId,
+      }),
+      now: now + 1,
+      resolvedByUserId: "user-1" as Id<"athenaUser">,
+      storeId,
+      terminalId,
+    });
+
+    expect(repeat).toMatchObject({
+      kind: "ok",
+      data: {
+        resolvedConflictIds: [],
+        skippedConflictIds: [],
+      },
+    });
+    expect(
+      ctx.tables.registerSession.filter(
+        (session) => session.status === "active",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("stops without patching when repair projection is no longer safe", async () => {
+    const duplicateOpenConflict = buildConflict({
+      localEventId: "event-open-replacement",
+      localRegisterSessionId: "register-replacement",
+      sequence: 1,
+    });
+    const closeoutVarianceConflict = buildConflict({
+      _id: "closeout-conflict" as Id<"posLocalSyncConflict">,
+      conflictType: "permission",
+      details: {
+        countedCash: 95,
+        expectedCash: 100,
+        variance: -5,
+      },
+      localEventId: "event-register-closed",
+      localRegisterSessionId: "registerSession-prior",
+      sequence: 2,
+      summary: REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY,
+    });
+    const ctx = buildCtx({
+      posLocalSyncConflict: [closeoutVarianceConflict, duplicateOpenConflict],
+      posLocalSyncEvent: [
+        buildEvent({
+          _id: "event-open-replacement-id" as Id<"posLocalSyncEvent">,
+          localEventId: "event-open-replacement",
+          localRegisterSessionId: "register-replacement",
+          sequence: 1,
+        }),
+      ],
+      registerSession: [
+        {
+          _id: "registerSession-prior" as Id<"registerSession">,
+          _creationTime: now - 30 * 60 * 1000,
+          storeId,
+          terminalId,
+          registerNumber: "A1",
+          status: "closing",
+          openedByStaffProfileId: "staff-1" as Id<"staffProfile">,
+          openedAt: now - 40 * 60 * 1000,
+          openingFloat: 100,
+          expectedCash: 100,
+        } as Doc<"registerSession">,
+      ],
+    });
+
+    const result = await resolveTerminalCloudRepair(ctx as never, {
+      expectedPreconditionHash: buildTerminalCloudRepairPreconditionHash({
+        safeConflictIds: [duplicateOpenConflict._id],
+        storeId,
+        terminalId,
+      }),
+      now,
+      resolvedByUserId: "user-1" as Id<"athenaUser">,
+      storeId,
+      terminalId,
+    });
+
+    expect(result).toMatchObject({
+      error: {
+        code: "precondition_failed",
+        metadata: {
+          preconditionDrift: true,
+        },
+      },
+      kind: "user_error",
+    });
+    expect(ctx.tables.posLocalSyncConflict).toContainEqual(
+      expect.objectContaining({
+        _id: duplicateOpenConflict._id,
+        status: "needs_review",
+      }),
+    );
+    expect(ctx.tables.posLocalSyncEvent).toContainEqual(
+      expect.objectContaining({
+        _id: "event-open-replacement-id",
+        status: "conflicted",
+      }),
+    );
+    expect(ctx.db.patch).not.toHaveBeenCalledWith(
+      "posLocalSyncConflict",
+      duplicateOpenConflict._id,
+      expect.anything(),
+    );
+    expect(ctx.db.patch).not.toHaveBeenCalledWith(
+      "posLocalSyncEvent",
+      "event-open-replacement-id",
+      expect.anything(),
+    );
   });
 
   it("stops without patching when the preview precondition drifted", async () => {
@@ -71,15 +374,72 @@ describe("resolveTerminalCloudRepair", () => {
   });
 });
 
-function buildCtx(seed: {
+type TestTables = {
+  operationalEvent: Array<Record<string, unknown>>;
   posLocalSyncConflict: Array<Doc<"posLocalSyncConflict">>;
   posLocalSyncEvent: Array<Doc<"posLocalSyncEvent">>;
-}) {
+  posLocalSyncMapping: Array<Record<string, unknown>>;
+  posTerminal: Array<Doc<"posTerminal">>;
+  registerSession: Array<Doc<"registerSession">>;
+  staffProfile: Array<Doc<"staffProfile">>;
+  staffRoleAssignment: Array<Record<string, unknown>>;
+  store: Array<Doc<"store">>;
+};
+
+function buildCtx(seed: Partial<TestTables>) {
+  const tables: TestTables = {
+    operationalEvent: [],
+    posLocalSyncConflict: seed.posLocalSyncConflict ?? [],
+    posLocalSyncEvent: seed.posLocalSyncEvent ?? [],
+    posLocalSyncMapping: seed.posLocalSyncMapping ?? [],
+    posTerminal: seed.posTerminal ?? [buildTerminal()],
+    registerSession: seed.registerSession ?? [],
+    staffProfile: seed.staffProfile ?? [buildStaffProfile()],
+    staffRoleAssignment: seed.staffRoleAssignment ?? [
+      {
+        _id: "role-1",
+        staffProfileId: "staff-1",
+        storeId,
+        role: "cashier",
+        status: "active",
+      },
+    ],
+    store: seed.store ?? [buildStore()],
+  };
+  const insertCounts = new Map<string, number>();
+  const patch = vi.fn(
+    async (tableName: keyof TestTables, id: string, patchValue: Record<string, unknown>) => {
+      const row = tables[tableName].find((item) => item._id === id);
+      if (row) Object.assign(row, patchValue);
+    },
+  );
+
   return {
+    tables,
     db: {
-      patch: vi.fn(async () => undefined),
-      query: vi.fn((tableName: keyof typeof seed) =>
-        buildQuery(seed[tableName] as Array<Record<string, unknown>>),
+      get: vi.fn(async (tableName: keyof TestTables, id: string) => {
+        return tables[tableName].find((item) => item._id === id) ?? null;
+      }),
+      insert: vi.fn(async (tableName: keyof TestTables, input: Record<string, unknown>) => {
+        const nextCount = (insertCounts.get(tableName) ?? 0) + 1;
+        insertCounts.set(tableName, nextCount);
+        const id = `${tableName}-${nextCount}`;
+        if (!tables[tableName]) {
+          tables[tableName] = [] as never;
+        }
+        tables[tableName].push({
+          _id: id,
+          _creationTime: now,
+          ...input,
+        } as never);
+        return id;
+      }),
+      normalizeId: vi.fn((tableName: keyof TestTables, value: string) => {
+        return tables[tableName].some((item) => item._id === value) ? value : null;
+      }),
+      patch,
+      query: vi.fn((tableName: keyof TestTables) =>
+        buildQuery((tables[tableName] ?? []) as Array<Record<string, unknown>>),
       ),
     },
   };
@@ -87,23 +447,83 @@ function buildCtx(seed: {
 
 function buildQuery(rows: Array<Record<string, unknown>>) {
   let currentRows = [...rows];
+  const applyEq = (field: string, value: unknown) => {
+    currentRows = currentRows.filter((row) => row[field] === value);
+  };
+  const chain = {
+    filter: vi.fn((_build: unknown) => {
+      return chain;
+    }),
+    first: vi.fn(async () => currentRows[0] ?? null),
+    order: vi.fn((direction: "asc" | "desc") => {
+      currentRows = [...currentRows].sort((left, right) => {
+        const leftTime = Number(left._creationTime ?? 0);
+        const rightTime = Number(right._creationTime ?? 0);
+        return direction === "desc" ? rightTime - leftTime : leftTime - rightTime;
+      });
+      return chain;
+    }),
+    take: vi.fn(async (count: number) => currentRows.slice(0, count)),
+    unique: vi.fn(async () => currentRows[0] ?? null),
+  };
   return {
     withIndex: vi.fn((_indexName: string, build: (q: {
       eq: (field: string, value: unknown) => unknown;
+      gt: (field: string, value: unknown) => unknown;
     }) => unknown) => {
       const q = {
         eq: vi.fn((field: string, value: unknown) => {
-          currentRows = currentRows.filter((row) => row[field] === value);
+          applyEq(field, value);
+          return q;
+        }),
+        gt: vi.fn((field: string, value: unknown) => {
+          currentRows = currentRows.filter((row) => Number(row[field]) > Number(value));
           return q;
         }),
       };
       build(q);
-      return {
-        first: vi.fn(async () => currentRows[0] ?? null),
-        take: vi.fn(async (count: number) => currentRows.slice(0, count)),
-      };
+      return chain;
     }),
+    filter: chain.filter,
+    first: chain.first,
+    order: chain.order,
+    take: chain.take,
+    unique: chain.unique,
   };
+}
+
+function buildTerminal(
+  overrides: Partial<Doc<"posTerminal">> = {},
+): Doc<"posTerminal"> {
+  return {
+    _id: terminalId,
+    _creationTime: now - 30 * 60 * 1000,
+    storeId,
+    registerNumber: "A1",
+    status: "active",
+    ...overrides,
+  } as Doc<"posTerminal">;
+}
+
+function buildStaffProfile(
+  overrides: Partial<Doc<"staffProfile">> = {},
+): Doc<"staffProfile"> {
+  return {
+    _id: "staff-1" as Id<"staffProfile">,
+    _creationTime: now - 30 * 60 * 1000,
+    storeId,
+    status: "active",
+    ...overrides,
+  } as Doc<"staffProfile">;
+}
+
+function buildStore(overrides: Partial<Doc<"store">> = {}): Doc<"store"> {
+  return {
+    _id: storeId,
+    _creationTime: now - 30 * 60 * 1000,
+    organizationId: "org-1" as Id<"organization">,
+    ...overrides,
+  } as Doc<"store">;
 }
 
 function buildConflict(
@@ -137,6 +557,7 @@ function buildEvent(
     localRegisterSessionId: "register-1",
     localEventId: "event-1",
     eventType: "register_opened",
+    sequence: 1,
     occurredAt: now - 20 * 60 * 1000,
     staffProfileId: "staff-1" as Id<"staffProfile">,
     payload: {

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.ts
@@ -6,8 +6,22 @@ import {
   type CommandResult,
 } from "../../../../shared/commandResult";
 import {
+  canReuseCloudRegisterSessionForLocalOpen as canReuseCloudRegisterSessionForLocalOpenPolicy,
+  canSupersedeReviewedRegisterSessionForLocalOpen as canSupersedeReviewedRegisterSessionForLocalOpenPolicy,
+  isRegisterCloseoutReviewConflict,
+} from "../../../../shared/registerSessionLifecyclePolicy";
+import { createConvexLocalSyncRepository } from "../../infrastructure/repositories/localSyncRepository";
+import { parseStoredLocalSyncEvent } from "../sync/ingestLocalEvents";
+import { projectLocalSyncEvent } from "../sync/projectLocalEvents";
+import type {
+  LocalSyncRegisterReviewConflictFact,
+  ParsedPosLocalSyncEventInput,
+  SyncProjectionRepository,
+} from "../sync/types";
+import {
   buildTerminalCloudRepairPreview,
   classifyTerminalCloudRepairConflict,
+  type SafeTerminalCloudRepairConflict,
 } from "./cloudRepairPolicy";
 import {
   getTerminalRecoverySourceEvent,
@@ -64,18 +78,260 @@ export async function resolveTerminalCloudRepair(
     });
   }
 
-  for (const conflictId of preview.safeConflictIds) {
-    await patchTerminalRecoveryConflict(ctx, conflictId, {
+  const localSyncRepository = createConvexLocalSyncRepository(ctx);
+  const safeConflicts = classified.filter(
+    (item): item is SafeTerminalCloudRepairConflict =>
+      item.kind === "safe_duplicate_register_opened",
+  );
+  const conflictToRepair = selectLatestSafeDuplicateOpenConflict(safeConflicts);
+  const obsoleteSafeConflicts = safeConflicts
+    .filter((conflict) => conflict.conflictId !== conflictToRepair?.conflictId)
+    .filter(
+      (conflict) =>
+        conflictToRepair === undefined ||
+        conflict.sequence <= conflictToRepair.sequence,
+    );
+
+  if (conflictToRepair) {
+    const sourceEvent = await getTerminalRecoverySourceEvent(ctx, {
+      storeId: args.storeId,
+      terminalId: args.terminalId,
+      localEventId: conflictToRepair.localEventId,
+    });
+    if (!sourceEvent) {
+      return userError({
+        code: "precondition_failed",
+        message: "Terminal recovery evidence changed. Preview the repair again.",
+        metadata: {
+          preconditionDrift: true,
+        },
+      });
+    }
+
+    const parsed = parseStoredLocalSyncEvent(localSyncRepository, sourceEvent);
+    if (!parsed.ok) {
+      return userError({
+        code: "precondition_failed",
+        message: "Terminal recovery evidence changed. Preview the repair again.",
+        metadata: {
+          preconditionDrift: true,
+        },
+      });
+    }
+    if (
+      !(await canRepairProjectRegisterOpen(localSyncRepository, {
+        event: parsed.event,
+        now: sourceEvent.acceptedAt ?? args.now,
+        storeId: args.storeId,
+        terminalId: args.terminalId,
+      }))
+    ) {
+      return userError({
+        code: "precondition_failed",
+        message: "Terminal recovery evidence changed. Preview the repair again.",
+        metadata: {
+          preconditionDrift: true,
+        },
+      });
+    }
+
+    const projection = await projectLocalSyncEvent(localSyncRepository, {
+      storeId: args.storeId,
+      terminalId: args.terminalId,
+      event: parsed.event,
+      syncEventId: sourceEvent._id,
+      now: sourceEvent.acceptedAt ?? args.now,
+      options: {
+        trustStoredStaffProof: true,
+      },
+    });
+    if (projection.status !== "projected" || projection.conflicts.length > 0) {
+      return userError({
+        code: "precondition_failed",
+        message: "Terminal recovery evidence changed. Preview the repair again.",
+        metadata: {
+          preconditionDrift: true,
+        },
+      });
+    }
+
+    await localSyncRepository.resolveConflictsForEvent({
+      storeId: args.storeId,
+      terminalId: args.terminalId,
+      localEventId: sourceEvent.localEventId,
+      resolvedAt: args.now,
+    });
+    await localSyncRepository.patchEvent(sourceEvent._id, {
+      status: "projected",
+      projectedAt: args.now,
+    });
+    await patchTerminalRecoveryConflict(ctx, conflictToRepair.conflictId, {
       resolvedAt: args.now,
       resolvedByStaffProfileId: args.resolvedByStaffProfileId,
       resolvedByUserId: args.resolvedByUserId,
       status: "resolved",
     });
+    await Promise.all(
+      obsoleteSafeConflicts.map((conflict) =>
+        patchTerminalRecoveryConflict(ctx, conflict.conflictId, {
+          resolvedAt: args.now,
+          resolvedByStaffProfileId: args.resolvedByStaffProfileId,
+          resolvedByUserId: args.resolvedByUserId,
+          status: "resolved",
+        }),
+      ),
+    );
   }
+  const resolvedConflictIds = conflictToRepair
+    ? [
+        conflictToRepair.conflictId,
+        ...obsoleteSafeConflicts.map((conflict) => conflict.conflictId),
+      ]
+    : [];
 
   return ok({
     preconditionHash: preview.preconditionHash,
-    resolvedConflictIds: preview.safeConflictIds,
+    resolvedConflictIds,
     skippedConflictIds: preview.skipped.map((item) => item.conflictId),
   });
+}
+
+function selectLatestSafeDuplicateOpenConflict(
+  conflicts: SafeTerminalCloudRepairConflict[],
+) {
+  return [...conflicts].sort(
+    (left, right) =>
+      right.sequence - left.sequence ||
+      String(right.conflictId).localeCompare(String(left.conflictId)),
+  )[0];
+}
+
+async function canRepairProjectRegisterOpen(
+  repository: SyncProjectionRepository,
+  args: {
+    event: ParsedPosLocalSyncEventInput;
+    now: number;
+    storeId: Parameters<SyncProjectionRepository["getStore"]>[0];
+    terminalId: Parameters<SyncProjectionRepository["getTerminal"]>[0];
+  },
+) {
+  if (args.event.eventType !== "register_opened") return false;
+
+  const terminal = await repository.getTerminal(args.terminalId);
+  const staff = await repository.getStaffProfile(args.event.staffProfileId);
+  const terminalRegisterNumber = normalizeRepairString(terminal?.registerNumber);
+  const payloadRegisterNumber = normalizeRepairString(args.event.payload.registerNumber);
+  if (
+    !terminal ||
+    terminal.storeId !== args.storeId ||
+    terminal.status !== "active" ||
+    !terminalRegisterNumber ||
+    (payloadRegisterNumber && payloadRegisterNumber !== terminalRegisterNumber)
+  ) {
+    return false;
+  }
+
+  const hasActiveOpenRole = staff
+    ? await repository.hasActivePosRole({
+        staffProfileId: args.event.staffProfileId,
+        storeId: args.storeId,
+        allowedRoles: ["cashier", "manager"],
+      })
+    : false;
+  if (
+    !staff ||
+    staff.storeId !== args.storeId ||
+    staff.status !== "active" ||
+    !hasActiveOpenRole
+  ) {
+    return false;
+  }
+
+  const directRegisterSessionId = repository.normalizeCloudId(
+    "registerSession",
+    args.event.localRegisterSessionId,
+  );
+  if (directRegisterSessionId) {
+    const registerSession = await repository.getRegisterSession(directRegisterSessionId);
+    return canReuseCloudRegisterSessionForLocalOpenPolicy({
+      hasOpenRegisterCloseoutReview: false,
+      registerSession,
+      storeId: args.storeId,
+      terminalId: args.terminalId,
+    });
+  }
+
+  const blockingRegisterSession = await repository.findBlockingRegisterSession({
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+    registerNumber: terminalRegisterNumber,
+  });
+  if (!blockingRegisterSession) return true;
+
+  const reviewState = await getRepairOpenRegisterCloseoutReviewState(repository, {
+    registerSessionId: blockingRegisterSession._id,
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+  });
+
+  return canSupersedeReviewedRegisterSessionForLocalOpenPolicy({
+    hasOpenRegisterCloseoutReview: reviewState.hasOpenRegisterCloseoutReview,
+    replacementLocalRegisterSessionId: args.event.localRegisterSessionId,
+    replacementSequence: args.event.sequence,
+    registerSession: blockingRegisterSession,
+    reviewSequence: reviewState.latestReviewSequence ?? null,
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+  });
+}
+
+async function getRepairOpenRegisterCloseoutReviewState(
+  repository: SyncProjectionRepository,
+  args: {
+    registerSessionId: Parameters<
+      SyncProjectionRepository["listOpenRegisterReviewConflictFacts"]
+    >[0]["registerSessionId"];
+    storeId: Parameters<SyncProjectionRepository["getStore"]>[0];
+    terminalId: Parameters<SyncProjectionRepository["getTerminal"]>[0];
+  },
+) {
+  const conflicts = (
+    await repository.listOpenRegisterReviewConflictFacts(args)
+  )
+    .filter((fact) =>
+      repairFactMatchesRegisterSessionCloseoutReview(fact, args.registerSessionId),
+    )
+    .map((fact) => fact.conflict);
+
+  return {
+    hasOpenRegisterCloseoutReview: conflicts.length > 0,
+    latestReviewSequence: conflicts.reduce<number | undefined>(
+      (latest, conflict) =>
+        latest === undefined ? conflict.sequence : Math.max(latest, conflict.sequence),
+      undefined,
+    ),
+  };
+}
+
+function repairFactMatchesRegisterSessionCloseoutReview(
+  fact: LocalSyncRegisterReviewConflictFact,
+  registerSessionId: Parameters<
+    SyncProjectionRepository["listOpenRegisterReviewConflictFacts"]
+  >[0]["registerSessionId"],
+) {
+  if (!isRegisterCloseoutReviewConflict(fact.conflict)) return false;
+  if (
+    fact.registerSessionMapping?.cloudTable === "registerSession" &&
+    fact.registerSessionMapping.cloudId === registerSessionId
+  ) {
+    return true;
+  }
+
+  return fact.directRegisterSession?._id === registerSessionId;
+}
+
+function normalizeRepairString(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
 }

--- a/packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts
+++ b/packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts
@@ -157,110 +157,120 @@ describe("registerSessionLifecyclePolicy", () => {
       canSupersedeReviewedRegisterSessionForLocalOpen({
         hasOpenRegisterCloseoutReview: true,
         replacementLocalRegisterSessionId: "replacement-local-drawer",
-        replacementSequence: 12,
+        replacementSequence: 2,
         registerSession: {
           localRegisterSessionId: "reviewed-local-drawer",
           status: "closing",
           storeId: "store-1",
           terminalId: "terminal-1",
         },
-        reviewSequence: 10,
+        reviewSequence: 2,
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toBe(false);
+    expect(
+      canSupersedeReviewedRegisterSessionForLocalOpen({
+        hasOpenRegisterCloseoutReview: true,
+        replacementLocalRegisterSessionId: "replacement-local-drawer",
+        replacementSequence: 3,
+        registerSession: {
+          localRegisterSessionId: "reviewed-local-drawer",
+          status: "closing",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        },
+        reviewSequence: 2,
         storeId: "store-1",
         terminalId: "terminal-1",
       }),
     ).toBe(true);
     expect(
       canSupersedeReviewedRegisterSessionForLocalOpen({
+        allowUnknownReviewSequence: true,
         hasOpenRegisterCloseoutReview: true,
         replacementLocalRegisterSessionId: "replacement-local-drawer",
-        replacementSequence: 12,
         registerSession: {
           localRegisterSessionId: "reviewed-local-drawer",
           status: "closeout_rejected",
           storeId: "store-1",
           terminalId: "terminal-1",
         },
-        reviewSequence: 10,
         storeId: "store-1",
         terminalId: "terminal-1",
       }),
     ).toBe(true);
     expect(
       canSupersedeReviewedRegisterSessionForLocalOpen({
+        allowUnknownReviewSequence: true,
         hasOpenRegisterCloseoutReview: true,
         replacementLocalRegisterSessionId: "replacement-local-drawer",
-        replacementSequence: 12,
         registerSession: {
           localRegisterSessionId: "reviewed-local-drawer",
           status: "closed",
           storeId: "store-1",
           terminalId: "terminal-1",
         },
-        reviewSequence: 10,
         storeId: "store-1",
         terminalId: "terminal-1",
       }),
     ).toBe(false);
     expect(
       canSupersedeReviewedRegisterSessionForLocalOpen({
+        allowUnknownReviewSequence: true,
         hasOpenRegisterCloseoutReview: true,
         replacementLocalRegisterSessionId: "reviewed-local-drawer",
-        replacementSequence: 12,
         registerSession: {
           localRegisterSessionId: "reviewed-local-drawer",
           status: "closing",
           storeId: "store-1",
           terminalId: "terminal-1",
         },
-        reviewSequence: 10,
         storeId: "store-1",
         terminalId: "terminal-1",
       }),
     ).toBe(false);
     expect(
       canSupersedeReviewedRegisterSessionForLocalOpen({
+        allowUnknownReviewSequence: true,
         hasOpenRegisterCloseoutReview: true,
         replacementLocalRegisterSessionId: "replacement-local-drawer",
-        replacementSequence: 9,
         registerSession: {
           localRegisterSessionId: "reviewed-local-drawer",
           status: "closing",
           storeId: "store-1",
           terminalId: "terminal-1",
         },
-        reviewSequence: 10,
         storeId: "store-1",
         terminalId: "terminal-1",
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       canSupersedeReviewedRegisterSessionForLocalOpen({
+        allowUnknownReviewSequence: true,
         hasOpenRegisterCloseoutReview: true,
         replacementLocalRegisterSessionId: "replacement-local-drawer",
-        replacementSequence: 12,
         registerSession: {
           localRegisterSessionId: "reviewed-local-drawer",
           status: "closing",
           storeId: "store-2",
           terminalId: "terminal-1",
         },
-        reviewSequence: 10,
         storeId: "store-1",
         terminalId: "terminal-1",
       }),
     ).toBe(false);
     expect(
       canSupersedeReviewedRegisterSessionForLocalOpen({
+        allowUnknownReviewSequence: true,
         hasOpenRegisterCloseoutReview: true,
         replacementLocalRegisterSessionId: "replacement-local-drawer",
-        replacementSequence: 12,
         registerSession: {
           localRegisterSessionId: "reviewed-local-drawer",
           status: "closing",
           storeId: "store-1",
           terminalId: "terminal-2",
         },
-        reviewSequence: 10,
         storeId: "store-1",
         terminalId: "terminal-1",
       }),

--- a/packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts
+++ b/packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts
@@ -124,29 +124,40 @@ export function canReuseCloudRegisterSessionForLocalOpen(input: {
   );
 }
 
+type RegisterSessionSupersedeFreshnessInput =
+  | {
+      replacementSequence: number;
+      reviewSequence: number | null | undefined;
+      allowUnknownReviewSequence?: never;
+    }
+  | {
+      allowUnknownReviewSequence: true;
+      replacementSequence?: number | null;
+      reviewSequence?: number | null;
+    };
+
 export function canSupersedeReviewedRegisterSessionForLocalOpen(input: {
   hasOpenRegisterCloseoutReview: boolean;
   replacementLocalRegisterSessionId: string;
-  replacementSequence: number;
   registerSession?: RegisterSessionLifecycleScopedSession | null;
-  reviewSequence?: number | null;
   storeId: string;
   terminalId: string;
-}) {
+} & RegisterSessionSupersedeFreshnessInput) {
   const isDistinctReplacement =
     input.replacementLocalRegisterSessionId !==
       input.registerSession?.localRegisterSessionId &&
     input.replacementLocalRegisterSessionId !==
       input.registerSession?.cloudRegisterSessionId;
-  const isNewerThanReview =
-    input.reviewSequence === null ||
+  const hasFreshReplacement =
+    input.allowUnknownReviewSequence === true ||
     input.reviewSequence === undefined ||
+    input.reviewSequence === null ||
     input.replacementSequence > input.reviewSequence;
 
   return (
     isScopedRegisterSession(input) &&
     isDistinctReplacement &&
-    isNewerThanReview &&
+    hasFreshReplacement &&
     (isRegisterSessionSaleUsable(input.registerSession) ||
       input.registerSession?.status === "closing" ||
       input.registerSession?.status === "closeout_rejected") &&

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
@@ -183,6 +183,35 @@ describe("RegisterDrawerGate", () => {
     expect(onCloseoutSecondaryAction).toHaveBeenCalledTimes(1);
   });
 
+  it("labels compact cloud session codes", () => {
+    renderGate({
+      closeoutCountedCash: "100.00",
+      expectedCash: 10002,
+      mode: "closeoutBlocked",
+      registerSessionCode: "8980ZC",
+      registerSessionCodeScope: "cloud",
+    });
+
+    expect(screen.getByText("Cloud session")).toBeInTheDocument();
+    expect(screen.getByText("8980ZC")).toBeInTheDocument();
+  });
+
+  it("labels compact local session codes", () => {
+    renderGate({
+      closeoutCountedCash: "100.00",
+      expectedCash: 10002,
+      mode: "closeoutBlocked",
+      registerSessionCode: "F48D56",
+      registerSessionCodeScope: "local",
+    });
+
+    expect(screen.getByText("Local session")).toBeInTheDocument();
+    expect(screen.getByText("F48D56")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/local-register-/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows terminal repair copy and sign-out action", async () => {
     const user = userEvent.setup();
     const onSignOut = vi.fn();

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -26,7 +26,7 @@ function CashControlsButton({
 }: {
   className?: string;
   registerSessionId?: string;
-  variant?: "default" | "ghost";
+  variant?: "default" | "ghost" | "workflow";
 }) {
   return (
     <Button asChild className={className} type="button" variant={variant}>
@@ -70,14 +70,22 @@ function getVarianceTone(variance?: number) {
   return variance > 0 ? "text-success" : "text-danger";
 }
 
-function RegisterSessionCode({ code }: { code?: string }) {
+function RegisterSessionCode({
+  code,
+  scope,
+}: {
+  code?: string;
+  scope?: "cloud" | "local";
+}) {
   if (!code) {
     return null;
   }
 
+  const label = scope === "local" ? "Local session" : "Cloud session";
+
   return (
     <p className="text-xs leading-5 text-muted-foreground/80">
-      Cloud session{" "}
+      {label}{" "}
       <span className="font-mono text-foreground/65">{code}</span>
     </p>
   );
@@ -394,7 +402,7 @@ export function RegisterDrawerGate({
                   isLoading={Boolean(drawerGate.isSubmitting)}
                   onClick={handleSubmitButtonClick}
                   type="button"
-                  variant="default"
+                  variant="workflow"
                 >
                   {drawerGate.closeoutSecondaryActionLabel ??
                     "Open replacement drawer"}
@@ -405,7 +413,7 @@ export function RegisterDrawerGate({
                 <CashControlsButton
                   className="w-full sm:w-auto"
                   registerSessionId={drawerGate.cashControlsRegisterSessionId}
-                  variant="default"
+                  variant="workflow"
                 />
               ) : null}
 
@@ -443,7 +451,10 @@ export function RegisterDrawerGate({
             ) : null}
 
             <div className="flex justify-end">
-              <RegisterSessionCode code={drawerGate.registerSessionCode} />
+              <RegisterSessionCode
+                code={drawerGate.registerSessionCode}
+                scope={drawerGate.registerSessionCodeScope}
+              />
             </div>
           </div>
         ) : (
@@ -475,9 +486,9 @@ export function RegisterDrawerGate({
                       {drawerGate.closeoutDraftVariance === undefined
                         ? "Pending count"
                         : formatCurrency(
-                            currency,
-                            drawerGate.closeoutDraftVariance,
-                          )}
+                          currency,
+                          drawerGate.closeoutDraftVariance,
+                        )}
                     </dd>
                   </div>
                 </dl>
@@ -573,7 +584,10 @@ export function RegisterDrawerGate({
             </form>
 
             <div className="mt-6 flex justify-end">
-              <RegisterSessionCode code={drawerGate.registerSessionCode} />
+              <RegisterSessionCode
+                code={drawerGate.registerSessionCode}
+                scope={drawerGate.registerSessionCodeScope}
+              />
             </div>
           </>
         )}

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -881,6 +881,135 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     });
   });
 
+  it("self-heals uploaded register open reviews from status-only route entry", async () => {
+    mocks.ingestLocalEvents.mockResolvedValue({
+      kind: "ok",
+      data: {
+        accepted: [
+          {
+            localEventId: "event-open",
+            sequence: 1,
+            status: "projected",
+          },
+        ],
+        held: [],
+        mappings: [
+          {
+            _id: "mapping-open",
+            storeId: "store-1",
+            terminalId: "terminal-cloud-1",
+            localRegisterSessionId: "register-1",
+            localEventId: "event-open",
+            localIdKind: "registerSession",
+            localId: "register-1",
+            cloudTable: "registerSession",
+            cloudId: "register-session-1",
+            createdAt: 12,
+          },
+        ],
+        conflicts: [],
+        syncCursor: {
+          localRegisterSessionId: "register-1",
+          acceptedThroughSequence: 1,
+        },
+      },
+    });
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-open",
+            payload: {
+              openingFloat: 100,
+              registerNumber: "1",
+            },
+            sequence: 1,
+            sync: { status: "needs_review", uploaded: true },
+            type: "register.opened",
+          }),
+          buildLocalEvent({
+            localEventId: "event-closeout",
+            payload: {
+              countedCash: 90,
+            },
+            sequence: 2,
+            sync: { status: "needs_review", uploaded: true },
+            type: "register.closeout_started",
+          }),
+        ],
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      markEventsNeedsReview: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      clearDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+      readDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: {
+          localRegisterSessionId: "register-1",
+          observedAt: 1,
+          reason: "lifecycle_rejected",
+          status: "blocked",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      writeLocalCloudMapping: vi.fn(async () => ({
+        ok: true,
+        value: {},
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+    };
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        mode: "status-only",
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.ingestLocalEvents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          events: [
+            expect.objectContaining({
+              eventType: "register_opened",
+              localEventId: "event-open",
+            }),
+          ],
+        }),
+      ),
+    );
+    expect(mocks.ingestLocalEvents.mock.calls[0]?.[0].events).toHaveLength(1);
+    await waitFor(() =>
+      expect(store.markEventsSynced).toHaveBeenCalledWith(["event-open"], {
+        uploaded: true,
+      }),
+    );
+    expect(store.markEventsNeedsReview).not.toHaveBeenCalled();
+  });
+
   it("does not manually retry review events that were never uploaded", async () => {
     const store = {
       listEvents: vi.fn(async () => ({

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -393,6 +393,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
         syncSeed: NonNullable<typeof provisionedSeed>,
         options: {
           includeUploadedReviewEvents?: boolean;
+          onlyUploadedRegisterOpenReviewEvents?: boolean;
           onlyUploadedReviewEvents?: boolean;
         } = {},
       ) =>
@@ -437,6 +438,11 @@ export function usePosLocalSyncRuntimeStatus(input: {
                   options.includeUploadedReviewEvents === true &&
                   event.sync.status === "needs_review" &&
                   event.sync.uploaded;
+                const isUploadedRegisterOpenReviewEvent =
+                  isUploadedReviewEvent && event.type === "register.opened";
+                if (options.onlyUploadedRegisterOpenReviewEvents === true) {
+                  return isUploadedRegisterOpenReviewEvent;
+                }
                 if (options.onlyUploadedReviewEvents === true) {
                   return isUploadedReviewEvent;
                 }
@@ -719,6 +725,18 @@ export function usePosLocalSyncRuntimeStatus(input: {
             const scheduler = createDrainScheduler(provisionedSeed);
             stopSchedulers.push(() => scheduler.stop());
             scheduler.trigger(trigger, { priority: "high" });
+          }
+
+          if (
+            trigger !== "manual-retry" &&
+            hasUploadedRegisterOpenReviewEvents(eventsResult.value.events)
+          ) {
+            const scheduler = createDrainScheduler(provisionedSeed, {
+              includeUploadedReviewEvents: true,
+              onlyUploadedRegisterOpenReviewEvents: true,
+            });
+            stopSchedulers.push(() => scheduler.stop());
+            scheduler.trigger("manual-retry", { priority: "high" });
           }
 
           if (trigger === "manual-retry") {
@@ -2004,6 +2022,15 @@ function hasPendingSyncableExpenseEvents(
         event.sync.status === "syncing" ||
         event.sync.status === "failed") &&
       isSyncablePosLocalEvent(event, uploadSupport),
+  );
+}
+
+function hasUploadedRegisterOpenReviewEvents(events: PosLocalEventRecord[]) {
+  return events.some(
+    (event) =>
+      event.type === "register.opened" &&
+      event.sync.status === "needs_review" &&
+      event.sync.uploaded === true,
   );
 }
 

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.test.ts
@@ -10,6 +10,7 @@ import {
   getCloseoutCloudRegisterSessionId,
   getCloseoutLocalRegisterSessionId,
   getLatestLocalRegisterLifecycleEvent,
+  getPendingLocalCloseoutRegisterSession,
   isKnownCloudRegisterSessionBlockingLocalProjection,
   readLocalSyncStatus,
 } from "./registerDrawerPresentation";
@@ -162,6 +163,64 @@ describe("registerDrawerPresentation", () => {
     );
 
     expect(latest?.type).toBe("register.reopened");
+  });
+
+  it("returns pending local closeout presentation evidence", () => {
+    const session = getPendingLocalCloseoutRegisterSession(
+      readModel({
+        activeRegisterSession: {
+          expectedCash: 5_000,
+          localRegisterSessionId: "local-register-1",
+          openedAt: 1,
+          openingFloat: 5_000,
+          countedCash: 4_800,
+          status: "closing",
+        },
+        sourceEvents: [
+          localEvent({
+            sequence: 2,
+            sync: { status: "pending" },
+            type: "register.closeout_started",
+          }),
+        ],
+      }),
+    );
+
+    expect(session).toEqual(
+      expect.objectContaining({
+        countedCash: 4_800,
+        expectedCash: 5_000,
+        localRegisterSessionId: "local-register-1",
+        status: "closing",
+        variance: -200,
+        localSyncStatus: {
+          status: "pending_sync",
+          pendingEventCount: 1,
+        },
+      }),
+    );
+
+    expect(
+      getPendingLocalCloseoutRegisterSession(
+        readModel({
+          activeRegisterSession: {
+            expectedCash: 5_000,
+            localRegisterSessionId: "local-register-1",
+            openedAt: 1,
+            openingFloat: 5_000,
+            countedCash: 5_000,
+            status: "closing",
+          },
+          sourceEvents: [
+            localEvent({
+              sequence: 2,
+              sync: { status: "synced" },
+              type: "register.closeout_started",
+            }),
+          ],
+        }),
+      ),
+    ).toBeNull();
   });
 
   it("preserves command user errors when the drawer cannot be opened", () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts
@@ -221,3 +221,39 @@ export function getLatestLocalRegisterLifecycleEvent(
       .at(-1) ?? null
   );
 }
+
+export function getPendingLocalCloseoutRegisterSession(
+  model: PosLocalRegisterReadModel | null,
+) {
+  const activeRegisterSession = model?.activeRegisterSession;
+  const latestLifecycleEvent = getLatestLocalRegisterLifecycleEvent(model);
+  if (
+    !activeRegisterSession ||
+    activeRegisterSession.status !== "closing" ||
+    latestLifecycleEvent?.type !== "register.closeout_started" ||
+    latestLifecycleEvent.sync.status === "synced"
+  ) {
+    return null;
+  }
+
+  return {
+    cloudRegisterSessionId: activeRegisterSession.cloudRegisterSessionId,
+    localRegisterSessionId: activeRegisterSession.localRegisterSessionId,
+    status: activeRegisterSession.status,
+    terminalId: activeRegisterSession.terminalId,
+    registerNumber: activeRegisterSession.registerNumber,
+    openingFloat: activeRegisterSession.openingFloat,
+    expectedCash: activeRegisterSession.expectedCash,
+    countedCash: activeRegisterSession.countedCash,
+    managerApprovalRequestId: undefined,
+    openedAt: activeRegisterSession.openedAt,
+    variance:
+      activeRegisterSession.countedCash === undefined
+        ? undefined
+        : activeRegisterSession.countedCash - activeRegisterSession.expectedCash,
+    localSyncStatus: {
+      status: "pending_sync" as const,
+      pendingEventCount: 1,
+    },
+  };
+}

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -250,6 +250,7 @@ export interface RegisterDrawerGateState {
   closeoutSubmittedReason?: "manager_review" | "pending_sync";
   closeoutSecondaryActionLabel?: string;
   registerSessionCode?: string;
+  registerSessionCodeScope?: "cloud" | "local";
   expectedCash?: number;
   canOpenCashControls?: boolean;
   cashControlsRegisterSessionId?: Id<"registerSession">;

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -3253,7 +3253,7 @@ describe("useRegisterViewModel", () => {
     expect(result.current.cashierCard?.cashierName).toBe("Offline Manager");
   });
 
-  it("holds submitted closing drawer as review-only and exposes replacement opening", async () => {
+  it("opens replacement drawer setup directly for submitted review-only closeouts", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -3290,34 +3290,26 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(result.current.drawerGate).not.toBeNull();
-    expect(result.current.drawerGate?.mode).toBe("closeoutBlocked");
+    expect(result.current.drawerGate?.mode).toBe("initialSetup");
     expect(result.current.drawerGate?.registerNumber).toBe("1");
     expect(result.current.productEntry.disabled).toBe(true);
     expect(mockStartSession).not.toHaveBeenCalled();
     expect(mockOpenDrawer).not.toHaveBeenCalled();
     expect(result.current.drawerGate?.onSubmit).toEqual(expect.any(Function));
-    expect(result.current.drawerGate?.closeoutSecondaryActionLabel).toBe(
-      "Open replacement drawer",
-    );
+    expect(result.current.drawerGate?.openingFloat).toBe("");
+    expect(result.current.drawerGate?.notes).toBe("");
+    expect(
+      result.current.drawerGate?.closeoutSecondaryActionLabel,
+    ).toBeUndefined();
     expect(result.current.drawerGate?.onSubmitCloseout).toBeUndefined();
     expect(result.current.drawerGate?.onReopenRegister).toBeUndefined();
-    expect(result.current.drawerGate?.closeoutSubmittedReason).toBe(
-      "manager_review",
-    );
-    expect(result.current.drawerGate?.expectedCash).toBe(5_000);
+    expect(result.current.drawerGate?.closeoutSubmittedReason).toBeUndefined();
     expect(
       result.current.drawerGate?.hasPendingCloseoutApproval,
-    ).toBe(true);
-    expect(
-      result.current.drawerGate?.cashControlsRegisterSessionId,
-    ).toBe("drawer-1");
-    expect(
-      result.current.drawerGate?.closeoutSubmittedCountedCash,
-    ).toBe(4_500);
-    expect(result.current.drawerGate?.closeoutSubmittedVariance).toBe(-500);
+    ).toBeUndefined();
   });
 
-  it("holds rejected closeout drawers as review-only replacement context", async () => {
+  it("opens replacement drawer setup directly for rejected closeout drawers", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -3352,17 +3344,16 @@ describe("useRegisterViewModel", () => {
       );
     });
 
-    expect(result.current.drawerGate?.mode).toBe("closeoutBlocked");
+    expect(result.current.drawerGate?.mode).toBe("initialSetup");
     expect(result.current.drawerGate?.onSubmit).toEqual(expect.any(Function));
     expect(result.current.drawerGate?.onReopenRegister).toBeUndefined();
-    expect(result.current.drawerGate?.closeoutSubmittedReason).toBe(
-      "manager_review",
-    );
-    expect(result.current.drawerGate?.closeoutSecondaryActionLabel).toBe(
-      "Open replacement drawer",
-    );
+    expect(result.current.drawerGate?.closeoutSubmittedReason).toBeUndefined();
+    expect(
+      result.current.drawerGate?.closeoutSecondaryActionLabel,
+    ).toBeUndefined();
     expect(result.current.productEntry.disabled).toBe(true);
     expect(mockStartSession).not.toHaveBeenCalled();
+    expect(mockOpenDrawer).not.toHaveBeenCalled();
   });
 
   it("allows a newer local drawer to sell while a different cloud closeout awaits manager review", async () => {
@@ -3768,6 +3759,13 @@ describe("useRegisterViewModel", () => {
 
     expect(result.current.drawerGate?.mode).toBe("closeoutBlocked");
     expect(result.current.drawerGate?.expectedCash).toBe(5_000);
+    expect(result.current.drawerGate?.registerSessionCode).toMatch(
+      /^[A-Z0-9-]{6}$/,
+    );
+    expect(result.current.drawerGate?.registerSessionCode).not.toContain(
+      "local-register",
+    );
+    expect(result.current.drawerGate?.registerSessionCodeScope).toBe("cloud");
     expect(result.current.drawerGate?.closeoutSecondaryActionLabel).toBe(
       "Return to sale",
     );
@@ -9602,7 +9600,7 @@ describe("useRegisterViewModel", () => {
     expect(result.current.checkout.payments).toEqual([]);
   });
 
-  it("opens the drawer gate after a local closeout is submitted", async () => {
+  it("shows the closeout gate immediately after a local closeout is submitted", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -9677,6 +9675,8 @@ describe("useRegisterViewModel", () => {
     expect(
       result.current.drawerGate?.closeoutSubmittedVariance,
     ).toBeUndefined();
+    expect(result.current.drawerGate?.closeoutSecondaryActionLabel).toBeUndefined();
+    expect(result.current.drawerGate?.onSubmit).toEqual(expect.any(Function));
     expect(result.current.drawerGate?.onSubmitCloseout).toBeUndefined();
     expect(result.current.productEntry.disabled).toBe(true);
     expect(result.current.closeoutControl?.canCloseout).toBe(false);
@@ -9757,8 +9757,41 @@ describe("useRegisterViewModel", () => {
     expect(result.current.drawerGate).not.toBeNull();
     expect(result.current.drawerGate?.mode).toBe("initialSetup");
     expect(result.current.drawerGate?.closeoutSubmittedReason).toBeUndefined();
+    expect(
+      result.current.drawerGate?.closeoutSecondaryActionLabel,
+    ).toBeUndefined();
+    expect(result.current.drawerGate?.onSubmit).toEqual(expect.any(Function));
     expect(result.current.drawerGate?.onSubmitCloseout).toBeUndefined();
     expect(result.current.productEntry.disabled).toBe(true);
+
+    await act(async () => {
+      await result.current.sessionPanel?.onStartNewSession();
+    });
+
+    expect(mockStartSession).not.toHaveBeenCalled();
+    expect(mockAppendLocalEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "session.started" }),
+    );
+
+    act(() => {
+      result.current.drawerGate?.onOpeningFloatChange?.("12.00");
+      result.current.drawerGate?.onNotesChange?.("Replacement drawer");
+    });
+
+    await act(async () => {
+      await result.current.drawerGate?.onSubmit?.();
+    });
+
+    expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        localRegisterSessionId: expect.not.stringMatching(/^local-register-1$/),
+        payload: expect.objectContaining({
+          notes: "Replacement drawer",
+          openingFloat: 1_200,
+        }),
+        type: "register.opened",
+      }),
+    );
   });
 
   it("does not present a synced local closeout as pending sync or closeout in progress", async () => {
@@ -9877,6 +9910,13 @@ describe("useRegisterViewModel", () => {
     act(() => {
       result.current.closeoutControl?.onRequestCloseout();
     });
+    expect(result.current.drawerGate?.registerSessionCode).toMatch(
+      /^[A-Z0-9-]{6}$/,
+    );
+    expect(result.current.drawerGate?.registerSessionCode).not.toContain(
+      "local-register",
+    );
+    expect(result.current.drawerGate?.registerSessionCodeScope).toBe("local");
     act(() => {
       result.current.drawerGate?.onCloseoutCountedCashChange?.("50.00");
     });

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -97,6 +97,7 @@ import {
 } from "./catalogSearchPresentation";
 import { useRegisterCatalogIndex } from "./useRegisterCatalogIndex";
 import { buildPosSyncStatusPresentation } from "@/lib/pos/presentation/syncStatusPresentation";
+import { formatRegisterSessionCode } from "@/lib/pos/presentation/registerSessionCode";
 import {
   canOperateRegister,
   getStaffDisplayNameFromAuthResult,
@@ -149,6 +150,7 @@ import {
   getCloseoutCloudRegisterSessionCode,
   getCloseoutCloudRegisterSessionId,
   getCloseoutLocalRegisterSessionId,
+  getPendingLocalCloseoutRegisterSession,
   isKnownCloudRegisterSessionBlockingLocalProjection,
   readLocalSyncStatus,
 } from "./registerDrawerPresentation";
@@ -1764,11 +1766,17 @@ export function useRegisterViewModel(): RegisterViewModel {
         },
       }
     : null;
+  const pendingLocalCloseoutRegisterSession =
+    getPendingLocalCloseoutRegisterSession(localRegisterReadModel);
   const activeCloseoutRegisterSession =
     closeoutBlockedRegisterSession ??
+    pendingLocalCloseoutRegisterSession ??
     (isCloseoutRequested
       ? (localCloseoutRegisterSession ?? saleUsableActiveRegisterSession)
       : null);
+  const activeCloseoutCanOpenReplacementDrawer = Boolean(
+    closeoutBlockedRegisterSession || pendingLocalCloseoutRegisterSession,
+  );
   const activeCloseoutRegisterSessionHasSyncReview = Boolean(
     findRegisterCloseoutReviewItem(activeCloseoutRegisterSession),
   );
@@ -1810,6 +1818,8 @@ export function useRegisterViewModel(): RegisterViewModel {
         : localSaleAuthorityBlockReason === "drawer_authority" &&
             hasRecoverableDrawerAuthorityBlock
           ? "drawerAuthorityRepair"
+          : activeCloseoutCanOpenReplacementDrawer && canSignedInStaffOpenDrawer
+            ? "initialSetup"
           : hasCloseoutBlockedDrawerState || activeCloseoutRegisterSession
             ? "closeoutBlocked"
             : hasMissingDrawerRecoveryState ||
@@ -5143,10 +5153,20 @@ export function useRegisterViewModel(): RegisterViewModel {
       activeCloseoutRegisterSession,
       localRegisterReadModel,
     ) ??
-    getCloseoutLocalRegisterSessionId(
-      activeCloseoutRegisterSession,
-      localRegisterReadModel,
+    formatRegisterSessionCode(
+      getCloseoutLocalRegisterSessionId(
+        activeCloseoutRegisterSession,
+        localRegisterReadModel,
+      ),
     );
+  const activeCloseoutRegisterSessionCodeScope:
+    | "cloud"
+    | "local"
+    | undefined = activeCloseoutRegisterSessionCode
+    ? activeCloseoutCloudRegisterSessionCode
+      ? "cloud"
+      : "local"
+    : undefined;
   const shouldShowDrawerGate = Boolean(
     requiresDrawerGate ||
     activeCloseoutRegisterSession ||
@@ -5211,11 +5231,12 @@ export function useRegisterViewModel(): RegisterViewModel {
                 activeCloseoutRegisterSession?.variance,
               closeoutNotes,
               closeoutSubmittedReason: activeCloseoutSubmittedReason,
-              closeoutSecondaryActionLabel: closeoutBlockedRegisterSession
+              closeoutSecondaryActionLabel: activeCloseoutCanOpenReplacementDrawer
                 ? "Open replacement drawer"
                 : "Return to sale",
               registerSessionCode: activeCloseoutRegisterSessionCode,
-              onCloseoutSecondaryAction: closeoutBlockedRegisterSession
+              registerSessionCodeScope: activeCloseoutRegisterSessionCodeScope,
+              onCloseoutSecondaryAction: activeCloseoutCanOpenReplacementDrawer
                 ? undefined
                 : handleCancelRegisterCloseout,
               expectedCash: activeCloseoutRegisterSession?.expectedCash,
@@ -5225,7 +5246,7 @@ export function useRegisterViewModel(): RegisterViewModel {
                 (activeCloseoutCloudRegisterSessionCode as
                   | Id<"registerSession">
                   | undefined),
-              canOpenDrawer: closeoutBlockedRegisterSession
+              canOpenDrawer: activeCloseoutCanOpenReplacementDrawer
                 ? canSignedInStaffOpenDrawer
                 : undefined,
               hasPendingCloseoutApproval: Boolean(
@@ -5246,13 +5267,13 @@ export function useRegisterViewModel(): RegisterViewModel {
                 setCloseoutNotes(value);
                 setDrawerErrorMessage(null);
               },
-              onSubmit: closeoutBlockedRegisterSession
+              onSubmit: activeCloseoutCanOpenReplacementDrawer
                 ? handleOpenDrawer
                 : undefined,
               onSubmitCloseout: activeCloseoutSubmittedReason
                 ? undefined
                 : handleSubmitRegisterCloseout,
-              onReopenRegister: closeoutBlockedRegisterSession
+              onReopenRegister: activeCloseoutCanOpenReplacementDrawer
                 ? undefined
                 : isCashierManager && !activeCloseoutRegisterSessionHasSyncReview
                   ? handleReopenRegisterCloseout


### PR DESCRIPTION
## Summary
- route closeout-with-replacement directly to the open drawer gate and make the replacement drawer CTA open that gate instead of firing the action immediately
- allow local register-open events to self-heal after closeout review conflicts while preserving sequence freshness and duplicate-open idempotency
- format local/cloud session labels consistently in the register gate

## Validation
- unanimous reviewer approval: TypeScript, adversarial, project standards
- `bun run --filter '@athena/webapp' test -- convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.test.ts convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts convex/pos/application/sync/projectLocalEvents.test.ts shared/registerSessionLifecyclePolicy.test.ts src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts src/components/pos/register/RegisterDrawerGate.test.tsx src/lib/pos/presentation/register/registerDrawerPresentation.test.ts src/lib/pos/presentation/register/useRegisterViewModel.test.ts`\n- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`\n- `bun run graphify:rebuild`\n- `bun run harness:review --base origin/main`\n- branch pre-push hook passed all 6 steps, including full webapp tests, production build, offline e2e, prod POS smoke, behavior scenarios, and inferential review\n