### PR TITLE
feat: enrich storefront context and product workspace state

### DIFF
--- a/docs/solutions/logic-errors/athena-context-events-and-search-url-state-2026-06-25.md
+++ b/docs/solutions/logic-errors/athena-context-events-and-search-url-state-2026-06-25.md
@@ -1,0 +1,70 @@
+---
+title: Athena Context Events And Search URL State Stay Retry Safe
+date: 2026-06-25
+category: logic-errors
+module: athena-webapp
+problem_type: context_event_idempotency_and_url_pagination_drift
+component: context-events-products-workspace
+symptoms:
+  - "Adding storefront device context could turn duplicate tracking retries into idempotency conflicts"
+  - "Deep-linked product search pages could render empty results when page exceeded the loaded result count"
+  - "URL page normalization could run before async SKU search results loaded"
+root_cause: mutable_context_fields_and_loading_state_were_mixed_into_durable_identity
+resolution_type: idempotency_hash_boundary_and_loaded_state_pagination_clamp
+severity: medium
+tags:
+  - context-events
+  - idempotency
+  - products
+  - url-state
+  - pagination
+  - storefront
+---
+
+# Athena Context Events And Search URL State Stay Retry Safe
+
+## Problem
+
+Two durable identity boundaries can drift when UI context is added after the
+original event or URL was created:
+
+- Storefront context events need coarse device and environment metadata for
+  intelligence, but the same idempotency key can be retried after viewport,
+  user-agent classification, or deployment behavior changes.
+- Product search pages restore from URL state, but the current result count is
+  async. A deep link can request a page before SKU search results have loaded.
+
+If these runtime details participate directly in duplicate detection or route
+normalization, Athena can create false conflicts or erase useful navigation
+state before the data boundary has settled.
+
+## Solution
+
+Keep contextual metadata as evidence, not identity:
+
+- Persist coarse context-event `environment` fields for prompt compilation and
+  device distribution.
+- Exclude `environment` from the semantic idempotency envelope hash. Payload,
+  event id, store, surface, schema, and idempotency key remain identity; runtime
+  device context does not.
+- Test both environment-to-environment stability and compatibility between
+  no-environment hashes and environment-bearing retries.
+
+For URL-backed search pagination:
+
+- Parse and clamp the requested page for display.
+- Normalize out-of-range pages back into the URL only after the async search
+  query has resolved.
+- Preserve the URL page while search results are loading so a valid deep link
+  does not collapse to page 1.
+
+## Prevention
+
+- Before adding new fields to an idempotent event append command, decide whether
+  they are identity, payload evidence, or runtime context. Only identity fields
+  belong in the semantic envelope hash.
+- Add regression tests that compare old minimal hashes to new enriched event
+  shapes when adding optional context fields.
+- For URL-backed pagination over async data, test both the loaded out-of-range
+  case and the loading state. The former should normalize; the latter should
+  preserve the URL until data arrives.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7983 nodes · 9372 edges · 2055 communities detected
+- 7994 nodes · 9391 edges · 2055 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2297,60 +2297,60 @@ Cohesion: 0.17
 Nodes (19): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady(), mapSyncStatus() (+11 more)
 
 ### Community 51 - "Community 51"
+Cohesion: 0.16
+Nodes (17): asRecord(), buildSnapshotHash(), buildStoreInsightsPromptFromContextBundle(), buildStoreInsightsPromptFromContextEvents(), buildUserInsightsPromptFromContextBundle(), buildUserInsightsPromptFromContextEvents(), compactContextEventsForPrompt(), compactEnvironmentForPrompt() (+9 more)
+
+### Community 52 - "Community 52"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 52 - "Community 52"
+### Community 53 - "Community 53"
 Cohesion: 0.15
 Nodes (16): findLatestOpenOperatingDay(), getTodaySummary(), getTransactionById(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile() (+8 more)
 
-### Community 53 - "Community 53"
+### Community 54 - "Community 54"
 Cohesion: 0.21
 Nodes (21): detectFormat(), extractJsonRows(), flattenJsonRows(), inferProductName(), isRecord(), looksLikeLabel(), normalizeKey(), normalizeLegacyRow() (+13 more)
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.25
 Nodes (21): asRecord(), errorFor(), getLocalExpenseSessionId(), getOrCreateSession(), isExpenseEvent(), itemSource(), itemSourceKey(), numberField() (+13 more)
 
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.18
 Nodes (18): assertValidEodLocalCompletionWindowMinutes(), assertValidEodThreshold(), assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getEodAutoCompletePolicyConfigWithCtx() (+10 more)
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.13
 Nodes (12): getLatestRuntimeStatusForTerminal(), getTerminalByFingerprint(), getTerminalSyncEvidence(), isActionableRejectedSyncEvent(), isActionableTerminalReviewSyncEvent(), mapTerminalRecord(), mergeRuntimeStatusPatch(), omitUndefined() (+4 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.21
 Nodes (18): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), formatRecoveryCode(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode() (+10 more)
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.1
 Nodes (4): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onStartRemoteAssist()
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.13
 Nodes (9): asCloudOperableSession(), countPendingSyncableLocalEventsForStaff(), hasSyncedSaleLocalEventsForStaff(), hasUploadedLocalEventsForStaff(), isCloudOperableSession(), isEmptyLocalSaleShell(), selectPassiveCloseoutBlockedRegisterSession(), trimOptional() (+1 more)
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
-
-### Community 64 - "Community 64"
-Cohesion: 0.19
-Nodes (15): asRecord(), buildSnapshotHash(), buildStoreInsightsPromptFromContextBundle(), buildStoreInsightsPromptFromContextEvents(), buildUserInsightsPromptFromContextBundle(), buildUserInsightsPromptFromContextEvents(), compactContextEventsForPrompt(), getPromptBundleMetadata() (+7 more)
 
 ### Community 65 - "Community 65"
 Cohesion: 0.27
@@ -2437,168 +2437,168 @@ Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
 ### Community 86 - "Community 86"
+Cohesion: 0.23
+Nodes (13): buildAbusePartitionKey(), buildServerContextTrackingEnvelope(), deriveBrowserFamily(), deriveContextEnvironment(), deriveOsFamily(), derivePrimarySubject(), isAcceptedSyntheticContext(), isRecord() (+5 more)
+
+### Community 87 - "Community 87"
 Cohesion: 0.19
 Nodes (10): buildLatestRunDebugPayload(), getBoundedDebugRunsByCapability(), getLatestDebugRunByCapability(), getLatestDebugRunBySubject(), isActiveRunStale(), isActiveRunStatus(), selectLatestDebugRunFromCandidates(), shouldRecoverActiveRun() (+2 more)
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.13
 Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.24
 Nodes (15): buildGeneratedControlId(), captureRemoteAssistCoBrowseFrame(), collectSanitizedSurface(), collectSensitiveRegions(), collectVisibleText(), getControlId(), getControlPriority(), getElementLabel() (+7 more)
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.22
 Nodes (11): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), getInvalidationNodes(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline() (+3 more)
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.23
 Nodes (13): collectConvexReturnValidatorContractFindings(), escapeRegExp(), extractConvexPublicFunctionsWithReturns(), fileExists(), findMatchingDefinitionEnd(), hasConvexReturnContractProofForExport(), isConvexReturnContractSourcePath(), isRelevantConvexContractProofPath() (+5 more)
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.22
 Nodes (9): buildHistoricalContextEventAppendArgs(), buildHistoricalImportIdempotencyKey(), buildPrimarySubject(), buildStoppedReport(), countOmittedFields(), createEmptyReport(), increment(), planHistoricalStorefrontContextImport() (+1 more)
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.32
 Nodes (14): buildPosOperatorSnapshot(), buildRecentDayBuckets(), buildSummaryTrendBucket(), buildTransactionDateBuckets(), calculateDeltaPercent(), formatHourLabel(), formatPaymentMethodLabel(), formatShortDate() (+6 more)
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.26
 Nodes (11): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), classifyRegisterSessionSyncReview(), findTransactionIdForSyncEvent(), hasInventoryReviewWorkItemForProjectedSale(), listOpenLocalSyncConflictsByRegisterSession(), numberDetail() (+3 more)
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.28
 Nodes (14): buildActorRefs(), buildReturnExchangeTraceEvent(), buildReturnExchangeTraceRecord(), buildTraceEvent(), buildTraceRecord(), compactDetails(), recordOnlineOrderReturnExchangeTraceBestEffort(), recordOnlineOrderTraceBestEffort() (+6 more)
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.17
 Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.18
 Nodes (7): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.22
 Nodes (10): extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), normalizeIdentifier(), parseCatalogSearchInput(), searchByText(), searchRegisterCatalog() (+2 more)
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.14
 Nodes (0):
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.16
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.26
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.22
 Nodes (6): buildParticipantIdentity(), getDataPublishRouting(), getParticipantRole(), isAllowedSender(), LiveKitRemoteAssistClient, parseParticipantRole()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.26
 Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.23
 Nodes (8): canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), getSaleBlockingDrawerAuthority(), isDrawerAuthoritySaleBlocking(), isRegisterSessionConflictBlocking(), isRegisterSessionReplacementBlocking(), isRegisterSessionSaleUsable(), isScopedRegisterSession()
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.22
 Nodes (6): buildTrustedInventoryFinalizationPayload(), buildTrustedInventoryMoneyPayload(), getTrustedInventoryReviewValidationMessage(), isNonNegativeInteger(), parseVariantDisplayMoney(), resolveTrustedInventoryReviewState()
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.17
 Nodes (2): getNextTransactionPageSearch(), getNextTransactionTimeFilterSearch()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.29
 Nodes (10): applyTheme(), emitThemeChange(), getStorage(), getStoredThemeMode(), getSystemTheme(), getThemeSnapshot(), initializeAthenaTheme(), isThemeMode() (+2 more)
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
-
-### Community 126 - "Community 126"
-Cohesion: 0.29
-Nodes (9): buildAbusePartitionKey(), buildServerContextTrackingEnvelope(), derivePrimarySubject(), isAcceptedSyntheticContext(), isRecord(), readPayload(), readRequiredNumber(), readRequiredString() (+1 more)
 
 ### Community 127 - "Community 127"
 Cohesion: 0.33
@@ -2633,56 +2633,56 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 135 - "Community 135"
-Cohesion: 0.36
-Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 136 - "Community 136"
 Cohesion: 0.36
-Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
+Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
 ### Community 137 - "Community 137"
+Cohesion: 0.36
+Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
+
+### Community 138 - "Community 138"
 Cohesion: 0.2
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.25
 Nodes (7): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
-
-### Community 147 - "Community 147"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 148 - "Community 148"
 Cohesion: 0.18
@@ -2785,516 +2785,516 @@ Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
 ### Community 173 - "Community 173"
+Cohesion: 0.28
+Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
+
+### Community 174 - "Community 174"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.28
 Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.25
 Nodes (2): isValidMessageBlocker(), isValidPriority()
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+
+### Community 187 - "Community 187"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 186 - "Community 186"
+### Community 188 - "Community 188"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 187 - "Community 187"
+### Community 189 - "Community 189"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 188 - "Community 188"
+### Community 190 - "Community 190"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 189 - "Community 189"
+### Community 191 - "Community 191"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 190 - "Community 190"
+### Community 192 - "Community 192"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 191 - "Community 191"
+### Community 193 - "Community 193"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 192 - "Community 192"
+### Community 194 - "Community 194"
 Cohesion: 0.29
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 193 - "Community 193"
+### Community 195 - "Community 195"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 194 - "Community 194"
+### Community 196 - "Community 196"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 195 - "Community 195"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 196 - "Community 196"
-Cohesion: 0.5
-Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
 ### Community 197 - "Community 197"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 198 - "Community 198"
-Cohesion: 0.36
-Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
+Cohesion: 0.5
+Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
 ### Community 199 - "Community 199"
-Cohesion: 0.36
-Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
-
-### Community 200 - "Community 200"
-Cohesion: 0.39
-Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
-
-### Community 201 - "Community 201"
-Cohesion: 0.29
-Nodes (2): appendTransition(), applyOnlineOrderUpdate()
-
-### Community 202 - "Community 202"
-Cohesion: 0.25
-Nodes (1): DataTableRowActions()
-
-### Community 203 - "Community 203"
-Cohesion: 0.32
-Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
-
-### Community 204 - "Community 204"
-Cohesion: 0.25
-Nodes (1): ResizeObserverStub
-
-### Community 205 - "Community 205"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 206 - "Community 206"
+### Community 200 - "Community 200"
+Cohesion: 0.36
+Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
+
+### Community 201 - "Community 201"
+Cohesion: 0.36
+Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+
+### Community 202 - "Community 202"
+Cohesion: 0.39
+Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
+
+### Community 203 - "Community 203"
 Cohesion: 0.29
-Nodes (2): handleKeyDown(), isDebugShortcut()
+Nodes (2): appendTransition(), applyOnlineOrderUpdate()
+
+### Community 204 - "Community 204"
+Cohesion: 0.25
+Nodes (1): DataTableRowActions()
+
+### Community 205 - "Community 205"
+Cohesion: 0.32
+Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
+
+### Community 206 - "Community 206"
+Cohesion: 0.25
+Nodes (1): ResizeObserverStub
 
 ### Community 207 - "Community 207"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 208 - "Community 208"
+Cohesion: 0.29
+Nodes (2): handleKeyDown(), isDebugShortcut()
+
+### Community 209 - "Community 209"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 210 - "Community 210"
 Cohesion: 0.39
 Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
-### Community 209 - "Community 209"
+### Community 211 - "Community 211"
 Cohesion: 0.39
 Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
 
-### Community 210 - "Community 210"
+### Community 212 - "Community 212"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 211 - "Community 211"
+### Community 213 - "Community 213"
 Cohesion: 0.29
 Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
 
-### Community 212 - "Community 212"
+### Community 214 - "Community 214"
 Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
-### Community 213 - "Community 213"
+### Community 215 - "Community 215"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 214 - "Community 214"
+### Community 216 - "Community 216"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 215 - "Community 215"
+### Community 217 - "Community 217"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 216 - "Community 216"
-Cohesion: 0.43
-Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
-
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 225 - "Community 225"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 226 - "Community 226"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 227 - "Community 227"
-Cohesion: 0.48
-Nodes (6): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), isDuplicateRegisterOpenConflict(), skipped()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 228 - "Community 228"
 Cohesion: 0.48
-Nodes (5): canRepairProjectRegisterOpen(), getRepairOpenRegisterCloseoutReviewState(), normalizeRepairString(), resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+Nodes (6): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), isDuplicateRegisterOpenConflict(), skipped()
 
 ### Community 229 - "Community 229"
 Cohesion: 0.48
-Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
+Nodes (5): canRepairProjectRegisterOpen(), getRepairOpenRegisterCloseoutReviewState(), normalizeRepairString(), resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 230 - "Community 230"
+Cohesion: 0.48
+Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
+
+### Community 231 - "Community 231"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.33
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
-
-### Community 243 - "Community 243"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 244 - "Community 244"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 245 - "Community 245"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 246 - "Community 246"
 Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 247 - "Community 247"
 Cohesion: 0.33
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 248 - "Community 248"
-Cohesion: 0.29
-Nodes (1): ResizeObserverStub
+Cohesion: 0.33
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 249 - "Community 249"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
 ### Community 250 - "Community 250"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 251 - "Community 251"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 253 - "Community 253"
-Cohesion: 0.52
-Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 254 - "Community 254"
 Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 255 - "Community 255"
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+
+### Community 256 - "Community 256"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.38
 Nodes (3): getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusSignature()
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.33
 Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
-
-### Community 259 - "Community 259"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 260 - "Community 260"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 261 - "Community 261"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 262 - "Community 262"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 262 - "Community 262"
+### Community 263 - "Community 263"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 263 - "Community 263"
+### Community 264 - "Community 264"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 264 - "Community 264"
+### Community 265 - "Community 265"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 265 - "Community 265"
+### Community 266 - "Community 266"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 266 - "Community 266"
+### Community 267 - "Community 267"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.47
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 270 - "Community 270"
+### Community 271 - "Community 271"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 271 - "Community 271"
+### Community 272 - "Community 272"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
 
-### Community 272 - "Community 272"
+### Community 273 - "Community 273"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.4
 Nodes (2): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.6
 Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
-### Community 280 - "Community 280"
+### Community 281 - "Community 281"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 284 - "Community 284"
+### Community 285 - "Community 285"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 285 - "Community 285"
+### Community 286 - "Community 286"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 286 - "Community 286"
+### Community 287 - "Community 287"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 287 - "Community 287"
+### Community 288 - "Community 288"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 288 - "Community 288"
-Cohesion: 0.4
-Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 289 - "Community 289"
 Cohesion: 0.4
-Nodes (2): moveFeaturedItem(), saveOrder()
+Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 290 - "Community 290"
+Cohesion: 0.4
+Nodes (2): moveFeaturedItem(), saveOrder()
+
+### Community 291 - "Community 291"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 291 - "Community 291"
+### Community 292 - "Community 292"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 292 - "Community 292"
+### Community 293 - "Community 293"
 Cohesion: 0.4
 Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
-### Community 293 - "Community 293"
+### Community 294 - "Community 294"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 294 - "Community 294"
+### Community 295 - "Community 295"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 295 - "Community 295"
+### Community 296 - "Community 296"
 Cohesion: 0.4
 Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
-### Community 296 - "Community 296"
+### Community 297 - "Community 297"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 297 - "Community 297"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 298 - "Community 298"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 299 - "Community 299"
-Cohesion: 0.47
-Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 300 - "Community 300"
-Cohesion: 0.4
-Nodes (2): cn(), formatCatalogMetric()
+Cohesion: 0.47
+Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
 
 ### Community 301 - "Community 301"
 Cohesion: 0.33

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2127
-- Graph nodes: 7983
-- Graph edges: 9372
+- Graph nodes: 7994
+- Graph edges: 9391
 - Communities: 2055
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 55) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 56) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `storefrontContextEvents.ts` (17 edges, Community 77) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
-- `checkoutSession.ts` (14 edges, Community 90) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 91) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (15 edges, Community 91) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 185) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 91) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossCluster()` (4 edges, Community 91) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossClusterWithPipeline()` (4 edges, Community 91) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (15 edges, Community 92) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.test.js` (6 edges, Community 187) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `createRedisClient()` (4 edges, Community 92) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossCluster()` (4 edges, Community 92) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossClusterWithPipeline()` (4 edges, Community 92) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/contextTracking/contextBundles.test.ts
+++ b/packages/athena-webapp/convex/contextTracking/contextBundles.test.ts
@@ -41,6 +41,12 @@ function contextEvent(
     sourceRefs: [],
     visibilityMode: "store_admin",
     retentionClass: "standard",
+    environment: {
+      deviceClass: "mobile",
+      browserFamily: "safari",
+      osFamily: "ios",
+      viewportBucket: "sm",
+    },
     synthetic: false,
     ...overrides,
   };
@@ -86,7 +92,94 @@ describe("contextEvent storefront bundle compilation", () => {
         id: "context_event_valid",
         eventId: "storefront.product_viewed",
         contextSchemaVersion: 1,
+        environment: {
+          deviceClass: "mobile",
+          browserFamily: "safari",
+          osFamily: "ios",
+          viewportBucket: "sm",
+        },
         payload: { productId: "product_1", categorySlug: "wigs" },
+      },
+    ]);
+  });
+
+  it("uses context-event environment metadata for device distribution", () => {
+    const bundle = buildStoreInsightsContextBundleFromContextEvents([
+      contextEvent({
+        _id: "context_event_mobile" as ContextEventRow["_id"],
+        environment: {
+          deviceClass: "mobile",
+          browserFamily: "safari",
+          osFamily: "ios",
+          viewportBucket: "sm",
+        },
+      }),
+      contextEvent({
+        _id: "context_event_desktop" as ContextEventRow["_id"],
+        environment: {
+          deviceClass: "desktop",
+          browserFamily: "chrome",
+          osFamily: "macos",
+          viewportBucket: "xl",
+        },
+      }),
+      contextEvent({
+        _id: "context_event_tablet" as ContextEventRow["_id"],
+        environment: {
+          deviceClass: "tablet",
+          browserFamily: "safari",
+          osFamily: "ios",
+          viewportBucket: "lg",
+        },
+      }),
+      contextEvent({
+        _id: "context_event_bot" as ContextEventRow["_id"],
+        environment: {
+          deviceClass: "bot",
+          browserFamily: "other",
+          osFamily: "other",
+          viewportBucket: "unknown",
+        },
+      }),
+    ]);
+
+    expect(bundle.payloadSummary.deviceDistribution).toMatchObject({
+      mobile: "50%",
+      desktop: "25%",
+      unknown: "25%",
+    });
+    expect(readCompactEvents(bundle)).toMatchObject([
+      {
+        environment: {
+          deviceClass: "mobile",
+          browserFamily: "safari",
+          osFamily: "ios",
+          viewportBucket: "sm",
+        },
+      },
+      {
+        environment: {
+          deviceClass: "desktop",
+          browserFamily: "chrome",
+          osFamily: "macos",
+          viewportBucket: "xl",
+        },
+      },
+      {
+        environment: {
+          deviceClass: "tablet",
+          browserFamily: "safari",
+          osFamily: "ios",
+          viewportBucket: "lg",
+        },
+      },
+      {
+        environment: {
+          deviceClass: "bot",
+          browserFamily: "other",
+          osFamily: "other",
+          viewportBucket: "unknown",
+        },
       },
     ]);
   });

--- a/packages/athena-webapp/convex/contextTracking/contextBundles.ts
+++ b/packages/athena-webapp/convex/contextTracking/contextBundles.ts
@@ -207,6 +207,7 @@ function compileContextEvent(event: Doc<"contextEvent">): ContextPromptRecord | 
       event.primarySubjectType && event.primarySubjectId
         ? { type: event.primarySubjectType, id: event.primarySubjectId }
         : undefined,
+    environment: event.environment,
     payload,
   };
 }

--- a/packages/athena-webapp/convex/contextTracking/contextEvents.test.ts
+++ b/packages/athena-webapp/convex/contextTracking/contextEvents.test.ts
@@ -56,4 +56,34 @@ describe("context event append safeguards", () => {
       }),
     );
   });
+
+  it("keeps retry duplicate hashes stable when environment metadata changes", () => {
+    const base = {
+      storeId: "store_1",
+      surface: "storefront",
+      eventId: "storefront.route_viewed",
+      schemaVersion: 1,
+      idempotencyKey: "route:session:/shop",
+      occurredAt: 1_700_000_000_000,
+      payload: { route: "/shop" },
+    };
+
+    expect(
+      buildContextEventSemanticEnvelopeHash({
+        ...base,
+        environment: { deviceClass: "mobile" },
+      }),
+    ).toBe(
+      buildContextEventSemanticEnvelopeHash({
+        ...base,
+        environment: { deviceClass: "desktop" },
+      }),
+    );
+    expect(
+      buildContextEventSemanticEnvelopeHash({
+        ...base,
+        environment: { deviceClass: "mobile" },
+      }),
+    ).toBe(buildContextEventSemanticEnvelopeHash(base));
+  });
 });

--- a/packages/athena-webapp/convex/contextTracking/contextEvents.ts
+++ b/packages/athena-webapp/convex/contextTracking/contextEvents.ts
@@ -32,10 +32,12 @@ export function buildContextEventSemanticEnvelopeHash(args: {
   payload: Record<string, unknown>;
   [key: string]: unknown;
 }) {
+  const hashArgs = { ...args };
+  delete hashArgs.environment;
   const payloadHash = buildSnapshotHash(args.payload);
 
   return buildSnapshotHash({
-    ...args,
+    ...hashArgs,
     occurredAt: undefined,
     payloadHash,
     payload: undefined,
@@ -165,6 +167,7 @@ export const appendContextEvent = internalMutation({
         })) ?? [],
       visibilityMode: registration.visibilityMode,
       retentionClass: registration.retentionClass,
+      environment: args.environment,
       synthetic: args.synthetic,
       abusePartitionKey: args.abusePartitionKey,
       historicalImportRunId: args.historicalImportRunId,

--- a/packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.test.ts
+++ b/packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildServerContextTrackingEnvelope,
+  deriveContextEnvironment,
   derivePrimarySubject,
   isAllowedTrackingOrigin,
 } from "./trackingEvents";
@@ -76,7 +77,72 @@ describe("tracking event route subject derivation", () => {
       sessionRef: undefined,
       sourceRefs: [],
       synthetic: false,
+      environment: {
+        deviceClass: "unknown",
+        browserFamily: "unknown",
+        osFamily: "unknown",
+        viewportBucket: "unknown",
+      },
       abusePartitionKey: "store_1:actor:guest:guest_1",
+    });
+  });
+
+  it("derives coarse device context from request headers and client viewport buckets", () => {
+    expect(
+      buildServerContextTrackingEnvelope({
+        body: {
+          surface: "storefront",
+          eventId: "storefront.route_viewed",
+          schemaVersion: 1,
+          idempotencyKey: "route:mobile",
+          occurredAt: 1_700_000_000_000,
+          payload: { route: "/shop" },
+          environment: {
+            deviceClass: "desktop",
+            browserFamily: "firefox",
+            osFamily: "windows",
+            viewportBucket: "sm",
+          },
+        },
+        storeId: "store_1" as never,
+        organizationId: "org_1" as never,
+        originHeader: "https://wigclub.store",
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+      }),
+    ).toMatchObject({
+      environment: {
+        deviceClass: "mobile",
+        browserFamily: "safari",
+        osFamily: "ios",
+        viewportBucket: "sm",
+      },
+    });
+  });
+
+  it("classifies tablets and bots without storing raw user-agent text", () => {
+    expect(
+      deriveContextEnvironment({
+        userAgent:
+          "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Version/17.0 Safari/604.1",
+        viewportBucket: "lg",
+      }),
+    ).toEqual({
+      deviceClass: "tablet",
+      browserFamily: "safari",
+      osFamily: "ios",
+      viewportBucket: "lg",
+    });
+
+    expect(
+      deriveContextEnvironment({
+        userAgent: "AthenaSyntheticBot/1.0",
+      }),
+    ).toMatchObject({
+      deviceClass: "bot",
+      browserFamily: "other",
+      osFamily: "other",
+      viewportBucket: "unknown",
     });
   });
 

--- a/packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts
+++ b/packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../utils";
 
 const trackingEventRoutes: HonoWithConvex<ActionCtx> = new Hono();
+type ViewportBucket = "sm" | "md" | "lg" | "xl" | "unknown";
 
 trackingEventRoutes.post("/", async (c) => {
   if (!isAllowedTrackingOrigin(c.req.header("origin"))) {
@@ -34,6 +35,7 @@ trackingEventRoutes.post("/", async (c) => {
     organizationId,
     originHeader: c.req.header("origin"),
     syntheticHeader: c.req.header("x-athena-synthetic-monitor"),
+    userAgent: c.req.header("user-agent"),
     ipAddress: readTrackingIpAddress(
       c.req.header("x-forwarded-for"),
       c.req.header("x-real-ip"),
@@ -68,12 +70,17 @@ export function buildServerContextTrackingEnvelope(input: {
   organizationId?: Id<"organization">;
   originHeader?: string;
   syntheticHeader?: string;
+  userAgent?: string;
   ipAddress?: string;
   storefrontActor?: { kind: "storefrontUser" | "guest"; id: unknown };
 }) {
   const payload = readPayload(input.body.payload);
   const primarySubject = derivePrimarySubject(input.body.eventId, payload);
   const synthetic = isAcceptedSyntheticContext(input.body, input.syntheticHeader);
+  const environment = deriveContextEnvironment({
+    userAgent: input.userAgent,
+    viewportBucket: readViewportBucket(input.body),
+  });
   const actorRef = input.storefrontActor
     ? {
         kind: input.storefrontActor.kind,
@@ -98,12 +105,74 @@ export function buildServerContextTrackingEnvelope(input: {
     sourceRefs: [],
     visibilityMode: "store_admin" as const,
     retentionClass: "standard" as const,
+    environment,
     synthetic,
     abusePartitionKey: buildAbusePartitionKey({
       storeId: input.storeId,
       actorRef,
     }),
   };
+}
+
+export function deriveContextEnvironment(input: {
+  userAgent?: string;
+  viewportBucket?: ViewportBucket;
+}) {
+  const userAgent = input.userAgent ?? "";
+  const normalized = userAgent.toLowerCase();
+  const isBot =
+    /(bot|crawler|spider|crawling|preview|monitor|synthetic)/.test(
+      normalized,
+    );
+  const isIpad = /\bipad\b/.test(normalized);
+  const isTablet = isIpad || (/\bandroid\b/.test(normalized) && !/\bmobile\b/.test(normalized));
+  const isMobile =
+    !isTablet && /\b(mobile|iphone|ipod|android)\b/.test(normalized);
+
+  return {
+    deviceClass: isBot
+      ? "bot"
+      : isTablet
+        ? "tablet"
+        : isMobile
+          ? "mobile"
+          : userAgent
+            ? "desktop"
+            : "unknown",
+    browserFamily: deriveBrowserFamily(normalized),
+    osFamily: deriveOsFamily(normalized),
+    viewportBucket: input.viewportBucket ?? "unknown",
+  } as const;
+}
+
+function deriveBrowserFamily(normalizedUserAgent: string) {
+  if (!normalizedUserAgent) return "unknown";
+  if (/\bedg\//.test(normalizedUserAgent)) return "edge";
+  if (/\bfirefox\//.test(normalizedUserAgent)) return "firefox";
+  if (/\bchrome\//.test(normalizedUserAgent) || /\bcrios\//.test(normalizedUserAgent)) {
+    return "chrome";
+  }
+  if (/\bsafari\//.test(normalizedUserAgent)) return "safari";
+  return "other";
+}
+
+function deriveOsFamily(normalizedUserAgent: string) {
+  if (!normalizedUserAgent) return "unknown";
+  if (/\biphone\b|\bipad\b|\bipod\b/.test(normalizedUserAgent)) return "ios";
+  if (/\bandroid\b/.test(normalizedUserAgent)) return "android";
+  if (/\bmac os x\b|\bmacintosh\b/.test(normalizedUserAgent)) return "macos";
+  if (/\bwindows\b/.test(normalizedUserAgent)) return "windows";
+  if (/\blinux\b/.test(normalizedUserAgent)) return "linux";
+  return "other";
+}
+
+function readViewportBucket(body: Record<string, unknown>): ViewportBucket | undefined {
+  const environment = body.environment;
+  if (!isRecord(environment)) return undefined;
+  const value = environment.viewportBucket;
+  return value === "sm" || value === "md" || value === "lg" || value === "xl"
+    ? value
+    : undefined;
 }
 
 export function isAllowedTrackingOrigin(origin?: string) {

--- a/packages/athena-webapp/convex/intelligence/capabilities/insights.ts
+++ b/packages/athena-webapp/convex/intelligence/capabilities/insights.ts
@@ -21,6 +21,12 @@ export type ContextPromptRecord = {
     type?: string;
     id?: string;
   };
+  environment?: {
+    deviceClass?: string;
+    browserFamily?: string;
+    osFamily?: string;
+    viewportBucket?: string;
+  };
   payload?: Record<string, string | number | boolean | null>;
 };
 
@@ -82,6 +88,7 @@ export function compactContextEventsForPrompt(contextEvents: ContextPromptRecord
     actorRef: item.actorRef,
     sessionRef: item.sessionRef,
     primarySubject: item.primarySubject,
+    environment: compactEnvironmentForPrompt(item.environment),
     payload: compactPayloadForPrompt(item.payload),
   }));
 }
@@ -123,7 +130,7 @@ export function buildStoreInsightsPromptFromContextEvents(
   const metricRows = contextEvents.map((item) => ({
     _creationTime: item.occurredAt,
     action: item.eventId,
-    device: "unknown",
+    device: normalizeDeviceClassForMetrics(item.environment?.deviceClass),
   }));
   const deviceDistribution = calculateDeviceDistribution(metricRows as any[]);
   const activityTrend = calculateActivityTrend(metricRows as any[]);
@@ -288,6 +295,63 @@ function compactPayloadForPrompt(
   );
 
   return Object.keys(compacted).length > 0 ? compacted : undefined;
+}
+
+function compactEnvironmentForPrompt(
+  environment: ContextPromptRecord["environment"],
+) {
+  if (!environment) return undefined;
+
+  const compacted = {
+    deviceClass: readAllowedEnvironmentValue(environment.deviceClass, [
+      "mobile",
+      "tablet",
+      "desktop",
+      "bot",
+      "unknown",
+    ]),
+    browserFamily: readAllowedEnvironmentValue(environment.browserFamily, [
+      "chrome",
+      "safari",
+      "firefox",
+      "edge",
+      "other",
+      "unknown",
+    ]),
+    osFamily: readAllowedEnvironmentValue(environment.osFamily, [
+      "ios",
+      "android",
+      "macos",
+      "windows",
+      "linux",
+      "other",
+      "unknown",
+    ]),
+    viewportBucket: readAllowedEnvironmentValue(environment.viewportBucket, [
+      "sm",
+      "md",
+      "lg",
+      "xl",
+      "unknown",
+    ]),
+  };
+
+  return Object.fromEntries(
+    Object.entries(compacted).filter(([, value]) => value !== undefined),
+  );
+}
+
+function readAllowedEnvironmentValue<T extends string>(
+  value: string | undefined,
+  allowedValues: readonly T[],
+) {
+  return allowedValues.includes(value as T) ? (value as T) : undefined;
+}
+
+function normalizeDeviceClassForMetrics(deviceClass: string | undefined) {
+  if (deviceClass === "desktop") return "desktop";
+  if (deviceClass === "mobile" || deviceClass === "tablet") return "mobile";
+  return "unknown";
 }
 
 function stableStringify(value: unknown): string {

--- a/packages/athena-webapp/convex/schemas/contextTracking.ts
+++ b/packages/athena-webapp/convex/schemas/contextTracking.ts
@@ -62,6 +62,48 @@ export const contextSubjectRefValidator = v.object({
   label: v.optional(v.string()),
 });
 
+export const contextEnvironmentValidator = v.object({
+  deviceClass: v.optional(
+    v.union(
+      v.literal("mobile"),
+      v.literal("tablet"),
+      v.literal("desktop"),
+      v.literal("bot"),
+      v.literal("unknown"),
+    ),
+  ),
+  browserFamily: v.optional(
+    v.union(
+      v.literal("chrome"),
+      v.literal("safari"),
+      v.literal("firefox"),
+      v.literal("edge"),
+      v.literal("other"),
+      v.literal("unknown"),
+    ),
+  ),
+  osFamily: v.optional(
+    v.union(
+      v.literal("ios"),
+      v.literal("android"),
+      v.literal("macos"),
+      v.literal("windows"),
+      v.literal("linux"),
+      v.literal("other"),
+      v.literal("unknown"),
+    ),
+  ),
+  viewportBucket: v.optional(
+    v.union(
+      v.literal("sm"),
+      v.literal("md"),
+      v.literal("lg"),
+      v.literal("xl"),
+      v.literal("unknown"),
+    ),
+  ),
+});
+
 export const contextEventAppendArgsValidator = {
   storeId: v.id("store"),
   organizationId: v.optional(v.id("organization")),
@@ -79,6 +121,7 @@ export const contextEventAppendArgsValidator = {
   sourceRefs: v.optional(v.array(intelligenceSourceRefValidator)),
   visibilityMode: intelligenceVisibilityModeValidator,
   retentionClass: contextRetentionClassValidator,
+  environment: v.optional(contextEnvironmentValidator),
   synthetic: v.optional(v.boolean()),
   abusePartitionKey: v.optional(v.string()),
   historicalImportRunId: v.optional(v.string()),
@@ -115,6 +158,7 @@ export const contextEventSchema = v.object({
   sourceRefs: v.array(intelligenceSourceRefValidator),
   visibilityMode: intelligenceVisibilityModeValidator,
   retentionClass: contextRetentionClassValidator,
+  environment: v.optional(contextEnvironmentValidator),
   synthetic: v.optional(v.boolean()),
   abusePartitionKey: v.optional(v.string()),
   historicalImportRunId: v.optional(v.string()),

--- a/packages/athena-webapp/shared/intelligence/contextEventTypes.ts
+++ b/packages/athena-webapp/shared/intelligence/contextEventTypes.ts
@@ -1,5 +1,6 @@
 import type {
   ContextPayload,
+  ContextEnvironment,
   ContextRetentionClass,
   ContextSourceRef,
   ContextSubjectRef,
@@ -31,6 +32,7 @@ export type ContextEventInput<
   primarySubject?: ContextSubjectRef;
   subjectRefs?: ContextSubjectRef[];
   sourceRefs?: ContextSourceRef[];
+  environment?: Pick<ContextEnvironment, "viewportBucket">;
   synthetic?: boolean;
 };
 

--- a/packages/athena-webapp/shared/intelligence/contextTypes.ts
+++ b/packages/athena-webapp/shared/intelligence/contextTypes.ts
@@ -60,6 +60,20 @@ export type ContextSourceRef = {
   synthetic?: boolean;
 };
 
+export type ContextEnvironment = {
+  deviceClass?: "mobile" | "tablet" | "desktop" | "bot" | "unknown";
+  browserFamily?: "chrome" | "safari" | "firefox" | "edge" | "other" | "unknown";
+  osFamily?:
+    | "ios"
+    | "android"
+    | "macos"
+    | "windows"
+    | "linux"
+    | "other"
+    | "unknown";
+  viewportBucket?: "sm" | "md" | "lg" | "xl" | "unknown";
+};
+
 export type ContextTrackingEnvelope = {
   surface: string;
   eventId: string;
@@ -75,5 +89,6 @@ export type ContextTrackingEnvelope = {
   sourceRefs?: ContextSourceRef[];
   visibilityMode: ContextVisibilityMode;
   retentionClass: ContextRetentionClass;
+  environment?: ContextEnvironment;
   synthetic?: boolean;
 };

--- a/packages/athena-webapp/shared/intelligence/eventBuilder.ts
+++ b/packages/athena-webapp/shared/intelligence/eventBuilder.ts
@@ -1,5 +1,6 @@
 import type {
   ContextActorRef,
+  ContextEnvironment,
   ContextPayload,
   ContextPrimitiveValue,
   ContextSessionRef,
@@ -14,6 +15,7 @@ import {
 
 type BuildContextEventOptions = {
   actorRef?: ContextActorRef;
+  environment?: ContextEnvironment;
   sessionRef?: ContextSessionRef;
   now?: () => number;
 };
@@ -66,6 +68,7 @@ export function buildContextEventEnvelope(
     sourceRefs: input.sourceRefs,
     visibilityMode: definition.visibilityMode,
     retentionClass: definition.retentionClass,
+    environment: input.environment ?? options.environment,
     synthetic: input.synthetic,
   };
 }

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -1126,7 +1126,11 @@ describe("DailyOperationsViewContent", () => {
       "font-medium",
       "text-foreground",
     );
-    expect(automationHeading.parentElement).toHaveClass("gap-layout-sm");
+    expect(automationHeading.parentElement).toHaveClass("gap-layout-md");
+    expect(automationHeading.parentElement?.lastElementChild).toHaveClass(
+      "divide-y",
+      "divide-border/70",
+    );
     const automationTime = within(automationPanel!).getByText(/[48]:30 AM/);
 
     expect(automationTime).toHaveClass("tabular-nums");
@@ -1159,6 +1163,7 @@ describe("DailyOperationsViewContent", () => {
     const closeAutomationRow = closeAutomationLink.closest("article");
 
     expect(closeAutomationRow).toHaveClass(
+      "py-layout-sm",
       "sm:flex-row",
       "sm:justify-between",
     );
@@ -1319,21 +1324,24 @@ describe("DailyOperationsViewContent", () => {
       screen.getByRole("link", { name: "Start EOD Review" }),
     ).toBeInTheDocument();
     expect(
-      screen.getAllByText(
-        "Store day started. Review the carried-forward items when a manager is available.",
-      ).length,
-    ).toBeGreaterThan(0);
-    expect(
-      screen.getByText("Register session still needs closeout"),
+      screen.getByText("Opening Handoff has carry-forward review items."),
     ).toBeInTheDocument();
+    expect(screen.getByText("Pending checkout")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("2 other manager review items")).toBeInTheDocument();
     expect(
-      screen.getByText("Cash variance reviewed at close"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Ebin tinted lace")).toBeInTheDocument();
+      screen.queryByText("Register session still needs closeout"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Cash variance reviewed at close"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Ebin tinted lace")).not.toBeInTheDocument();
     expect(screen.queryByText("Hooded dryer bonnet")).not.toBeInTheDocument();
     expect(screen.queryByText("Eco lip balm")).not.toBeInTheDocument();
     expect(screen.queryByText("Hidden lace bond")).not.toBeInTheDocument();
-    expect(screen.getByText("3 more items in the full Opening workflow.")).toBeInTheDocument();
+    expect(
+      screen.queryByText("3 more items in the full Opening workflow."),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole("link", {
         name: "Review all Opening Handoff review items",

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -1054,19 +1054,19 @@ function AutomationStatusPanel({
   if (variant === "compact") {
     return (
       <section className="rounded-md border border-border bg-surface-raised px-layout-md py-layout-sm shadow-surface">
-        <div className="flex flex-col gap-layout-sm">
+        <div className="flex flex-col gap-layout-md">
           <h3 className="flex shrink-0 items-center gap-layout-xs text-sm font-medium text-foreground">
             <Bot aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
             Athena automation
           </h3>
-          <div className="flex min-w-0 flex-col gap-layout-xs">
+          <div className="flex min-w-0 flex-col divide-y divide-border/70">
             {statuses.map((status) => {
               const label = getAutomationLaneLabel(status.lane);
               const link = status.sourceLink;
 
               return (
                 <article
-                  className="flex min-w-0 flex-col gap-layout-xs sm:flex-row sm:items-start sm:justify-between"
+                  className="flex min-w-0 flex-col gap-layout-xs py-layout-sm first:pt-0 last:pb-0 sm:flex-row sm:items-start sm:justify-between"
                   key={status.id}
                 >
                   <div className="min-w-0">
@@ -1314,19 +1314,18 @@ function AutomationReviewEvidencePanel({
     isPendingCheckoutReview,
   ).length;
   const otherReviewCount = evidenceItems.length - pendingCheckoutCount;
-  const previewItems = evidenceItems.slice(0, REVIEW_EVIDENCE_PREVIEW_LIMIT);
-  const hiddenItemCount = Math.max(
-    evidenceItems.length - REVIEW_EVIDENCE_PREVIEW_LIMIT,
-    0,
-  );
+  const primaryBucketLabel =
+    pendingCheckoutCount > 0 ? "Pending checkout" : "Manager review";
+  const primaryBucketCount =
+    pendingCheckoutCount > 0 ? pendingCheckoutCount : otherReviewCount;
 
   return (
     <section
       aria-labelledby="daily-operations-opening-review-title"
-      className="rounded-lg border border-warning/25 bg-surface p-layout-md shadow-surface"
+      className="rounded-lg border border-warning/25 bg-surface-raised p-layout-md shadow-surface"
     >
       <div className="flex items-start justify-between gap-layout-sm">
-        <div className="min-w-0">
+        <div className="min-w-0 space-y-layout-xs">
           <h3
             className="flex items-center gap-layout-xs text-sm font-medium text-foreground"
             id="daily-operations-opening-review-title"
@@ -1334,6 +1333,9 @@ function AutomationReviewEvidencePanel({
             <CircleAlert aria-hidden="true" className="h-4 w-4 text-warning" />
             Opening review
           </h3>
+          <p className="text-xs leading-5 text-muted-foreground">
+            Opening Handoff has carry-forward review items.
+          </p>
         </div>
         <Badge
           className="shrink-0 border-warning/30 bg-warning/10 text-warning-foreground shadow-sm"
@@ -1343,48 +1345,23 @@ function AutomationReviewEvidencePanel({
         </Badge>
       </div>
 
-      <p className="mt-layout-xs text-sm leading-6 text-foreground">
-        Store day started. Review the carried-forward items when a manager is
-        available.
-      </p>
-      <p className="mt-1 text-xs leading-5 text-muted-foreground">
-        POS stays open while these items remain visible in their owning
-        workflows.
-      </p>
-
-      <div className="mt-layout-md grid grid-cols-2 gap-layout-xs">
-        <ReviewEvidenceCount
-          label="Pending checkout"
-          value={pendingCheckoutCount}
-        />
-        <ReviewEvidenceCount label="Other" value={otherReviewCount} />
+      <div className="mt-layout-md rounded-md border border-border/70 bg-background/60 px-layout-sm py-layout-xs">
+        <div className="flex items-baseline justify-between gap-layout-sm">
+          <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+            {primaryBucketLabel}
+          </p>
+          <p className="text-base font-medium tabular-nums text-foreground">
+            {primaryBucketCount}
+          </p>
+        </div>
+        {pendingCheckoutCount > 0 && otherReviewCount > 0 ? (
+          <p className="mt-1 text-xs text-muted-foreground">
+            {otherReviewCount} other manager review{" "}
+            {otherReviewCount === 1 ? "item" : "items"}
+          </p>
+        ) : null}
       </div>
 
-      <div className="mt-layout-md divide-y divide-border/70 border-y border-border/70">
-        {previewItems.map((item) => (
-          <article className="py-layout-sm" key={item.id}>
-            <div className="min-w-0">
-              <p className="text-sm font-medium leading-5 text-foreground">
-                {getReviewEvidenceTitle(item)}
-              </p>
-              {getReviewEvidenceDetail(item) ? (
-                <p className="mt-0.5 line-clamp-2 text-xs leading-5 text-muted-foreground">
-                  {getReviewEvidenceDetail(item)}
-                </p>
-              ) : null}
-              <p className="mt-1 truncate text-xs text-muted-foreground">
-                {getReviewEvidenceContextLabel(item)}
-              </p>
-            </div>
-          </article>
-        ))}
-      </div>
-      {hiddenItemCount > 0 ? (
-        <p className="mt-layout-sm text-xs leading-5 text-muted-foreground">
-          {formatReviewEvidenceHiddenCount(hiddenItemCount)} in the full Opening
-          workflow.
-        </p>
-      ) : null}
       <Button
         asChild
         className="mt-layout-md w-full"
@@ -1411,63 +1388,13 @@ function AutomationReviewEvidencePanel({
 }
 
 const PENDING_CHECKOUT_REVIEW_PREFIX = "Review pending checkout item:";
-const DEFAULT_CARRY_FORWARD_DETAIL =
-  "This unresolved carry-forward item remains open and must be acknowledged for Opening.";
-const REVIEW_EVIDENCE_PREVIEW_LIMIT = 3;
-
-function ReviewEvidenceCount({
-  label,
-  value,
-}: {
-  label: string;
-  value: number;
-}) {
-  return (
-    <div className="rounded-md border border-border/70 bg-background/60 px-layout-sm py-layout-xs">
-      <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
-        {label}
-      </p>
-      <p className="mt-0.5 text-base font-medium tabular-nums text-foreground">
-        {value}
-      </p>
-    </div>
-  );
-}
 
 function formatReviewEvidenceCount(count: number) {
   return count === 1 ? "1 item to review" : `${count} items to review`;
 }
 
-function formatReviewEvidenceHiddenCount(count: number) {
-  return count === 1 ? "1 more item" : `${count} more items`;
-}
-
 function isPendingCheckoutReview(item: DailyOperationsReviewEvidence) {
   return item.label.startsWith(PENDING_CHECKOUT_REVIEW_PREFIX);
-}
-
-function getReviewEvidenceTitle(item: DailyOperationsReviewEvidence) {
-  if (isPendingCheckoutReview(item)) {
-    return item.label.slice(PENDING_CHECKOUT_REVIEW_PREFIX.length).trim();
-  }
-
-  return item.label;
-}
-
-function getReviewEvidenceContextLabel(item: DailyOperationsReviewEvidence) {
-  if (isPendingCheckoutReview(item)) {
-    return "Pending checkout item";
-  }
-
-  return item.source?.label ?? "Manager review item";
-}
-
-function getReviewEvidenceDetail(item: DailyOperationsReviewEvidence) {
-  if (!item.message || item.message === DEFAULT_CARRY_FORWARD_DETAIL) {
-    return null;
-  }
-
-  return item.message;
 }
 
 function HistoricalWorkflowPanel({

--- a/packages/athena-webapp/src/components/products/Products.test.tsx
+++ b/packages/athena-webapp/src/components/products/Products.test.tsx
@@ -29,7 +29,11 @@ const mockedProducts = vi.hoisted(() => ({
     productCount: number;
     updatedAt?: number;
   },
-  skuSearchResults: [] as unknown[],
+  skuSearchResults: [] as unknown[] | undefined,
+}));
+const routerMocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  search: {} as Record<string, unknown>,
 }));
 
 class ResizeObserverStub {
@@ -44,7 +48,8 @@ vi.mock("@tanstack/react-router", () => ({
   Link: ({ children }: { children: React.ReactNode }) => (
     <a href="#products">{children}</a>
   ),
-  useSearch: () => ({}),
+  useNavigate: () => routerMocks.navigate,
+  useSearch: () => routerMocks.search,
 }));
 
 vi.mock("~/src/hooks/useGetCategories", () => ({
@@ -86,6 +91,10 @@ vi.mock("convex/react", () => ({
       "query" in args &&
       "limit" in args
     ) {
+      if (mockedProducts.skuSearchResults === undefined) {
+        return undefined;
+      }
+
       return {
         candidateOverflow: false,
         results: mockedProducts.skuSearchResults,
@@ -149,6 +158,8 @@ describe("Products", () => {
       productCount: 0,
     };
     mockedProducts.skuSearchResults = [];
+    routerMocks.navigate.mockReset();
+    routerMocks.search = {};
   });
 
   it("quick adds a product with variants from the products workspace", async () => {
@@ -484,6 +495,159 @@ describe("Products", () => {
     expect(screen.getByText("9")).toBeInTheDocument();
     expect(screen.getByText("4")).toBeInTheDocument();
     expect(repairCatalogSummaryMock).not.toHaveBeenCalled();
+  });
+
+  it("restores product search from the URL query", () => {
+    routerMocks.search = { query: "angeli" };
+    mockedProducts.skuSearchResults = [
+      makeSkuSearchResult(
+        makeProduct({
+          id: "product-angeli",
+          inventoryCount: 0,
+          name: "Angeli",
+          sku: "ANGELI-1",
+        }),
+      ),
+    ];
+
+    render(<Products />);
+
+    expect(
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
+    ).toHaveValue("angeli");
+    expect(screen.getByText("Angeli")).toBeInTheDocument();
+  });
+
+  it("keeps product search changes in the URL", async () => {
+    const user = userEvent.setup();
+
+    render(<Products />);
+
+    await user.type(
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
+      "bonnet",
+    );
+
+    expect(routerMocks.navigate).toHaveBeenLastCalledWith({
+      replace: true,
+      search: expect.any(Function),
+    });
+    const writeQuerySearch = routerMocks.navigate.mock.calls.at(-1)?.[0]
+      .search as (current: Record<string, unknown>) => Record<string, unknown>;
+    expect(writeQuerySearch({ o: "/return", page: 3 })).toEqual({
+      o: "/return",
+      query: "bonnet",
+    });
+
+    await user.clear(
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
+    );
+
+    const clearQuerySearch = routerMocks.navigate.mock.calls.at(-1)?.[0]
+      .search as (current: Record<string, unknown>) => Record<string, unknown>;
+    expect(clearQuerySearch({ o: "/return", query: "bonnet" })).toEqual({
+      o: "/return",
+    });
+  });
+
+  it("restores product search pagination from the URL page", () => {
+    routerMocks.search = { page: 3, query: "mizani" };
+    mockedProducts.skuSearchResults = Array.from({ length: 25 }, (_, index) =>
+      makeSkuSearchResult(
+        makeProduct({
+          id: `product-mizani-${index + 1}`,
+          inventoryCount: 0,
+          name: `Mizani ${String(index + 1).padStart(2, "0")}`,
+          sku: `MIZANI-${index + 1}`,
+        }),
+      ),
+    );
+
+    render(<Products />);
+
+    expect(screen.getByText("Page 3 of 3")).toBeInTheDocument();
+    expect(screen.getByText("Mizani 21")).toBeInTheDocument();
+    expect(screen.queryByText("Mizani 01")).not.toBeInTheDocument();
+  });
+
+  it("clamps out-of-range product search pages from the URL", async () => {
+    routerMocks.search = { page: 999, query: "mizani" };
+    mockedProducts.skuSearchResults = Array.from({ length: 25 }, (_, index) =>
+      makeSkuSearchResult(
+        makeProduct({
+          id: `product-mizani-${index + 1}`,
+          inventoryCount: 0,
+          name: `Mizani ${String(index + 1).padStart(2, "0")}`,
+          sku: `MIZANI-${index + 1}`,
+        }),
+      ),
+    );
+
+    render(<Products />);
+
+    expect(screen.getByText("Page 3 of 3")).toBeInTheDocument();
+    expect(screen.getByText("Mizani 21")).toBeInTheDocument();
+    expect(screen.queryByText("Mizani 01")).not.toBeInTheDocument();
+
+    await waitFor(() => expect(routerMocks.navigate).toHaveBeenCalled());
+    const normalizePageSearch = routerMocks.navigate.mock.calls.at(-1)?.[0]
+      .search as (current: Record<string, unknown>) => Record<string, unknown>;
+    expect(normalizePageSearch({ query: "mizani", page: 999 })).toEqual({
+      query: "mizani",
+      page: 3,
+    });
+  });
+
+  it("preserves product search page URLs while search results are loading", () => {
+    routerMocks.search = { page: 3, query: "mizani" };
+    mockedProducts.skuSearchResults = undefined;
+
+    render(<Products />);
+
+    expect(
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
+    ).toHaveValue("mizani");
+    expect(routerMocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it("keeps product search pagination changes in the URL", async () => {
+    const user = userEvent.setup();
+    routerMocks.search = { query: "mizani" };
+    mockedProducts.skuSearchResults = Array.from({ length: 11 }, (_, index) =>
+      makeSkuSearchResult(
+        makeProduct({
+          id: `product-mizani-${index + 1}`,
+          inventoryCount: 0,
+          name: `Mizani ${index + 1}`,
+          sku: `MIZANI-${index + 1}`,
+        }),
+      ),
+    );
+
+    render(<Products />);
+
+    await user.click(
+      screen.getByRole("button", { name: /go to next page/i }),
+    );
+
+    expect(routerMocks.navigate).toHaveBeenLastCalledWith({
+      replace: true,
+      search: expect.any(Function),
+    });
+    const writePageSearch = routerMocks.navigate.mock.calls.at(-1)?.[0]
+      .search as (current: Record<string, unknown>) => Record<string, unknown>;
+    expect(writePageSearch({ query: "mizani" })).toEqual({
+      page: 2,
+      query: "mizani",
+    });
   });
 
   it("repairs an unbackfilled catalog summary instead of leaving metrics permanently pending", async () => {

--- a/packages/athena-webapp/src/components/products/Products.tsx
+++ b/packages/athena-webapp/src/components/products/Products.tsx
@@ -1,4 +1,4 @@
-import { Link, useSearch } from "@tanstack/react-router";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { useGetCategories } from "~/src/hooks/useGetCategories";
 import { getOrigin } from "~/src/lib/navigationUtils";
 import { Button } from "../ui/button";
@@ -35,9 +35,25 @@ import type { Id } from "~/convex/_generated/dataModel";
 import { api } from "~/convex/_generated/api";
 import { SkuSearchFilterBar } from "../stock-ops/SkuSearchFilterBar";
 
+const PRODUCT_SEARCH_PAGE_SIZE = 10;
+
+function getProductSearchPageIndex(page: number | string | undefined) {
+  const pageNumber =
+    typeof page === "number"
+      ? page
+      : typeof page === "string"
+        ? Number(page)
+        : 1;
+
+  if (!Number.isFinite(pageNumber) || pageNumber < 1) {
+    return 0;
+  }
+
+  return Math.floor(pageNumber) - 1;
+}
+
 export default function Products() {
   const categories = useGetCategories();
-  const [searchValue, setSearchValue] = useState("");
   const [isQuickAddOpen, setIsQuickAddOpen] = useState(false);
   const [quickAddInitialName, setQuickAddInitialName] = useState("");
   const [quickAddInitialLookupCode, setQuickAddInitialLookupCode] =
@@ -45,7 +61,13 @@ export default function Products() {
   const { hasFullAdminAccess } = usePermissions();
   const { activeStore } = useGetActiveStore();
   const { user } = useAuth();
-  const { o } = useSearch({ strict: false });
+  const navigate = useNavigate();
+  const { o, page, query } = useSearch({ strict: false }) as {
+    o?: string;
+    page?: number;
+    query?: string;
+  };
+  const [searchValue, setSearchValue] = useState(() => query ?? "");
   const quickAddProductSku = usePOSQuickAddProductSku();
   const repairCatalogSummary = useMutation(
     api.inventory.products.repairCatalogSummary,
@@ -77,9 +99,19 @@ export default function Products() {
     [activeStore?._id, skuSearchResults?.results],
   );
   const hasSearchInput = searchValue.trim().length > 0;
+  const isSearchLoading = hasSearchInput && skuSearchResults === undefined;
   const filteredProducts = hasSearchInput ? searchProducts : null;
   const hasActiveFilters = hasSearchInput;
   const showSearchResults = hasActiveFilters;
+  const requestedSearchPageIndex = getProductSearchPageIndex(page);
+  const searchResultPageCount = Math.max(
+    1,
+    Math.ceil((filteredProducts?.length ?? 0) / PRODUCT_SEARCH_PAGE_SIZE),
+  );
+  const searchPageIndex = Math.min(
+    requestedSearchPageIndex,
+    searchResultPageCount - 1,
+  );
   const unresolvedProductCount = catalogSummary?.missingInfoProductCount ?? 0;
   const categoryCount = catalogSummary?.categoryCount ?? 0;
   const productCount = catalogSummary?.productCount ?? 0;
@@ -90,6 +122,47 @@ export default function Products() {
     catalogSummary.needsRefresh === true;
   const formatCatalogMetric = (value: number) =>
     isCatalogSummaryPending ? "..." : value.toLocaleString();
+
+  useEffect(() => {
+    const nextSearchValue = query ?? "";
+    setSearchValue((currentSearchValue) =>
+      currentSearchValue === nextSearchValue
+        ? currentSearchValue
+        : nextSearchValue,
+    );
+  }, [query]);
+
+  useEffect(() => {
+    if (
+      !showSearchResults ||
+      isSearchLoading ||
+      requestedSearchPageIndex === searchPageIndex
+    ) {
+      return;
+    }
+
+    void navigate({
+      replace: true,
+      search: ((current: Record<string, unknown>) => {
+        const next = { ...current };
+        const nextPage = searchPageIndex + 1;
+
+        if (nextPage > 1) {
+          next.page = nextPage;
+        } else {
+          delete next.page;
+        }
+
+        return next;
+      }) as never,
+    });
+  }, [
+    isSearchLoading,
+    navigate,
+    requestedSearchPageIndex,
+    searchPageIndex,
+    showSearchResults,
+  ]);
 
   useEffect(() => {
     if (!activeStore?._id || catalogSummary === undefined) return;
@@ -157,8 +230,46 @@ export default function Products() {
     setIsQuickAddOpen(true);
   };
 
+  const handleQueryChange = (nextSearchValue: string) => {
+    setSearchValue(nextSearchValue);
+
+    void navigate({
+      replace: true,
+      search: ((current: Record<string, unknown>) => {
+        const next = { ...current };
+
+        if (nextSearchValue.trim()) {
+          next.query = nextSearchValue;
+        } else {
+          delete next.query;
+        }
+        delete next.page;
+
+        return next;
+      }) as never,
+    });
+  };
+
   const handleClearFilters = () => {
-    setSearchValue("");
+    handleQueryChange("");
+  };
+
+  const handleSearchPageIndexChange = (nextPageIndex: number) => {
+    void navigate({
+      replace: true,
+      search: ((current: Record<string, unknown>) => {
+        const next = { ...current };
+        const nextPage = nextPageIndex + 1;
+
+        if (nextPage > 1) {
+          next.page = nextPage;
+        } else {
+          delete next.page;
+        }
+
+        return next;
+      }) as never,
+    });
   };
 
   return (
@@ -205,7 +316,7 @@ export default function Products() {
               ariaLabel="Product search and filters"
               hasActiveFilters={hasActiveFilters}
               onClearFilters={handleClearFilters}
-              onQueryChange={setSearchValue}
+              onQueryChange={handleQueryChange}
               query={searchValue}
               searchId="product-sku-search"
               searchLabel="Search products, SKUs, or barcodes"
@@ -227,6 +338,8 @@ export default function Products() {
                   <GenericDataTable
                     data={filteredProducts}
                     columns={productColumns}
+                    pageIndex={searchPageIndex}
+                    onPageIndexChange={handleSearchPageIndexChange}
                     tableId="all-products-search"
                   />
                 ) : (

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -898,6 +898,7 @@ describe("useRegisterViewModel", () => {
     expect(result.current.customerPanel.customerInfo.name).toBe("Ama Serwa");
     expect(result.current.cashierCard?.cashierName).toBe("Ama K.");
     expect(result.current.productEntry.canQuickAddProduct).toBe(true);
+    expect(result.current.productEntry.canAddPendingCheckoutItem).toBe(true);
     expect(result.current.authDialog?.open).toBe(false);
     expect(result.current.syncStatus).toBeNull();
   });
@@ -7608,6 +7609,7 @@ describe("useRegisterViewModel", () => {
     );
     expect(result.current.closeoutControl?.canCorrectOpeningFloat).toBe(false);
     expect(result.current.productEntry.canQuickAddProduct).toBe(false);
+    expect(result.current.productEntry.canAddPendingCheckoutItem).toBe(false);
 
     act(() => {
       result.current.drawerGate?.onOpeningFloatChange?.("50.00");

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -5597,7 +5597,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       isSearchLoading: isRegisterSearchLoading,
       isSearchReady: isRegisterCatalogReady,
       canQuickAddProduct: terminalCanTransactProducts && isCashierManager,
-      canAddPendingCheckoutItem: terminalCanTransactProducts,
+      canAddPendingCheckoutItem: terminalCanTransactProducts && isCashierManager,
       pendingCheckoutContext:
         staffProfileId && terminal?._id && activeRegisterSessionId
           ? {

--- a/packages/storefront-webapp/src/lib/storefrontContextEvents.test.ts
+++ b/packages/storefront-webapp/src/lib/storefrontContextEvents.test.ts
@@ -23,6 +23,7 @@ const baseContext = {
   origin: "homepage",
   sessionId: "session_ctx_123",
   userType: "guest" as const,
+  viewportBucket: "md" as const,
 };
 
 describe("storefront context events", () => {
@@ -65,6 +66,9 @@ describe("storefront context events", () => {
       sessionRef: {
         kind: "storefront_session",
         id: "session_ctx_123",
+      },
+      environment: {
+        viewportBucket: "md",
       },
     });
     expect(first.idempotencyKey).toBe(second.idempotencyKey);

--- a/packages/storefront-webapp/src/lib/storefrontContextEvents.ts
+++ b/packages/storefront-webapp/src/lib/storefrontContextEvents.ts
@@ -148,6 +148,9 @@ export function createStorefrontContextTrackingEnvelope({
   return buildStorefrontContextEvent(
     {
       ...input,
+      environment: baseContext.viewportBucket
+        ? { viewportBucket: baseContext.viewportBucket }
+        : undefined,
       origin: input.origin ?? baseContext.origin,
       synthetic:
         input.synthetic ??

--- a/packages/storefront-webapp/src/lib/storefrontObservability.test.ts
+++ b/packages/storefront-webapp/src/lib/storefrontObservability.test.ts
@@ -4,11 +4,12 @@ import {
   SYNTHETIC_MONITOR_ORIGIN,
   STOREFRONT_OBSERVABILITY_ACTION,
   STOREFRONT_OBSERVABILITY_SESSION_KEY,
-  resolveStorefrontAnalyticsOrigin,
   createStorefrontObservabilityContext,
   createStorefrontObservabilityPayload,
   getOrCreateStorefrontObservabilitySessionId,
   isSyntheticMonitorOrigin,
+  resolveStorefrontAnalyticsOrigin,
+  resolveViewportBucket,
   trackStorefrontEvent,
 } from "./storefrontObservability";
 
@@ -90,6 +91,7 @@ describe("storefront observability", () => {
         utm_source: "instagram",
       },
       guestId: "guest_123",
+      viewportWidth: 390,
       storage,
     });
 
@@ -106,6 +108,7 @@ describe("storefront observability", () => {
       route: "/shop",
       origin: "instagram",
       userType: "guest",
+      viewportBucket: "sm",
     });
     expect(secondContext).toMatchObject({
       route: "/shop/bag",
@@ -119,6 +122,14 @@ describe("storefront observability", () => {
     expect(getOrCreateStorefrontObservabilitySessionId(storage)).toBe(
       firstContext.sessionId,
     );
+  });
+
+  it("buckets viewport widths without storing raw dimensions", () => {
+    expect(resolveViewportBucket(375)).toBe("sm");
+    expect(resolveViewportBucket(800)).toBe("md");
+    expect(resolveViewportBucket(1100)).toBe("lg");
+    expect(resolveViewportBucket(1440)).toBe("xl");
+    expect(resolveViewportBucket(Number.NaN)).toBe("unknown");
   });
 
   it("reserves a canonical origin for synthetic monitors in browser automation", () => {

--- a/packages/storefront-webapp/src/lib/storefrontObservability.ts
+++ b/packages/storefront-webapp/src/lib/storefrontObservability.ts
@@ -55,6 +55,7 @@ const storefrontObservabilityBaseContextSchema = z.object({
   origin: z.string().optional(),
   sessionId: z.string().min(1),
   userType: storefrontObservabilityUserTypeSchema,
+  viewportBucket: z.enum(["sm", "md", "lg", "xl", "unknown"]).optional(),
 });
 
 const storefrontObservabilityErrorSchema = z.object({
@@ -99,6 +100,7 @@ type StorefrontObservabilityRuntimeContext = {
     utm_source?: string;
   };
   isBrowserAutomation?: boolean;
+  viewportWidth?: number;
   userId?: string;
   guestId?: string;
   storage?: Pick<Storage, "getItem" | "setItem">;
@@ -202,7 +204,26 @@ export function createStorefrontObservabilityContext(
       runtimeContext.storage,
     ),
     userType,
+    viewportBucket: resolveViewportBucket(runtimeContext.viewportWidth),
   });
+}
+
+export function resolveViewportBucket(explicitViewportWidth?: number) {
+  const hasExplicitViewportWidth = explicitViewportWidth !== undefined;
+  const viewportWidth = hasExplicitViewportWidth
+    ? typeof explicitViewportWidth === "number" &&
+      Number.isFinite(explicitViewportWidth)
+      ? explicitViewportWidth
+      : undefined
+    : typeof window !== "undefined"
+      ? window.innerWidth
+      : undefined;
+
+  if (typeof viewportWidth !== "number") return "unknown";
+  if (viewportWidth < 640) return "sm";
+  if (viewportWidth < 1024) return "md";
+  if (viewportWidth < 1280) return "lg";
+  return "xl";
 }
 
 export function createStorefrontObservabilityPayload(


### PR DESCRIPTION
## Summary

- Persist coarse storefront device/environment context through tracking events and context bundles without changing idempotent retry semantics.
- Preserve Products workspace search query and page in the URL, including clamped out-of-range pages after search results load.
- Polish Daily Operations and Products workspace surfaces, refresh graphify outputs, and document the reusable idempotency/search URL-state pattern.

## Review

- Subagent reviewers reached unanimous approval after fixes: correctness, testing, TypeScript, API contract, and simplicity.
- Reviewer-driven fixes included excluding environment from context-event semantic hashes and preserving product search page URLs while SKU search results are still loading.

## Validation

- `bun run --filter '@athena/webapp' test -- convex/contextTracking/contextBundles.test.ts convex/contextTracking/contextEvents.test.ts convex/http/domains/core/routes/trackingEvents.test.ts src/components/products/Products.test.tsx src/components/operations/DailyOperationsView.test.tsx src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
- `bun run --filter '@athena/storefront-webapp' test -- src/lib/storefrontContextEvents.test.ts src/lib/storefrontObservability.test.ts`
- `bun run graphify:rebuild`
- `bun run pr:athena`
