### PR TITLE
Fix register closeout void review policy

### DIFF
--- a/docs/plans/2026-06-25-003-fix-register-closeout-void-policy-plan.html
+++ b/docs/plans/2026-06-25-003-fix-register-closeout-void-policy-plan.html
@@ -1,0 +1,268 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>fix: Allow approved sale voids during register closeout review</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --ink: #1f2933;
+        --muted: #5c6b73;
+        --line: #d9e2e7;
+        --panel: #f7fafb;
+        --accent: #2f6f73;
+        --warn: #8a5a00;
+        --ok: #1f7a4d;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        color: var(--ink);
+        background: #ffffff;
+        font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      header {
+        border-bottom: 1px solid var(--line);
+        background: var(--panel);
+      }
+      .wrap {
+        max-width: 1080px;
+        margin: 0 auto;
+        padding: 28px 24px;
+      }
+      h1 {
+        margin: 0 0 8px;
+        font-size: 30px;
+        line-height: 1.2;
+        letter-spacing: 0;
+      }
+      h2 {
+        margin: 32px 0 12px;
+        font-size: 20px;
+        letter-spacing: 0;
+      }
+      h3 {
+        margin: 22px 0 8px;
+        font-size: 16px;
+      }
+      p {
+        margin: 0 0 12px;
+      }
+      a {
+        color: var(--accent);
+      }
+      code {
+        padding: 1px 5px;
+        border: 1px solid var(--line);
+        border-radius: 4px;
+        background: #f4f7f8;
+        font-size: 0.92em;
+      }
+      nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 18px;
+      }
+      nav a {
+        padding: 6px 10px;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: #ffffff;
+        text-decoration: none;
+      }
+      .meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        color: var(--muted);
+      }
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 3px 8px;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: #ffffff;
+        color: var(--muted);
+        font-size: 13px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 12px;
+      }
+      .card {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 14px;
+        background: #ffffff;
+      }
+      .callout {
+        border-left: 4px solid var(--accent);
+        background: var(--panel);
+        padding: 12px 14px;
+        margin: 12px 0;
+      }
+      .warning {
+        border-left-color: var(--warn);
+      }
+      ul {
+        margin: 0 0 12px 20px;
+        padding: 0;
+      }
+      li {
+        margin: 5px 0;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 12px 0;
+      }
+      th,
+      td {
+        border: 1px solid var(--line);
+        padding: 9px;
+        text-align: left;
+        vertical-align: top;
+      }
+      th {
+        background: var(--panel);
+      }
+      .unit {
+        border-top: 1px solid var(--line);
+        padding-top: 16px;
+        margin-top: 16px;
+      }
+      .unit strong {
+        color: var(--accent);
+      }
+      footer {
+        border-top: 1px solid var(--line);
+        color: var(--muted);
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="wrap">
+        <h1>fix: Allow approved sale voids during register closeout review</h1>
+        <div class="meta">
+          <span class="badge">Type: fix</span>
+          <span class="badge">Status: active</span>
+          <span class="badge">Date: 2026-06-25</span>
+          <span class="badge">Source: <a href="./2026-06-25-003-fix-register-closeout-void-policy-plan.md">markdown plan</a></span>
+        </div>
+        <nav aria-label="Plan sections">
+          <a href="#summary">Summary</a>
+          <a href="#requirements">Requirements</a>
+          <a href="#decisions">Decisions</a>
+          <a href="#units">Units</a>
+          <a href="#risks">Risks</a>
+          <a href="#verification">Verification</a>
+        </nav>
+      </div>
+    </header>
+    <main class="wrap">
+      <section id="summary">
+        <h2>Summary</h2>
+        <p>Approved completed-sale voids should be able to apply while the original register session is in <code>closing</code>, so Cash Controls can update expected cash and variance before final closure.</p>
+        <div class="callout">
+          Closeout submission stays available. Final register closure waits while pending <code>pos_transaction_void</code> approvals exist.
+        </div>
+      </section>
+
+      <section id="requirements">
+        <h2>Requirements</h2>
+        <div class="grid">
+          <div class="card"><strong>Lifecycle</strong><br>Allow void application for <code>open</code>, <code>active</code>, and <code>closing</code>; keep <code>closed</code> blocked.</div>
+          <div class="card"><strong>Closeout</strong><br>Do not block cashier submission or counting; defer final closure until void approvals settle.</div>
+          <div class="card"><strong>Cash Controls</strong><br>Show a minimal pending void count, route managers to <code>/operations/approvals</code>, and expose authorized <code>Finalize closeout</code> after review clears.</div>
+          <div class="card"><strong>Policy</strong><br>Move void applicability into a named shared lifecycle policy instead of reusing sale usability.</div>
+        </div>
+      </section>
+
+      <section id="decisions">
+        <h2>Key Decisions</h2>
+        <ul>
+          <li>Add a named void-application policy in <code>shared/registerSessionLifecyclePolicy.ts</code>.</li>
+          <li>Allow <code>closing</code> only for approved void application, not for new sale creation.</li>
+          <li>Defer final closure, not closeout submission, when pending void approvals exist.</li>
+          <li>Start with the existing <code>approvalRequest.by_registerSessionId</code> index for pending-void lookup.</li>
+          <li>Extend the closeout result contract so submitted-but-unresolved does not masquerade as <code>closed</code>.</li>
+          <li>Finalize resolved closeouts through Cash Controls with <code>Finalize closeout</code> instead of hiding closure inside void approval resolution.</li>
+          <li>Use a shared closeout-finalization guard for every path that can mark a register <code>closed</code>, including async variance approval and local sync closeout projection.</li>
+          <li>Recompute variance at finalization after voids settle, and keep finalization server-authorized.</li>
+        </ul>
+      </section>
+
+      <section id="units">
+        <h2>Implementation Units</h2>
+        <article class="unit">
+          <h3>U1. Centralize void register-session lifecycle policy</h3>
+          <p><strong>Goal:</strong> Add and test a named policy for void applicability across register-session statuses.</p>
+          <p><strong>Files:</strong> <code>shared/registerSessionLifecyclePolicy.ts</code>, <code>shared/registerSessionLifecyclePolicy.test.ts</code></p>
+        </article>
+        <article class="unit">
+          <h3>U2. Apply queued void approvals through the void lifecycle policy</h3>
+          <p><strong>Goal:</strong> Allow queued approvals to apply in <code>closing</code> while preserving existing blockers.</p>
+          <p><strong>Files:</strong> <code>convex/pos/application/commands/completeTransaction.ts</code>, <code>convex/operations/approvalRequests.ts</code>, related tests.</p>
+        </article>
+        <article class="unit">
+          <h3>U3. Expose pending void approvals in Cash Controls read models</h3>
+          <p><strong>Goal:</strong> Project pending void review counts into dashboard and register-session snapshots with minimal, server-filtered review data.</p>
+          <p><strong>Files:</strong> <code>convex/cashControls/deposits.ts</code>, <code>convex/cashControls/deposits.test.ts</code></p>
+        </article>
+        <article class="unit">
+          <h3>U4. Defer final closeout closure while void approvals are pending</h3>
+          <p><strong>Goal:</strong> Begin closeout normally, then leave the register in <code>closing</code> until void approvals settle; gate every closure path, recompute variance, and provide manager/full-admin <code>Finalize closeout</code> once review clears.</p>
+          <p><strong>Files:</strong> <code>convex/cashControls/closeouts.ts</code>, <code>convex/pos/application/sync/projectLocalEvents.ts</code>, closeout, local sync, and trace lifecycle tests.</p>
+        </article>
+        <article class="unit">
+          <h3>U5. Surface pending void review in Cash Controls UI</h3>
+          <p><strong>Goal:</strong> Show managers why the register remains unresolved, link to <code>/operations/approvals</code> with return context, and expose <code>Finalize closeout</code> once pending void review clears.</p>
+          <p><strong>Files:</strong> <code>CashControlsDashboard.tsx</code>, <code>RegisterSessionView.tsx</code>, optional approval queue label tests.</p>
+        </article>
+      </section>
+
+      <section id="risks">
+        <h2>Risks</h2>
+        <table>
+          <thead>
+            <tr><th>Risk</th><th>Mitigation</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Accidentally allowing new sales on <code>closing</code></td><td>Keep sale usability unchanged and test it beside the new void policy.</td></tr>
+            <tr><td>Closeout contract drift</td><td>Update validators, command types, and React callers together.</td></tr>
+            <tr><td>Pending void approvals stay invisible</td><td>Add dashboard and detail-page read-model coverage.</td></tr>
+            <tr><td>Final closure remains blocked after review</td><td>Filter only pending approvals and cover resolved states.</td></tr>
+            <tr><td>A close path bypasses pending-void review</td><td>Use one shared closeout-finalization guard before any register status changes to <code>closed</code>.</td></tr>
+            <tr><td>Finalization closes under stale variance policy</td><td>Recompute variance after voids settle and require approval when the new variance crosses policy.</td></tr>
+            <tr><td>Deferred finalization bypasses approval controls</td><td>Require server-side store and manager/full-admin checks, plus proof lifecycle tests.</td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="verification">
+        <h2>Verification Strategy</h2>
+        <ul>
+          <li>Shared lifecycle tests enumerate all register-session statuses.</li>
+          <li>Command tests prove queued void approval succeeds for <code>closing</code> and fails for <code>closed</code>.</li>
+          <li>Cash Controls backend tests prove pending voids defer final closure but not submission.</li>
+          <li>Closeout tests cover submit, inline manager approval, async variance approval, and finalization paths.</li>
+          <li>UI tests prove pending void review copy and approval routing appear without hiding closeout submission.</li>
+          <li>After implementation, run the focused webapp tests, TypeScript, Convex audit, graph rebuild, and diff check.</li>
+        </ul>
+      </section>
+    </main>
+    <footer>
+      <div class="wrap">
+        Canonical source: docs/plans/2026-06-25-003-fix-register-closeout-void-policy-plan.md
+      </div>
+    </footer>
+  </body>
+</html>

--- a/docs/plans/2026-06-25-003-fix-register-closeout-void-policy-plan.md
+++ b/docs/plans/2026-06-25-003-fix-register-closeout-void-policy-plan.md
@@ -1,0 +1,430 @@
+---
+title: "fix: Allow approved sale voids during register closeout review"
+type: fix
+status: active
+date: 2026-06-25
+---
+
+# fix: Allow approved sale voids during register closeout review
+
+## Summary
+
+Approved completed-sale voids should be able to apply while the original register session is in `closing`, so Cash Controls can update expected cash and variance before final closure. The work centralizes the register-session lifecycle policy for void application, keeps closeout submission unblocked, and makes Cash Controls hold the drawer unresolved while pending void approvals remain.
+
+---
+
+## Problem Frame
+
+Queued void approvals are currently tied to the original `registerSessionId`, but approving them reuses POS sale usability. That means a drawer that has submitted closeout and moved to `closing` blocks the approved void with drawer-closed copy even though the lower register transaction recorder can already post void adjustments after selling stops.
+
+---
+
+## Requirements
+
+### Void Approval / Application
+
+- R1. Void approval requests remain tied to the original sale, store, terminal, transaction, and register session.
+- R2. Applying an approved queued sale void is allowed for register sessions in `open`, `active`, or `closing`.
+- R3. Applying a void remains blocked for missing drawer context, wrong store, wrong terminal, `closed` register sessions, completed EOD, non-completed sales, refunded or already voided sales, adjustment conflicts, and linked service allocations.
+
+### Closeout Lifecycle
+
+- R4. POS closeout submission remains unblocked by pending void approvals; cashiers can submit and count closeouts normally.
+- R5. Final register closure is deferred while pending `pos_transaction_void` approvals exist for the register session.
+- R6. Once all pending `pos_transaction_void` approval requests for the register session are approved, rejected, or cancelled, Cash Controls can finalize closeout using the updated expected cash and variance.
+- R7. Cash Controls exposes a `Finalize closeout` action for submitted `closing` sessions once pending void approvals resolve; resubmitting the same count is not the required operator path.
+- R8. Final closeout authorization is enforced server-side for the finalization command, including store scope and manager/full-admin authority.
+- R9. Finalization recomputes closeout variance policy after pending void approvals settle, because approved voids can change expected cash after the original count was submitted.
+
+### Cash Controls Visibility
+
+- R10. Cash Controls surfaces pending void approvals on affected register sessions with a count, calm operator copy, and a route to the approval work.
+- R11. Cash Controls read models expose only the minimum pending-void fields needed for review visibility and routing, with manager-review evidence gated at the server boundary.
+
+### Shared Policy
+
+- R12. The lifecycle rule is encoded as a named shared policy, not an ad hoc reuse of sale-usability helpers.
+
+---
+
+## Scope Boundaries
+
+- This plan does not change cashier-side creation of completed-sale void requests beyond preserving the existing async approval rail.
+- This plan does not allow new sales on `closing` or `closeout_rejected` register sessions.
+- This plan does not reopen fully `closed` register sessions for void application.
+- This plan does not redesign Daily Close, approval queues, or register closeout UX outside the pending-void surfaces needed for this flow.
+- This plan does not change completed EOD policy; sales in completed EOD still require reopening EOD before voiding.
+
+### Deferred to Follow-Up Work
+
+- Broader register lifecycle vocabulary cleanup across all POS correction commands: separate refactor after this policy is proven in void and closeout paths.
+- Full approval-workspace IA redesign: future UX work if the existing approval route cannot carry enough context.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts` creates `pos_transaction_void` approval requests with `registerSessionId`, validates queued approvals in `resolveTransactionVoidApprovalDecisionWithCtx`, and currently calls `validateTransactionVoidPreconditions` with `requireUsableRegisterSession: true`.
+- `packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts` already owns named lifecycle decisions such as sale usability and replacement-session policy. It is the right home for a void-application policy.
+- `packages/athena-webapp/shared/registerSessionStatus.ts` defines `open`, `active`, `closing`, `closeout_rejected`, and `closed`; POS sale usability is only `open` and `active`.
+- `packages/athena-webapp/convex/operations/registerSessions.ts` only blocks `adjustmentKind: "sale"` when a session is not POS usable. `adjustmentKind: "void"` is already able to update register totals after selling stops.
+- `packages/athena-webapp/convex/cashControls/closeouts.ts` begins closeout before final closure, but the successful result currently only models `action: "closed"`, so this work needs an explicit submitted-but-unresolved outcome.
+- `packages/athena-webapp/convex/cashControls/deposits.ts` currently maps pending `variance_review` approvals by register session for Cash Controls; it does not project pending `pos_transaction_void` approvals into dashboard or register-session snapshots.
+- `packages/athena-webapp/convex/schema.ts` already has `approvalRequest.by_registerSessionId`, which is suitable for register-session pending-void lookup.
+- `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx` and `CashControlsDashboard.tsx` are the UI surfaces where the pending-void blocker should appear.
+- `packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx` already verifies normalized void failure copy for register and EOD blockers.
+- `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts` can project a local `register_closed` event by patching the register session directly to `closed`; this path must participate in the same pending-void closure guard.
+
+### Institutional Learnings
+
+- `docs/solutions/logic-errors/athena-pos-sync-review-workspace-boundaries-2026-06-19.md` explicitly says queued void approvals may outlive an active drawer, replay should bypass the usable-drawer check only for `closing`, and `closed` still blocks.
+- `docs/solutions/logic-errors/athena-pos-register-review-and-adjusted-sale-projection-2026-05-21.md` says review state must project into register totals rather than stopping at flags.
+- `docs/solutions/logic-errors/athena-command-approval-policy-boundary-2026-05-01.md` says approval-sensitive actions must enforce approved retry server-side at the command boundary.
+- `docs/product-copy-tone.md` says operator-facing copy should lead with system state, name the next action when known, and normalize backend wording before display.
+
+### External References
+
+- None used. The repo has direct domain patterns and a prior solution note for this exact lifecycle edge.
+
+---
+
+## Key Technical Decisions
+
+- Add a named void-application policy in `shared/registerSessionLifecyclePolicy.ts`: this keeps void semantics distinct from sale usability while preserving the existing sale blocker.
+- Allow `closing` only for approved void application, not for cashier sale creation or inline void request creation: the policy supports manager-reviewed ledger correction after closeout submission without reopening POS selling.
+- Defer final closure, not closeout submission, when pending void approvals exist: operators can count and submit normally, but the register remains unresolved until review decisions settle.
+- Reuse `approvalRequest.by_registerSessionId` for pending-void lookup first: this avoids schema churn unless implementation profiling shows the status/type filter needs a dedicated compound index.
+- Model the closeout result contract explicitly for submitted-but-unresolved closeouts: UI and command callers should not infer "closed" when pending void review intentionally keeps the session in `closing`.
+- Finalize resolved closeouts through Cash Controls, not as a hidden side effect of void approval resolution: approval application updates register totals, then Cash Controls exposes `Finalize closeout` for the submitted `closing` session and closes against the latest expected cash and counted cash.
+- Treat the pending-void gate as a closeout-finalization invariant, not a branch-local check: `submitRegisterSessionCloseout`, inline-manager-approved closeout closure, async `reviewRegisterSessionCloseout` approval, local sync `register_closed` projection, and the new finalization action must all use the same guard before any register status changes to `closed`.
+- Recompute closeout review at finalization after void approvals settle. If the updated expected cash makes the variance require approval, finalization must require or reuse valid manager approval according to the closeout policy instead of closing under stale zero-variance or pre-void approval assumptions.
+- Authorization remains command-owned: `Finalize closeout` must verify store scope and manager/full-admin authority server-side before closing a submitted session.
+- Staff attribution remains command-owned: public Cash Controls mutations must bind client-supplied staff profile ids to the authenticated Athena user before using them as submitter, closer, reviewer, or audit actors.
+- Stale-client controls are backed by server guards: deposit recording must reject new deposits while register-scoped sale-void approvals are pending, matching the Cash Controls UI lockout.
+- Variance approval proof is not reused implicitly across the deferred closure gap: implementation must either persist durable approved-closeout state when the original proof is consumed at submission, or require a fresh action/subject/store-bound one-use proof at finalization.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should `closing` be allowed for approved void application? Yes. The prior solution note states this exact behavior, and the register transaction recorder already supports void adjustments after selling stops.
+- Should `closeout_rejected` be allowed? No for this slice. The product summary said "probably closing" and final sign-off target is closeout submission under review; rejected closeouts require recount/correction and should stay out unless implementation reveals an existing correction path that safely needs parity.
+- Should pending void approvals block POS closeout submission? No. They only defer final closure and create Cash Controls review visibility.
+
+### Deferred to Implementation
+
+- Exact closeout result action name: choose the smallest command-result value for the submitted-but-unresolved state, such as `action: "submitted_pending_void_review"`, while the operator-facing finalization control is `Finalize closeout`.
+- Whether a dedicated `approvalRequest` compound index is needed: start with `by_registerSessionId`; add a targeted index only if query shape or validator constraints require it.
+- Exact proof lifecycle for inline-approved variance closeouts deferred by pending voids: choose durable approved-closeout state or fresh finalization proof after confirming the existing closeout approval record shape, but do not carry an already-consumed proof across the split action.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+stateDiagram-v2
+  [*] --> Open
+  Open --> Active
+  Active --> Closing: closeout submitted
+  Closing --> Closed: no pending void approvals and closeout can finalize
+  Closing --> Closing: approved void updates expected cash and variance
+  Closing --> Closing: rejected or cancelled void clears blocker
+  Closed --> [*]
+
+  note right of Open
+    Sales and void requests allowed by existing POS policy.
+  end note
+
+  note right of Closing
+    New sales remain blocked.
+    Approved queued voids may apply.
+    Final closure waits for pending void approvals.
+  end note
+```
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1[U1 lifecycle policy] --> U2[U2 void command replay]
+  U1 --> U4[U4 closeout finalization gate]
+  U2 --> U3[U3 Cash Controls read models]
+  U3 --> U5[U5 Cash Controls UI and copy]
+  U4 --> U5
+```
+
+- U1. **Centralize void register-session lifecycle policy**
+
+**Goal:** Add a named shared policy for whether a void may apply to a register session.
+
+**Requirements:** R2, R3, R12
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts`
+- Test: `packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts`
+
+**Approach:**
+- Add a policy that accepts the register-session status plus store and terminal identity context needed by void application.
+- Treat `open`, `active`, and `closing` as allowed for void application.
+- Treat `closed` and `closeout_rejected` as blocked for this slice.
+- Keep sale usability unchanged and covered by existing tests.
+
+**Execution note:** Implement policy tests first so the command change cannot accidentally broaden POS sale usability.
+
+**Patterns to follow:**
+- Existing `isRegisterSessionSaleUsable` and replacement-session helpers in `registerSessionLifecyclePolicy.ts`.
+- Existing lifecycle tests that enumerate statuses explicitly.
+
+**Test scenarios:**
+- Happy path: `open`, `active`, and `closing` register sessions in the same store and terminal are void-applicable.
+- Error path: `closed` and `closeout_rejected` sessions are not void-applicable.
+- Error path: missing session, wrong store, or wrong terminal is not void-applicable and remains distinguishable from status-only failure.
+- Regression: `isRegisterSessionSaleUsable` still returns false for `closing`.
+
+**Verification:**
+- The shared lifecycle policy names void applicability directly and tests document every current register-session status.
+
+---
+
+- U2. **Apply queued void approvals through the void lifecycle policy**
+
+**Goal:** Allow approved queued voids to apply while the original drawer is `closing`, while preserving all existing void blockers.
+
+**Requirements:** R1, R2, R3, R12
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+- Modify: `packages/athena-webapp/convex/operations/approvalRequests.ts`
+- Test: `packages/athena-webapp/convex/pos/application/completeTransaction.test.ts`
+- Test: `packages/athena-webapp/convex/operations/approvalRequests.test.ts`
+- Test: `packages/athena-webapp/convex/pos/public/transactions.test.ts`
+
+**Approach:**
+- Replace the queued approval path's ad hoc POS-sale usability check with the new void policy.
+- Keep inline/current POS void request behavior sale-usable unless implementation confirms the current command path should share the same approved-application policy after proof consumption.
+- Preserve existing checks for completed sale status, item adjustments, completed EOD, drawer context, same store, same terminal, and linked service allocations.
+- Keep approval request matching server-side through `requireMatchingPendingVoidApprovalRequest`.
+- Normalize any changed error text through existing command-result and UI presentation paths.
+
+**Patterns to follow:**
+- Existing async void approval flow in `resolveTransactionVoidApprovalDecisionWithCtx`.
+- Existing approval dispatch in `operations/approvalRequests.ts`.
+- Existing tests around `blocks a queued completed-sale void when the original drawer is closing`, which should become the positive regression for `closing`.
+
+**Test scenarios:**
+- Happy path: approving a pending `pos_transaction_void` request for a completed sale whose original register session is `closing` applies void side effects, records register-session void movement, patches transaction void fields, and resolves the approval request.
+- Error path: approving the same request for a `closed` register session still throws a precondition failure and performs no void side effects.
+- Error path: wrong terminal, wrong store, missing session, missing `registerSessionId`, and missing `terminalId` still block before side effects.
+- Error path: completed EOD still blocks with the existing EOD-specific message.
+- Integration: `approvalRequests.resolveApprovalRequest` still dispatches approved `pos_transaction_void` decisions into the void command path and maps precondition failures to user errors.
+
+**Verification:**
+- Queued approval replay accepts `closing` and rejects `closed` without weakening sale creation or void-request creation rules.
+
+---
+
+- U3. **Expose pending void approvals in Cash Controls read models**
+
+**Goal:** Make Cash Controls aware of unresolved void approvals for each register session with minimal, server-filtered review data.
+
+**Requirements:** R1, R5, R6, R10, R11
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.ts` if a shared helper belongs there after implementation discovery
+- Test: `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+
+**Approach:**
+- Query pending `approvalRequest` rows for the relevant register sessions and filter to `requestType: "pos_transaction_void"` and `status: "pending"`.
+- Add a compact pending-void summary to dashboard rows and register-session snapshots. The read model should include count, safe approval ids, transaction number or display label when already allowed on the surface, and route context. It should not return notes, decision notes, raw metadata, staff proof data, or sensitive financial/review evidence to callers that cannot act on manager review.
+- Gate manager-review evidence at the server/query boundary, not only in React rendering. Non-manager or POS-only callers may see the register unresolved count if the existing Cash Controls access model allows the page, but not privileged review details.
+- Keep existing `variance_review` pending approval mapping intact.
+- Avoid leaking raw backend conflict or approval notes as primary operator copy.
+
+**Patterns to follow:**
+- Current `variance_review` mapping by `registerSessionId` in `deposits.ts`.
+- Cash Controls snapshot shape used by `RegisterSessionView.test.tsx`.
+- Product copy tone guidance for converting backend evidence into operator state.
+
+**Test scenarios:**
+- Happy path: dashboard snapshot includes a pending void count for a visible register session with one pending `pos_transaction_void` approval.
+- Happy path: register-session snapshot includes pending void approval summary rows for that session.
+- Edge case: approved, rejected, and cancelled void approval requests are excluded.
+- Edge case: pending void approval for another register session is excluded.
+- Edge case: pending variance approvals continue to populate the existing closeout review state without being counted as void approvals.
+- Edge case: two pending void approvals on the same register continue blocking finalization after one resolves and one remains pending.
+- Error path: non-manager or POS-only query context does not receive raw pending-void metadata, notes, decision notes, staff proof fields, or manager-only review evidence.
+
+**Verification:**
+- Cash Controls read models can distinguish pending void review from variance review and expose the void review count without changing existing variance behavior.
+
+---
+
+- U4. **Defer final closeout closure while void approvals are pending**
+
+**Goal:** Preserve closeout submission while preventing any final register closure path from closing until pending void approvals settle.
+
+**Requirements:** R4, R5, R6, R7, R8, R9
+
+**Dependencies:** U1, U3
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Modify: `packages/athena-webapp/shared/commandResult.ts` or validators only if the closeout result contract requires shared type coverage
+- Test: `packages/athena-webapp/convex/cashControls/closeouts.test.ts`
+- Test: `packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts` if trace lifecycle expectations change
+- Test: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+
+**Approach:**
+- Add a shared closeout-finalization guard/helper that checks pending `pos_transaction_void` approvals tied to the register session before any path marks a register session `closed`.
+- Use that guard in `submitRegisterSessionCloseout`, inline-manager-approved submit closeout, async `reviewRegisterSessionCloseout` approval, local sync `register_closed` projection in `projectLocalEvents.ts`, and the `Finalize closeout` path.
+- For local sync closeout projection with pending void approvals, leave the register in `closing` and surface review evidence rather than patching directly to `closed`.
+- If pending void approvals exist, return a successful submitted/unresolved closeout result and leave the register session in `closing`.
+- Add or reuse an explicit Cash Controls finalization command path for `closing` sessions whose pending void approvals have all resolved. The operator-facing control is `Finalize closeout`, and it closes against the latest register-session expected cash and counted cash.
+- Apply the same pending-void finalization gate to zero-variance closeouts, inline-manager-approved variance closeouts, and async variance-review approvals.
+- Before finalizing after pending voids resolve, recompute closeout review from current `expectedCash` and submitted `countedCash`. If the post-void variance requires approval, require the appropriate manager approval path before closing.
+- Enforce finalization authorization in the Convex command: the actor must be in the same store and must be a manager or full admin. POS-only or wrong-store callers must fail before state mutation.
+- For inline manager-approved variance closeouts that cannot close because pending voids remain, do not reuse the already-consumed approval proof at finalization. Either persist a durable approved-closeout state tied to the original action, subject, store, and approver, or require a fresh finalization proof when the manager clicks `Finalize closeout`.
+- Ensure rejected or cancelled void approvals no longer block final closure.
+- Keep existing variance approval behavior intact; pending variance review already leaves the session unresolved.
+
+**Execution note:** Characterize current closeout result consumers before naming the new success action so UI and command validators change together.
+
+**Patterns to follow:**
+- Existing `approval_required` return for variance review, which already keeps closeout unresolved.
+- Existing `beginRegisterSessionCloseout` then `closeRegisterSession` sequence in `submitRegisterSessionCloseout`.
+- Existing local sync closeout projection tests in `projectLocalEvents.test.ts`.
+- Existing register-session trace stages for `closeout_submitted` and `closed`.
+
+**Test scenarios:**
+- Happy path: submitting closeout with pending void approvals records closeout submission, leaves the session `closing`, returns the submitted/unresolved action, and does not call `closeRegisterSession`.
+- Happy path: after pending void approvals are resolved, `Finalize closeout` closes the session using the latest expected cash and variance.
+- Happy path: approving async `reviewRegisterSessionCloseout` while void approvals are pending marks the variance approval approved when appropriate, leaves the session `closing`, returns submitted/unresolved state, and does not emit final closed trace.
+- Happy path: projecting a local `register_closed` sync event while pending void approvals exist leaves the session `closing`, preserves closeout evidence, and does not patch status to `closed`.
+- Edge case: finalization recomputes variance after an approved cash void changes expected cash; if the new variance crosses policy, finalization requires manager approval rather than closing under the stale original result.
+- Edge case: zero-variance closeout with pending void approvals remains unresolved rather than closing immediately.
+- Edge case: inline manager-approved variance closeout with pending void approvals remains unresolved rather than closing immediately.
+- Edge case: mixed approve/reject/cancel outcomes across multiple void approvals keep finalization blocked until the last pending row is resolved.
+- Error path: wrong-store, POS-only, cashier-only, and missing-actor finalization attempts fail before `closeRegisterSession`.
+- Error path: an already-consumed variance approval proof cannot be replayed at finalization.
+- Regression: variance approval required still returns `approval_required` when no inline manager proof is supplied.
+- Integration: trace history records closeout submission without emitting a final closed trace until closure actually occurs.
+
+**Verification:**
+- Pending void approvals can no longer be stranded behind a prematurely closed register session, and closeout submission remains available to cashiers.
+
+---
+
+- U5. **Surface pending void review in Cash Controls UI**
+
+**Goal:** Show managers why the register remains unresolved and route them to the approval work.
+
+**Requirements:** R5, R6, R7, R10
+
+**Dependencies:** U3, U4
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx`
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/OperationsQueueView.tsx` if the existing approval route needs a better void label
+- Test: `packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx`
+- Test: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+- Test: `packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx` if route or label copy changes there
+
+**Approach:**
+- Add an operator-facing callout on the register session page when pending void approvals exist.
+- Add a compact dashboard indicator for affected register sessions so Cash Controls review starts from the list view.
+- Use copy shaped like: "Void review pending. Review the pending sale void before final closeout can complete."
+- Link to the existing `/operations/approvals` destination for the pending void rows, preserving the current Cash Controls register URL as the return origin when the route supports `o=`.
+- Keep submit/count controls available while the pending-void callout explains why final closure is not complete.
+- When pending void approvals are resolved and the session is still `closing`, expose `Finalize closeout` instead of relying on operators to infer that they should resubmit the same count.
+- If the session is `closeout_rejected` with pending void approvals, make the next action explicit: resolve the rejected closeout through the existing reopen/recount path first, then replay or decide the pending void approvals. Do not present an unfulfillable void approval as the primary Cash Controls action.
+- Detail-page callout ordering should keep active closeout variance or synced closeout review first, then pending void review, then informational sync/session notices. Dashboard rows should group all unresolved drawer work under the register status area, with pending void review shown as a blocker only when it prevents final closure.
+- Manager flow: open the affected register in Cash Controls, follow `Review void approvals` to `/operations/approvals`, approve/reject/cancel the pending sale void rows, return to the register page via the origin link or navigation, then use `Finalize closeout` when no pending void approvals remain.
+
+**Patterns to follow:**
+- Existing closeout review callouts and left-rail status language in `RegisterSessionView.tsx`.
+- Existing dashboard session status badges in `CashControlsDashboard.tsx`.
+- `docs/product-copy-tone.md` for restrained, operational copy.
+
+**Test scenarios:**
+- Happy path: register session view shows pending void count and approval link when snapshot includes pending void approvals.
+- Happy path: dashboard row flags a register session with pending void approvals.
+- Edge case: no callout appears when all void approvals are resolved.
+- Edge case: multiple pending void approvals show an accurate count, and mixed resolved/pending approvals count only pending rows.
+- Edge case: `closeout_rejected` plus pending void approval shows reopen/recount as the next Cash Controls action and does not make void approval look directly applyable.
+- Edge case: route or decision failures leave the pending-void callout visible and show normalized error copy without losing the submitted closeout state.
+- Edge case: loading or stale approval data uses existing Cash Controls loading conventions and never shows a false `Finalize closeout` action until pending state is known.
+- Integration: closeout submit button remains available when pending void approvals exist.
+- Integration: finalization action appears after pending void approvals resolve for a submitted closeout that is still `closing`.
+- Integration: Cash Controls-to-approvals handoff starts at the register page, opens `/operations/approvals` scoped by route/origin context, resolves the relevant pending void approval, and returns or lands the manager on the same register's `Finalize closeout` action.
+- Integration: finalization success gives the same closed-state confirmation pattern as a normal successful closeout.
+- Copy regression: backend request type `pos_transaction_void` does not appear as raw UI text.
+
+**Verification:**
+- Managers can see why a submitted closeout remains unresolved and can navigate to the pending approval without blocking cashier closeout submission.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** POS transaction void approval, approval request resolution, register-session transaction recording, Cash Controls closeout, Cash Controls snapshots, and approval UI all participate in the flow.
+- **Error propagation:** Command-boundary failures should remain `user_error` or approval-resolution mapped errors; UI should normalize backend wording before display.
+- **State lifecycle risks:** The critical lifecycle is `active/open -> closing -> closed`; this work intentionally adds void application inside `closing` but keeps final closure blocked until pending void approvals settle.
+- **API surface parity:** Any generated validators or shared result types for `submitRegisterSessionCloseout` must include the new submitted/unresolved action before UI callers consume it.
+- **Integration coverage:** Unit tests must prove register expected cash and variance update before closure after an approved void in `closing`; UI tests must prove operators see pending review while submission stays available.
+- **Unchanged invariants:** New sales remain limited to POS-usable sessions, completed EOD still blocks voids, and closed register sessions are not mutated by queued void approvals.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Accidentally allowing new sales on `closing` sessions | Keep sale usability unchanged and add regression tests in the shared lifecycle policy. |
+| Closeout result contract drift between Convex validators and React callers | Change command result validator, type expectations, and UI tests in the same unit. |
+| Pending void approvals become invisible outside Cash Controls | Reuse approval request data with register-session context and add dashboard plus detail-page tests. |
+| Final closure remains blocked after void review resolution | Filter only `status: "pending"` approvals and cover approved, rejected, and cancelled cases. |
+| Raw backend request types leak into UI | Add UI copy tests that assert operational labels and absence of `pos_transaction_void`. |
+
+---
+
+## Documentation / Operational Notes
+
+- Add or update a `docs/solutions/logic-errors/` note after implementation, because this fixes a lifecycle boundary between POS approval replay and Cash Controls closeout finalization.
+- Run `bun run graphify:rebuild` after code changes, per repo instructions.
+- This plan intentionally does not start implementation; it is ready for `/ce-work` once approved.
+
+---
+
+## Sources & References
+
+- `graphify-out/GRAPH_REPORT.md`
+- `graphify-out/wiki/index.md`
+- `graphify-out/wiki/packages/athena-webapp.md`
+- `packages/athena-webapp/docs/agent/code-map.md`
+- `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+- `packages/athena-webapp/convex/cashControls/closeouts.ts`
+- `packages/athena-webapp/convex/cashControls/deposits.ts`
+- `packages/athena-webapp/convex/operations/registerSessions.ts`
+- `packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts`
+- `packages/athena-webapp/shared/registerSessionStatus.ts`
+- `docs/solutions/logic-errors/athena-pos-sync-review-workspace-boundaries-2026-06-19.md`
+- `docs/solutions/logic-errors/athena-pos-register-review-and-adjusted-sale-projection-2026-05-21.md`
+- `docs/solutions/logic-errors/athena-command-approval-policy-boundary-2026-05-01.md`
+- `docs/product-copy-tone.md`

--- a/docs/solutions/logic-errors/athena-register-closeout-pending-void-policy-2026-06-25.md
+++ b/docs/solutions/logic-errors/athena-register-closeout-pending-void-policy-2026-06-25.md
@@ -1,0 +1,92 @@
+---
+title: Athena Register Closeout Pending Void Policy
+date: 2026-06-25
+category: logic-errors
+module: athena-webapp
+problem_type: lifecycle_state_error
+component: cash-controls
+symptoms:
+  - "Queued completed-sale void approvals fail after closeout submission"
+  - "Cash Controls can close a register before pending void approvals update expected cash"
+  - "A stale Cash Controls form can try to record deposits while void review is pending"
+root_cause: void_application_reused_pos_sale_usable_register_status_while_closeout_finalization_ignored_pending_void_approvals
+resolution_type: code_fix
+severity: high
+tags:
+  - cash-controls
+  - pos
+  - register-session
+  - closeout
+  - voids
+  - approval-policy
+related:
+  - docs/solutions/logic-errors/athena-pos-completed-transaction-void-reversal-2026-05-21.md
+  - docs/solutions/logic-errors/athena-pos-closeout-review-only-lifecycle-2026-06-25.md
+  - docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md
+---
+
+# Athena Register Closeout Pending Void Policy
+
+## Problem
+
+Completed-sale void replay and register closeout finalization are different
+lifecycle decisions. A register session in `closing` is no longer sale-usable,
+but it can still need an approved void so expected cash and variance remain
+accurate before the final close.
+
+The bug pattern appears when queued void approval replay reuses POS sale
+usability, while Cash Controls finalization ignores pending
+`pos_transaction_void` approvals. That combination can block the valid approved
+void with drawer-closed copy, or close the register before pending void review
+has updated the cash ledger.
+
+## Solution
+
+Use separate named policies for sale usability, void application, and final
+closeout:
+
+- Sales require an `open` or `active` drawer.
+- Approved completed-sale void application allows `open`, `active`, and
+  `closing`.
+- `closed`, `closeout_rejected`, wrong-store, wrong-terminal, and missing
+  session states still block void application.
+- Pending `pos_transaction_void` approvals are a final-close blocker, not a
+  closeout-submission blocker.
+- Cashiers can submit the count and leave the register in `closing`; managers
+  review or reject the voids; then finalization recomputes variance from the
+  current register session before closing.
+- Public closeout mutations bind client-supplied staff attribution to the
+  authenticated Athena user before writing submitter, closer, requester, or
+  audit fields.
+- Final closeout verifies manager authority server-side even when recomputed
+  variance is exact and no variance approval proof is required.
+- Deposit recording checks pending register-scoped void approvals server-side
+  before writing a new deposit, so stale mounted UI cannot bypass the lockout.
+
+Expose pending voids in Cash Controls with a small safe summary keyed by
+`registerSessionId`: count, approval id, transaction id/number, and optional work
+item id. Do not expose approval notes, decision notes, raw metadata, proof ids,
+or reviewer ids in the cash-controls register summary.
+
+## Prevention
+
+- Check every closeout closure boundary, not only the visible submit button:
+  direct closeout submission, inline manager variance approval, async variance
+  approval resolution, local-sync `register_closed` projection, and explicit
+  finalization.
+- Keep approved void application policy in shared lifecycle helpers rather than
+  reusing sale usability in command branches.
+- Recompute closeout review at finalization after pending void approvals settle,
+  because approved voids can change expected cash after the original count.
+- Add stale-client tests for UI lockouts that also need server enforcement, such
+  as deposits while pending void approvals exist.
+- Add negative auth tests for client-supplied staff profile ids at public Cash
+  Controls mutation boundaries.
+- Keep pending-void read models narrow; route managers to approval work without
+  returning raw approval notes or proof metadata to Cash Controls summaries.
+
+## Related
+
+- `docs/solutions/logic-errors/athena-pos-completed-transaction-void-reversal-2026-05-21.md`
+- `docs/solutions/logic-errors/athena-pos-closeout-review-only-lifecycle-2026-06-25.md`
+- `docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7994 nodes · 9391 edges · 2055 communities detected
+- 8002 nodes · 9399 edges · 2055 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2177,28 +2177,28 @@ Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
 ### Community 21 - "Community 21"
+Cohesion: 0.07
+Nodes (8): arrayDetail(), buildCashControlsDashboardSnapshot(), buildReviewedSaleProjectionEvent(), normalizeReviewedNonCashOverpaymentPayload(), numberDetail(), recordDetail(), roundCurrencyAmount(), sumDepositsBySession()
+
+### Community 22 - "Community 22"
 Cohesion: 0.11
 Nodes (21): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), buildLocalAvailabilityEventIndex(), cartItemLineEventKey(), cartItemLineKey(), cartItemsFromLocalRegisterModel(), cartLineSourceKey(), formatLocalPendingCheckoutSku() (+13 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.12
 Nodes (26): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildInventorySnapshotRowsForProductSkusWithCtx(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle() (+18 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.11
 Nodes (24): buildGitProcessEnv(), buildProviderSkip(), collectCommandsForChangedFiles(), commandDisplayName(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs() (+16 more)
-
-### Community 26 - "Community 26"
-Cohesion: 0.08
-Nodes (8): arrayDetail(), buildCashControlsDashboardSnapshot(), buildReviewedSaleProjectionEvent(), normalizeReviewedNonCashOverpaymentPayload(), numberDetail(), recordDetail(), roundCurrencyAmount(), sumDepositsBySession()
 
 ### Community 27 - "Community 27"
 Cohesion: 0.14
@@ -2297,80 +2297,80 @@ Cohesion: 0.17
 Nodes (19): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady(), mapSyncStatus() (+11 more)
 
 ### Community 51 - "Community 51"
+Cohesion: 0.11
+Nodes (6): asBoolean(), asNumber(), asRecord(), buildRegisterCloseoutVarianceTimelineMessage(), formatCloseoutVarianceAmount(), getCashControlsConfig()
+
+### Community 52 - "Community 52"
 Cohesion: 0.16
 Nodes (17): asRecord(), buildSnapshotHash(), buildStoreInsightsPromptFromContextBundle(), buildStoreInsightsPromptFromContextEvents(), buildUserInsightsPromptFromContextBundle(), buildUserInsightsPromptFromContextEvents(), compactContextEventsForPrompt(), compactEnvironmentForPrompt() (+9 more)
 
-### Community 52 - "Community 52"
+### Community 53 - "Community 53"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 53 - "Community 53"
+### Community 54 - "Community 54"
 Cohesion: 0.15
 Nodes (16): findLatestOpenOperatingDay(), getTodaySummary(), getTransactionById(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile() (+8 more)
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.21
 Nodes (21): detectFormat(), extractJsonRows(), flattenJsonRows(), inferProductName(), isRecord(), looksLikeLabel(), normalizeKey(), normalizeLegacyRow() (+13 more)
 
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.25
 Nodes (21): asRecord(), errorFor(), getLocalExpenseSessionId(), getOrCreateSession(), isExpenseEvent(), itemSource(), itemSourceKey(), numberField() (+13 more)
 
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.18
 Nodes (18): assertValidEodLocalCompletionWindowMinutes(), assertValidEodThreshold(), assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getEodAutoCompletePolicyConfigWithCtx() (+10 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.13
 Nodes (12): getLatestRuntimeStatusForTerminal(), getTerminalByFingerprint(), getTerminalSyncEvidence(), isActionableRejectedSyncEvent(), isActionableTerminalReviewSyncEvent(), mapTerminalRecord(), mergeRuntimeStatusPatch(), omitUndefined() (+4 more)
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.21
 Nodes (18): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), formatRecoveryCode(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode() (+10 more)
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.1
 Nodes (4): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onStartRemoteAssist()
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.13
 Nodes (9): asCloudOperableSession(), countPendingSyncableLocalEventsForStaff(), hasSyncedSaleLocalEventsForStaff(), hasUploadedLocalEventsForStaff(), isCloudOperableSession(), isEmptyLocalSaleShell(), selectPassiveCloseoutBlockedRegisterSession(), trimOptional() (+1 more)
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.27
 Nodes (18): assertConformsToExportedReturns(), collectReturnValidatorIssues(), decodeSerializedFloat64(), decodeSerializedInt64(), decodeSerializedLiteralValue(), describeValue(), formatReturnValidatorIssues(), isConvexValue() (+10 more)
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.2
 Nodes (17): acknowledgeTerminalRecoveryCommand(), buildExecutionId(), claimTerminalRecoveryCommand(), containsSecretLikeField(), getRuntimeAppUpdateEvidence(), isActiveCommand(), isEquivalentCommand(), issueTerminalRecoveryCommand() (+9 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.22
 Nodes (18): assertPrAthenaProofReady(), classifySnapshotError(), collectFilesUnder(), collectProofSnapshot(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof() (+10 more)
-
-### Community 69 - "Community 69"
-Cohesion: 0.14
-Nodes (6): asBoolean(), asNumber(), asRecord(), buildRegisterCloseoutVarianceTimelineMessage(), formatCloseoutVarianceAmount(), getCashControlsConfig()
 
 ### Community 70 - "Community 70"
 Cohesion: 0.17
@@ -2517,52 +2517,52 @@ Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
 ### Community 106 - "Community 106"
+Cohesion: 0.21
+Nodes (8): canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), getSaleBlockingDrawerAuthority(), isDrawerAuthoritySaleBlocking(), isRegisterSessionConflictBlocking(), isRegisterSessionReplacementBlocking(), isRegisterSessionSaleUsable(), isScopedRegisterSession()
+
+### Community 107 - "Community 107"
 Cohesion: 0.14
 Nodes (0):
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.16
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.26
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.22
 Nodes (6): buildParticipantIdentity(), getDataPublishRouting(), getParticipantRole(), isAllowedSender(), LiveKitRemoteAssistClient, parseParticipantRole()
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.26
 Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
-
-### Community 117 - "Community 117"
-Cohesion: 0.23
-Nodes (8): canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), getSaleBlockingDrawerAuthority(), isDrawerAuthoritySaleBlocking(), isRegisterSessionConflictBlocking(), isRegisterSessionReplacementBlocking(), isRegisterSessionSaleUsable(), isScopedRegisterSession()
 
 ### Community 118 - "Community 118"
 Cohesion: 0.22
@@ -2633,56 +2633,56 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 135 - "Community 135"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 136 - "Community 136"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 137 - "Community 137"
+### Community 136 - "Community 136"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 138 - "Community 138"
+### Community 137 - "Community 137"
 Cohesion: 0.2
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 139 - "Community 139"
+### Community 138 - "Community 138"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 140 - "Community 140"
+### Community 139 - "Community 139"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 141 - "Community 141"
+### Community 140 - "Community 140"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 142 - "Community 142"
+### Community 141 - "Community 141"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 143 - "Community 143"
+### Community 142 - "Community 142"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 144 - "Community 144"
+### Community 143 - "Community 143"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 145 - "Community 145"
+### Community 144 - "Community 144"
 Cohesion: 0.25
 Nodes (7): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus()
 
-### Community 146 - "Community 146"
+### Community 145 - "Community 145"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 147 - "Community 147"
+### Community 146 - "Community 146"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
+
+### Community 147 - "Community 147"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 148 - "Community 148"
 Cohesion: 0.18
@@ -2817,24 +2817,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 181 - "Community 181"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 182 - "Community 182"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 183 - "Community 183"
+### Community 182 - "Community 182"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 184 - "Community 184"
+### Community 183 - "Community 183"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 185 - "Community 185"
+### Community 184 - "Community 184"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 185 - "Community 185"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 186 - "Community 186"
 Cohesion: 0.39

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2127
-- Graph nodes: 7994
-- Graph edges: 9391
+- Graph nodes: 8002
+- Graph edges: 9399
 - Communities: 2055
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,7 +19,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 56) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 57) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `storefrontContextEvents.ts` (17 edges, Community 77) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
 - `checkoutSession.ts` (14 edges, Community 91) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 

--- a/packages/athena-webapp/convex/cashControls/closeouts.test.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.test.ts
@@ -4,12 +4,21 @@ import {
   buildRegisterSessionCloseoutReview,
   buildRegisterSessionVarianceApprovalRequirement,
   correctRegisterSessionOpeningFloat,
+  finalizeRegisterSessionCloseout,
   getCashControlsConfig,
   reopenRegisterSessionCloseout,
   reviewRegisterSessionCloseout,
   submitRegisterSessionCloseout,
 } from "./closeouts";
 import { assertConformsToExportedReturns } from "../lib/returnValidatorContract";
+
+vi.mock("../lib/athenaUserAuth", () => ({
+  requireAuthenticatedAthenaUserWithCtx: vi.fn(async () => ({
+    _id: "manager-user-1",
+    email: "manager@example.com",
+  })),
+  requireOrganizationMemberRoleWithCtx: vi.fn(async () => undefined),
+}));
 
 function getSource(relativePath: string) {
   return readFileSync(new URL(relativePath, import.meta.url), "utf8");
@@ -39,10 +48,49 @@ describe("cash control closeouts", () => {
         },
       },
     };
+    const submittedCloseoutResult = {
+      kind: "ok" as const,
+      data: {
+        action: "submitted" as const,
+        closeoutReview: {
+          hasVariance: true,
+          requiresApproval: false,
+          variance: -100,
+        },
+        pendingVoidApprovalCount: 1,
+        registerSession: {
+          _id: "session-1",
+          status: "closing",
+        },
+      },
+    };
+    const finalizedCloseoutResult = {
+      kind: "ok" as const,
+      data: {
+        action: "closed" as const,
+        closeoutReview: {
+          hasVariance: false,
+          requiresApproval: false,
+          variance: 0,
+        },
+        registerSession: {
+          _id: "session-1",
+          status: "closed",
+        },
+      },
+    };
 
     assertConformsToExportedReturns(
       submitRegisterSessionCloseout,
       validationError,
+    );
+    assertConformsToExportedReturns(
+      submitRegisterSessionCloseout,
+      submittedCloseoutResult,
+    );
+    assertConformsToExportedReturns(
+      finalizeRegisterSessionCloseout,
+      finalizedCloseoutResult,
     );
     assertConformsToExportedReturns(
       reopenRegisterSessionCloseout,
@@ -202,7 +250,7 @@ describe("cash control closeouts", () => {
     expect(source).toContain("buildRegisterSessionVarianceApprovalRequirement");
     expect(source).toContain("recordOperationalEventWithCtx");
     expect(source).toContain("consumeCommandApprovalProofWithCtx");
-    expect(source).toContain("requestedByStaffProfileId: args.actorStaffProfileId");
+    expect(source).toContain("resolveCloseoutActorStaffProfileId");
     expect(source).toContain("beginRegisterSessionCloseout");
     expect(source).toContain("closeRegisterSession");
     expect(source).toContain("decideApprovalRequest");
@@ -222,7 +270,7 @@ describe("cash control closeouts", () => {
     expect(source).toContain("internal.operations.registerSessions.correctRegisterSessionOpeningFloat");
     expect(source).toContain("register_session_opening_float_corrected");
     expect(source).toContain("opening_float_corrected");
-    expect(source).toContain("requestedByStaffProfileId: args.actorStaffProfileId");
+    expect(source).toContain("requestedByStaffProfileId: actorStaffProfileId");
   });
 
   it("exposes closed-closeout reopening as an append-only correction path", () => {
@@ -232,7 +280,7 @@ describe("cash control closeouts", () => {
     expect(source).toContain("register_session_closeout_reopened");
     expect(source).toContain("stage: \"closeout_reopened\"");
     expect(source).toContain("metadata: previousCloseout");
-    expect(source).toContain("requestedByStaffProfileId: args.requestedByStaffProfileId");
+    expect(source).toContain("requestedByStaffProfileId: actorStaffProfileId");
     expect(source).toContain("REGISTER_CLOSEOUT_MODIFICATION_SUBMIT_ACTION");
     expect(source).toContain("closeoutModificationApprovalProofId");
     expect(source).toContain(
@@ -367,9 +415,14 @@ describe("cash control closeouts", () => {
             };
           }
 
+          if (table === "store") {
+            return { _id: "store-1", organizationId: "org-1" };
+          }
+
           if (table === "staffProfile") {
             return {
               _id: "staff-1",
+              linkedUserId: "manager-user-1",
               organizationId: "org-1",
               status: "active",
               storeId: "store-1",
@@ -443,10 +496,13 @@ describe("cash control closeouts", () => {
               subjectType: "register_session",
             };
           }
-          if (table === "store") return { _id: "store-1", currency: "GHS" };
+          if (table === "store") {
+            return { _id: "store-1", currency: "GHS", organizationId: "org-1" };
+          }
           if (table === "staffProfile") {
             return {
-              _id: "manager-1",
+              _id: "staff-1",
+              linkedUserId: "manager-user-1",
               organizationId: "org-1",
               status: "active",
               storeId: "store-1",
@@ -581,6 +637,9 @@ describe("cash control closeouts", () => {
               storeId: "store-1",
             };
           }
+          if (table === "store") {
+            return { _id: "store-1", organizationId: "org-1" };
+          }
           if (table === "approvalProof") {
             return {
               _id: "proof-1",
@@ -598,6 +657,7 @@ describe("cash control closeouts", () => {
           if (table === "staffProfile") {
             return {
               _id: "staff-1",
+              linkedUserId: "manager-user-1",
               organizationId: "org-1",
               status: "active",
               storeId: "store-1",
@@ -677,6 +737,18 @@ describe("cash control closeouts", () => {
               subjectType: "register_session",
             };
           }
+          if (table === "store") {
+            return { _id: "store-1", currency: "GHS", organizationId: "org-1" };
+          }
+          if (table === "staffProfile") {
+            return {
+              _id: "staff-1",
+              linkedUserId: "manager-user-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
           return null;
         }),
         insert,
@@ -739,6 +811,7 @@ describe("cash control closeouts", () => {
           if (table === "staffProfile") {
             return {
               _id: "staff-1",
+              linkedUserId: "manager-user-1",
               organizationId: "org-1",
               status: "active",
               storeId: "store-1",
@@ -794,6 +867,751 @@ describe("cash control closeouts", () => {
       expect.objectContaining({ kind: "async_request" }),
     );
     expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("submits closeout without final closure when pending void approvals exist", async () => {
+    const registerSession = {
+      _id: "session-1",
+      expectedCash: 30000,
+      openedAt: 1,
+      organizationId: "org-1",
+      registerNumber: "A1",
+      status: "open",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    };
+    const closingSession = {
+      ...registerSession,
+      countedCash: 20000,
+      status: "closing",
+      variance: -10000,
+    };
+    const runMutation = vi.fn(async (_name: unknown, args: unknown) => {
+      expect(args).toMatchObject({
+        countedCash: 20000,
+        registerSessionId: "session-1",
+      });
+      return closingSession;
+    });
+    const insert = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string) => {
+          if (table === "registerSession") return registerSession;
+          if (table === "store") {
+            return { _id: "store-1", currency: "GHS", organizationId: "org-1" };
+          }
+          if (table === "staffProfile") {
+            return {
+              _id: "manager-1",
+              linkedUserId: "manager-user-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+          return null;
+        }),
+        insert,
+        patch: vi.fn(),
+        query: vi.fn((table: string) => ({
+          withIndex: vi.fn(() => ({
+            collect: vi.fn(async () =>
+              table === "approvalRequest"
+                ? [
+                    {
+                      _id: "void-approval-1",
+                      registerSessionId: "session-1",
+                      requestType: "pos_transaction_void",
+                      status: "pending",
+                      storeId: "store-1",
+                      subjectType: "pos_transaction",
+                    },
+                  ]
+                : [],
+            ),
+          })),
+        })),
+      },
+      runMutation,
+      runQuery: vi.fn(async () => ({ _id: "store-1" })),
+    };
+
+    const result = await getHandler(submitRegisterSessionCloseout)(ctx, {
+      actorStaffProfileId: "manager-1",
+      actorUserId: "user-1",
+      countedCash: 20000,
+      notes: "Count recorded before void review.",
+      registerSessionId: "session-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "submitted",
+        pendingVoidApprovalCount: 1,
+        registerSession: closingSession,
+      },
+    });
+    expect(insert).not.toHaveBeenCalledWith(
+      "approvalRequest",
+      expect.anything(),
+    );
+    expect(runMutation).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects closeout submit when the staff actor belongs to another user", async () => {
+    const runMutation = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string) => {
+          if (table === "store") {
+            return { _id: "store-1", currency: "GHS", organizationId: "org-1" };
+          }
+          if (table === "staffProfile") {
+            return {
+              _id: "manager-1",
+              linkedUserId: "other-user-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+          return null;
+        }),
+      },
+      runMutation,
+    };
+
+    const result = await getHandler(submitRegisterSessionCloseout)(ctx, {
+      actorStaffProfileId: "manager-1",
+      countedCash: 20000,
+      registerSessionId: "session-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "authorization_failed",
+        message: "Closeout staff actor does not match the signed-in user.",
+      },
+    });
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("rejects closeout approval proof payloads while pending void approvals exist", async () => {
+    const registerSession = {
+      _id: "session-1",
+      expectedCash: 30000,
+      openedAt: 1,
+      organizationId: "org-1",
+      registerNumber: "A1",
+      status: "open",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    };
+    const runMutation = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string) => {
+          if (table === "registerSession") return registerSession;
+          if (table === "store") {
+            return { _id: "store-1", currency: "GHS", organizationId: "org-1" };
+          }
+          if (table === "staffProfile") {
+            return {
+              _id: "manager-1",
+              linkedUserId: "manager-user-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+          return null;
+        }),
+        query: vi.fn((table: string) => ({
+          withIndex: vi.fn(() => ({
+            collect: vi.fn(async () =>
+              table === "approvalRequest"
+                ? [
+                    {
+                      _id: "void-approval-1",
+                      registerSessionId: "session-1",
+                      requestType: "pos_transaction_void",
+                      status: "pending",
+                      storeId: "store-1",
+                      subjectType: "pos_transaction",
+                    },
+                  ]
+                : [],
+            ),
+          })),
+        })),
+      },
+      runMutation,
+      runQuery: vi.fn(async () => ({ _id: "store-1" })),
+    };
+
+    const result = await getHandler(submitRegisterSessionCloseout)(ctx, {
+      actorStaffProfileId: "manager-1",
+      actorUserId: "user-1",
+      approvalProofId: "proof-1",
+      countedCash: 20000,
+      registerSessionId: "session-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message:
+          "Resolve pending void approvals before approving final closeout.",
+      },
+    });
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("blocks final closeout while pending void approvals remain", async () => {
+    const registerSession = {
+      _id: "session-1",
+      countedCash: 30000,
+      expectedCash: 30000,
+      openedAt: 1,
+      organizationId: "org-1",
+      registerNumber: "A1",
+      status: "closing",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    };
+    const runMutation = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string) => {
+          if (table === "registerSession") return registerSession;
+          if (table === "store") {
+            return { _id: "store-1", currency: "GHS", organizationId: "org-1" };
+          }
+          if (table === "staffProfile") {
+            return {
+              _id: "manager-1",
+              linkedUserId: "manager-user-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+          return null;
+        }),
+        query: vi.fn((table: string) => ({
+          withIndex: vi.fn(() => ({
+            collect: vi.fn(async () =>
+              table === "approvalRequest"
+                ? [
+                    {
+                      _id: "void-approval-1",
+                      registerSessionId: "session-1",
+                      requestType: "pos_transaction_void",
+                      status: "pending",
+                      storeId: "store-1",
+                      subjectType: "pos_transaction",
+                    },
+                  ]
+                : [],
+            ),
+          })),
+        })),
+      },
+      runMutation,
+      runQuery: vi.fn(async () => ({ _id: "store-1" })),
+    };
+
+    const result = await getHandler(finalizeRegisterSessionCloseout)(ctx, {
+      actorStaffProfileId: "manager-1",
+      actorUserId: "user-1",
+      registerSessionId: "session-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Resolve pending void approvals before finalizing closeout.",
+      },
+    });
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("finalizes exact-match submitted closeouts without a variance approval proof", async () => {
+    const registerSession = {
+      _id: "session-1",
+      countedCash: 30000,
+      expectedCash: 30000,
+      openedAt: 1,
+      organizationId: "org-1",
+      registerNumber: "A1",
+      status: "closing",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    };
+    const closedSession = {
+      ...registerSession,
+      closedAt: 100,
+      closedByStaffProfileId: "staff-1",
+      closedByUserId: "manager-user-1",
+      status: "closed",
+    };
+    const runMutation = vi.fn(async () => closedSession);
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string) => {
+          if (table === "registerSession") return registerSession;
+          if (table === "store") {
+            return { _id: "store-1", currency: "GHS", organizationId: "org-1" };
+          }
+          if (table === "staffProfile") {
+            return {
+              _id: "staff-1",
+              linkedUserId: "manager-user-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+          return null;
+        }),
+        insert: vi.fn(),
+        patch: vi.fn(),
+        query: vi.fn((table: string) => ({
+          withIndex: vi.fn(() => ({
+            collect: vi.fn(async () => []),
+            take: vi.fn(async () =>
+              table === "staffRoleAssignment"
+                ? [
+                    {
+                      organizationId: "org-1",
+                      role: "manager",
+                      status: "active",
+                      storeId: "store-1",
+                    },
+                  ]
+                : [],
+            ),
+          })),
+        })),
+      },
+      runMutation,
+      runQuery: vi.fn(async () => ({ _id: "store-1" })),
+    };
+
+    const result = await getHandler(finalizeRegisterSessionCloseout)(ctx, {
+      actorStaffProfileId: "staff-1",
+      registerSessionId: "session-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "closed",
+        registerSession: closedSession,
+      },
+    });
+    expect(ctx.db.get).not.toHaveBeenCalledWith("approvalProof", expect.anything());
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        closedByStaffProfileId: "staff-1",
+        closedByUserId: "manager-user-1",
+        countedCash: 30000,
+        registerSessionId: "session-1",
+      }),
+    );
+  });
+
+  it("rejects exact-match finalization when the staff actor belongs to another user", async () => {
+    const runMutation = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string) => {
+          if (table === "store") {
+            return { _id: "store-1", currency: "GHS", organizationId: "org-1" };
+          }
+          if (table === "staffProfile") {
+            return {
+              _id: "manager-1",
+              linkedUserId: "other-user-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+          return null;
+        }),
+      },
+      runMutation,
+    };
+
+    const result = await getHandler(finalizeRegisterSessionCloseout)(ctx, {
+      actorStaffProfileId: "manager-1",
+      registerSessionId: "session-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "authorization_failed",
+        message: "Closeout staff actor does not match the signed-in user.",
+      },
+    });
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("rejects exact-match finalization when the signed-in staff actor is not a manager", async () => {
+    const registerSession = {
+      _id: "session-1",
+      countedCash: 30000,
+      expectedCash: 30000,
+      openedAt: 1,
+      organizationId: "org-1",
+      registerNumber: "A1",
+      status: "closing",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    };
+    const runMutation = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string) => {
+          if (table === "registerSession") return registerSession;
+          if (table === "store") {
+            return { _id: "store-1", currency: "GHS", organizationId: "org-1" };
+          }
+          if (table === "staffProfile") {
+            return {
+              _id: "staff-1",
+              linkedUserId: "manager-user-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+          return null;
+        }),
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({
+            collect: vi.fn(async () => []),
+            take: vi.fn(async () => []),
+          })),
+        })),
+      },
+      runMutation,
+      runQuery: vi.fn(async () => ({ _id: "store-1" })),
+    };
+
+    const result = await getHandler(finalizeRegisterSessionCloseout)(ctx, {
+      actorStaffProfileId: "staff-1",
+      registerSessionId: "session-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "authorization_failed",
+        message: "Only managers can finalize register closeouts.",
+      },
+    });
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("requires manager proof when finalizing a submitted variance closeout", async () => {
+    const registerSession = {
+      _id: "session-1",
+      countedCash: 20000,
+      expectedCash: 30000,
+      openedAt: 1,
+      organizationId: "org-1",
+      registerNumber: "A1",
+      status: "closing",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    };
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string) => {
+          if (table === "registerSession") return registerSession;
+          if (table === "store") {
+            return { _id: "store-1", currency: "GHS", organizationId: "org-1" };
+          }
+          if (table === "staffProfile") {
+            return {
+              _id: "manager-1",
+              linkedUserId: "manager-user-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+          return null;
+        }),
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({
+            collect: vi.fn(async () => []),
+          })),
+        })),
+      },
+      runMutation: vi.fn(),
+      runQuery: vi.fn(async () => ({ _id: "store-1" })),
+    };
+
+    const result = await getHandler(finalizeRegisterSessionCloseout)(ctx, {
+      actorStaffProfileId: "manager-1",
+      actorUserId: "user-1",
+      registerSessionId: "session-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toMatchObject({
+      kind: "approval_required",
+      approval: {
+        action: {
+          key: "cash_controls.register_session.review_variance",
+        },
+        requiredRole: "manager",
+      },
+    });
+  });
+
+  it("allows managers to finalize variance closeout after pending void approvals clear", async () => {
+    const registerSession = {
+      _id: "session-1",
+      countedCash: 20000,
+      expectedCash: 30000,
+      openedAt: 1,
+      organizationId: "org-1",
+      registerNumber: "A1",
+      status: "closing",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    };
+    const closedSession = {
+      ...registerSession,
+      closedAt: 100,
+      closedByStaffProfileId: "manager-1",
+      status: "closed",
+    };
+    const runMutation = vi.fn(async () => closedSession);
+    const insert = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string) => {
+          if (table === "registerSession") return registerSession;
+          if (table === "approvalProof") {
+            return {
+              _id: "proof-1",
+              actionKey: "cash_controls.register_session.review_variance",
+              approvedByStaffProfileId: "manager-1",
+              expiresAt: Date.now() + 60_000,
+              requestedByStaffProfileId: "manager-1",
+              requiredRole: "manager",
+              storeId: "store-1",
+              subjectId: "session-1",
+              subjectLabel: "A1",
+              subjectType: "register_session",
+            };
+          }
+          if (table === "store") {
+            return { _id: "store-1", currency: "GHS", organizationId: "org-1" };
+          }
+          if (table === "staffProfile") {
+            return {
+              _id: "manager-1",
+              linkedUserId: "manager-user-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+          return null;
+        }),
+        insert,
+        patch: vi.fn(),
+        query: vi.fn((table: string) => ({
+          withIndex: vi.fn(() => ({
+            collect: vi.fn(async () => []),
+            take: vi.fn(async () =>
+              table === "staffRoleAssignment"
+                ? [
+                    {
+                      organizationId: "org-1",
+                      role: "manager",
+                      status: "active",
+                      storeId: "store-1",
+                    },
+                  ]
+                : [],
+            ),
+          })),
+        })),
+      },
+      runMutation,
+      runQuery: vi.fn(async () => ({ _id: "store-1" })),
+    };
+
+    const result = await getHandler(finalizeRegisterSessionCloseout)(ctx, {
+      actorStaffProfileId: "manager-1",
+      actorUserId: "user-1",
+      approvalProofId: "proof-1",
+      registerSessionId: "session-1",
+      requestedByStaffProfileId: "manager-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "closed",
+        registerSession: closedSession,
+      },
+    });
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        closedByStaffProfileId: "manager-1",
+        countedCash: 20000,
+        registerSessionId: "session-1",
+      }),
+    );
+    expect(ctx.db.patch).toHaveBeenCalledWith("approvalProof", "proof-1", {
+      consumedAt: expect.any(Number),
+    });
+  });
+
+  it("keeps variance approval approved but unclosed while void approvals are pending", async () => {
+    const registerSession = {
+      _id: "session-1",
+      countedCash: 20000,
+      expectedCash: 30000,
+      managerApprovalRequestId: "approval-1",
+      openedAt: 1,
+      organizationId: "org-1",
+      registerNumber: "A1",
+      status: "closing",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      variance: -10000,
+    };
+    const approvalRequest = {
+      _id: "approval-1",
+      registerSessionId: "session-1",
+      requestType: "variance_review",
+      status: "pending",
+      storeId: "store-1",
+      subjectId: "session-1",
+      subjectType: "register_session",
+    };
+    const reviewedApprovalRequest = {
+      ...approvalRequest,
+      status: "approved",
+    };
+    const runMutation = vi.fn(async () => reviewedApprovalRequest);
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string) => {
+          if (table === "registerSession") return registerSession;
+          if (table === "approvalRequest") return approvalRequest;
+          if (table === "approvalProof") {
+            return {
+              _id: "proof-1",
+              actionKey: "cash_controls.register_session.review_variance",
+              approvedByStaffProfileId: "manager-1",
+              expiresAt: Date.now() + 60_000,
+              requiredRole: "manager",
+              storeId: "store-1",
+              subjectId: "session-1",
+              subjectLabel: "A1",
+              subjectType: "register_session",
+            };
+          }
+          if (table === "store") {
+            return { _id: "store-1", currency: "GHS", organizationId: "org-1" };
+          }
+          if (table === "staffProfile") {
+            return {
+              _id: "manager-1",
+              linkedUserId: "manager-user-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+          return null;
+        }),
+        insert: vi.fn(),
+        patch: vi.fn(),
+        query: vi.fn((table: string) => ({
+          withIndex: vi.fn(() => ({
+            collect: vi.fn(async () =>
+              table === "approvalRequest"
+                ? [
+                    {
+                      _id: "void-approval-1",
+                      registerSessionId: "session-1",
+                      requestType: "pos_transaction_void",
+                      status: "pending",
+                      storeId: "store-1",
+                      subjectType: "pos_transaction",
+                    },
+                  ]
+                : [],
+            ),
+            take: vi.fn(async () =>
+              table === "staffRoleAssignment"
+                ? [
+                    {
+                      organizationId: "org-1",
+                      role: "manager",
+                      status: "active",
+                      storeId: "store-1",
+                    },
+                  ]
+                : [],
+            ),
+          })),
+        })),
+      },
+      runMutation,
+    };
+
+    const result = await getHandler(reviewRegisterSessionCloseout)(ctx, {
+      approvalProofId: "proof-1",
+      decision: "approved",
+      registerSessionId: "session-1",
+      reviewedByUserId: "manager-user-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "approved",
+        approvalRequest: reviewedApprovalRequest,
+        registerSession,
+      },
+    });
+    expect(runMutation).toHaveBeenCalledTimes(1);
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        approvalRequestId: "approval-1",
+        decision: "approved",
+      }),
+    );
   });
 
   it("requires manager approval for same opening float corrections", async () => {

--- a/packages/athena-webapp/convex/cashControls/closeouts.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.ts
@@ -16,6 +16,10 @@ import {
 import { recordRegisterSessionTraceBestEffort } from "../operations/registerSessionTracing";
 import { commandResultValidator } from "../lib/commandResultValidators";
 import { toDisplayAmount } from "../lib/currency";
+import {
+  requireAuthenticatedAthenaUserWithCtx,
+  requireOrganizationMemberRoleWithCtx,
+} from "../lib/athenaUserAuth";
 import { currencyFormatter } from "../utils";
 import {
   approvalRequired,
@@ -134,12 +138,27 @@ type SubmitRegisterSessionCloseoutArgs = {
   storeId: Id<"store">;
 };
 
+type FinalizeRegisterSessionCloseoutArgs = {
+  actorStaffProfileId?: Id<"staffProfile">;
+  actorUserId?: Id<"athenaUser">;
+  approvalProofId?: Id<"approvalProof">;
+  registerSessionId: Id<"registerSession">;
+  requestedByStaffProfileId?: Id<"staffProfile">;
+  storeId: Id<"store">;
+};
+
 type SubmitRegisterSessionCloseoutResult =
-  {
-    action: "closed";
-    closeoutReview: RegisterSessionCloseoutReview;
-    registerSession: Doc<"registerSession"> | null;
-  };
+  | {
+      action: "closed";
+      closeoutReview: RegisterSessionCloseoutReview;
+      registerSession: Doc<"registerSession"> | null;
+    }
+  | {
+      action: "submitted";
+      closeoutReview: RegisterSessionCloseoutReview;
+      pendingVoidApprovalCount: number;
+      registerSession: Doc<"registerSession"> | null;
+    };
 
 type ReviewRegisterSessionCloseoutArgs = {
   approvalProofId: Id<"approvalProof">;
@@ -238,11 +257,19 @@ const closeoutReviewValidator = v.object({
 });
 
 const submitRegisterSessionCloseoutResultValidator = commandResultValidator(
-  v.object({
-    action: v.literal("closed"),
-    closeoutReview: closeoutReviewValidator,
-    registerSession: v.union(v.null(), v.any()),
-  }),
+  v.union(
+    v.object({
+      action: v.literal("closed"),
+      closeoutReview: closeoutReviewValidator,
+      registerSession: v.union(v.null(), v.any()),
+    }),
+    v.object({
+      action: v.literal("submitted"),
+      closeoutReview: closeoutReviewValidator,
+      pendingVoidApprovalCount: v.number(),
+      registerSession: v.union(v.null(), v.any()),
+    }),
+  ),
 );
 
 const reviewRegisterSessionCloseoutResultValidator = v.union(
@@ -470,6 +497,53 @@ export function buildRegisterSessionVarianceApprovalRequirement(args: {
   };
 }
 
+async function countPendingVoidApprovalsForRegisterSession(
+  ctx: Pick<MutationCtx, "db">,
+  args: {
+    registerSessionId: Id<"registerSession">;
+    storeId: Id<"store">;
+  },
+) {
+  if (typeof ctx.db.query !== "function") {
+    return 0;
+  }
+
+  const query = ctx.db
+    .query("approvalRequest")
+    .withIndex("by_registerSessionId", (q) =>
+      q.eq("registerSessionId", args.registerSessionId),
+    );
+
+  if (typeof query.collect !== "function") {
+    return 0;
+  }
+
+  const approvalRequests =
+    // eslint-disable-next-line @convex-dev/no-collect-in-query -- Register-session scoped pending void approvals are bounded by manager-review workflow volume and must be checked before final closure.
+    await query.collect();
+
+  return approvalRequests.filter(
+    (approvalRequest) =>
+      approvalRequest.storeId === args.storeId &&
+      approvalRequest.status === "pending" &&
+      approvalRequest.requestType === "pos_transaction_void" &&
+      approvalRequest.subjectType === "pos_transaction",
+  ).length;
+}
+
+function submittedCloseoutPendingVoidsResult(args: {
+  closeoutReview: RegisterSessionCloseoutReview;
+  pendingVoidApprovalCount: number;
+  registerSession: Doc<"registerSession"> | null;
+}): CommandResult<SubmitRegisterSessionCloseoutResult> {
+  return ok({
+    action: "submitted" as const,
+    closeoutReview: args.closeoutReview,
+    pendingVoidApprovalCount: args.pendingVoidApprovalCount,
+    registerSession: args.registerSession,
+  });
+}
+
 async function listRegisterSessionsForCloseout(
   ctx: Pick<QueryCtx, "db">,
   storeId: Id<"store">
@@ -552,6 +626,54 @@ async function staffProfileCanReviewCloseoutVariance(
   );
 }
 
+async function requireCashControlsStoreAccess(
+  ctx: QueryCtx | MutationCtx,
+  storeId: Id<"store">,
+) {
+  const store = await ctx.db.get("store", storeId);
+  if (!store) {
+    throw new Error("Store not found.");
+  }
+
+  const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
+  await requireOrganizationMemberRoleWithCtx(ctx, {
+    allowedRoles: ["full_admin", "pos_only"],
+    failureMessage: "You do not have access to cash controls.",
+    organizationId: store.organizationId,
+    userId: athenaUser._id,
+  });
+
+  return { athenaUser, store };
+}
+
+async function resolveCloseoutActorStaffProfileId(
+  ctx: Pick<MutationCtx, "db">,
+  args: {
+    athenaUserId: Id<"athenaUser">;
+    staffProfileId?: Id<"staffProfile">;
+    storeId: Id<"store">;
+  },
+): Promise<CommandResult<Id<"staffProfile"> | undefined>> {
+  if (!args.staffProfileId) {
+    return ok(undefined);
+  }
+
+  const staffProfile = await ctx.db.get("staffProfile", args.staffProfileId);
+  if (
+    !staffProfile ||
+    staffProfile.storeId !== args.storeId ||
+    staffProfile.status !== "active" ||
+    staffProfile.linkedUserId !== args.athenaUserId
+  ) {
+    return userError({
+      code: "authorization_failed",
+      message: "Closeout staff actor does not match the signed-in user.",
+    });
+  }
+
+  return ok(staffProfile._id);
+}
+
 async function cancelPendingApprovalIfNeeded(args: {
   ctx: Pick<MutationCtx, "db" | "runMutation">;
   approvalRequestId?: Id<"approvalRequest">;
@@ -590,10 +712,8 @@ export const getCloseoutSnapshot = query({
     ctx: QueryCtx,
     args: { storeId: Id<"store"> }
   ): Promise<CloseoutSnapshot> => {
-    const [registerSessions, store] = await Promise.all([
-      listRegisterSessionsForCloseout(ctx, args.storeId),
-      ctx.runQuery(internal.inventory.stores.findById, { id: args.storeId }),
-    ]);
+    const { store } = await requireCashControlsStoreAccess(ctx, args.storeId);
+    const registerSessions = await listRegisterSessionsForCloseout(ctx, args.storeId);
     const config = getCashControlsConfig(store);
     const approvalRequestIds = Array.from(
       new Set(
@@ -705,10 +825,21 @@ export const submitRegisterSessionCloseout = mutation({
       });
     }
 
-    const [registerSession, store] = await Promise.all([
-      ctx.db.get("registerSession", args.registerSessionId),
-      ctx.runQuery(internal.inventory.stores.findById, { id: args.storeId }),
-    ]);
+    const { athenaUser, store } = await requireCashControlsStoreAccess(
+      ctx,
+      args.storeId,
+    );
+    const actorUserId = athenaUser._id;
+    const submitActorStaffProfileResult = await resolveCloseoutActorStaffProfileId(ctx, {
+      athenaUserId: athenaUser._id,
+      staffProfileId: args.actorStaffProfileId ?? args.requestedByStaffProfileId,
+      storeId: args.storeId,
+    });
+    if (submitActorStaffProfileResult.kind !== "ok") {
+      return submitActorStaffProfileResult;
+    }
+    const submitActorStaffProfileId = submitActorStaffProfileResult.data;
+    const registerSession = await ctx.db.get("registerSession", args.registerSessionId);
 
     if (!registerSession || registerSession.storeId !== args.storeId) {
       return userError({
@@ -737,8 +868,21 @@ export const submitRegisterSessionCloseout = mutation({
       config,
       expectedCash: registerSession.expectedCash,
     });
+    const pendingVoidApprovalCount =
+      await countPendingVoidApprovalsForRegisterSession(ctx, {
+        registerSessionId: registerSession._id,
+        storeId: args.storeId,
+      });
+
+    if (pendingVoidApprovalCount > 0 && args.approvalProofId) {
+      return userError({
+        code: "precondition_failed",
+        message:
+          "Resolve pending void approvals before approving final closeout.",
+      });
+    }
     const latestReopenedCloseout = getLatestReopenedCloseoutRecord(registerSession);
-    let closeoutSubmitActorStaffProfileId = args.actorStaffProfileId;
+    let closeoutSubmitActorStaffProfileId = submitActorStaffProfileId;
     let approvedByStaffProfileId: Id<"staffProfile"> | undefined;
 
     if (latestReopenedCloseout) {
@@ -758,7 +902,7 @@ export const submitRegisterSessionCloseout = mutation({
         action: REGISTER_CLOSEOUT_MODIFICATION_SUBMIT_ACTION,
         approvalProofId: args.closeoutModificationApprovalProofId,
         requiredRole: "manager",
-        requestedByStaffProfileId: args.requestedByStaffProfileId,
+        requestedByStaffProfileId: closeoutSubmitActorStaffProfileId,
         storeId: args.storeId,
         subject: {
           type: "register_session",
@@ -786,7 +930,11 @@ export const submitRegisterSessionCloseout = mutation({
       approvedByStaffProfileId = proof.data.approvedByStaffProfileId;
     }
 
-    if (closeoutReview.requiresApproval && args.approvalProofId) {
+    if (
+      closeoutReview.requiresApproval &&
+      args.approvalProofId &&
+      pendingVoidApprovalCount === 0
+    ) {
       if (!registerSession.organizationId) {
         return userError({
           code: "precondition_failed",
@@ -830,6 +978,7 @@ export const submitRegisterSessionCloseout = mutation({
     if (
       closeoutReview.requiresApproval &&
       !args.approvalProofId &&
+      pendingVoidApprovalCount === 0 &&
       closeoutSubmitActorStaffProfileId &&
       !approvedByStaffProfileId &&
       registerSession.organizationId
@@ -878,7 +1027,7 @@ export const submitRegisterSessionCloseout = mutation({
           } as typeof registerSession),
         occurredAt: closeoutSubmittedAt,
         actorStaffProfileId: closeoutSubmitActorStaffProfileId,
-        actorUserId: args.actorUserId,
+        actorUserId,
         countedCash: args.countedCash,
         variance: closeoutReview.variance,
       },
@@ -891,12 +1040,20 @@ export const submitRegisterSessionCloseout = mutation({
       workflowTraceId: registerSession.workflowTraceId,
     });
 
+    if (pendingVoidApprovalCount > 0) {
+      return submittedCloseoutPendingVoidsResult({
+        closeoutReview,
+        pendingVoidApprovalCount,
+        registerSession: closingSession ?? (await ctx.db.get("registerSession", registerSession._id)),
+      });
+    }
+
     if (closeoutReview.requiresApproval) {
       await cancelPendingApprovalIfNeeded({
         approvalRequestId: registerSession.managerApprovalRequestId,
         ctx,
         reviewedByStaffProfileId: closeoutSubmitActorStaffProfileId,
-        reviewedByUserId: args.actorUserId,
+        reviewedByUserId: actorUserId,
       });
 
       if (approvedByStaffProfileId) {
@@ -904,7 +1061,7 @@ export const submitRegisterSessionCloseout = mutation({
           internal.operations.registerSessions.closeRegisterSession,
           {
             closedByStaffProfileId: approvedByStaffProfileId,
-            closedByUserId: args.actorUserId,
+            closedByUserId: actorUserId,
             countedCash: args.countedCash,
             registerSessionId: args.registerSessionId,
           }
@@ -912,7 +1069,7 @@ export const submitRegisterSessionCloseout = mutation({
 
         await recordOperationalEventWithCtx(ctx, {
           actorStaffProfileId: approvedByStaffProfileId,
-          actorUserId: args.actorUserId,
+          actorUserId,
           eventType: "register_session_closeout_approved",
           message: "Manager approved the register closeout.",
           metadata: {
@@ -943,7 +1100,7 @@ export const submitRegisterSessionCloseout = mutation({
           session: closedSession ?? registerSession,
           occurredAt: closedSession?.closedAt,
           actorStaffProfileId: approvedByStaffProfileId,
-          actorUserId: args.actorUserId,
+          actorUserId,
           countedCash: args.countedCash,
           variance: closeoutReview.variance,
         });
@@ -960,7 +1117,7 @@ export const submitRegisterSessionCloseout = mutation({
           session: closedSession ?? registerSession,
           occurredAt: closedSession?.closedAt,
           actorStaffProfileId: approvedByStaffProfileId,
-          actorUserId: args.actorUserId,
+          actorUserId,
           countedCash: args.countedCash,
           variance: closeoutReview.variance,
         });
@@ -993,7 +1150,7 @@ export const submitRegisterSessionCloseout = mutation({
           registerSessionId: registerSession._id,
           requestType: "variance_review",
           requestedByStaffProfileId: closeoutSubmitActorStaffProfileId,
-          requestedByUserId: args.actorUserId,
+          requestedByUserId: actorUserId,
           storeId: args.storeId,
           subjectId: registerSession._id,
           subjectType: "register_session",
@@ -1012,11 +1169,10 @@ export const submitRegisterSessionCloseout = mutation({
       await ctx.db.patch("registerSession", registerSession._id, {
         managerApprovalRequestId: approvalRequestId,
       });
-      const store = await ctx.db.get("store", args.storeId);
 
       await recordOperationalEventWithCtx(ctx, {
         actorStaffProfileId: closeoutSubmitActorStaffProfileId,
-        actorUserId: args.actorUserId,
+        actorUserId,
         approvalRequestId,
         eventType: "register_session_variance_review_requested",
         message: buildRegisterCloseoutVarianceTimelineMessage({
@@ -1061,7 +1217,7 @@ export const submitRegisterSessionCloseout = mutation({
             } as typeof registerSession),
           occurredAt: approvalPendingAt,
           actorStaffProfileId: closeoutSubmitActorStaffProfileId,
-          actorUserId: args.actorUserId,
+          actorUserId,
           approvalRequestId,
           countedCash: args.countedCash,
           variance: closeoutReview.variance,
@@ -1082,14 +1238,14 @@ export const submitRegisterSessionCloseout = mutation({
       approvalRequestId: registerSession.managerApprovalRequestId,
       ctx,
       reviewedByStaffProfileId: closeoutSubmitActorStaffProfileId,
-      reviewedByUserId: args.actorUserId,
+      reviewedByUserId: actorUserId,
     });
 
     const closedSession = await ctx.runMutation(
       internal.operations.registerSessions.closeRegisterSession,
       {
         closedByStaffProfileId: closeoutSubmitActorStaffProfileId,
-        closedByUserId: args.actorUserId,
+        closedByUserId: actorUserId,
         countedCash: args.countedCash,
         registerSessionId: args.registerSessionId,
       }
@@ -1097,7 +1253,7 @@ export const submitRegisterSessionCloseout = mutation({
 
     await recordOperationalEventWithCtx(ctx, {
       actorStaffProfileId: closeoutSubmitActorStaffProfileId,
-      actorUserId: args.actorUserId,
+      actorUserId,
       eventType: "register_session_closed",
       message: closeoutReview.hasVariance
         ? `Register session closed with a variance of ${closeoutReview.variance}.`
@@ -1121,8 +1277,239 @@ export const submitRegisterSessionCloseout = mutation({
       session: closedSession ?? registerSession,
       occurredAt: closedSession?.closedAt,
       actorStaffProfileId: closeoutSubmitActorStaffProfileId,
-      actorUserId: args.actorUserId,
+      actorUserId,
       countedCash: args.countedCash,
+      variance: closeoutReview.variance,
+    });
+
+    await persistRegisterSessionWorkflowTraceIdBestEffort(ctx, {
+      registerSessionId: registerSession._id,
+      traceCreated: closedTraceResult.traceCreated,
+      traceId: closedTraceResult.traceId,
+      workflowTraceId: closedSession?.workflowTraceId,
+    });
+
+    return ok({
+      action: "closed" as const,
+      closeoutReview,
+      registerSession: closedSession,
+    });
+  },
+});
+
+export const finalizeRegisterSessionCloseout = mutation({
+  args: {
+    actorStaffProfileId: v.optional(v.id("staffProfile")),
+    actorUserId: v.optional(v.id("athenaUser")),
+    approvalProofId: v.optional(v.id("approvalProof")),
+    registerSessionId: v.id("registerSession"),
+    requestedByStaffProfileId: v.optional(v.id("staffProfile")),
+    storeId: v.id("store"),
+  },
+  returns: submitRegisterSessionCloseoutResultValidator,
+  handler: async (
+    ctx: MutationCtx,
+    args: FinalizeRegisterSessionCloseoutArgs,
+  ): Promise<ApprovalCommandResult<SubmitRegisterSessionCloseoutResult>> => {
+    const { athenaUser, store } = await requireCashControlsStoreAccess(
+      ctx,
+      args.storeId,
+    );
+    const actorUserId = athenaUser._id;
+    const requestedByStaffProfileResult =
+      await resolveCloseoutActorStaffProfileId(ctx, {
+        athenaUserId: athenaUser._id,
+        staffProfileId: args.requestedByStaffProfileId ?? args.actorStaffProfileId,
+        storeId: args.storeId,
+      });
+    if (requestedByStaffProfileResult.kind !== "ok") {
+      return requestedByStaffProfileResult;
+    }
+    const requestedByStaffProfileId = requestedByStaffProfileResult.data;
+    const registerSession = await ctx.db.get("registerSession", args.registerSessionId);
+
+    if (!registerSession || registerSession.storeId !== args.storeId) {
+      return userError({
+        code: "not_found",
+        message: "Register session not found for this store.",
+      });
+    }
+
+    if (registerSession.status === "closed") {
+      return userError({
+        code: "precondition_failed",
+        message: "Register session is already closed.",
+      });
+    }
+
+    if (registerSession.status !== "closing") {
+      return userError({
+        code: "precondition_failed",
+        message: "Register session is not in closeout.",
+      });
+    }
+
+    if (registerSession.countedCash === undefined) {
+      return userError({
+        code: "precondition_failed",
+        message: "Counted cash is required before finalizing closeout.",
+      });
+    }
+
+    const pendingVoidApprovalCount =
+      await countPendingVoidApprovalsForRegisterSession(ctx, {
+        registerSessionId: registerSession._id,
+        storeId: args.storeId,
+      });
+
+    if (pendingVoidApprovalCount > 0) {
+      return userError({
+        code: "precondition_failed",
+        message: "Resolve pending void approvals before finalizing closeout.",
+      });
+    }
+
+    const closeoutReview = buildRegisterSessionCloseoutReview({
+      countedCash: registerSession.countedCash,
+      config: getCashControlsConfig(store),
+      expectedCash: registerSession.expectedCash,
+    });
+
+    if (!registerSession.organizationId) {
+      return userError({
+        code: "precondition_failed",
+        message: "Register session is missing organization context.",
+      });
+    }
+
+    let closedByStaffProfileId = requestedByStaffProfileId;
+
+    if (!closeoutReview.requiresApproval) {
+      if (!requestedByStaffProfileId) {
+        return userError({
+          code: "authorization_failed",
+          message: "Manager staff authentication is required to finalize closeout.",
+        });
+      }
+
+      const canFinalize = await staffProfileCanReviewCloseoutVariance(ctx, {
+        organizationId: registerSession.organizationId,
+        staffProfileId: requestedByStaffProfileId,
+        storeId: args.storeId,
+      });
+
+      if (!canFinalize) {
+        return userError({
+          code: "authorization_failed",
+          message: "Only managers can finalize register closeouts.",
+        });
+      }
+    }
+
+    if (closeoutReview.requiresApproval && !args.approvalProofId) {
+      return approvalRequired(
+        buildRegisterSessionVarianceApprovalRequirement({
+          closeoutReview,
+          countedCash: registerSession.countedCash,
+          expectedCash: registerSession.expectedCash,
+          registerSession,
+        }),
+      );
+    }
+
+    if (closeoutReview.requiresApproval) {
+      const approvalProofId = args.approvalProofId;
+
+      if (!approvalProofId) {
+        return approvalRequired(
+          buildRegisterSessionVarianceApprovalRequirement({
+            closeoutReview,
+            countedCash: registerSession.countedCash,
+            expectedCash: registerSession.expectedCash,
+            registerSession,
+          }),
+        );
+      }
+
+      const proof = await consumeCommandApprovalProofWithCtx(ctx, {
+        action: REGISTER_VARIANCE_REVIEW_ACTION,
+        approvalProofId,
+        requiredRole: "manager",
+        requestedByStaffProfileId,
+        storeId: args.storeId,
+        subject: {
+          type: "register_session",
+          id: registerSession._id,
+          label: registerSession.registerNumber,
+        },
+      });
+
+      if (proof.kind !== "ok") {
+        return proof;
+      }
+
+      const canFinalize = await staffProfileCanReviewCloseoutVariance(ctx, {
+        organizationId: registerSession.organizationId,
+        staffProfileId: proof.data.approvedByStaffProfileId,
+        storeId: args.storeId,
+      });
+
+      if (!canFinalize) {
+        return userError({
+          code: "authorization_failed",
+          message: "Only managers can finalize register closeouts.",
+        });
+      }
+
+      closedByStaffProfileId = proof.data.approvedByStaffProfileId;
+    }
+
+    await cancelPendingApprovalIfNeeded({
+      approvalRequestId: registerSession.managerApprovalRequestId,
+      ctx,
+      reviewedByStaffProfileId: closedByStaffProfileId,
+      reviewedByUserId: actorUserId,
+      decisionNotes: "Finalized after pending void approvals were resolved.",
+    });
+
+    const closedSession = await ctx.runMutation(
+      internal.operations.registerSessions.closeRegisterSession,
+      {
+        closedByStaffProfileId,
+        closedByUserId: actorUserId,
+        countedCash: registerSession.countedCash,
+        registerSessionId: registerSession._id,
+      },
+    );
+
+    await recordOperationalEventWithCtx(ctx, {
+      actorStaffProfileId: closedByStaffProfileId,
+      actorUserId,
+      eventType: "register_session_closed",
+      message: closeoutReview.hasVariance
+        ? `Register session closed with a variance of ${closeoutReview.variance}.`
+        : "Register session closed with an exact cash match.",
+      metadata: {
+        countedCash: registerSession.countedCash,
+        expectedCash: registerSession.expectedCash,
+        variance: closeoutReview.variance,
+      },
+      organizationId: registerSession.organizationId,
+      reason: closeoutReview.reason,
+      registerSessionId: registerSession._id,
+      storeId: args.storeId,
+      subjectId: registerSession._id,
+      subjectLabel: registerSession.registerNumber,
+      subjectType: "register_session",
+    });
+
+    const closedTraceResult = await recordRegisterSessionTraceBestEffort(ctx, {
+      stage: "closed",
+      session: closedSession ?? registerSession,
+      occurredAt: closedSession?.closedAt,
+      actorStaffProfileId: closedByStaffProfileId,
+      actorUserId,
+      countedCash: registerSession.countedCash,
       variance: closeoutReview.variance,
     });
 
@@ -1155,6 +1542,17 @@ export const reopenRegisterSessionCloseout = mutation({
     ctx: MutationCtx,
     args: ReopenRegisterSessionCloseoutArgs
   ): Promise<CommandResult<ReopenRegisterSessionResult>> => {
+    const { athenaUser } = await requireCashControlsStoreAccess(ctx, args.storeId);
+    const actorUserId = athenaUser._id;
+    const actorStaffProfileResult = await resolveCloseoutActorStaffProfileId(ctx, {
+      athenaUserId: athenaUser._id,
+      staffProfileId: args.actorStaffProfileId ?? args.requestedByStaffProfileId,
+      storeId: args.storeId,
+    });
+    if (actorStaffProfileResult.kind !== "ok") {
+      return actorStaffProfileResult;
+    }
+    const actorStaffProfileId = actorStaffProfileResult.data;
     const registerSession = await ctx.db.get("registerSession", args.registerSessionId);
 
     if (!registerSession || registerSession.storeId !== args.storeId) {
@@ -1176,7 +1574,7 @@ export const reopenRegisterSessionCloseout = mutation({
         action: REGISTER_CLOSEOUT_REOPEN_ACTION,
         approvalProofId: args.approvalProofId,
         requiredRole: "manager",
-        requestedByStaffProfileId: args.requestedByStaffProfileId,
+        requestedByStaffProfileId: actorStaffProfileId,
         storeId: args.storeId,
         subject: {
           type: "register_session",
@@ -1212,7 +1610,7 @@ export const reopenRegisterSessionCloseout = mutation({
         ctx,
         {
           actorStaffProfileId: proof.data.approvedByStaffProfileId,
-          actorUserId: args.actorUserId,
+          actorUserId,
           registerSessionId: args.registerSessionId,
           reason: "Correction needed after manager rejection.",
         },
@@ -1221,7 +1619,7 @@ export const reopenRegisterSessionCloseout = mutation({
 
       await recordOperationalEventWithCtx(ctx, {
         actorStaffProfileId: proof.data.approvedByStaffProfileId,
-        actorUserId: args.actorUserId,
+        actorUserId,
         eventType: "register_session_closeout_reopened",
         message: "Rejected register closeout reopened for correction.",
         metadata: previousCloseout,
@@ -1242,7 +1640,7 @@ export const reopenRegisterSessionCloseout = mutation({
         },
         occurredAt: reopenedAt,
         actorStaffProfileId: proof.data.approvedByStaffProfileId,
-        actorUserId: args.actorUserId,
+        actorUserId,
         countedCash: registerSession.countedCash,
         reason: "Correction needed after manager rejection.",
         variance: registerSession.variance,
@@ -1281,7 +1679,7 @@ export const reopenRegisterSessionCloseout = mutation({
         action: REGISTER_CLOSEOUT_REOPEN_ACTION,
         approvalProofId: args.approvalProofId,
         requiredRole: "manager",
-        requestedByStaffProfileId: args.requestedByStaffProfileId,
+        requestedByStaffProfileId: actorStaffProfileId,
         storeId: args.storeId,
         subject: {
           type: "register_session",
@@ -1319,7 +1717,7 @@ export const reopenRegisterSessionCloseout = mutation({
         internal.operations.registerSessions.reopenClosedRegisterSessionCloseout,
         {
           actorStaffProfileId: proof.data.approvedByStaffProfileId,
-          actorUserId: args.actorUserId,
+          actorUserId,
           reason: "Closed register closeout reopened for correction.",
           registerSessionId: args.registerSessionId,
         }
@@ -1328,7 +1726,7 @@ export const reopenRegisterSessionCloseout = mutation({
 
       await recordOperationalEventWithCtx(ctx, {
         actorStaffProfileId: proof.data.approvedByStaffProfileId,
-        actorUserId: args.actorUserId,
+        actorUserId,
         eventType: "register_session_closeout_reopened",
         message: "Closed register closeout reopened for correction.",
         metadata: previousCloseout,
@@ -1349,7 +1747,7 @@ export const reopenRegisterSessionCloseout = mutation({
         },
         occurredAt: reopenedAt,
         actorStaffProfileId: proof.data.approvedByStaffProfileId,
-        actorUserId: args.actorUserId,
+        actorUserId,
         countedCash: registerSession.countedCash,
         reason: "Correction needed after closeout was saved.",
         variance: registerSession.variance,
@@ -1373,8 +1771,8 @@ export const reopenRegisterSessionCloseout = mutation({
       approvalRequestId: registerSession.managerApprovalRequestId,
       ctx,
       decisionNotes: "Register closeout reopened from POS.",
-      reviewedByStaffProfileId: args.actorStaffProfileId,
-      reviewedByUserId: args.actorUserId,
+      reviewedByStaffProfileId: actorStaffProfileId,
+      reviewedByUserId: actorUserId,
     });
 
     const reopenedSession = await ctx.runMutation(
@@ -1385,8 +1783,8 @@ export const reopenRegisterSessionCloseout = mutation({
     );
 
     await recordOperationalEventWithCtx(ctx, {
-      actorStaffProfileId: args.actorStaffProfileId,
-      actorUserId: args.actorUserId,
+      actorStaffProfileId,
+      actorUserId,
       eventType: "register_session_closeout_reopened",
       message: "Register closeout reopened from POS.",
       organizationId: registerSession.organizationId,
@@ -1436,6 +1834,18 @@ export const correctRegisterSessionOpeningFloat = mutation({
       });
     }
 
+    const { athenaUser } = await requireCashControlsStoreAccess(ctx, args.storeId);
+    const actorUserId = athenaUser._id;
+    const actorStaffProfileResult = await resolveCloseoutActorStaffProfileId(ctx, {
+      athenaUserId: athenaUser._id,
+      staffProfileId: args.actorStaffProfileId,
+      storeId: args.storeId,
+    });
+    if (actorStaffProfileResult.kind !== "ok") {
+      return actorStaffProfileResult;
+    }
+    const actorStaffProfileId = actorStaffProfileResult.data;
+
     const registerSession = await ctx.db.get(
       "registerSession",
       args.registerSessionId
@@ -1472,7 +1882,7 @@ export const correctRegisterSessionOpeningFloat = mutation({
       action: REGISTER_OPENING_FLOAT_CORRECTION_ACTION,
       approvalProofId: args.approvalProofId,
       requiredRole: "manager",
-      requestedByStaffProfileId: args.actorStaffProfileId,
+      requestedByStaffProfileId: actorStaffProfileId,
       storeId: args.storeId,
       subject: {
         type: "register_session",
@@ -1505,7 +1915,7 @@ export const correctRegisterSessionOpeningFloat = mutation({
 
     await recordOperationalEventWithCtx(ctx, {
       actorStaffProfileId: approvalProof.data.approvedByStaffProfileId,
-      actorUserId: args.actorUserId,
+      actorUserId,
       eventType: "register_session_opening_float_corrected",
       message: "Register session opening float corrected.",
       metadata: {
@@ -1535,7 +1945,7 @@ export const correctRegisterSessionOpeningFloat = mutation({
       },
       occurredAt: correctionOccurredAt,
       actorStaffProfileId: approvalProof.data.approvedByStaffProfileId,
-      actorUserId: args.actorUserId,
+      actorUserId,
       correctedOpeningFloat: args.correctedOpeningFloat,
       previousOpeningFloat,
       reason,
@@ -1571,6 +1981,8 @@ export const reviewRegisterSessionCloseout = mutation({
     ctx: MutationCtx,
     args: ReviewRegisterSessionCloseoutArgs
   ): Promise<CommandResult<ReviewRegisterSessionCloseoutResult>> => {
+    const { athenaUser } = await requireCashControlsStoreAccess(ctx, args.storeId);
+    const reviewedByUserId = athenaUser._id;
     const registerSession = await ctx.db.get("registerSession", args.registerSessionId);
 
     if (!registerSession || registerSession.storeId !== args.storeId) {
@@ -1651,7 +2063,7 @@ export const reviewRegisterSessionCloseout = mutation({
         decision: args.decision,
         decisionNotes: trimOptional(args.decisionNotes),
         reviewedByStaffProfileId,
-        reviewedByUserId: args.reviewedByUserId,
+        reviewedByUserId,
       }
     );
 
@@ -1663,11 +2075,25 @@ export const reviewRegisterSessionCloseout = mutation({
         });
       }
 
+      const pendingVoidApprovalCount =
+        await countPendingVoidApprovalsForRegisterSession(ctx, {
+          registerSessionId: registerSession._id,
+          storeId: args.storeId,
+        });
+
+      if (pendingVoidApprovalCount > 0) {
+        return ok({
+          action: "approved" as const,
+          approvalRequest: reviewedApprovalRequest,
+          registerSession,
+        });
+      }
+
       const closedSession = await ctx.runMutation(
         internal.operations.registerSessions.closeRegisterSession,
         {
           closedByStaffProfileId: reviewedByStaffProfileId,
-          closedByUserId: args.reviewedByUserId,
+          closedByUserId: reviewedByUserId,
           countedCash: registerSession.countedCash,
           registerSessionId: registerSession._id,
         }
@@ -1675,7 +2101,7 @@ export const reviewRegisterSessionCloseout = mutation({
 
       await recordOperationalEventWithCtx(ctx, {
         actorStaffProfileId: reviewedByStaffProfileId,
-        actorUserId: args.reviewedByUserId,
+        actorUserId: reviewedByUserId,
         approvalRequestId: approvalRequest._id,
         eventType: "register_session_closeout_approved",
         message: "Manager approved the register closeout.",
@@ -1701,7 +2127,7 @@ export const reviewRegisterSessionCloseout = mutation({
         session: closedSession ?? registerSession,
         occurredAt: closedSession?.closedAt,
         actorStaffProfileId: reviewedByStaffProfileId,
-        actorUserId: args.reviewedByUserId,
+        actorUserId: reviewedByUserId,
         approvalRequestId: approvalRequest._id,
         countedCash: registerSession.countedCash,
         variance: registerSession.variance,
@@ -1719,7 +2145,7 @@ export const reviewRegisterSessionCloseout = mutation({
         session: closedSession ?? registerSession,
         occurredAt: closedSession?.closedAt,
         actorStaffProfileId: reviewedByStaffProfileId,
-        actorUserId: args.reviewedByUserId,
+        actorUserId: reviewedByUserId,
         countedCash: registerSession.countedCash,
         variance: registerSession.variance,
       });
@@ -1744,7 +2170,7 @@ export const reviewRegisterSessionCloseout = mutation({
 
     await recordOperationalEventWithCtx(ctx, {
       actorStaffProfileId: reviewedByStaffProfileId,
-      actorUserId: args.reviewedByUserId,
+      actorUserId: reviewedByUserId,
       approvalRequestId: approvalRequest._id,
       eventType: "register_session_closeout_rejected",
       message: "Manager rejected the register closeout for recount or correction.",
@@ -1771,7 +2197,7 @@ export const reviewRegisterSessionCloseout = mutation({
       session: rejectedSession ?? registerSession,
       occurredAt: rejectionOccurredAt,
       actorStaffProfileId: reviewedByStaffProfileId,
-      actorUserId: args.reviewedByUserId,
+      actorUserId: reviewedByUserId,
       approvalRequestId: approvalRequest._id,
       countedCash: registerSession.countedCash,
       variance: registerSession.variance,

--- a/packages/athena-webapp/convex/cashControls/deposits.test.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.test.ts
@@ -486,6 +486,30 @@ describe("cash control deposits", () => {
           registerSessionId: "session_closing" as Id<"registerSession">,
         },
       ],
+      pendingVoidApprovalsBySessionId: new Map([
+        [
+          "session_closing" as Id<"registerSession">,
+          {
+            count: 2,
+            items: [
+              {
+                approvalRequestId: "void_approval_1" as Id<"approvalRequest">,
+                requestedAt: 25,
+                transactionId: "txn_1",
+                transactionNumber: "POS-1001",
+                workItemId: "work_item_1" as Id<"operationalWorkItem">,
+              },
+              {
+                approvalRequestId: "void_approval_2" as Id<"approvalRequest">,
+                requestedAt: 26,
+                transactionId: "txn_2",
+                transactionNumber: "POS-1002",
+                workItemId: null,
+              },
+            ],
+          },
+        ],
+      ]),
       syncConflictsBySessionId: new Map([
         [
           "session_open" as Id<"registerSession">,
@@ -592,6 +616,19 @@ describe("cash control deposits", () => {
         _id: "approval_1",
         notes: "Counted twice before manager review.",
         status: "pending",
+      },
+      pendingVoidApprovals: {
+        count: 2,
+        items: [
+          expect.objectContaining({
+            approvalRequestId: "void_approval_1",
+            transactionNumber: "POS-1001",
+          }),
+          expect.objectContaining({
+            approvalRequestId: "void_approval_2",
+            transactionNumber: "POS-1002",
+          }),
+        ],
       },
       terminalName: "Back counter",
       totalDeposited: 500,
@@ -970,6 +1007,7 @@ describe("cash control deposits", () => {
       staffProfile: [
         {
           _id: "manager_1",
+          linkedUserId: "athena_user_1",
           organizationId: "org_1",
           status: "active",
           storeId: "store_1",
@@ -1061,6 +1099,88 @@ describe("cash control deposits", () => {
         }),
       ]),
     );
+  });
+
+  it("rejects synced register review when the manager actor belongs to another user", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_1",
+          conflictType: "permission",
+          createdAt: 1,
+          details: {},
+          localEventId: "event_1",
+          localRegisterSessionId: "local-register-1",
+          sequence: 1,
+          status: "needs_review",
+          storeId: "store_1",
+          summary: "Register was not open before this sale synced.",
+          terminalId: "terminal_1",
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_1",
+          eventType: "sale_completed",
+          localEventId: "event_1",
+          localRegisterSessionId: "local-register-1",
+          occurredAt: 2,
+          payload: {},
+          sequence: 1,
+          status: "conflicted",
+          storeId: "store_1",
+          submittedAt: 4,
+          terminalId: "terminal_1",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "manager_1",
+          linkedUserId: "athena_user_2",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      staffRoleAssignment: [
+        {
+          _id: "role_1",
+          organizationId: "org_1",
+          role: "manager",
+          staffProfileId: "manager_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+    });
+
+    const result = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual(
+      userError({
+        code: "authorization_failed",
+        message: "Only managers can resolve synced register reviews.",
+      }),
+    );
+    expect(ctx.tables.get("posLocalSyncConflict")).toEqual([
+      expect.objectContaining({
+        _id: "sync_conflict_1",
+        status: "needs_review",
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncEvent")).toEqual([
+      expect.objectContaining({
+        _id: "sync_event_1",
+        status: "conflicted",
+      }),
+    ]);
   });
 
   it("applies reviewed inventory sale activity without forcing a stock mutation", async () => {
@@ -1190,6 +1310,7 @@ describe("cash control deposits", () => {
       staffProfile: [
         {
           _id: "manager_1",
+          linkedUserId: "athena_user_1",
           organizationId: "org_1",
           status: "active",
           storeId: "store_1",
@@ -1445,6 +1566,7 @@ describe("cash control deposits", () => {
       staffProfile: [
         {
           _id: "manager_1",
+          linkedUserId: "athena_user_1",
           organizationId: "org_1",
           status: "active",
           storeId: "store_1",
@@ -1802,6 +1924,7 @@ describe("cash control deposits", () => {
       staffProfile: [
         {
           _id: "manager_1",
+          linkedUserId: "athena_user_1",
           organizationId: "org_1",
           status: "active",
           storeId: "store_1",
@@ -1955,6 +2078,7 @@ describe("cash control deposits", () => {
       staffProfile: [
         {
           _id: "manager_1",
+          linkedUserId: "athena_user_1",
           organizationId: "org_1",
           status: "active",
           storeId: "store_1",
@@ -2389,6 +2513,7 @@ describe("cash control deposits", () => {
       staffProfile: [
         {
           _id: "manager_1",
+          linkedUserId: "athena_user_1",
           organizationId: "org_1",
           status: "active",
           storeId: "store_1",
@@ -2586,6 +2711,7 @@ describe("cash control deposits", () => {
       staffProfile: [
         {
           _id: "manager_1",
+          linkedUserId: "athena_user_1",
           organizationId: "org_1",
           status: "active",
           storeId: "store_1",
@@ -2733,6 +2859,7 @@ describe("cash control deposits", () => {
       staffProfile: [
         {
           _id: "manager_1",
+          linkedUserId: "athena_user_1",
           organizationId: "org_1",
           status: "active",
           storeId: "store_1",
@@ -2854,6 +2981,7 @@ describe("cash control deposits", () => {
       staffProfile: [
         {
           _id: "manager_1",
+          linkedUserId: "athena_user_1",
           organizationId: "org_1",
           status: "active",
           storeId: "store_1",
@@ -3043,6 +3171,7 @@ describe("cash control deposits", () => {
       staffProfile: [
         {
           _id: "manager_1",
+          linkedUserId: "athena_user_1",
           organizationId: "org_1",
           status: "active",
           storeId: "store_1",
@@ -3239,6 +3368,7 @@ describe("cash control deposits", () => {
       staffProfile: [
         {
           _id: "manager_1",
+          linkedUserId: "athena_user_1",
           organizationId: "org_1",
           status: "active",
           storeId: "store_1",
@@ -3374,6 +3504,7 @@ describe("cash control deposits", () => {
       staffProfile: [
         {
           _id: "manager_1",
+          linkedUserId: "athena_user_1",
           organizationId: "org_1",
           status: "active",
           storeId: "store_1",
@@ -3505,6 +3636,7 @@ describe("cash control deposits", () => {
       staffProfile: [
         {
           _id: "manager_1",
+          linkedUserId: "athena_user_1",
           organizationId: "org_1",
           status: "active",
           storeId: "store_1",
@@ -3676,6 +3808,7 @@ describe("cash control deposits", () => {
       staffProfile: [
         {
           _id: "manager_1",
+          linkedUserId: "athena_user_1",
           organizationId: "org_1",
           status: "active",
           storeId: "store_1",
@@ -3792,6 +3925,7 @@ describe("cash control deposits", () => {
       staffProfile: [
         {
           _id: "manager_1",
+          linkedUserId: "athena_user_1",
           organizationId: "org_1",
           status: "active",
           storeId: "store_1",
@@ -4556,6 +4690,43 @@ describe("cash control deposits", () => {
         kind: "user_error",
       }),
     );
+  });
+
+  it("rejects new deposits while register-scoped void approvals are pending", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      approvalRequest: [
+        {
+          _id: "void_approval_1",
+          createdAt: 1,
+          organizationId: "org_1",
+          posTransactionId: "transaction_1",
+          registerSessionId: "session_open",
+          requestType: "pos_transaction_void",
+          status: "pending",
+          storeId: "store_1",
+          subjectId: "transaction_1",
+          subjectType: "pos_transaction",
+        },
+      ],
+    });
+
+    await expect(
+      getHandler(recordRegisterSessionDeposit)(ctx as never, {
+        actorStaffProfileId: "staff_1" as Id<"staffProfile">,
+        amount: 100,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        storeId: "store_1" as Id<"store">,
+        submissionKey: "deposit-1",
+      }),
+    ).resolves.toEqual({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Resolve pending void approvals before recording a deposit.",
+      },
+    });
+
+    expect(ctx.tables.get("paymentAllocation")).toEqual([]);
   });
 
   it("records register-session deposits with authenticated actor refs", async () => {

--- a/packages/athena-webapp/convex/cashControls/deposits.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.ts
@@ -120,6 +120,17 @@ type CashControlApprovalRequest = Pick<
   "_id" | "notes" | "reason" | "requestedByStaffProfileId" | "status"
 >;
 
+type CashControlPendingVoidApprovalSummary = {
+  count: number;
+  items: Array<{
+    approvalRequestId: Id<"approvalRequest">;
+    requestedAt: number;
+    transactionId: Id<"posTransaction"> | string;
+    transactionNumber?: string | null;
+    workItemId?: Id<"operationalWorkItem"> | null;
+  }>;
+};
+
 type CashControlDepositAllocation = Pick<
   Doc<"paymentAllocation">,
   | "_id"
@@ -446,6 +457,7 @@ export function buildRegisterSessionDepositTargetId(args: {
 
 function buildRegisterSessionSummary(args: {
   approvalRequest?: CashControlApprovalRequest | null;
+  pendingVoidApprovals?: CashControlPendingVoidApprovalSummary | null;
   registerSession: CashControlRegisterSession;
   staffNamesById: StaffNameMap;
   syncConflicts?: CashControlSyncConflict[];
@@ -479,6 +491,10 @@ function buildRegisterSessionSummary(args: {
           status: args.approvalRequest.status,
         }
       : null,
+    pendingVoidApprovals: args.pendingVoidApprovals ?? {
+      count: 0,
+      items: [],
+    },
     localSyncStatus: buildRegisterSessionLocalSyncStatus(syncConflicts, {
       staffNamesById: args.staffNamesById,
     }),
@@ -526,6 +542,10 @@ export function buildCashControlsDashboardSnapshot(args: {
     CashControlApprovalRequest
   >;
   deposits: CashControlDepositAllocation[];
+  pendingVoidApprovalsBySessionId?: Map<
+    Id<"registerSession">,
+    CashControlPendingVoidApprovalSummary
+  >;
   registerSessions: CashControlRegisterSession[];
   staffNamesById: StaffNameMap;
   syncConflictsBySessionId?: Map<
@@ -548,6 +568,9 @@ export function buildCashControlsDashboardSnapshot(args: {
       buildRegisterSessionSummary({
         approvalRequest:
           args.approvalRequestsBySessionId.get(registerSession._id) ?? null,
+        pendingVoidApprovals:
+          args.pendingVoidApprovalsBySessionId?.get(registerSession._id) ??
+          null,
         registerSession,
         staffNamesById: args.staffNamesById,
         syncConflicts:
@@ -713,6 +736,83 @@ async function listRegisterSessionTransactions(
   });
 }
 
+function buildPendingVoidApprovalSummary(
+  approvalRequests: Doc<"approvalRequest">[],
+): CashControlPendingVoidApprovalSummary {
+  const items = approvalRequests
+    .sort((left, right) => left.createdAt - right.createdAt)
+    .map((approvalRequest) => ({
+      approvalRequestId: approvalRequest._id,
+      requestedAt: approvalRequest.createdAt,
+      transactionId:
+        approvalRequest.posTransactionId ??
+        approvalRequest.subjectId ??
+        "",
+      transactionNumber:
+        typeof approvalRequest.metadata?.transactionNumber === "string"
+          ? approvalRequest.metadata.transactionNumber
+          : null,
+      workItemId: approvalRequest.workItemId ?? null,
+    }))
+    .filter((item) => item.transactionId);
+
+  return {
+    count: items.length,
+    items,
+  };
+}
+
+async function listPendingVoidApprovalsForRegisterSession(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  args: {
+    registerSessionId: Id<"registerSession">;
+    storeId: Id<"store">;
+  },
+) {
+  const approvalRequests =
+    // eslint-disable-next-line @convex-dev/no-collect-in-query -- Register-session scoped approval queues are bounded by manager-review workflow volume and must not be truncated by the store-wide pending approval limit.
+    await ctx.db
+      .query("approvalRequest")
+      .withIndex("by_registerSessionId", (q) =>
+        q.eq("registerSessionId", args.registerSessionId),
+      )
+      .collect();
+
+  return approvalRequests.filter(
+    (approvalRequest) =>
+      approvalRequest.storeId === args.storeId &&
+      approvalRequest.status === "pending" &&
+      approvalRequest.requestType === "pos_transaction_void" &&
+      approvalRequest.subjectType === "pos_transaction",
+  );
+}
+
+async function listPendingVoidApprovalSummariesBySessionId(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    registerSessions: Array<Pick<Doc<"registerSession">, "_id">>;
+    storeId: Id<"store">;
+  },
+) {
+  const entries = await Promise.all(
+    args.registerSessions.map(async (registerSession) => {
+      const approvalRequests = await listPendingVoidApprovalsForRegisterSession(
+        ctx,
+        {
+          registerSessionId: registerSession._id,
+          storeId: args.storeId,
+        },
+      );
+      return [
+        registerSession._id,
+        buildPendingVoidApprovalSummary(approvalRequests),
+      ] as const;
+    }),
+  );
+
+  return new Map(entries);
+}
+
 function collectStaffProfileIds(args: {
   approvalRequests: CashControlApprovalRequest[];
   deposits: CashControlDepositAllocation[];
@@ -809,6 +909,11 @@ export const getDashboardSnapshot = query({
         ctx,
         dashboardRegisterSessions,
       );
+    const pendingVoidApprovalsBySessionId =
+      await listPendingVoidApprovalSummariesBySessionId(ctx, {
+        registerSessions: dashboardRegisterSessionsWithTraceIds,
+        storeId: args.storeId,
+      });
     const relevantApprovalRequests = pendingApprovalRequests.filter(
       (approvalRequest) =>
         approvalRequest.requestType === "variance_review" &&
@@ -841,6 +946,7 @@ export const getDashboardSnapshot = query({
     return buildCashControlsDashboardSnapshot({
       approvalRequestsBySessionId,
       deposits,
+      pendingVoidApprovalsBySessionId,
       registerSessions: dashboardRegisterSessionsWithTraceIds,
       staffNamesById,
       syncConflictsBySessionId,
@@ -870,6 +976,7 @@ export const getRegisterSessionSnapshot = query({
       timeline,
       transactions,
       approvalRequest,
+      pendingVoidApprovals,
       syncConflictsBySessionId,
       workflowTraceId,
     ] = await Promise.all([
@@ -885,6 +992,10 @@ export const getRegisterSessionSnapshot = query({
             registerSession.managerApprovalRequestId,
           )
         : Promise.resolve(null),
+      listPendingVoidApprovalsForRegisterSession(ctx, {
+        registerSessionId: args.registerSessionId,
+        storeId: args.storeId,
+      }),
       listRegisterSessionSyncReviewConflicts(ctx, args.storeId, {
         includeRejectedEvidence: true,
       }),
@@ -1008,6 +1119,8 @@ export const getRegisterSessionSnapshot = query({
       registerSession: {
         ...buildRegisterSessionSummary({
           approvalRequest,
+          pendingVoidApprovals:
+            buildPendingVoidApprovalSummary(pendingVoidApprovals),
           registerSession: registerSessionWithTraceId,
           staffNamesById,
           syncConflicts:
@@ -1142,6 +1255,21 @@ export const recordRegisterSessionDeposit = mutation({
       });
     }
 
+    const pendingVoidApprovals = await listPendingVoidApprovalsForRegisterSession(
+      ctx,
+      {
+        registerSessionId: registerSession._id,
+        storeId: args.storeId,
+      },
+    );
+
+    if (pendingVoidApprovals.length > 0) {
+      return userError({
+        code: "precondition_failed",
+        message: "Resolve pending void approvals before recording a deposit.",
+      });
+    }
+
     const deposit = await recordPaymentAllocationWithCtx(ctx, {
       actorStaffProfileId,
       actorUserId: athenaUserId,
@@ -1248,6 +1376,7 @@ export const resolveRegisterSessionSyncReview = mutation({
 
     const decision = args.decision ?? "approved";
     const isAutomaticResolution = !args.actorStaffProfileId;
+    let reviewActorStaffProfileId: Id<"staffProfile"> | undefined;
     if (decision === "rejected" && isAutomaticResolution) {
       return userError({
         code: "precondition_failed",
@@ -1256,9 +1385,21 @@ export const resolveRegisterSessionSyncReview = mutation({
       });
     }
     if (args.actorStaffProfileId) {
+      try {
+        reviewActorStaffProfileId = await resolveDepositActorStaffProfileId(ctx, {
+          athenaUserId: athenaUser._id,
+          staffProfileId: args.actorStaffProfileId,
+          storeId: args.storeId,
+        });
+      } catch {
+        return userError({
+          code: "authorization_failed",
+          message: "Only managers can resolve synced register reviews.",
+        });
+      }
       const canResolveReview = await staffProfileCanResolveSyncReview(ctx, {
         organizationId: store.organizationId,
-        staffProfileId: args.actorStaffProfileId,
+        staffProfileId: reviewActorStaffProfileId,
         storeId: args.storeId,
       });
       if (!canResolveReview) {
@@ -1419,8 +1560,8 @@ export const resolveRegisterSessionSyncReview = mutation({
           const conflictDetails = conflict.details ?? {};
           rejectedCloseoutLocalEventIds.add(syncEvent.localEventId);
           await recordOperationalEventWithCtx(ctx, {
-            ...(args.actorStaffProfileId
-              ? { actorStaffProfileId: args.actorStaffProfileId }
+            ...(reviewActorStaffProfileId
+              ? { actorStaffProfileId: reviewActorStaffProfileId }
               : {}),
             actorUserId: athenaUser._id,
             eventType: "register_session_sync_closeout_rejected",
@@ -1577,7 +1718,7 @@ export const resolveRegisterSessionSyncReview = mutation({
             requestedConflictIds.size > 0
               ? Array.from(requestedConflictIds)
               : conflicts.map((reviewConflict) => reviewConflict._id),
-          reviewActorStaffProfileId: args.actorStaffProfileId,
+          reviewActorStaffProfileId,
           trustStoredStaffProof: true,
         },
       });
@@ -1654,8 +1795,8 @@ export const resolveRegisterSessionSyncReview = mutation({
           conflictId,
           {
             resolvedAt,
-            ...(args.actorStaffProfileId
-              ? { resolvedByStaffProfileId: args.actorStaffProfileId }
+            ...(reviewActorStaffProfileId
+              ? { resolvedByStaffProfileId: reviewActorStaffProfileId }
               : {}),
             status: "resolved",
           },
@@ -1664,8 +1805,8 @@ export const resolveRegisterSessionSyncReview = mutation({
     );
 
     await recordOperationalEventWithCtx(ctx, {
-      ...(args.actorStaffProfileId
-        ? { actorStaffProfileId: args.actorStaffProfileId }
+      ...(reviewActorStaffProfileId
+        ? { actorStaffProfileId: reviewActorStaffProfileId }
         : {}),
       actorUserId: athenaUser._id,
       eventType: "register_session_sync_review_resolved",

--- a/packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts
+++ b/packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts
@@ -257,6 +257,19 @@ function createMutationCtx(seed?: {
           };
         }
 
+        if (
+          table === "approvalRequest" &&
+          indexName === "by_registerSessionId"
+        ) {
+          return {
+            collect: async () =>
+              approvalRequests.filter(
+                (request) =>
+                  request.registerSessionId === filters.registerSessionId,
+              ),
+          };
+        }
+
         throw new Error(`Unsupported query ${table}.${indexName}`);
       },
     })),

--- a/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
@@ -42,6 +42,7 @@ import {
   type CommandResult,
 } from "../../../../shared/commandResult";
 import { isPosUsableRegisterSessionStatus } from "../../../../shared/registerSessionStatus";
+import { getRegisterSessionVoidApplicationStatus } from "../../../../shared/registerSessionLifecyclePolicy";
 import {
   consumeInventoryHoldsForSession,
   readActiveInventoryHoldQuantitiesForSession,
@@ -1245,7 +1246,7 @@ async function validateTransactionVoidPreconditions(
   ctx: MutationCtx,
   transaction: NonNullable<Awaited<ReturnType<typeof getPosTransactionById>>>,
   options?: {
-    requireUsableRegisterSession?: boolean;
+    registerSessionPolicy?: "sale_usable" | "void_applicable";
   },
 ) {
   if (transaction.status === "void") {
@@ -1304,22 +1305,25 @@ async function validateTransactionVoidPreconditions(
     transaction.registerSessionId,
   );
 
-  if (
-    !registerSession ||
-    registerSession.storeId !== transaction.storeId ||
-    !registerSessionMatchesIdentity(registerSession, {
-      terminalId: transaction.terminalId,
-    })
-  ) {
-    return userError({
-      code: "precondition_failed",
-      message: "Drawer closed. Open the drawer before voiding this sale.",
-    });
-  }
-  if (
-    options?.requireUsableRegisterSession !== false &&
-    !isUsableRegisterSession(registerSession)
-  ) {
+  const registerSessionPolicy =
+    options?.registerSessionPolicy ?? "sale_usable";
+  const registerSessionAllowed =
+    registerSessionPolicy === "void_applicable"
+      ? getRegisterSessionVoidApplicationStatus({
+          registerSession,
+          storeId: transaction.storeId,
+          terminalId: transaction.terminalId,
+        }).allowed
+      : Boolean(
+          registerSession &&
+            registerSession.storeId === transaction.storeId &&
+            registerSessionMatchesIdentity(registerSession, {
+              terminalId: transaction.terminalId,
+            }) &&
+            isUsableRegisterSession(registerSession),
+        );
+
+  if (!registerSessionAllowed) {
     return userError({
       code: "precondition_failed",
       message: "Drawer closed. Open the drawer before voiding this sale.",
@@ -1756,15 +1760,11 @@ export async function resolveTransactionVoidApprovalDecisionWithCtx(
     throw new Error(matchingApprovalRequest.error.message);
   }
 
-  const registerSession = await getRegisterSessionById(
-    ctx,
-    transaction.registerSessionId as Id<"registerSession">,
-  );
   const preconditions = await validateTransactionVoidPreconditions(
     ctx,
     transaction,
     {
-      requireUsableRegisterSession: true,
+      registerSessionPolicy: "void_applicable",
     },
   );
   if (preconditions.kind !== "ok") {

--- a/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
+++ b/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
@@ -851,7 +851,7 @@ describe("voidTransaction", () => {
     );
   });
 
-  it("blocks a queued completed-sale void when the original drawer is closing", async () => {
+  it("applies a queued completed-sale void when the original drawer is closing", async () => {
     vi.mocked(getRegisterSessionById).mockResolvedValue({
       _id: "register-1",
       status: "closing",
@@ -883,9 +883,42 @@ describe("voidTransaction", () => {
         reviewedByStaffProfileId: "manager-1" as Id<"staffProfile">,
         reviewedByUserId: "manager-user-1" as Id<"athenaUser">,
       }),
-    ).rejects.toThrow("Drawer closed. Open the drawer before voiding this sale.");
-    expect(recordRetailVoidPaymentAllocations).not.toHaveBeenCalled();
-    expect(patchPosTransaction).not.toHaveBeenCalled();
+    ).resolves.toMatchObject({
+      approvalProofId: "decision-proof-1",
+      approvalRequestId: "approval-request-1",
+      approverStaffProfileId: "manager-1",
+      transactionId: "txn-1",
+    });
+    expect(recordRetailVoidPaymentAllocations).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        posTransactionId: "txn-1",
+        registerSessionId: "register-1",
+      }),
+    );
+    expect(recordOperationalEventWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        actorStaffProfileId: "manager-1",
+        actorUserId: "manager-user-1",
+        eventType: "pos_transaction_void_approval_proof_consumed",
+      }),
+    );
+    expect(patchPosTransaction).toHaveBeenCalledWith(
+      expect.anything(),
+      "txn-1",
+      expect.objectContaining({
+        status: "void",
+        voidApprovalProofId: "decision-proof-1",
+        voidApprovalRequestId: "approval-request-1",
+        voidApprovedByStaffProfileId: "manager-1",
+      }),
+    );
+    expect(ctx.db.patch).not.toHaveBeenCalledWith(
+      "approvalRequest",
+      "approval-request-1",
+      expect.any(Object),
+    );
   });
 
   it("blocks a queued completed-sale void when the original drawer is closed", async () => {

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -4076,6 +4076,53 @@ describe("projectLocalSyncEvent", () => {
     ]);
   });
 
+  it("keeps synced register closeout unresolved when pending void approvals exist", async () => {
+    const repository = createProjectionRepository({
+      pendingVoidApprovalCount: 1,
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-closed-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 3,
+        eventType: "register_closed",
+        occurredAt: 30,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: {
+          countedCash: 90,
+          notes: "Closed drawer with pending void review",
+        },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("projected");
+    expect(result.mappings).toEqual([
+      expect.objectContaining({
+        localIdKind: "closeout",
+        localId: "event-register-closed-1",
+      }),
+    ]);
+    expect(repository.registerSessionPatches).toEqual([
+      {
+        registerSessionId: "register-session-1",
+        patch: expect.objectContaining({
+          status: "closing",
+          countedCash: 90,
+          notes: "Closed drawer with pending void review",
+          variance: -10,
+        }),
+      },
+    ]);
+    expect(repository.recordedRegisterSessionTraces).toEqual([]);
+    expect(repository.createdOperationalEvents).toEqual([]);
+  });
+
   it("conflicts non-zero offline closeout variance for manager review", async () => {
     const repository = createProjectionRepository();
 
@@ -5589,6 +5636,7 @@ function createProjectionRepository(
     hasActivePosRole:
       | boolean
       | ((args: Parameters<SyncProjectionRepository["hasActivePosRole"]>[0]) => boolean);
+    pendingVoidApprovalCount: number;
     validStaffProof: boolean;
   }> = {},
 ): SyncProjectionRepository & {
@@ -5881,6 +5929,9 @@ function createProjectionRepository(
       return registerSession && registerSessionId === registerSession._id
         ? (registerSession as never)
         : null;
+    },
+    async countPendingVoidApprovalsForRegisterSession() {
+      return overrides.pendingVoidApprovalCount ?? 0;
     },
     async getActiveHeldQuantity(args) {
       if (args.excludeSessionId && overrides.existingPosSession?._id === args.excludeSessionId) {

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -3506,6 +3506,28 @@ async function projectRegisterClosed(
     return { status: "conflicted", mappings: [], conflicts: [conflict] };
   }
 
+  const pendingVoidApprovalCount =
+    (await repository.countPendingVoidApprovalsForRegisterSession?.({
+      registerSessionId: registerSession._id,
+      storeId: args.storeId,
+    })) ?? 0;
+
+  if (pendingVoidApprovalCount > 0) {
+    await repository.patchRegisterSession(registerSession._id, {
+      status: "closing",
+      countedCash,
+      variance,
+      notes: payload.notes,
+    });
+    const mapping = await createMapping(repository, args, {
+      localIdKind: "closeout",
+      localId: args.event.localEventId,
+      cloudTable: "registerSession",
+      cloudId: registerSession._id,
+    });
+    return { status: "projected", mappings: [mapping], conflicts: [] };
+  }
+
   if (
     roundMoney(variance) !== 0 &&
     args.options?.allowRegisterCloseoutVarianceProjection !== true

--- a/packages/athena-webapp/convex/pos/application/sync/types.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/types.ts
@@ -312,6 +312,10 @@ export type SyncProjectionRepository = {
   getRegisterSession(
     registerSessionId: Id<"registerSession">,
   ): Promise<Doc<"registerSession"> | null>;
+  countPendingVoidApprovalsForRegisterSession?(args: {
+    registerSessionId: Id<"registerSession">;
+    storeId: Id<"store">;
+  }): Promise<number>;
   getCustomerProfile(
     customerProfileId: Id<"customerProfile">,
   ): Promise<Doc<"customerProfile"> | null>;

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
@@ -150,6 +150,24 @@ export function createConvexLocalSyncRepository(
     getRegisterSession(registerSessionId) {
       return ctx.db.get("registerSession", registerSessionId);
     },
+    async countPendingVoidApprovalsForRegisterSession(args) {
+      const approvalRequests =
+        // eslint-disable-next-line @convex-dev/no-collect-in-query -- Register-session scoped pending void approvals are bounded by manager-review workflow volume and must be checked before synced closeout projection.
+        await ctx.db
+          .query("approvalRequest")
+          .withIndex("by_registerSessionId", (q) =>
+            q.eq("registerSessionId", args.registerSessionId),
+          )
+          .collect();
+
+      return approvalRequests.filter(
+        (approvalRequest) =>
+          approvalRequest.storeId === args.storeId &&
+          approvalRequest.status === "pending" &&
+          approvalRequest.requestType === "pos_transaction_void" &&
+          approvalRequest.subjectType === "pos_transaction",
+      ).length;
+    },
     async getActiveHeldQuantity(args) {
       const holds = await ctx.db
         .query("inventoryHold")

--- a/packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts
+++ b/packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts
@@ -4,6 +4,7 @@ import {
   canOpenReplacementDrawerForLocalBlock,
   canReuseCloudRegisterSessionForLocalOpen,
   canSupersedeReviewedRegisterSessionForLocalOpen,
+  getRegisterSessionVoidApplicationStatus,
   getSaleBlockingDrawerAuthority,
   isNonBlockingRegisterLifecycleReviewEvent,
   isRegisterCloseoutReviewConflict,
@@ -21,6 +22,70 @@ describe("registerSessionLifecyclePolicy", () => {
       false,
     );
     expect(isRegisterSessionSaleUsable({ status: "closed" })).toBe(false);
+  });
+
+  it("allows void application for open, active, and closing register sessions", () => {
+    for (const status of ["open", "active", "closing"] as const) {
+      expect(
+        getRegisterSessionVoidApplicationStatus({
+          registerSession: {
+            status,
+            storeId: "store-1",
+            terminalId: "terminal-1",
+          },
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        }),
+      ).toEqual({ allowed: true });
+    }
+  });
+
+  it("blocks void application for closed and rejected closeout sessions", () => {
+    for (const status of ["closeout_rejected", "closed"] as const) {
+      expect(
+        getRegisterSessionVoidApplicationStatus({
+          registerSession: {
+            status,
+            storeId: "store-1",
+            terminalId: "terminal-1",
+          },
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        }),
+      ).toEqual({ allowed: false, reason: "blocked_status" });
+    }
+  });
+
+  it("distinguishes void application scope failures", () => {
+    expect(
+      getRegisterSessionVoidApplicationStatus({
+        registerSession: null,
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toEqual({ allowed: false, reason: "missing_session" });
+    expect(
+      getRegisterSessionVoidApplicationStatus({
+        registerSession: {
+          status: "closing",
+          storeId: "store-2",
+          terminalId: "terminal-1",
+        },
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toEqual({ allowed: false, reason: "wrong_store" });
+    expect(
+      getRegisterSessionVoidApplicationStatus({
+        registerSession: {
+          status: "closing",
+          storeId: "store-1",
+          terminalId: "terminal-2",
+        },
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toEqual({ allowed: false, reason: "wrong_terminal" });
   });
 
   it("allows replacement for submitted closeouts without making them sale usable", () => {

--- a/packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts
+++ b/packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts
@@ -65,6 +65,47 @@ export function isRegisterSessionSaleUsable(
   return isPosUsableRegisterSessionStatus(session?.status);
 }
 
+export type RegisterSessionVoidApplicationStatus =
+  | { allowed: true }
+  | {
+      allowed: false;
+      reason:
+        | "missing_session"
+        | "wrong_store"
+        | "wrong_terminal"
+        | "blocked_status";
+    };
+
+export function getRegisterSessionVoidApplicationStatus(input: {
+  registerSession?: RegisterSessionLifecycleScopedSession | null;
+  storeId: string;
+  terminalId: string;
+}): RegisterSessionVoidApplicationStatus {
+  const { registerSession } = input;
+
+  if (!registerSession) {
+    return { allowed: false, reason: "missing_session" };
+  }
+
+  if (registerSession.storeId !== input.storeId) {
+    return { allowed: false, reason: "wrong_store" };
+  }
+
+  if (!registerSession.terminalId || registerSession.terminalId !== input.terminalId) {
+    return { allowed: false, reason: "wrong_terminal" };
+  }
+
+  if (
+    registerSession.status === "open" ||
+    registerSession.status === "active" ||
+    registerSession.status === "closing"
+  ) {
+    return { allowed: true };
+  }
+
+  return { allowed: false, reason: "blocked_status" };
+}
+
 export function isRegisterSessionConflictBlocking(
   session: Pick<RegisterSessionLifecycleScopedSession, "status"> | null | undefined,
 ) {

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
@@ -48,6 +48,17 @@ type DashboardApprovalRequest = {
   status: string;
 };
 
+type DashboardPendingVoidApprovals = {
+  count: number;
+  items: Array<{
+    approvalRequestId: string;
+    requestedAt: number;
+    transactionId: string;
+    transactionNumber?: string | null;
+    workItemId?: string | null;
+  }>;
+};
+
 export type CashControlsDashboardSession = {
   _id: string;
   closedAt?: number;
@@ -58,6 +69,7 @@ export type CashControlsDashboardSession = {
   openedAt: number;
   openingFloat: number;
   pendingApprovalRequest?: DashboardApprovalRequest | null;
+  pendingVoidApprovals?: DashboardPendingVoidApprovals | null;
   registerNumber?: string | null;
   status: string;
   terminalName?: string | null;
@@ -324,6 +336,10 @@ function CashPositionSummary({
 function getSessionActionLabel(session: CashControlsDashboardSession) {
   if (hasRegisterCloseoutSyncReview(session)) {
     return "Review closeout";
+  }
+
+  if ((session.pendingVoidApprovals?.count ?? 0) > 0) {
+    return "Review register";
   }
 
   if (session.pendingApprovalRequest || session.variance) {
@@ -1090,6 +1106,7 @@ function CashroomWorkflow({
       session.status === "closing" ||
       session.status === "closeout_rejected" ||
       Boolean(session.pendingApprovalRequest) ||
+      (session.pendingVoidApprovals?.count ?? 0) > 0 ||
       getSessionSyncStatus(session).status !== "synced",
   );
   const needsAttentionIds = new Set(

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -272,6 +272,17 @@ const baseSnapshot = {
   },
 };
 
+const activeSnapshot = {
+  ...baseSnapshot,
+  closeoutReview: null,
+  registerSession: {
+    ...baseSnapshot.registerSession,
+    countedCash: undefined,
+    status: "active",
+    variance: undefined,
+  },
+};
+
 describe("RegisterSessionViewContent", () => {
   beforeEach(() => {
     authMocks.useAuth.mockReset();
@@ -2157,6 +2168,129 @@ describe("RegisterSessionViewContent", () => {
     );
   });
 
+  it("finalizes a submitted closeout through staff authentication", async () => {
+    const user = userEvent.setup();
+    const onAuthenticateStaff = vi.fn().mockResolvedValue(
+      ok({
+        activeRoles: ["manager"],
+        staffProfile: { fullName: "Ato Kofi" },
+        staffProfileId: "staff-1",
+      }),
+    );
+    const onAuthenticateForApproval = vi.fn().mockResolvedValue(
+      ok({
+        approvalProofId: "approval-proof-1",
+        approvedByStaffProfileId: "staff-1",
+        expiresAt: Date.now() + 60_000,
+      }),
+    );
+    const onFinalizeCloseout = vi
+      .fn()
+      .mockResolvedValue(ok({ action: "closed" }));
+
+    render(
+      <RegisterSessionViewContent
+        actorUserId="user-1"
+        currency="GHS"
+        isLoading={false}
+        onAuthenticateForApproval={onAuthenticateForApproval}
+        onAuthenticateStaff={onAuthenticateStaff}
+        onFinalizeCloseout={onFinalizeCloseout}
+        onRecordDeposit={vi.fn()}
+        onReviewCloseout={vi.fn()}
+        onSubmitCloseout={vi.fn()}
+        registerSessionSnapshot={baseSnapshot}
+        storeId="store-1"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Finalize closeout" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Submit closeout" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Finalize closeout" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm staff for Finalize closeout",
+      }),
+    );
+
+    expect(onAuthenticateStaff).toHaveBeenCalledWith({
+      allowedRoles: ["manager"],
+      pinHash: "hashed-pin",
+      username: "ato",
+    });
+    await waitFor(() =>
+      expect(onFinalizeCloseout).toHaveBeenCalledWith({
+        actorStaffProfileId: "staff-1",
+        approvalProofId: undefined,
+        registerSessionId: "session-1",
+        requestedByStaffProfileId: "staff-1",
+      }),
+    );
+    expect(onAuthenticateForApproval).not.toHaveBeenCalled();
+  });
+
+  it("holds pending-void closeouts without submit, finalize, or deposit actions", () => {
+    render(
+      <RegisterSessionViewContent
+        actorStaffProfileId="staff-1"
+        actorUserId="user-1"
+        currency="GHS"
+        isLoading={false}
+        onAuthenticateStaff={vi.fn()}
+        onFinalizeCloseout={vi.fn()}
+        onRecordDeposit={vi.fn()}
+        onReviewCloseout={vi.fn()}
+        onSubmitCloseout={vi.fn()}
+        orgUrlSlug="wigclub"
+        registerSessionSnapshot={{
+          ...baseSnapshot,
+          registerSession: {
+            ...baseSnapshot.registerSession,
+            pendingVoidApprovals: {
+              count: 1,
+              items: [
+                {
+                  approvalRequestId: "void-approval-1",
+                  requestedAt: new Date("2026-04-21T18:30:00.000Z").getTime(),
+                  transactionId: "transaction-1",
+                  transactionNumber: "TXN-0031",
+                },
+              ],
+            },
+          },
+        }}
+        storeId="store-1"
+        storeUrlSlug="wigclub"
+      />,
+    );
+
+    expect(screen.getByText("Void review pending")).toBeInTheDocument();
+    expect(
+      screen.getByText("Sale void review blocks final closeout"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Review void approvals" }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/wigclub/operations/approvals?o=%252F",
+    );
+    expect(
+      screen.queryByRole("button", { name: "Submit closeout" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Finalize closeout" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Deposit amount")).toBeDisabled();
+    expect(screen.getByLabelText("Deposit reference")).toBeDisabled();
+    expect(screen.getByLabelText("Deposit notes")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Record deposit" })).toBeDisabled();
+  });
+
   it("uses manager approval to submit a reopened closeout correction", async () => {
     const user = userEvent.setup();
     const onAuthenticateStaff = vi.fn();
@@ -2341,7 +2475,7 @@ describe("RegisterSessionViewContent", () => {
         onRecordDeposit={vi.fn()}
         onReviewCloseout={vi.fn()}
         onSubmitCloseout={onSubmitCloseout}
-        registerSessionSnapshot={baseSnapshot}
+        registerSessionSnapshot={activeSnapshot}
         storeId="store-1"
       />,
     );
@@ -2403,7 +2537,7 @@ describe("RegisterSessionViewContent", () => {
         onRecordDeposit={vi.fn()}
         onReviewCloseout={vi.fn()}
         onSubmitCloseout={onSubmitCloseout}
-        registerSessionSnapshot={baseSnapshot}
+        registerSessionSnapshot={activeSnapshot}
         storeId="store-1"
       />,
     );
@@ -3103,7 +3237,7 @@ describe("RegisterSessionViewContent", () => {
         isLoading={false}
         onRecordDeposit={onRecordDeposit}
         {...closeoutHandlers}
-        registerSessionSnapshot={baseSnapshot}
+        registerSessionSnapshot={activeSnapshot}
         storeId="store-1"
       />,
     );
@@ -3160,7 +3294,7 @@ describe("RegisterSessionViewContent", () => {
       }
 
       if ("registerSessionId" in args) {
-        return baseSnapshot;
+        return activeSnapshot;
       }
 
       return [
@@ -3204,7 +3338,7 @@ describe("RegisterSessionViewContent", () => {
         isLoading={false}
         onRecordDeposit={onRecordDeposit}
         {...closeoutHandlers}
-        registerSessionSnapshot={baseSnapshot}
+        registerSessionSnapshot={activeSnapshot}
         storeId="store-1"
       />,
     );
@@ -3235,7 +3369,7 @@ describe("RegisterSessionViewContent", () => {
         isLoading={false}
         onRecordDeposit={onRecordDeposit}
         {...closeoutHandlers}
-        registerSessionSnapshot={baseSnapshot}
+        registerSessionSnapshot={activeSnapshot}
         storeId="store-1"
       />,
     );

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -105,6 +105,17 @@ type RegisterSessionApprovalRequest = {
   status: string;
 };
 
+type RegisterSessionPendingVoidApprovals = {
+  count: number;
+  items: Array<{
+    approvalRequestId: string;
+    requestedAt: number;
+    transactionId: string;
+    transactionNumber?: string | null;
+    workItemId?: string | null;
+  }>;
+};
+
 type RegisterSessionDetail = {
   _id: string;
   closedAt?: number;
@@ -122,6 +133,7 @@ type RegisterSessionDetail = {
   openedByStaffName?: string | null;
   openingFloat: number;
   pendingApprovalRequest?: RegisterSessionApprovalRequest | null;
+  pendingVoidApprovals?: RegisterSessionPendingVoidApprovals | null;
   registerNumber?: string | null;
   status: string;
   terminalName?: string | null;
@@ -216,6 +228,13 @@ type RegisterCloseoutSubmitArgs = {
   requestedByStaffProfileId?: string;
 };
 
+type RegisterCloseoutFinalizeArgs = {
+  actorStaffProfileId: string;
+  approvalProofId?: string;
+  registerSessionId: string;
+  requestedByStaffProfileId?: string;
+};
+
 type RegisterCloseoutReviewArgs = {
   approvalProofId: string;
   decision: "approved" | "rejected";
@@ -224,7 +243,8 @@ type RegisterCloseoutReviewArgs = {
 };
 
 type RegisterCloseoutCommandPayload = {
-  action?: "closed" | "approved" | "rejected" | "reopened";
+  action?: "closed" | "approved" | "rejected" | "reopened" | "submitted";
+  pendingVoidApprovalCount?: number;
 };
 
 type RegisterCloseoutCommandResult =
@@ -312,6 +332,9 @@ type RegisterSessionViewContentProps = {
   onSubmitCloseout: (
     args: RegisterCloseoutSubmitArgs,
   ) => Promise<RegisterCloseoutCommandResult>;
+  onFinalizeCloseout?: (
+    args: RegisterCloseoutFinalizeArgs,
+  ) => Promise<RegisterCloseoutCommandResult>;
   orgUrlSlug?: string;
   registerSessionSnapshot: RegisterSessionSnapshot | null;
   storeId?: string;
@@ -329,6 +352,10 @@ type CloseoutStaffAuthIntent =
       decision: "approved" | "rejected";
       decisionNotes?: string;
       kind: "review";
+      registerSessionId: string;
+    }
+  | {
+      kind: "finalize";
       registerSessionId: string;
     }
   | {
@@ -2330,6 +2357,7 @@ export function RegisterSessionViewContent({
   onAuthenticateStaff,
   onAuthenticateCloseoutReviewApproval,
   onCorrectOpeningFloat,
+  onFinalizeCloseout,
   onRecordDeposit,
   onReopenCloseout,
   onReviewCloseout,
@@ -2352,7 +2380,7 @@ export function RegisterSessionViewContent({
   const [managerNotes, setManagerNotes] = useState("");
   const [closeoutErrorMessage, setCloseoutErrorMessage] = useState("");
   const [pendingCloseoutAction, setPendingCloseoutAction] = useState<
-    "approved" | "rejected" | "reopen" | "submit" | null
+    "approved" | "finalize" | "rejected" | "reopen" | "submit" | null
   >(null);
   const [syncReviewErrorMessage, setSyncReviewErrorMessage] = useState("");
   const [isResolvingSyncReview, setIsResolvingSyncReview] = useState(false);
@@ -2645,6 +2673,28 @@ export function RegisterSessionViewContent({
     });
   }
 
+  async function handleFinalizeCloseout() {
+    if (!registerSession?._id) {
+      setCloseoutErrorMessage(
+        "A register session is required before finalizing a closeout",
+      );
+      return;
+    }
+
+    if (!onFinalizeCloseout) {
+      setCloseoutErrorMessage(
+        "Closeout finalization is not available yet. Try again after the register tools refresh.",
+      );
+      return;
+    }
+
+    setCloseoutErrorMessage("");
+    setCloseoutStaffAuthIntent({
+      kind: "finalize",
+      registerSessionId: registerSession._id,
+    });
+  }
+
   async function handleReviewCloseout(decision: "approved" | "rejected") {
     if (!registerSession?._id) {
       setCloseoutErrorMessage(
@@ -2797,7 +2847,12 @@ export function RegisterSessionViewContent({
       return;
     }
 
-    const action = intent.kind === "submit" ? "submit" : intent.decision;
+    const action =
+      intent.kind === "submit"
+        ? "submit"
+        : intent.kind === "finalize"
+          ? "finalize"
+          : intent.decision;
 
     setCloseoutErrorMessage("");
     setPendingCloseoutAction(action);
@@ -2829,6 +2884,35 @@ export function RegisterSessionViewContent({
                 }),
               onResult: () => undefined,
             })
+          : intent.kind === "finalize"
+            ? onFinalizeCloseout
+              ? await closeoutApprovalRunner.run({
+                  requestedByStaffProfileId:
+                    result.staffProfileId as Id<"staffProfile">,
+                  sameSubmissionApproval: credentials
+                    ? {
+                        canAttemptInlineManagerProof: isManagerStaff(result),
+                        pinHash: credentials.pinHash,
+                        requestedByStaffProfileId:
+                          result.staffProfileId as Id<"staffProfile">,
+                        username: credentials.username,
+                      }
+                    : undefined,
+                  execute: (approvalArgs) =>
+                    onFinalizeCloseout({
+                      actorStaffProfileId: result.staffProfileId,
+                      approvalProofId:
+                        approvalArgs.approvalProofId ?? result.approvalProofId,
+                      registerSessionId: intent.registerSessionId,
+                      requestedByStaffProfileId: result.staffProfileId,
+                    }),
+                  onResult: () => undefined,
+                })
+              : userError({
+                  code: "precondition_failed",
+                  message:
+                    "Closeout finalization is not available yet. Try again after the register tools refresh.",
+                })
           : result.approvalProofId
             ? await onReviewCloseout({
                 approvalProofId: result.approvalProofId,
@@ -3021,6 +3105,9 @@ export function RegisterSessionViewContent({
       : (registerSession?.variance ?? null);
   const hasPendingCloseoutApproval =
     registerSession?.pendingApprovalRequest?.status === "pending";
+  const pendingVoidApprovalCount =
+    registerSession?.pendingVoidApprovals?.count ?? 0;
+  const hasPendingVoidApprovals = pendingVoidApprovalCount > 0;
   const formattedApprovalReason = formatReviewReason(
     reviewReasonFormatter,
     registerSession?.pendingApprovalRequest?.reason,
@@ -3043,6 +3130,26 @@ export function RegisterSessionViewContent({
   const needsCloseoutCorrection =
     !isClosedRegisterSession &&
     (hasRejectedCloseoutApproval || hasCloseoutRejectionHistory);
+  const canFinalizeCloseout =
+    Boolean(registerSession) &&
+    registerSession?.status === "closing" &&
+    registerSession.countedCash !== undefined &&
+    !hasPendingCloseoutApproval &&
+    !hasPendingVoidApprovals &&
+    !needsCloseoutCorrection &&
+    Boolean(onFinalizeCloseout);
+  const isWaitingOnVoidReview =
+    Boolean(registerSession) &&
+    registerSession?.status === "closing" &&
+    hasPendingVoidApprovals &&
+    !needsCloseoutCorrection;
+  const isDepositActionLocked =
+    Boolean(pendingCloseoutAction) ||
+    Boolean(hasPendingCloseoutApproval) ||
+    Boolean(hasPendingVoidApprovals) ||
+    registerSession?.status === "closing" ||
+    registerSession?.status === "closeout_rejected" ||
+    registerSession?.status === "closed";
   const headerTitle = registerSession
     ? formatRegisterHeaderName(registerSession.registerNumber)
     : "Register detail";
@@ -3105,6 +3212,12 @@ export function RegisterSessionViewContent({
                 ? closeoutStaffAuthIntent.approveLabel
                 : closeoutStaffAuthIntent.rejectLabel,
           }
+        : closeoutStaffAuthIntent?.kind === "finalize"
+          ? {
+              title: "Closeout sign-in required",
+              description: "Authenticate to finalize closeout",
+              submitLabel: "Finalize closeout",
+            }
         : {
             title: "Closeout sign-in required",
             description: "Authenticate to submit closeout",
@@ -3234,6 +3347,37 @@ export function RegisterSessionViewContent({
     (isOpeningFloatCorrectionOpen ||
       Boolean(openingFloatCorrectionSuccess) ||
       (correctionTimeline.length > 0 && !isClosedRegisterSession));
+  const pendingVoidApprovalPanel =
+    registerSession && hasPendingVoidApprovals ? (
+      <section className="space-y-3 rounded-lg border border-warning-border bg-warning-soft p-layout-md">
+        <div className="space-y-1">
+          <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-warning">
+            Void review pending
+          </p>
+          <h2 className="font-display text-lg font-semibold text-foreground">
+            Sale void review blocks final closeout
+          </h2>
+          <p className="text-sm leading-6 text-muted-foreground">
+            Review{" "}
+            {pendingVoidApprovalCount === 1
+              ? "the pending sale void"
+              : `${pendingVoidApprovalCount} pending sale voids`}{" "}
+            before final closeout can complete.
+          </p>
+        </div>
+        {orgUrlSlug && storeUrlSlug ? (
+          <Button asChild size="sm" variant="outline">
+            <Link
+              params={{ orgUrlSlug, storeUrlSlug }}
+              search={{ o: getOrigin() }}
+              to="/$orgUrlSlug/store/$storeUrlSlug/operations/approvals"
+            >
+              Review void approvals
+            </Link>
+          </Button>
+        ) : null}
+      </section>
+    ) : null;
   const pendingCloseoutApprovalPanel =
     registerSession && hasPendingCloseoutApproval ? (
       <section className="space-y-4 rounded-[calc(var(--radius)*1.2)] border border-warning-border bg-warning-soft p-layout-lg shadow-surface">
@@ -3471,7 +3615,8 @@ export function RegisterSessionViewContent({
             onAuthenticateStaff({
               allowedRoles:
                 closeoutStaffAuthIntent?.kind === "review" ||
-                closeoutStaffAuthIntent?.kind === "sync_review"
+                closeoutStaffAuthIntent?.kind === "sync_review" ||
+                closeoutStaffAuthIntent?.kind === "finalize"
                   ? ["manager"]
                   : ["cashier", "manager"],
               pinHash: args.pinHash,
@@ -3740,6 +3885,7 @@ export function RegisterSessionViewContent({
                 </aside>
 
                 <div className="flex flex-col gap-layout-md px-layout-md py-layout-md md:gap-layout-lg md:px-layout-lg md:py-layout-lg">
+                  {pendingVoidApprovalPanel}
                   {pendingCloseoutApprovalPanel}
 
                   {shouldShowProminentCorrectionPanel ? (
@@ -4493,73 +4639,102 @@ export function RegisterSessionViewContent({
                         </div>
                       ) : null}
 
-                      <label className="block space-y-2">
-                        <span className="text-sm font-medium text-foreground">
-                          Counted cash ({formattedCurrency})
-                        </span>
-                        <Input
-                          aria-label="Closeout counted cash"
-                          className="border-input bg-background"
-                          min={0}
-                          onChange={(event) =>
-                            setCountedCash(event.target.value)
-                          }
-                          step="0.01"
-                          type="number"
-                          value={countedCash}
-                        />
-                      </label>
-
-                      <div className="rounded-lg border border-border bg-muted/20 p-4">
-                        <dl className="grid grid-cols-2 gap-3 text-sm">
+                      {canFinalizeCloseout ? (
+                        <div className="space-y-3 rounded-lg border border-border bg-background p-4">
                           <div className="space-y-1">
-                            <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                              Expected
-                            </dt>
-                            <dd className="font-numeric tabular-nums text-foreground">
-                              {formatCurrency(currency, expectedCash)}
-                            </dd>
+                            <p className="text-sm font-medium text-foreground">
+                              Ready for final closeout
+                            </p>
+                            <p className="text-sm leading-6 text-muted-foreground">
+                              Pending sale void review is resolved. Finalize
+                              this submitted closeout against the current
+                              expected cash.
+                            </p>
                           </div>
-                          <div className="space-y-1">
-                            <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                              Draft variance
-                            </dt>
-                            <dd
-                              className={`font-numeric tabular-nums ${getVarianceTone(draftVariance ?? undefined)}`}
-                            >
-                              {draftVariance === null
-                                ? "Pending count"
-                                : formatCurrency(currency, draftVariance)}
-                            </dd>
+                          <LoadingButton
+                            className="w-full"
+                            disabled={Boolean(pendingCloseoutAction)}
+                            isLoading={pendingCloseoutAction === "finalize"}
+                            onClick={() => void handleFinalizeCloseout()}
+                            type="button"
+                            variant="workflow"
+                          >
+                            Finalize closeout
+                          </LoadingButton>
+                        </div>
+                      ) : null}
+
+                      {!canFinalizeCloseout && !isWaitingOnVoidReview ? (
+                        <>
+                          <label className="block space-y-2">
+                            <span className="text-sm font-medium text-foreground">
+                              Counted cash ({formattedCurrency})
+                            </span>
+                            <Input
+                              aria-label="Closeout counted cash"
+                              className="border-input bg-background"
+                              min={0}
+                              onChange={(event) =>
+                                setCountedCash(event.target.value)
+                              }
+                              step="0.01"
+                              type="number"
+                              value={countedCash}
+                            />
+                          </label>
+
+                          <div className="rounded-lg border border-border bg-muted/20 p-4">
+                            <dl className="grid grid-cols-2 gap-3 text-sm">
+                              <div className="space-y-1">
+                                <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                  Expected
+                                </dt>
+                                <dd className="font-numeric tabular-nums text-foreground">
+                                  {formatCurrency(currency, expectedCash)}
+                                </dd>
+                              </div>
+                              <div className="space-y-1">
+                                <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                  Draft variance
+                                </dt>
+                                <dd
+                                  className={`font-numeric tabular-nums ${getVarianceTone(draftVariance ?? undefined)}`}
+                                >
+                                  {draftVariance === null
+                                    ? "Pending count"
+                                    : formatCurrency(currency, draftVariance)}
+                                </dd>
+                              </div>
+                            </dl>
                           </div>
-                        </dl>
-                      </div>
 
-                      <label className="block space-y-2">
-                        <span className="text-sm font-medium text-foreground">
-                          Closeout notes
-                        </span>
-                        <Textarea
-                          aria-label="Closeout notes"
-                          className="min-h-[96px] border-input bg-background"
-                          onChange={(event) =>
-                            setCloseoutNotes(event.target.value)
-                          }
-                          placeholder="Add drawer notes if anything needs follow-up."
-                          value={closeoutNotes}
-                        />
-                      </label>
+                          <label className="block space-y-2">
+                            <span className="text-sm font-medium text-foreground">
+                              Closeout notes
+                            </span>
+                            <Textarea
+                              aria-label="Closeout notes"
+                              className="min-h-[96px] border-input bg-background"
+                              onChange={(event) =>
+                                setCloseoutNotes(event.target.value)
+                              }
+                              placeholder="Add drawer notes if anything needs follow-up."
+                              value={closeoutNotes}
+                            />
+                          </label>
 
-                      <LoadingButton
-                        className="w-full"
-                        disabled={pendingCloseoutAction === "submit"}
-                        isLoading={pendingCloseoutAction === "submit"}
-                        onClick={() => void handleSubmitCloseout()}
-                        type="button"
-                        variant="workflow"
-                      >
-                        Submit closeout
-                      </LoadingButton>
+                          <LoadingButton
+                            className="w-full"
+                            disabled={Boolean(pendingCloseoutAction)}
+                            isLoading={pendingCloseoutAction === "submit"}
+                            onClick={() => void handleSubmitCloseout()}
+                            type="button"
+                            variant="workflow"
+                          >
+                            Submit closeout
+                          </LoadingButton>
+                        </>
+                      ) : null}
                     </div>
                   )}
 
@@ -4598,6 +4773,7 @@ export function RegisterSessionViewContent({
                     <Input
                       aria-label="Deposit amount"
                       className="border-input bg-background"
+                      disabled={isDepositActionLocked}
                       min={0}
                       onChange={(event) => setAmount(event.target.value)}
                       step="1"
@@ -4613,6 +4789,7 @@ export function RegisterSessionViewContent({
                     <Input
                       aria-label="Deposit reference"
                       className="border-input bg-background"
+                      disabled={isDepositActionLocked}
                       onChange={(event) => setReference(event.target.value)}
                       placeholder="BANK-123"
                       value={reference}
@@ -4626,6 +4803,7 @@ export function RegisterSessionViewContent({
                     <Textarea
                       aria-label="Deposit notes"
                       className="min-h-[110px] border-input bg-background"
+                      disabled={isDepositActionLocked}
                       onChange={(event) => setNotes(event.target.value)}
                       placeholder="Optional handoff or safe-drop notes."
                       value={notes}
@@ -4640,7 +4818,7 @@ export function RegisterSessionViewContent({
 
                   <LoadingButton
                     className="w-full"
-                    disabled={isRecordingDeposit}
+                    disabled={isRecordingDeposit || isDepositActionLocked}
                     isLoading={isRecordingDeposit}
                     onClick={() => void handleRecordDeposit()}
                     type="button"
@@ -4716,6 +4894,9 @@ export function RegisterSessionView() {
   );
   const submitRegisterSessionCloseout = useMutation(
     api.cashControls.closeouts.submitRegisterSessionCloseout,
+  );
+  const finalizeRegisterSessionCloseout = useMutation(
+    api.cashControls.closeouts.finalizeRegisterSessionCloseout,
   );
   const reviewRegisterSessionCloseout = useMutation(
     api.cashControls.closeouts.reviewRegisterSessionCloseout,
@@ -4858,6 +5039,40 @@ export function RegisterSessionView() {
             | undefined,
         countedCash: args.countedCash,
         notes: args.notes,
+        registerSessionId: args.registerSessionId as Id<"registerSession">,
+        requestedByStaffProfileId: args.requestedByStaffProfileId as
+          | Id<"staffProfile">
+          | undefined,
+        storeId: activeStore._id,
+      }),
+    );
+
+    if (result.kind === "ok") {
+      toast.success(
+        result.data?.action === "submitted"
+          ? "Closeout submitted"
+          : "Register session closed",
+      );
+    }
+
+    return result;
+  }
+
+  async function onFinalizeCloseout(args: RegisterCloseoutFinalizeArgs) {
+    if (!activeStore?._id || !user?._id) {
+      return userError({
+        code: "authentication_failed",
+        message: "You must be logged in to finalize a register closeout",
+      });
+    }
+
+    const result = await runCommand(() =>
+      finalizeRegisterSessionCloseout({
+        actorStaffProfileId: args.actorStaffProfileId as Id<"staffProfile">,
+        actorUserId: user._id,
+        approvalProofId: args.approvalProofId as
+          | Id<"approvalProof">
+          | undefined,
         registerSessionId: args.registerSessionId as Id<"registerSession">,
         requestedByStaffProfileId: args.requestedByStaffProfileId as
           | Id<"staffProfile">
@@ -5109,6 +5324,7 @@ export function RegisterSessionView() {
       }
       onAuthenticateStaff={onAuthenticateStaff}
       onCorrectOpeningFloat={onCorrectOpeningFloat}
+      onFinalizeCloseout={onFinalizeCloseout}
       onRecordDeposit={onRecordDeposit}
       onReopenCloseout={onReopenCloseout}
       onReviewCloseout={onReviewCloseout}


### PR DESCRIPTION
## Summary

- allow approved completed-sale voids to apply while the original register session is `closing`, using a named void-application lifecycle policy
- keep closeout submission unblocked while pending void approvals hold the register unresolved in Cash Controls
- add Cash Controls pending-void summaries, finalization flow, server-side final-close/deposit guards, staff actor binding, and local sync closure protection

## Review Loop

Unanimous final approval after fixes:
- Security: approved
- Correctness: approved
- Data integrity: approved
- Testing: approved
- Frontend/race: approved

## Validation

- `bunx vitest run packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts packages/athena-webapp/convex/cashControls/closeouts.test.ts packages/athena-webapp/convex/cashControls/deposits.test.ts --reporter=dot`
- `bunx vitest run packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts packages/athena-webapp/convex/cashControls/closeouts.test.ts packages/athena-webapp/convex/cashControls/deposits.test.ts packages/athena-webapp/convex/pos/application/completeTransaction.test.ts packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts --reporter=dot`
- `bun run --filter '@athena/webapp' test -- RegisterSessionView.test.tsx`
- `bun run --filter '@athena/webapp' typecheck`
- `bun run --filter '@athena/webapp' lint:frontend:changed`
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bun run pr:athena`

## Notes

`pr:athena` passed and recorded a reusable pre-push proof for tree `0147c286aa9909452ec3ab97e88f443064ec910b`.
