### PR TITLE
V26-867/V26-871 Repair register sync mapping reviews

### DIFF
--- a/docs/plans/2026-06-26-001-register-sync-mapping-repair-plan.html
+++ b/docs/plans/2026-06-26-001-register-sync-mapping-repair-plan.html
@@ -1,0 +1,248 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>fix: Repair missing register-session mappings for completed POS sales</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --ink: #1f2933;
+        --muted: #5f6f76;
+        --line: #d9e2e7;
+        --panel: #f7fafb;
+        --accent: #2f6f73;
+        --warn: #8a5a00;
+        --ok: #1f7a4d;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        color: var(--ink);
+        background: #fff;
+        font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      header {
+        border-bottom: 1px solid var(--line);
+        background: var(--panel);
+      }
+      .wrap {
+        max-width: 1080px;
+        margin: 0 auto;
+        padding: 28px 24px;
+      }
+      h1 {
+        margin: 0 0 8px;
+        font-size: 30px;
+        line-height: 1.2;
+        letter-spacing: 0;
+      }
+      h2 {
+        margin: 32px 0 12px;
+        font-size: 20px;
+        letter-spacing: 0;
+      }
+      h3 {
+        margin: 22px 0 8px;
+        font-size: 16px;
+      }
+      p { margin: 0 0 12px; }
+      code {
+        padding: 1px 5px;
+        border: 1px solid var(--line);
+        border-radius: 4px;
+        background: #f4f7f8;
+        font-size: 0.92em;
+      }
+      nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 18px;
+      }
+      nav a {
+        padding: 6px 10px;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: #fff;
+        color: var(--accent);
+        text-decoration: none;
+      }
+      .meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        color: var(--muted);
+      }
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 3px 8px;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: #fff;
+        color: var(--muted);
+        font-size: 13px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 12px;
+      }
+      .card {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 14px;
+        background: #fff;
+      }
+      .callout {
+        border-left: 4px solid var(--accent);
+        background: var(--panel);
+        padding: 12px 14px;
+        margin: 12px 0;
+      }
+      .warning { border-left-color: var(--warn); }
+      ul {
+        margin: 0 0 12px 20px;
+        padding: 0;
+      }
+      li { margin: 5px 0; }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 12px 0;
+      }
+      th, td {
+        border: 1px solid var(--line);
+        padding: 9px;
+        text-align: left;
+        vertical-align: top;
+      }
+      th { background: var(--panel); }
+      .unit {
+        border-top: 1px solid var(--line);
+        padding-top: 16px;
+        margin-top: 16px;
+      }
+      footer {
+        border-top: 1px solid var(--line);
+        color: var(--muted);
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="wrap">
+        <h1>fix: Repair missing register-session mappings for completed POS sales</h1>
+        <div class="meta">
+          <span class="badge">Type: fix</span>
+          <span class="badge">Status: active</span>
+          <span class="badge">Date: 2026-06-26</span>
+          <span class="badge">Source: markdown plan</span>
+        </div>
+        <nav aria-label="Plan sections">
+          <a href="#summary">Summary</a>
+          <a href="#requirements">Requirements</a>
+          <a href="#design">Design</a>
+          <a href="#units">Units</a>
+          <a href="#risks">Risks</a>
+          <a href="#verification">Verification</a>
+        </nav>
+      </div>
+    </header>
+    <main class="wrap">
+      <section id="summary">
+        <h2>Summary</h2>
+        <p>Completed local POS sales that sync without a usable register-session mapping should be repairable, not reject-only. A manager-approved repair creates or reuses the missing local-to-cloud register-session mapping, replays the original sale idempotently, and keeps inventory, payment, and closeout consequences explicit.</p>
+        <div class="callout">
+          Field example: register session <code>th7dggy861qj04qm0rbk3xk635898wcv</code> shows completed receipts under review, but the current backend classifies the missing mapping as generic review and leaves rejection as the available action.
+        </div>
+      </section>
+
+      <section id="requirements">
+        <h2>Requirements</h2>
+        <div class="grid">
+	          <div class="card"><strong>Review kind</strong><br>Classify missing register-session mappings as first-class repair review, including ungrouped conflicts that validate against the current register session.</div>
+	          <div class="card"><strong>Evidence</strong><br>Show full receipt, cashier, tender, item, local event, and target-drawer facts only to store-scoped managers.</div>
+	          <div class="card"><strong>Repair</strong><br>Require manager staff proof, selected conflict ids, a freshness token, repair mapping reuse, sale replay, and exact conflict settlement.</div>
+	          <div class="card"><strong>Closeout</strong><br>Use a generic closeout hold helper so pending void approvals and repairable sale-mapping conflicts both block final closure without blocking submitted counts.</div>
+        </div>
+      </section>
+
+      <section id="design">
+        <h2>Key Design</h2>
+        <ul>
+          <li>Add <code>missing_register_session_mapping</code> review kind and repair-aware action policy.</li>
+	          <li>Validate the explicit current Cash Controls register session and detect the finalization hold; v1 does not add target search or Operations UI.</li>
+	          <li>Evaluate ungrouped store/terminal missing-mapping conflicts against the current register session so repairable sales do not depend on a mapping before they appear.</li>
+	          <li>Create or reuse an audited repair mapping with same-target reuse across source event ids, then reuse <code>projectLocalSyncEvent</code>.</li>
+	          <li>Require a freshness token covering conflicts, source events, local register session, target session, Daily Close state, mapping state, and eligibility facts.</li>
+	          <li>Use existing reviewed-sale inventory and payment semantics to retain the sale while routing unsafe stock correction to Operations.</li>
+	          <li>Generalize the pending-void closeout guard into typed hold providers, then add repairable sale-mapping conflicts as another provider.</li>
+	          <li>Allow reviewed sale repair while an unresolved closeout is held, refresh expected cash and variance evidence, and never reopen finalized drawers.</li>
+	          <li>Keep Terminal Health explanatory only for these business-fact conflicts.</li>
+        </ul>
+      </section>
+
+      <section id="units">
+        <h2>Implementation Units</h2>
+        <article class="unit">
+	          <h3>U1. Validate target and finalization hold</h3>
+	          <p>Validate only the current register session and detect the closeout finalization hold from persisted store, terminal, register, Daily Close date/status, mapping, lifecycle, and ungrouped missing-mapping conflict facts.</p>
+	        </article>
+	        <article class="unit">
+	          <h3>U2. Classify and enrich review evidence</h3>
+	          <p>Add <code>missing_register_session_mapping</code>, attach completed-sale evidence, target validation facts, and the freshness token.</p>
+	        </article>
+	        <article class="unit">
+	          <h3>U3. Add manager-approved mapping repair mutation</h3>
+	          <p>Require linked manager staff proof, recompute persisted preconditions, create or reuse the repair mapping, replay the sale, audit the action, and preserve rejection as explicit intent.</p>
+	        </article>
+	        <article class="unit">
+	          <h3>U4. Replay repaired sale events</h3>
+	          <p>Use existing sale projection with focused natural-key recovery for the repaired <code>sale_completed</code> path and settle exact selected conflicts only.</p>
+	        </article>
+	        <article class="unit">
+	          <h3>U5. Generalize closeout holds</h3>
+	          <p>Extract the pending-void finalization guard into a shared POS sync/review policy helper with typed hold providers, add repairable sale-mapping conflicts as a provider, guard every final-close and deposit boundary, and refresh closeout evidence after repair.</p>
+	        </article>
+	        <article class="unit">
+	          <h3>U6. Update Cash Controls surface</h3>
+	          <p>Show <code>Repair and apply sale activity</code> for scoped repairable rows, including submitted-closeout hold states.</p>
+	        </article>
+	        <article class="unit">
+	          <h3>U7. Validate the implementation slice</h3>
+	          <p>Run focused backend and Cash Controls UI tests, then graphify after implementation code changes.</p>
+	        </article>
+      </section>
+
+      <section id="risks">
+        <h2>Risks</h2>
+        <table>
+          <thead><tr><th>Risk</th><th>Mitigation</th></tr></thead>
+          <tbody>
+	            <tr><td>Wrong drawer attachment</td><td>Explicit current-target validation and server-side precondition recomputation from persisted records.</td></tr>
+	            <tr><td>Duplicate records</td><td>Focused natural-key recovery and retry tests for the repaired sale path.</td></tr>
+	            <tr><td>Inventory review hidden</td><td>Retain sale and create/preserve Operations inventory review.</td></tr>
+	            <tr><td>Closeout totals drift</td><td>Hold final closure and deposits through the generic helper while pending void approvals or repairable sale-mapping conflicts remain, then refresh expected cash/variance evidence after repair.</td></tr>
+	            <tr><td>Sensitive evidence leak</td><td>Gate full review evidence to store-scoped manager proof and minimize Operations/unauthorized payloads.</td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="verification">
+        <h2>Verification</h2>
+        <ul>
+          <li><code>bun test packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts</code></li>
+          <li><code>bun test packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts</code></li>
+          <li><code>bun test packages/athena-webapp/convex/cashControls/deposits.test.ts</code></li>
+          <li><code>bun test packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx</code></li>
+	          <li><code>bun run graphify:rebuild</code> after implementation changes code.</li>
+        </ul>
+      </section>
+    </main>
+    <footer>
+      <div class="wrap">Generated from docs/plans/2026-06-26-001-register-sync-mapping-repair-plan.md</div>
+    </footer>
+  </body>
+</html>

--- a/docs/plans/2026-06-26-001-register-sync-mapping-repair-plan.md
+++ b/docs/plans/2026-06-26-001-register-sync-mapping-repair-plan.md
@@ -1,0 +1,525 @@
+---
+title: "fix: Repair missing register-session mappings for completed POS sales"
+type: fix
+status: active
+date: 2026-06-26
+---
+
+# fix: Repair missing register-session mappings for completed POS sales
+
+## Summary
+
+Completed local POS sales that sync without a usable register-session mapping should not be reject-only. The manager path should repair the missing local-to-cloud register-session mapping when Athena has enough evidence, replay the original completed sale idempotently, and retain the business record while preserving separate review work for inventory, payment, and closeout issues.
+
+The current state visible on register session `th7dggy861qj04qm0rbk3xk635898wcv` is a good field example: Cash Controls reports synced register activity that needs manager review, shows completed receipts under review, but only offers rejection because the missing mapping conflict falls through to the generic/unknown review policy.
+
+---
+
+## Problem Frame
+
+Local-first POS deliberately records completed sale events before cloud projection. When projection later cannot resolve `localRegisterSessionId` to a cloud `registerSessionId`, `projectLocalSyncEvent` creates `permission` conflicts with the summary `Register session mapping is missing for synced POS history.` Those conflicts are real, but the completed sales are not disposable. Treating the condition as reject-only discards recoverable business facts and makes Cash Controls a cleanup screen instead of a manager reconciliation surface.
+
+The boundary that needs to change is not just UI copy. Athena needs a first-class repair contract that:
+
+- proves the current Cash Controls register session is the safe target,
+- creates or reuses the missing mapping,
+- replays the source local event through existing projection,
+- resolves only the conflicts that actually settled,
+- keeps closeout, inventory, and payment consequences explicit.
+
+---
+
+## Requirements
+
+### Review Classification And Evidence
+
+- R1. Missing register-session mapping conflicts for completed `sale_completed` events classify as a first-class review kind, not `unknown`.
+- R2. The review kind exposes a repair-capable action policy only when the current Cash Controls register session is a safe explicit target; v1 does not search for or let managers choose alternate target sessions.
+- R2a. Register-session review reads and repair mutations must evaluate ungrouped store/terminal `needs_review` missing-mapping conflicts against the explicit current `registerSessionId`; true missing-mapping conflicts cannot depend on an existing mapping before they appear in the review set.
+- R3. Review evidence includes receipt, local transaction id, local register session id, local event id, sequence/upload order, cashier, terminal, register number, completed time, total, tender summary, item count, and item lines.
+- R4. Review evidence includes target-session validation facts for the current register session: cloud register session id, status, store, terminal, register number, opened time, Daily Close operating date/status, expected cash, and why the target is or is not repairable.
+- R5. Operator-facing copy uses calm product wording and does not expose raw backend conflict summaries as the final message.
+- R5a. Cash Controls read models expose full sale, tender, cashier, and cash-position evidence only to store-scoped manager users and existing store-scoped full-admin Cash Controls readers. Full-admin read access does not grant repair authority in v1. Other users get a minimal blocked/review-count payload with no tender details, counted cash, full item lines, staff identity, raw conflict payload, or source-event metadata.
+
+### Repair Contract
+
+- R6. Approval requires linked active manager staff proof for the source store at the server command boundary and records the actor, selected conflicts, source event ids, target register session, and repair result. This repair is never automatic and does not run from `pos_only` access without manager proof.
+- R6a. The server derives source store, terminal, local register session, source event, and target register session from persisted records. Client-supplied store/terminal/register ids are preconditions only and are rejected if they do not match persisted state.
+- R7. Repair refuses cross-store, cross-terminal, wrong-register, wrong-operating-date, superseded-session, `closed`, finalized Daily Close, finalized register closeout, and closeout-incompatible targets before creating any mapping or replaying any event.
+- R8. Repair refuses to overwrite an existing `posLocalSyncMapping` that maps the same local register session to a different cloud register session.
+- R9. Repair creates or reuses a `posLocalSyncMapping` for `localIdKind: "registerSession"` through a dedicated repair helper before replaying the preserved source event.
+- R10. Reprojection is idempotent across sync retry, manager double-submit, and known partial projection for the repaired `sale_completed` path.
+- R11. Repair approval requires exact `reviewConflictIds` and a freshness token. Approval resolves only exact selected conflicts, except sibling conflicts that are explicitly proven to represent the same settled source condition.
+- R12. Rejection remains available for invalid, duplicate, or unsafe local activity, but it records manager intent and retains the local event evidence.
+
+### Sale, Inventory, Payment, And Closeout Semantics
+
+- R13. Sale repair retains the completed sale and payment evidence; it never rewrites receipt totals or drops sale lines to make projection easier.
+- R14. If inventory cannot safely decrement, the sale still projects and Athena creates or preserves the Operations-owned `synced_sale_inventory_review` work item.
+- R15. Payment projection preserves original evidence but ledger allocations must reconcile to sale total under existing reviewed-sale payment rules.
+- R16. Closeout submission and counting remain allowed while finalization holds exist. Final register closure is blocked while any hold provider reports an active hold, including pending completed-sale void approvals and repairable missing-mapping completed-sale conflicts, even when the submitted closeout has no variance.
+- R16a. Closeout hold mechanics are generic: each provider returns a stable hold kind, count, blocking reason, manager-facing copy key, safe routing/action metadata, sensitive-evidence policy, and the facts needed to recompute the hold before finalization.
+- R16b. Cash-affecting hold providers also block register-session deposit recording while active, preserving the existing pending-void deposit precondition and extending it to repairable missing-mapping sale holds.
+- R17. Repair into `open` or `active` sessions is allowed when the sale occurred within the current operating date. Repair into `closing` is allowed only when final closure is already being held for repairable completed-sale mapping conflicts, the sale occurred before closeout submission, and the closeout is not finalized.
+- R18. Applying a repaired sale while the target session is `closing` updates expected cash and closeout/variance review evidence, keeps the closeout unresolved, and allows finalization only after `listRegisterSessionCloseoutHolds` reports no active providers and normal variance policy passes.
+- R18a. Closeout and duplicate-closeout conflicts remain open with clear copy after sale repair unless they are the exact selected conflict or are explicitly proven to be the same settled source condition. v1 does not reopen finalized closeouts or settle duplicate closeout rows as a side effect of sale repair.
+
+### Surfaces
+
+- R19. Cash Controls register detail shows repairable completed sale rows with a primary `Repair and apply sale activity` decision, scoped to selected review conflict ids.
+- R20. Mixed review groups do not get a global drawer-level repair button unless every selected item has the same safe action scope.
+- R21. No Operations UI changes in v1. Existing Operations work items may remain as-is, but v1 adds no new Operations links, copy, repair controls, or evidence presentation.
+- R22. Terminal Health remains explanatory for business-fact conflicts; it must not auto-repair completed sale/payment/inventory/closeout facts.
+
+---
+
+## Scope Boundaries
+
+- This plan does not implement code.
+- This plan does not create a support-only backfill script as the primary path; the product path is manager-approved repair where evidence is sufficient.
+- This plan does not auto-attach across terminal, store, register, or operating-day mismatch.
+- This plan does not reopen finalized Daily Close or finalized register closeouts in this slice.
+- This plan does not make Terminal Health a hidden business-record repair surface.
+- This plan does not redesign all POS local sync conflict types; it handles the missing register-session mapping gap for completed sales from Cash Controls.
+- This plan does not add Operations repair UI in v1.
+- This plan does not reopen `closed` sessions. Closeout submission can move a register to unresolved `closing`, but final closure is held until repairable completed-sale mapping conflicts are resolved.
+- This plan does not add a second closeout-hold branch for sale-mapping conflicts; it generalizes the existing pending-void finalization guard so future hold providers can plug in.
+
+### Deferred Follow-Up Work
+
+- A controlled support tool for ambiguous multiple-candidate repairs.
+- Reopen/carry-forward policy for already finalized Daily Close after late sale repair.
+- Broader local sync repair dashboard if more repair kinds prove product-worthy.
+- Operations Queue repair action parity after the Cash Controls path is proven.
+- Duplicate-closeout sibling settlement beyond exact selected/same-source conflicts.
+
+---
+
+## Context & Research
+
+### Observed Field State
+
+- URL context: `/wigclub/store/wigclub/cash-controls/registers/th7dggy861qj04qm0rbk3xk635898wcv`.
+- Register detail shows `needs review` for synced register activity and completed receipts under review.
+- The review reason is `Register session mapping is missing for synced POS history.`
+- The current UI presents rejection as the available reviewed sale action because the backend classification falls through to reject-only.
+
+### Relevant Code And Patterns
+
+- `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts` emits missing mapping conflicts from pending checkout, sale completion, sale clear, and register closeout projection paths.
+- `packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts` resolves register sessions by `posLocalSyncMapping`, then falls back only when the local id is already a valid cloud register session id in the same store/terminal.
+- `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts` classifies register-session sync review kinds and currently has no distinct missing-mapping repair kind.
+- `packages/athena-webapp/convex/cashControls/deposits.ts` owns `resolveRegisterSessionSyncReview`; it applies known reviewed sale, inventory, staff, closeout, and server-rejected cases but cannot repair missing register-session mappings.
+- Existing review grouping can miss true missing-mapping conflicts because grouping by register session currently depends on either an existing mapping or a local id that already normalizes to a cloud register session. The v1 read/mutation contract must explicitly evaluate ungrouped store/terminal missing-mapping conflicts against the current register detail session.
+- `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx` already renders row-level review decisions and passes scoped `reviewConflictIds`.
+- `packages/athena-webapp/convex/operations/operationalWorkItems.ts` surfaces mapped register sync review work to Operations; v1 should not add direct Operations repair unless required after Cash Controls is fixed.
+- `packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts` intentionally avoids auto-repair for sale/payment/inventory/closeout facts.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md` says completed local sales must be preserved and conflicts promoted to review instead of rewriting or hiding local history.
+- `docs/solutions/architecture/athena-pos-cashier-continuity-review-deferral-2026-06-20.md` says recoverable sync invariants should become review evidence instead of cashier blockers or discarded sales.
+- `docs/solutions/logic-errors/athena-cash-controls-sale-sync-review-evidence-2026-06-18.md` says Cash Controls review must show sale evidence and the original selected sync conflict must not block its own idempotent replay.
+- `docs/solutions/logic-errors/athena-pos-register-sync-closeout-review-recovery-2026-05-23.md` says review commands must settle the source sync event, not only the review row.
+- `docs/solutions/logic-errors/athena-pos-sync-review-workspace-boundaries-2026-06-19.md` says Cash Controls owns drawer/sale decisions, Operations owns inventory correction, and raw backend wording is not product copy.
+- `docs/solutions/logic-errors/athena-pos-register-sync-and-catalog-recovery-2026-05-26.md` says POS and Cash Controls should share sync review state and idempotent projection semantics.
+- `docs/product-copy-tone.md` says operator-facing copy should lead with state, name the next action, and normalize backend wording.
+
+### External References
+
+- None. The repo has direct domain patterns and current backend/UI surfaces for this repair.
+
+---
+
+## Key Technical Decisions
+
+- Add a distinct review kind, tentatively `missing_register_session_mapping`, instead of overloading `register_not_open_sale` or `inventory_review`.
+- Add a validation helper for the explicit current Cash Controls register session target; v1 does not perform alternate target discovery.
+- Extend the register-session review read path to include ungrouped store/terminal missing-mapping conflicts when they validate against the current register session. Use the same helper from the mutation before filtering exact `reviewConflictIds`.
+- Repair orchestration is owned by the Cash Controls mutation. The mutation validates preconditions, creates/reuses the mapping, calls projection, and settles only eligible selected conflicts.
+- Add a dedicated `createOrReuseRegisterSessionRepairMapping` repository contract. It reuses a same local-register-session to same cloud-register-session mapping regardless of original `localEventId`, rejects different targets as a precondition failure, and records manager repair audit metadata separately.
+- Require a precondition hash returned by the read model and submitted by the UI. It covers selected conflict ids/statuses, source event ids/statuses, local register session id, current target register session id/status, mapping state, Daily Close status, and target validation facts.
+- Treat an existing same-target repair mapping as idempotent; treat a different-target mapping as a hard precondition failure.
+- Use the existing reviewed sale projection options for inventory shortfalls and payment mismatch handling instead of inventing a second sale projector.
+- Generalize the existing completed-sale void final-closeout guard into a closeout hold registry/helper. Pending void approvals and repairable missing-mapping completed-sale conflicts both become hold providers.
+- Allow closeout submission/counting to proceed, but run the generic hold helper before final closure: active holds keep the session in unresolved `closing` until each provider reports clear.
+- Allow reviewed sale repair into that unresolved `closing` state under manager proof, update expected cash and closeout/variance evidence, and keep the closeout unresolved until repairable sale-mapping conflicts settle.
+- Block repair into fully `closed`, finalized register closeout, or finalized Daily Close states for this slice; do not reopen closed sessions.
+- Define operating date by the store's Daily Close/opening-day record for the current register session. The sale `occurredAt` must map to that same operating date using the same store-day helper used by operations closeout code; if no current day can be proven, repair is blocked.
+- Resolve exact selected conflicts only. Sibling conflicts stay open unless the mutation proves they are the same settled source condition.
+- Keep reject as an explicit manager decision, not the default action for recoverable missing mappings.
+- Full-admin without linked manager staff proof is not accepted for this v1 repair path; that can be revisited after audit semantics are explicit.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should missing mapping stay reject-only? No. Completed sales are business records and should be repairable when evidence is safe.
+- Should Terminal Health auto-repair this? No. Sale/payment/inventory/closeout facts belong in manager review, not support auto-repair.
+- Should the repair create a mapping or pass an override directly into projection? Create an audited mapping first, then reuse projection.
+- Should inventory failure block sale retention? No. Retain sale/payment and hand inventory correction to Operations.
+- Should repair support `closing` target sessions? Yes, but only for unresolved closeouts whose final closure is held for repairable completed-sale mapping conflicts. This mirrors the completed-sale void pattern: submit/count can proceed, final closure waits, and repair updates closeout evidence before finalization.
+- Should Operations expose the repair button in v1? No. Keep repair in Cash Controls. Operations UI changes, including links, minimized states, and repair buttons, are deferred from v1.
+
+### Deferred To Implementation
+
+- Exact enum/action names for the new review kind and action policy.
+- Exact store-day helper function name for deriving the Daily Close operating date from sale `occurredAt`.
+- Exact audit event name for manager-created repair mappings.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A[Local sale_completed sync event] --> B{Register-session mapping exists?}
+  B -->|yes| C[Existing projection]
+  B -->|no| D[Missing mapping conflict]
+  D --> E[Cash Controls review evidence]
+  E --> F{Current register session validates?}
+  F -->|no| G[Blocked copy / reject remains available]
+  F -->|yes| H[UI sends selected conflict ids and freshness token]
+  H --> I[Manager approves repair]
+  I --> J[Create or reuse audited registerSession mapping]
+  J --> K[Replay source sale_completed event through projectLocalSyncEvent]
+  K --> L{Projection settled?}
+  L -->|yes| M[Resolve exact selected conflicts]
+  L -->|inventory shortfall| N[Retain sale and open Operations inventory review]
+  M --> O{Closeout submitted?}
+  O -->|yes| P[Refresh expected cash and keep closeout unresolved]
+  O -->|no| Q[Register remains open/active]
+```
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1[U1 target validation and hold detection helper] --> U2[U2 classify and enrich review evidence]
+  U2 --> U3[U3 manager repair mutation]
+  U3 --> U4[U4 sale replay and strict conflict settlement]
+  U1 --> U5[U5 closeout finalization guard wiring]
+  U4 --> U5
+  U2 --> U6[U6 Cash Controls UI]
+  U5 --> U6
+  U6 --> U7[U7 validation and regression suite]
+```
+
+- U1. **Validate the explicit Cash Controls target and finalization hold**
+
+**Goal:** Centralize repair eligibility and finalization-hold detection for the current register session so read model, mutation, and closeout commands enforce the same target rules.
+
+**Requirements:** R2, R2a, R4, R5a, R7, R8, R16, R17
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.ts` if the hold detector belongs closer to closeout commands
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts` if repository access needs a helper
+- Test: `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+
+**Approach:**
+- Validate only the current Cash Controls `registerSessionId` as target; do not search alternate candidates in v1.
+- Add a register-session-scoped helper that scans store/terminal `needs_review` missing-mapping conflicts not already grouped by mapping, then evaluates each one against the current target session.
+- Add a finalization-hold predicate that returns whether repairable completed-sale missing-mapping conflicts should keep the current session in unresolved `closing`.
+- Candidate must match persisted source store, terminal, register number when present, and Daily Close operating date.
+- Compute operating date from the same store-day/Daily Close helper used by operations closeout code; sale `occurredAt` must map to the current register session's active Daily Close day.
+- Existing same-target mapping is eligible/idempotent.
+- Existing different-target mapping is blocked.
+- `closing` sessions are eligible only when U1's finalization-hold predicate is true and the closeout is not finalized.
+- Fully `closed`, finalized register closeout, and finalized Daily Close sessions are blocked before mapping creation or replay.
+- Emit machine-readable blocker codes, read-side authorization state, and normalized display copy.
+
+**Test scenarios:**
+- Current open/active same-terminal/register/day target is repairable.
+- Current unresolved `closing` target is repairable when the finalization hold is active, the sale occurred before closeout submission, and neither register closeout nor Daily Close is finalized.
+- Ungrouped missing-mapping conflict appears under the current register session when the target validates.
+- Ungrouped missing-mapping conflict stays out of the current register session when target validation fails.
+- Wrong store, wrong terminal, wrong register, wrong operating date, finalized `closed`, finalized closeout, and completed Daily Close are blocked.
+- `closing` without the repairable-conflict finalization hold is blocked.
+- Existing different mapping is a hard precondition failure.
+- Existing same mapping behaves as idempotent repair.
+- Unauthorized and non-full-admin non-manager read access receives minimized/redacted evidence.
+
+---
+
+- U2. **Classify missing register-session mapping as repairable review**
+
+**Goal:** Make missing mapping conflicts first-class review items with sale evidence, target validation, and action policy.
+
+**Requirements:** R1, R2, R3, R4, R5, R5a, R19, R20
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.test.ts` if present, otherwise cover via `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+
+**Approach:**
+- Add review kind `missing_register_session_mapping`.
+- Detect conflicts with missing mapping summaries/details from completed sale events and attach existing sale summary evidence.
+- Include ungrouped missing-mapping conflicts returned by U1 under the current register session, with enough metadata to preserve exact selected conflict ids.
+- Return `repair_or_reject`-style action policy only when U1 validates the current register session as repairable.
+- Return blocked copy and support-needed evidence when U1 blocks the current target.
+- Include `targetRegisterSessionId`, `candidatePreconditionHash`, and target validation facts in the review item returned to the UI.
+
+**Test scenarios:**
+- Completed sale missing mapping produces repairable review kind with sale evidence and a freshness token.
+- Completed sale missing mapping produces a repairable action for `closing + finalization hold` when U1 validates the target.
+- Non-sale missing mapping stays non-repairable unless explicitly supported.
+- Blocked targets show normalized copy and no repair action.
+- Unauthorized readers cannot infer tender, cashier, counted cash, item-line, raw conflict, or source event details.
+
+---
+
+- U3. **Add manager-approved mapping repair mutation**
+
+**Goal:** Repair the missing mapping under server-side authorization and stable preconditions.
+
+**Requirements:** R6, R6a, R8, R9, R11, R12, R22
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts`
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts`
+- Test: `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+
+**Approach:**
+- This mutation is the single repair orchestration boundary: it validates, creates/reuses mapping, calls projection, and settles selected conflicts.
+- Add mutation input for store, register session, terminal, target register session, selected conflict ids, and precondition hash. `reviewConflictIds` and the hash are required for repair approval.
+- Derive source store, terminal, source events, local register session, and target register session from persisted records; reject mismatched client arguments.
+- Require linked active manager staff proof for the source store. Do not allow automatic repair or full-admin-without-staff-profile repair in v1.
+- Recompute explicit target eligibility inside the mutation.
+- Before filtering `reviewConflictIds`, load both already grouped conflicts and ungrouped store/terminal missing-mapping conflicts evaluated through U1 for the explicit current register session.
+- Create or reuse `posLocalSyncMapping` through `createOrReuseRegisterSessionRepairMapping`, which reuses same-target mappings across source event ids and rejects different targets.
+- When the target is `closing`, require the final-closeout hold state and the sale-before-closeout precondition before replay.
+- Record an operational event/audit trace with selected conflicts, source events, target, actor, and outcome.
+- Reject does not delete local evidence; it settles exact selected source conflicts as manager-rejected.
+
+**Test scenarios:**
+- Manager repair creates mapping and records audit metadata.
+- POS-only without manager proof cannot repair.
+- Full-admin without linked manager staff proof cannot repair in v1.
+- Manager from another store cannot repair.
+- Stale precondition fails without side effects.
+- Reject records intent and leaves local event evidence available.
+- Same-target mapping with a different original `localEventId` is reused; different-target mapping fails.
+- Repair mutation accepts selected ids from the ungrouped missing-mapping helper when target validation succeeds.
+
+---
+
+- U4. **Replay repaired sale events and settle exact selected conflicts**
+
+**Goal:** Reuse existing sale projection for the repaired `sale_completed` source event without broadening projector behavior.
+
+**Requirements:** R10, R11, R13, R14, R15
+
+**Dependencies:** U3
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts` only if event status settlement needs shared handling
+- Test: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts`
+
+**Approach:**
+- After repair mapping exists, call `projectLocalSyncEvent` for selected `sale_completed` source events with reviewed-sale projection options.
+- Add an explicit reviewed-closeout sale-repair option for `closing` targets so this path bypasses normal sale-usability only under manager proof and final-closeout hold preconditions.
+- Add only the natural-key recovery guards needed by this replay path: receipt/local transaction, POS session, payment `externalReference`, inventory review local id, service allocation references, and inventory movement disposition.
+- Resolve exact selected conflict ids only after the source event status is settled or the sale side effects are proven already present.
+- Resolve sibling conflicts only when they are explicitly proven to represent the same settled source condition; leave inventory/payment/closeout siblings open otherwise.
+- If inventory cannot safely mutate, keep sale/payment projected and create/preserve Operations review.
+- When replay applies to a `closing` target, update expected cash and closeout/variance evidence without finalizing the closeout.
+- Recompute expected cash and variance from current persisted register facts after replay and before the finalization hold is recomputed or any final close proceeds.
+
+**Test scenarios:**
+- Repair and replay creates exactly one transaction/payment/item set.
+- Double-submit and sync retry do not duplicate records.
+- Orphaned transaction/payment/work-item records with missing mappings are recovered by natural key or fail cleanly without duplication.
+- Inventory shortfall retains sale and creates `synced_sale_inventory_review`.
+- Repairing a sale first does not make later replay/settlement of original register-open or closeout source events throw on same-target register-session mapping.
+- Mixed review groups settle exact selected ids only.
+- Repair into `closing` updates expected cash/variance evidence and leaves the closeout unresolved.
+
+---
+
+- U5. **Generalize closeout finalization holds and refresh closeout evidence**
+
+**Goal:** Reuse and generalize the pending-void closeout hold mechanics so cashiers can submit/count closeout while any pluggable closeout hold prevents unsafe final closure.
+
+**Requirements:** R16, R16a, R16b, R17, R18, R18a
+
+**Dependencies:** U2, U4
+
+**Files:**
+- Add/modify: `packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts` or equivalent POS sync/review policy module
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Test: `packages/athena-webapp/convex/operations/registerSessions.trace.test.ts` only to document that the low-level close helper remains a state-transition primitive
+- Test: `packages/athena-webapp/convex/cashControls/closeouts.test.ts`
+- Test: `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+
+**Approach:**
+- Own `listRegisterSessionCloseoutHolds` in a POS sync/review policy module that can be imported by `cashControls/closeouts.ts`, `cashControls/deposits.ts`, and `pos/application/sync/projectLocalEvents.ts` without creating a Cash Controls-to-Operations dependency inversion.
+- Extract the existing pending-void closeout checks into a shared register-session finalization hold helper, tentatively `listRegisterSessionCloseoutHolds`.
+- Model each hold as a typed provider result. Initial providers:
+  - `pending_completed_sale_void_approvals`, backed by the existing pending-void approval lookup.
+  - `repairable_missing_register_session_mapping_sales`, backed by U1's repairable missing-mapping conflict predicate.
+- Before any path marks the register session `closed`, call the generic hold helper and block finalization if any provider reports an active hold.
+- Keep `closeRegisterSession` / operations register-session transition helpers as dumb state-transition primitives. Do not make them query review state.
+- Apply the hold guard at every current close caller before invoking a close helper or directly patching `closed`: direct closeout submission/finalization, inline manager variance approval, async variance approval resolution, local-sync `register_closed` projection, and any future explicit finalization command.
+- Apply the same helper to `recordRegisterSessionDeposit`, blocking deposits when any cash-affecting hold provider is active. Initial cash-affecting providers are `pending_completed_sale_void_approvals` and `repairable_missing_register_session_mapping_sales`.
+- If holds exist, accept closeout submission/count data but keep the register in unresolved `closing`/manager-review state with clear review evidence, even when variance would otherwise be zero.
+- After each repair or explicit rejection, recompute expected cash, variance, and the finalization hold from persisted register facts. Final closeout can proceed only when `listRegisterSessionCloseoutHolds` reports no active providers and normal variance policy passes.
+- Preserve the existing pending-void behavior through the new helper. The refactor must not change pending-void copy, result shape, or tests except to route through the generic hold abstraction.
+- Keep hold provider payloads minimized. Sensitive sale, approval, staff, and tender facts remain behind their owning review surfaces; the closeout guard only needs hold kind, count, copy key, and routing/action metadata.
+- Use the same helper for read-model callouts and command preconditions so the UI and mutation do not drift.
+
+**Test scenarios:**
+- Existing pending-void closeout hold tests still pass through the generic helper.
+- Existing pending-void deposit-blocking tests still pass through the generic helper with unchanged or equivalent copy/result behavior.
+- Multiple hold providers can be active at once; finalization remains blocked until all holds clear.
+- Deposits are blocked while a repairable sale-mapping hold is active, and while multiple cash-affecting providers are active.
+- Zero-variance closeout with repairable sale-mapping conflicts is submitted but not finalized.
+- Variance closeout with repairable sale-mapping conflicts remains in manager review and does not hide the sale repair work.
+- Repair while `closing` updates expected cash/variance evidence and keeps finalization blocked until all repairable sale-mapping conflicts settle.
+- Direct closeout finalization, inline manager variance approval, async variance approval resolution, and local-sync `register_closed` projection all call the hold helper before closing.
+- Operations `closeRegisterSession` remains a dumb transition primitive; caller tests prove closeout/review owners enforce holds before calling it.
+- After repair/reject clears the sale-mapping hold, normal closeout finalization can proceed only if no other hold providers remain active.
+- Finalized `closed` sessions are not reopened.
+
+---
+
+- U6. **Update Cash Controls review surface**
+
+**Goal:** Present repairable completed sale activity with scoped decisions and calm copy.
+
+**Requirements:** R3, R4, R5, R5a, R16, R18, R19, R20
+
+**Dependencies:** U1, U3, U5
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`
+- Test: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+
+**Approach:**
+- Add row action copy such as `Repair and apply sale activity`.
+- Use state copy such as `Completed sale needs register repair before it can sync.`
+- Show evidence in three levels:
+  - Row summary: receipt, total, completed time, cashier when authorized, terminal/register, current drawer, and repairability reason.
+  - Expanded detail: item lines, tender summary, local ids, sequence/upload order, and source review reason.
+  - Confirmation: `Sale to apply` beside `Target drawer`, plus inventory and closeout consequences.
+- Show closeout-held state when applicable: `Closeout submitted. Repair reviewed sale activity before finalizing this drawer.`
+- Submit `targetRegisterSessionId`, `candidatePreconditionHash`, and exact `reviewConflictIds` with the repair action.
+- Hide drawer-level bulk action when selected review rows have mixed action scopes.
+- Cover interaction states:
+  - repairable: primary `Repair and apply sale activity`, secondary `Reject reviewed sale activity`;
+  - no safe current target: disabled repair, secondary reject, copy `Register repair is blocked. Review the drawer state before applying this sale.`;
+  - multiple/alternate candidates: no repair action in v1, copy `Register repair needs support review.`;
+  - closing with finalization hold: repair action remains available, copy `Closeout submitted. Repair reviewed sale activity before finalizing this drawer.`;
+  - closed/finalized day: no repair action, copy `Drawer is finalized. This sale needs support review before it can be applied.`;
+  - in flight: disable row actions and show progress copy `Repairing sale activity...`;
+  - stale precondition: keep row open and show `Review details changed. Refresh before applying this sale.`;
+  - unauthorized: no repair action and copy `Manager approval required.`;
+  - success: remove repaired row or move it to resolved state and refresh linked transactions;
+  - inventory partial: show sale applied and state that inventory review remains open without adding new Operations links in v1;
+  - rejection success: row resolves as manager-rejected without implying the sale disappeared;
+  - mutation failure: keep row open with generic recovery copy.
+
+**Test scenarios:**
+- Repairable sale row shows receipt, cashier, tender, total, target drawer, and repair action.
+- Mixed review rows keep row-level decisions and no unsafe global repair button.
+- Raw backend summary does not appear as primary operator copy.
+- Unauthorized/minimized state hides tender, counted cash, item-line, cashier, raw conflict, and source event details.
+- Stale-precondition, in-flight, success, inventory-partial, rejection-success, and mutation-failure states render with the intended copy.
+- Submitted closeout held by repairable sale-mapping conflicts renders repair actions and finalization guidance.
+
+---
+
+- U7. **Validation and regression suite**
+
+**Goal:** Prove repair retains records without broadening unsafe sync behavior.
+
+**Requirements:** All
+
+**Dependencies:** U1-U6
+
+**Files:**
+- Test: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts`
+- Test: `packages/athena-webapp/convex/cashControls/closeouts.test.ts`
+- Test: `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+- Test: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+- Validate: `packages/athena-webapp/docs/agent/testing.md`
+
+**Approach:**
+- Start with focused backend tests for repair and replay.
+- Add UI tests for review copy and action scoping.
+- Run the POS local sync/register validation set and cash-controls slice.
+- After implementation changes code, run `bun run graphify:rebuild`.
+
+---
+
+## Risks And Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Wrong drawer attachment corrupts cash controls | Target validation refuses mismatched store, terminal, register, operating date, existing mapping, invalid `closing`, `closed`, and finalized Daily Close states; mutation recomputes eligibility from persisted records. |
+| Duplicate transactions/payments/inventory | The repair path adds focused natural-key recovery for repaired `sale_completed` replay and tests retry/double-submit. |
+| Sale repair hides inventory work | Sale projection resolves mapping conflict but creates/preserves Operations inventory review when stock cannot mutate. |
+| Closeout totals drift silently | Closeout submission is allowed, but final closure is held while repairable sale-mapping conflicts remain; repaired sales refresh expected cash/variance evidence before finalization. |
+| Generic closeout hold becomes a vague framework | Limit v1 providers to existing pending void approvals and repairable missing-mapping sales, with typed provider outputs and regression tests for both. |
+| UI suggests a sale disappeared | Copy says completed sale needs register repair before sync; rejection is explicit and preserves evidence. |
+| Sensitive review evidence leaks | Read models gate full sale/tender/cash/staff/source-event evidence to store-scoped manager users or existing store-scoped full-admin Cash Controls readers, while repair remains manager-proof-only. |
+| Support auto-repair mutates business facts | Terminal Health remains read/explain only for these conflicts. |
+
+---
+
+## Acceptance Criteria
+
+- A completed sale with missing register-session mapping appears as a repairable Cash Controls review item only when the current `open`, `active`, or eligible unresolved `closing` register session validates as the safe target.
+- Manager approval requires linked active manager staff proof for the source store, exact `reviewConflictIds`, and the freshness token.
+- Manager approval creates/reuses the repair mapping, replays the source `sale_completed` event, and resolves exact selected conflicts only after projection settles.
+- Retry, double-submit, and sync retry create no duplicate records on the repaired sale path.
+- Unsafe targets are blocked with operator-readable copy and no side effects.
+- Inventory shortfall keeps the completed sale and opens or preserves Operations inventory review.
+- Closeout submission/counting remains available, but final closure is held through the generic closeout hold helper while pending void approvals or repairable missing-mapping completed-sale conflicts remain.
+- Pending completed-sale void closeout behavior is preserved through the generic helper without copy, result-shape, or authorization regressions.
+- Pending completed-sale void deposit blocking is preserved through the generic helper, and repairable sale-mapping holds also block deposits until the hold clears.
+- Repair into unresolved `closing` updates expected cash/variance evidence and keeps closeout unresolved until all active hold providers settle.
+- Fully closed sessions, finalized register closeouts, and finalized Daily Close sessions are not mutated by this slice.
+- Operations exposes no v1 repair controls, no new linked states, and no sensitive evidence.
+- Terminal Health does not offer auto-repair for sale/payment/inventory/closeout business facts.
+
+---
+
+## Verification Plan
+
+- Focused backend:
+  - `bun test packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+  - `bun test packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts`
+  - `bun test packages/athena-webapp/convex/cashControls/deposits.test.ts`
+- Focused UI:
+  - `bun test packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+- Repo-required after code changes:
+  - `bun run graphify:rebuild`
+- Delivery gate:
+  - Use the POS local sync/register and cash-controls slices documented in `packages/athena-webapp/docs/agent/testing.md`.
+  - Run broader `bun run pr:athena` after reviewer approval for implementation work.
+
+---
+
+## Rollout Notes
+
+- Ship behind linked store-scoped manager staff proof; no cashier workflow change is required.
+- Prefer a small backend-first implementation that makes repair safe and testable before widening UI affordances.
+- For existing production conflicts, repair should be performed through the same audited mutation once deployed, not through direct table edits.

--- a/docs/solutions/logic-errors/athena-register-closeout-generic-holds-2026-06-26.md
+++ b/docs/solutions/logic-errors/athena-register-closeout-generic-holds-2026-06-26.md
@@ -1,0 +1,84 @@
+---
+title: Athena Register Closeout Generic Holds
+date: 2026-06-26
+category: logic-errors
+module: athena-webapp
+problem_type: lifecycle_state_error
+component: cash-controls
+symptoms:
+  - "Completed synced sales with missing register-session mappings can only be rejected"
+  - "Closeout finalization can run before repairable synced sale corrections settle"
+  - "New cash-affecting register corrections risk adding one-off closeout gates"
+root_cause: closeout_hold_logic_was_encoded_as_pending_void_specific_branches
+resolution_type: shared_closeout_hold_policy
+severity: high
+tags:
+  - cash-controls
+  - pos
+  - register-session
+  - closeout
+  - local-sync
+  - approval-policy
+related:
+  - docs/solutions/logic-errors/athena-register-closeout-pending-void-policy-2026-06-25.md
+  - docs/solutions/logic-errors/athena-cash-controls-sale-sync-review-evidence-2026-06-18.md
+  - docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md
+---
+
+# Athena Register Closeout Generic Holds
+
+## Problem
+
+Register closeout finalization has to wait for any unresolved work that can
+change expected cash. Pending completed-sale void approvals were the first case,
+but synced completed sales with a missing register-session mapping have the same
+cash effect: the business sale exists and should be repaired into the drawer
+rather than rejected just to clear the review.
+
+Keeping the lock as a pending-void branch makes the next correction type easy to
+miss. Closeout submission, finalization, variance review approval, local-sync
+closeout projection, and deposit recording all need the same answer.
+
+## Solution
+
+Represent unresolved register corrections as `RegisterSessionCloseoutHold`
+records:
+
+- Each provider returns a stable `kind`, `count`, `cashAffecting` flag, and safe
+  operator metadata for one register session.
+- Closeout submission can still move the drawer into `closing` while
+  cash-affecting holds exist. It does not inline-consume manager variance proof
+  or close the drawer until the holds clear.
+- Finalization, async closeout approval completion, local-sync
+  `register_closed` projection, and deposit recording all call the shared hold
+  helper instead of checking only pending void approvals.
+- Void-only holds keep the established void-specific operator copy. Mixed or
+  non-void holds use generic pending register correction copy so future
+  providers do not need new closeout strings at every boundary.
+- Completed-sale register mapping repair is an `apply_or_reject` sync review
+  kind. Manager approval creates or reuses the missing local register-session
+  mapping for the already-completed transaction, then marks the source sync
+  event projected when no sibling conflicts remain.
+
+## Prevention
+
+- Add new cash-affecting closeout gates as hold providers, not as separate
+  checks in closeout, deposit, or local-sync projection code.
+- Keep hold metadata narrow. Cash Controls needs counts, kind, and safe
+  references, not raw approval notes, conflict payloads, proof ids, or reviewer
+  internals.
+- Test every closeout closure boundary for new hold kinds: closeout submission,
+  finalization, async closeout review approval, `register_closed` projection,
+  and stale deposit submission.
+- For repairable synced sale reviews, retain completed sale records whenever a
+  unique completed transaction can be matched. Reject remains available for
+  manager cleanup, but it should not be the only path.
+- Closed and closeout-rejected sessions remain terminal for mapping repair.
+  `closing` is allowed only while the matching local closeout evidence keeps the
+  sale before the closeout in the terminal sync sequence.
+
+## Related
+
+- `docs/solutions/logic-errors/athena-register-closeout-pending-void-policy-2026-06-25.md`
+- `docs/solutions/logic-errors/athena-cash-controls-sale-sync-review-evidence-2026-06-18.md`
+- `docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2127 files · ~0 words
+- 2128 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8002 nodes · 9400 edges · 2055 communities detected
+- 8032 nodes · 9450 edges · 2056 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2065,6 +2065,7 @@
 - [[_COMMUNITY_Community 2052|Community 2052]]
 - [[_COMMUNITY_Community 2053|Community 2053]]
 - [[_COMMUNITY_Community 2054|Community 2054]]
+- [[_COMMUNITY_Community 2055|Community 2055]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2110,7 +2111,7 @@ Nodes (60): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLan
 
 ### Community 4 - "Community 4"
 Cohesion: 0.09
-Nodes (59): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), capNonCashPaymentsToExpectedTotal(), collectExistingSaleMappings() (+51 more)
+Nodes (60): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), capNonCashPaymentsToExpectedTotal(), collectExistingSaleMappings() (+52 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.09
@@ -2126,59 +2127,59 @@ Nodes (48): buildFinalTrustedQuantitiesByRowNumber(), buildProductPageFinalizati
 
 ### Community 8 - "Community 8"
 Cohesion: 0.06
-Nodes (26): asRecord(), createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), getExpenseLocalSessionId(), getUploadSequenceScopeId(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeLocalEventPayload() (+18 more)
+Nodes (27): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatCompactTextList(), formatPaymentMethods(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp() (+19 more)
 
 ### Community 9 - "Community 9"
+Cohesion: 0.06
+Nodes (26): asRecord(), createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), getExpenseLocalSessionId(), getUploadSequenceScopeId(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeLocalEventPayload() (+18 more)
+
+### Community 10 - "Community 10"
 Cohesion: 0.09
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
 
-### Community 10 - "Community 10"
+### Community 11 - "Community 11"
 Cohesion: 0.06
 Nodes (21): assertPosLocalStoreOk(), buildRuntimeAppUpdateInput(), clearAcceptedTerminalIntegrityState(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus() (+13 more)
 
-### Community 11 - "Community 11"
+### Community 12 - "Community 12"
 Cohesion: 0.06
 Nodes (22): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+14 more)
 
-### Community 12 - "Community 12"
+### Community 13 - "Community 13"
 Cohesion: 0.09
 Nodes (34): annotateTerminalSyncEvidenceReviewTargets(), buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalRecoveryActions(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryManualReview(), buildTerminalRecoveryPreview() (+26 more)
 
-### Community 13 - "Community 13"
+### Community 14 - "Community 14"
 Cohesion: 0.07
 Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
-### Community 14 - "Community 14"
+### Community 15 - "Community 15"
+Cohesion: 0.07
+Nodes (10): arrayDetail(), buildCashControlsDashboardSnapshot(), buildReviewedSaleProjectionEvent(), getCompletedTransactionForRegisterMappingRepair(), normalizeReviewedNonCashOverpaymentPayload(), numberDetail(), recordDetail(), roundCurrencyAmount() (+2 more)
+
+### Community 16 - "Community 16"
 Cohesion: 0.08
 Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
 
-### Community 15 - "Community 15"
+### Community 17 - "Community 17"
 Cohesion: 0.12
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
-### Community 16 - "Community 16"
+### Community 18 - "Community 18"
 Cohesion: 0.14
 Nodes (34): asRecord(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale() (+26 more)
 
-### Community 17 - "Community 17"
+### Community 19 - "Community 19"
 Cohesion: 0.12
 Nodes (32): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+24 more)
 
-### Community 18 - "Community 18"
-Cohesion: 0.07
-Nodes (11): formatCompactTextList(), formatPaymentMethods(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary(), formatReviewTypeSummary(), formatTimestamp() (+3 more)
-
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
 Cohesion: 0.16
 Nodes (31): completed(), executeCallbackCommand(), executeClearStaleDrawerAuthority(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand(), executeUpdateApp(), failed() (+23 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
-
-### Community 21 - "Community 21"
-Cohesion: 0.07
-Nodes (8): arrayDetail(), buildCashControlsDashboardSnapshot(), buildReviewedSaleProjectionEvent(), normalizeReviewedNonCashOverpaymentPayload(), numberDetail(), recordDetail(), roundCurrencyAmount(), sumDepositsBySession()
 
 ### Community 22 - "Community 22"
 Cohesion: 0.11
@@ -2297,36 +2298,36 @@ Cohesion: 0.17
 Nodes (19): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady(), mapSyncStatus() (+11 more)
 
 ### Community 51 - "Community 51"
-Cohesion: 0.11
-Nodes (6): asBoolean(), asNumber(), asRecord(), buildRegisterCloseoutVarianceTimelineMessage(), formatCloseoutVarianceAmount(), getCashControlsConfig()
-
-### Community 52 - "Community 52"
 Cohesion: 0.16
 Nodes (17): asRecord(), buildSnapshotHash(), buildStoreInsightsPromptFromContextBundle(), buildStoreInsightsPromptFromContextEvents(), buildUserInsightsPromptFromContextBundle(), buildUserInsightsPromptFromContextEvents(), compactContextEventsForPrompt(), compactEnvironmentForPrompt() (+9 more)
 
-### Community 53 - "Community 53"
+### Community 52 - "Community 52"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 54 - "Community 54"
+### Community 53 - "Community 53"
 Cohesion: 0.15
 Nodes (16): findLatestOpenOperatingDay(), getTodaySummary(), getTransactionById(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile() (+8 more)
 
-### Community 55 - "Community 55"
+### Community 54 - "Community 54"
 Cohesion: 0.21
 Nodes (21): detectFormat(), extractJsonRows(), flattenJsonRows(), inferProductName(), isRecord(), looksLikeLabel(), normalizeKey(), normalizeLegacyRow() (+13 more)
 
-### Community 56 - "Community 56"
+### Community 55 - "Community 55"
 Cohesion: 0.25
 Nodes (21): asRecord(), errorFor(), getLocalExpenseSessionId(), getOrCreateSession(), isExpenseEvent(), itemSource(), itemSourceKey(), numberField() (+13 more)
 
-### Community 57 - "Community 57"
+### Community 56 - "Community 56"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 58 - "Community 58"
+### Community 57 - "Community 57"
 Cohesion: 0.18
 Nodes (18): assertValidEodLocalCompletionWindowMinutes(), assertValidEodThreshold(), assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getEodAutoCompletePolicyConfigWithCtx() (+10 more)
+
+### Community 58 - "Community 58"
+Cohesion: 0.11
+Nodes (6): asBoolean(), asNumber(), asRecord(), buildRegisterCloseoutVarianceTimelineMessage(), formatCloseoutVarianceAmount(), getCashControlsConfig()
 
 ### Community 59 - "Community 59"
 Cohesion: 0.18
@@ -2445,48 +2446,48 @@ Cohesion: 0.19
 Nodes (10): buildLatestRunDebugPayload(), getBoundedDebugRunsByCapability(), getLatestDebugRunByCapability(), getLatestDebugRunBySubject(), isActiveRunStale(), isActiveRunStatus(), selectLatestDebugRunFromCandidates(), shouldRecoverActiveRun() (+2 more)
 
 ### Community 88 - "Community 88"
+Cohesion: 0.25
+Nodes (12): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), classifyRegisterSessionSyncReview(), findProjectedRegisterSessionIdForRepairableMissingMapping(), findTransactionIdForSyncEvent(), hasInventoryReviewWorkItemForProjectedSale(), listOpenLocalSyncConflictsByRegisterSession() (+4 more)
+
+### Community 89 - "Community 89"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.13
 Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.24
 Nodes (15): buildGeneratedControlId(), captureRemoteAssistCoBrowseFrame(), collectSanitizedSurface(), collectSensitiveRegions(), collectVisibleText(), getControlId(), getControlPriority(), getElementLabel() (+7 more)
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.22
 Nodes (11): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), getInvalidationNodes(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline() (+3 more)
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.23
 Nodes (13): collectConvexReturnValidatorContractFindings(), escapeRegExp(), extractConvexPublicFunctionsWithReturns(), fileExists(), findMatchingDefinitionEnd(), hasConvexReturnContractProofForExport(), isConvexReturnContractSourcePath(), isRelevantConvexContractProofPath() (+5 more)
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.22
 Nodes (9): buildHistoricalContextEventAppendArgs(), buildHistoricalImportIdempotencyKey(), buildPrimarySubject(), buildStoppedReport(), countOmittedFields(), createEmptyReport(), increment(), planHistoricalStorefrontContextImport() (+1 more)
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.32
 Nodes (14): buildPosOperatorSnapshot(), buildRecentDayBuckets(), buildSummaryTrendBucket(), buildTransactionDateBuckets(), calculateDeltaPercent(), formatHourLabel(), formatPaymentMethodLabel(), formatShortDate() (+6 more)
-
-### Community 98 - "Community 98"
-Cohesion: 0.26
-Nodes (11): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), classifyRegisterSessionSyncReview(), findTransactionIdForSyncEvent(), hasInventoryReviewWorkItemForProjectedSale(), listOpenLocalSyncConflictsByRegisterSession(), numberDetail() (+3 more)
 
 ### Community 99 - "Community 99"
 Cohesion: 0.17
@@ -2758,15 +2759,15 @@ Nodes (5): clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), r
 
 ### Community 166 - "Community 166"
 Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 167 - "Community 167"
 Cohesion: 0.39
-Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 168 - "Community 168"
 Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
 ### Community 169 - "Community 169"
 Cohesion: 0.39
@@ -2817,24 +2818,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 181 - "Community 181"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 182 - "Community 182"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 183 - "Community 183"
+### Community 182 - "Community 182"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 184 - "Community 184"
+### Community 183 - "Community 183"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 185 - "Community 185"
+### Community 184 - "Community 184"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 185 - "Community 185"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 186 - "Community 186"
 Cohesion: 0.39
@@ -2969,208 +2970,208 @@ Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
 ### Community 219 - "Community 219"
+Cohesion: 0.38
+Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
+
+### Community 220 - "Community 220"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 226 - "Community 226"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 227 - "Community 227"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 228 - "Community 228"
-Cohesion: 0.48
-Nodes (6): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), isDuplicateRegisterOpenConflict(), skipped()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 229 - "Community 229"
 Cohesion: 0.48
-Nodes (5): canRepairProjectRegisterOpen(), getRepairOpenRegisterCloseoutReviewState(), normalizeRepairString(), resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+Nodes (6): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), isDuplicateRegisterOpenConflict(), skipped()
 
 ### Community 230 - "Community 230"
 Cohesion: 0.48
-Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
+Nodes (5): canRepairProjectRegisterOpen(), getRepairOpenRegisterCloseoutReviewState(), normalizeRepairString(), resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 231 - "Community 231"
+Cohesion: 0.48
+Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
+
+### Community 232 - "Community 232"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.33
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
-
-### Community 244 - "Community 244"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 245 - "Community 245"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 246 - "Community 246"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 247 - "Community 247"
 Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 248 - "Community 248"
 Cohesion: 0.33
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 249 - "Community 249"
-Cohesion: 0.29
-Nodes (1): ResizeObserverStub
+Cohesion: 0.33
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 250 - "Community 250"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
 ### Community 251 - "Community 251"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 252 - "Community 252"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 254 - "Community 254"
-Cohesion: 0.52
-Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 255 - "Community 255"
 Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 256 - "Community 256"
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+
+### Community 257 - "Community 257"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.38
 Nodes (3): getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusSignature()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.33
 Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
-
-### Community 260 - "Community 260"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 261 - "Community 261"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 262 - "Community 262"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 263 - "Community 263"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 263 - "Community 263"
+### Community 264 - "Community 264"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 264 - "Community 264"
+### Community 265 - "Community 265"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 265 - "Community 265"
+### Community 266 - "Community 266"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 266 - "Community 266"
+### Community 267 - "Community 267"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
-
-### Community 269 - "Community 269"
-Cohesion: 0.47
-Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
 ### Community 270 - "Community 270"
 Cohesion: 0.33
@@ -3189,132 +3190,132 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 274 - "Community 274"
+Cohesion: 0.47
+Nodes (3): canListRegisterSessionSyncConflicts(), listPendingCompletedSaleVoidApprovals(), listRegisterSessionCloseoutHolds()
+
+### Community 275 - "Community 275"
 Cohesion: 0.4
 Nodes (2): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository()
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 280 - "Community 280"
+### Community 281 - "Community 281"
 Cohesion: 0.6
 Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 284 - "Community 284"
+### Community 285 - "Community 285"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 285 - "Community 285"
+### Community 286 - "Community 286"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 286 - "Community 286"
+### Community 287 - "Community 287"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 287 - "Community 287"
+### Community 288 - "Community 288"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 288 - "Community 288"
+### Community 289 - "Community 289"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 289 - "Community 289"
-Cohesion: 0.4
-Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 290 - "Community 290"
 Cohesion: 0.4
-Nodes (2): moveFeaturedItem(), saveOrder()
+Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 291 - "Community 291"
+Cohesion: 0.4
+Nodes (2): moveFeaturedItem(), saveOrder()
+
+### Community 292 - "Community 292"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 292 - "Community 292"
+### Community 293 - "Community 293"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 293 - "Community 293"
+### Community 294 - "Community 294"
 Cohesion: 0.4
 Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
-### Community 294 - "Community 294"
+### Community 295 - "Community 295"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 295 - "Community 295"
+### Community 296 - "Community 296"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 296 - "Community 296"
+### Community 297 - "Community 297"
 Cohesion: 0.4
 Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
-### Community 297 - "Community 297"
+### Community 298 - "Community 298"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 298 - "Community 298"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 299 - "Community 299"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 300 - "Community 300"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 301 - "Community 301"
 Cohesion: 0.47
 Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
 
-### Community 301 - "Community 301"
+### Community 302 - "Community 302"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 302 - "Community 302"
+### Community 303 - "Community 303"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 303 - "Community 303"
+### Community 304 - "Community 304"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 304 - "Community 304"
+### Community 305 - "Community 305"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 305 - "Community 305"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 306 - "Community 306"
 Cohesion: 0.33
@@ -3329,200 +3330,200 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 309 - "Community 309"
-Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
-
-### Community 310 - "Community 310"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 310 - "Community 310"
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 311 - "Community 311"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 312 - "Community 312"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 313 - "Community 313"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 314 - "Community 314"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 315 - "Community 315"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 313 - "Community 313"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 314 - "Community 314"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 315 - "Community 315"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
 ### Community 316 - "Community 316"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 317 - "Community 317"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 318 - "Community 318"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 319 - "Community 319"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 320 - "Community 320"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 321 - "Community 321"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 322 - "Community 322"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 323 - "Community 323"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 324 - "Community 324"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 324 - "Community 324"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 325 - "Community 325"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 326 - "Community 326"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 326 - "Community 326"
+### Community 327 - "Community 327"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 327 - "Community 327"
+### Community 328 - "Community 328"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 328 - "Community 328"
+### Community 329 - "Community 329"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 329 - "Community 329"
+### Community 330 - "Community 330"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 330 - "Community 330"
+### Community 331 - "Community 331"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 331 - "Community 331"
+### Community 332 - "Community 332"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 332 - "Community 332"
+### Community 333 - "Community 333"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
-### Community 333 - "Community 333"
+### Community 334 - "Community 334"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 334 - "Community 334"
+### Community 335 - "Community 335"
 Cohesion: 0.6
 Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
-### Community 335 - "Community 335"
+### Community 336 - "Community 336"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 336 - "Community 336"
-Cohesion: 0.5
-Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 337 - "Community 337"
 Cohesion: 0.5
-Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
+Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 338 - "Community 338"
+Cohesion: 0.5
+Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
+
+### Community 339 - "Community 339"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 339 - "Community 339"
+### Community 340 - "Community 340"
 Cohesion: 0.5
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 340 - "Community 340"
+### Community 341 - "Community 341"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 341 - "Community 341"
+### Community 342 - "Community 342"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 342 - "Community 342"
+### Community 343 - "Community 343"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 343 - "Community 343"
+### Community 344 - "Community 344"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
-
-### Community 344 - "Community 344"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 345 - "Community 345"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 346 - "Community 346"
-Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
-
-### Community 347 - "Community 347"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 347 - "Community 347"
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 348 - "Community 348"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 349 - "Community 349"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 350 - "Community 350"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 350 - "Community 350"
+### Community 351 - "Community 351"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 351 - "Community 351"
+### Community 352 - "Community 352"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 352 - "Community 352"
+### Community 353 - "Community 353"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 353 - "Community 353"
+### Community 354 - "Community 354"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 354 - "Community 354"
+### Community 355 - "Community 355"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 355 - "Community 355"
+### Community 356 - "Community 356"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 356 - "Community 356"
+### Community 357 - "Community 357"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
-
-### Community 357 - "Community 357"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 358 - "Community 358"
 Cohesion: 0.4
@@ -3533,12 +3534,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 360 - "Community 360"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 361 - "Community 361"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 361 - "Community 361"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 362 - "Community 362"
 Cohesion: 0.4
@@ -3553,20 +3554,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 365 - "Community 365"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 366 - "Community 366"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 366 - "Community 366"
+### Community 367 - "Community 367"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 367 - "Community 367"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 368 - "Community 368"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 369 - "Community 369"
 Cohesion: 0.4
@@ -3585,84 +3586,84 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 373 - "Community 373"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 374 - "Community 374"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 375 - "Community 375"
+### Community 376 - "Community 376"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 376 - "Community 376"
+### Community 377 - "Community 377"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 377 - "Community 377"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 378 - "Community 378"
 Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 379 - "Community 379"
 Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
 ### Community 380 - "Community 380"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 381 - "Community 381"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 381 - "Community 381"
+### Community 382 - "Community 382"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 382 - "Community 382"
+### Community 383 - "Community 383"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 383 - "Community 383"
+### Community 384 - "Community 384"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 384 - "Community 384"
+### Community 385 - "Community 385"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 385 - "Community 385"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 386 - "Community 386"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 387 - "Community 387"
 Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 388 - "Community 388"
 Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
 ### Community 389 - "Community 389"
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+
+### Community 390 - "Community 390"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 390 - "Community 390"
+### Community 391 - "Community 391"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 391 - "Community 391"
+### Community 392 - "Community 392"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
-
-### Community 392 - "Community 392"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 393 - "Community 393"
 Cohesion: 0.4
@@ -3673,76 +3674,76 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 395 - "Community 395"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 396 - "Community 396"
 Cohesion: 0.5
-Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 397 - "Community 397"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
 ### Community 398 - "Community 398"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 399 - "Community 399"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 400 - "Community 400"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 401 - "Community 401"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 402 - "Community 402"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 402 - "Community 402"
+### Community 403 - "Community 403"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 403 - "Community 403"
+### Community 404 - "Community 404"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 404 - "Community 404"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 405 - "Community 405"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 406 - "Community 406"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 407 - "Community 407"
-Cohesion: 0.6
-Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
-
-### Community 408 - "Community 408"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 408 - "Community 408"
+Cohesion: 0.6
+Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
+
 ### Community 409 - "Community 409"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 410 - "Community 410"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 410 - "Community 410"
+### Community 411 - "Community 411"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 411 - "Community 411"
+### Community 412 - "Community 412"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
-
-### Community 412 - "Community 412"
-Cohesion: 0.67
-Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
 ### Community 413 - "Community 413"
 Cohesion: 0.5
@@ -3750,39 +3751,39 @@ Nodes (0):
 
 ### Community 414 - "Community 414"
 Cohesion: 0.67
-Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
+Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
 ### Community 415 - "Community 415"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 416 - "Community 416"
+Cohesion: 0.67
+Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
+
+### Community 417 - "Community 417"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 416 - "Community 416"
+### Community 418 - "Community 418"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
 
-### Community 417 - "Community 417"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 418 - "Community 418"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 419 - "Community 419"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 420 - "Community 420"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 421 - "Community 421"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 422 - "Community 422"
-Cohesion: 0.67
-Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 423 - "Community 423"
 Cohesion: 0.5
@@ -3790,15 +3791,15 @@ Nodes (0):
 
 ### Community 424 - "Community 424"
 Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
+Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
 ### Community 425 - "Community 425"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 426 - "Community 426"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 427 - "Community 427"
 Cohesion: 0.5
@@ -3813,48 +3814,48 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 430 - "Community 430"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
-
-### Community 431 - "Community 431"
-Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
-
-### Community 432 - "Community 432"
-Cohesion: 0.67
-Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
-
-### Community 433 - "Community 433"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 431 - "Community 431"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 432 - "Community 432"
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+
+### Community 433 - "Community 433"
+Cohesion: 0.67
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+
 ### Community 434 - "Community 434"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
 ### Community 435 - "Community 435"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 436 - "Community 436"
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 437 - "Community 437"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 437 - "Community 437"
+### Community 438 - "Community 438"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 439 - "Community 439"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 438 - "Community 438"
+### Community 440 - "Community 440"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
-
-### Community 439 - "Community 439"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 440 - "Community 440"
-Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 441 - "Community 441"
 Cohesion: 0.5
@@ -3862,27 +3863,27 @@ Nodes (0):
 
 ### Community 442 - "Community 442"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 443 - "Community 443"
-Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 444 - "Community 444"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 445 - "Community 445"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 446 - "Community 446"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 447 - "Community 447"
-Cohesion: 0.67
-Nodes (2): buildCtx(), buildQueryCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 448 - "Community 448"
 Cohesion: 0.5
@@ -3890,19 +3891,19 @@ Nodes (0):
 
 ### Community 449 - "Community 449"
 Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
+Nodes (2): buildCtx(), buildQueryCtx()
 
 ### Community 450 - "Community 450"
-Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 451 - "Community 451"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 452 - "Community 452"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 453 - "Community 453"
 Cohesion: 0.5
@@ -3913,76 +3914,76 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 455 - "Community 455"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 456 - "Community 456"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 457 - "Community 457"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 456 - "Community 456"
+### Community 458 - "Community 458"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 457 - "Community 457"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 458 - "Community 458"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 459 - "Community 459"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 460 - "Community 460"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 461 - "Community 461"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 462 - "Community 462"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 463 - "Community 463"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 464 - "Community 464"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 465 - "Community 465"
-Cohesion: 0.83
-Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 466 - "Community 466"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 467 - "Community 467"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.83
+Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
 ### Community 468 - "Community 468"
-Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 469 - "Community 469"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 470 - "Community 470"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 471 - "Community 471"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 472 - "Community 472"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 473 - "Community 473"
 Cohesion: 0.5
@@ -4009,68 +4010,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 479 - "Community 479"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 480 - "Community 480"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 481 - "Community 481"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 482 - "Community 482"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 483 - "Community 483"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 484 - "Community 484"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 485 - "Community 485"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 486 - "Community 486"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 487 - "Community 487"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 488 - "Community 488"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 489 - "Community 489"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
+
+### Community 490 - "Community 490"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 490 - "Community 490"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
 ### Community 491 - "Community 491"
-Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 492 - "Community 492"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 493 - "Community 493"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 494 - "Community 494"
 Cohesion: 0.67
-Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
 ### Community 495 - "Community 495"
 Cohesion: 0.5
@@ -4078,7 +4079,7 @@ Nodes (0):
 
 ### Community 496 - "Community 496"
 Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
+Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
 ### Community 497 - "Community 497"
 Cohesion: 0.5
@@ -4086,59 +4087,59 @@ Nodes (0):
 
 ### Community 498 - "Community 498"
 Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 499 - "Community 499"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 500 - "Community 500"
+Cohesion: 0.67
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
+
+### Community 501 - "Community 501"
 Cohesion: 0.67
 Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
-### Community 500 - "Community 500"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 501 - "Community 501"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 502 - "Community 502"
-Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 503 - "Community 503"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 504 - "Community 504"
-Cohesion: 0.83
-Nodes (3): completedEvent(), event(), item()
+Cohesion: 0.67
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
 ### Community 505 - "Community 505"
-Cohesion: 0.67
-Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 506 - "Community 506"
 Cohesion: 0.83
-Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
+Nodes (3): completedEvent(), event(), item()
 
 ### Community 507 - "Community 507"
-Cohesion: 0.83
-Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
+Cohesion: 0.67
+Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
 ### Community 508 - "Community 508"
 Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
 ### Community 509 - "Community 509"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
 ### Community 510 - "Community 510"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
 ### Community 511 - "Community 511"
-Cohesion: 0.83
-Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 512 - "Community 512"
 Cohesion: 0.5
@@ -4146,23 +4147,23 @@ Nodes (0):
 
 ### Community 513 - "Community 513"
 Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
 ### Community 514 - "Community 514"
-Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 515 - "Community 515"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 516 - "Community 516"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 517 - "Community 517"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 518 - "Community 518"
 Cohesion: 0.5
@@ -4189,67 +4190,67 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 524 - "Community 524"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 525 - "Community 525"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 526 - "Community 526"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 525 - "Community 525"
+### Community 527 - "Community 527"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 526 - "Community 526"
+### Community 528 - "Community 528"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 527 - "Community 527"
+### Community 529 - "Community 529"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 528 - "Community 528"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
-
-### Community 529 - "Community 529"
-Cohesion: 0.67
-Nodes (2): write(), writePublicQueryWithReturns()
 
 ### Community 530 - "Community 530"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 531 - "Community 531"
+Cohesion: 0.67
+Nodes (2): write(), writePublicQueryWithReturns()
+
+### Community 532 - "Community 532"
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+
+### Community 533 - "Community 533"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 532 - "Community 532"
+### Community 534 - "Community 534"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 533 - "Community 533"
+### Community 535 - "Community 535"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 534 - "Community 534"
+### Community 536 - "Community 536"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 535 - "Community 535"
+### Community 537 - "Community 537"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 536 - "Community 536"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 537 - "Community 537"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 538 - "Community 538"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 539 - "Community 539"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 540 - "Community 540"
@@ -4257,12 +4258,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 541 - "Community 541"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 542 - "Community 542"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 542 - "Community 542"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 543 - "Community 543"
 Cohesion: 0.67
@@ -4321,28 +4322,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 557 - "Community 557"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 558 - "Community 558"
 Cohesion: 1.0
 Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
-### Community 558 - "Community 558"
+### Community 559 - "Community 559"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 559 - "Community 559"
+### Community 560 - "Community 560"
 Cohesion: 1.0
 Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
-### Community 560 - "Community 560"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 561 - "Community 561"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 562 - "Community 562"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 563 - "Community 563"
 Cohesion: 0.67
@@ -4357,12 +4358,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 566 - "Community 566"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 567 - "Community 567"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 567 - "Community 567"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 568 - "Community 568"
 Cohesion: 0.67
@@ -4385,12 +4386,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 573 - "Community 573"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 574 - "Community 574"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 574 - "Community 574"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 575 - "Community 575"
 Cohesion: 0.67
@@ -4405,16 +4406,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 578 - "Community 578"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 579 - "Community 579"
 Cohesion: 1.0
-Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 580 - "Community 580"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
 
 ### Community 581 - "Community 581"
 Cohesion: 0.67
@@ -4425,28 +4426,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 583 - "Community 583"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 584 - "Community 584"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 585 - "Community 585"
 Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 586 - "Community 586"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 587 - "Community 587"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 588 - "Community 588"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 588 - "Community 588"
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 589 - "Community 589"
 Cohesion: 0.67
@@ -4454,11 +4455,11 @@ Nodes (0):
 
 ### Community 590 - "Community 590"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 591 - "Community 591"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 592 - "Community 592"
 Cohesion: 0.67
@@ -4473,12 +4474,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 595 - "Community 595"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 596 - "Community 596"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 596 - "Community 596"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 597 - "Community 597"
 Cohesion: 0.67
@@ -4497,28 +4498,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 601 - "Community 601"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 602 - "Community 602"
 Cohesion: 1.0
 Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
-### Community 602 - "Community 602"
-Cohesion: 0.67
-Nodes (1): FadeIn()
-
 ### Community 603 - "Community 603"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 604 - "Community 604"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 605 - "Community 605"
-Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
-
-### Community 606 - "Community 606"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 606 - "Community 606"
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 607 - "Community 607"
 Cohesion: 0.67
@@ -4526,15 +4527,15 @@ Nodes (0):
 
 ### Community 608 - "Community 608"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 609 - "Community 609"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
 
 ### Community 610 - "Community 610"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 611 - "Community 611"
 Cohesion: 0.67
@@ -4545,16 +4546,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 613 - "Community 613"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 614 - "Community 614"
 Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 615 - "Community 615"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 616 - "Community 616"
 Cohesion: 0.67
@@ -4589,12 +4590,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 624 - "Community 624"
-Cohesion: 1.0
-Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
-
-### Community 625 - "Community 625"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 625 - "Community 625"
+Cohesion: 1.0
+Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
 
 ### Community 626 - "Community 626"
 Cohesion: 0.67
@@ -4614,79 +4615,79 @@ Nodes (0):
 
 ### Community 630 - "Community 630"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 631 - "Community 631"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 632 - "Community 632"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 633 - "Community 633"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 634 - "Community 634"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 635 - "Community 635"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 636 - "Community 636"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 637 - "Community 637"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 638 - "Community 638"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 638 - "Community 638"
+### Community 639 - "Community 639"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 639 - "Community 639"
+### Community 640 - "Community 640"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 640 - "Community 640"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 641 - "Community 641"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 642 - "Community 642"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 643 - "Community 643"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 644 - "Community 644"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 645 - "Community 645"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 646 - "Community 646"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 647 - "Community 647"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 648 - "Community 648"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 649 - "Community 649"
 Cohesion: 0.67
@@ -4718,11 +4719,11 @@ Nodes (0):
 
 ### Community 656 - "Community 656"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 657 - "Community 657"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 658 - "Community 658"
 Cohesion: 0.67
@@ -4749,44 +4750,44 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 664 - "Community 664"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 665 - "Community 665"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 665 - "Community 665"
+### Community 666 - "Community 666"
 Cohesion: 0.67
 Nodes (1): isInMaintenanceMode()
 
-### Community 666 - "Community 666"
+### Community 667 - "Community 667"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 667 - "Community 667"
+### Community 668 - "Community 668"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 668 - "Community 668"
+### Community 669 - "Community 669"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 669 - "Community 669"
-Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 670 - "Community 670"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 671 - "Community 671"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 672 - "Community 672"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 673 - "Community 673"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 673 - "Community 673"
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 674 - "Community 674"
 Cohesion: 0.67
@@ -4813,76 +4814,76 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 680 - "Community 680"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 681 - "Community 681"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 682 - "Community 682"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 683 - "Community 683"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 684 - "Community 684"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 685 - "Community 685"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 686 - "Community 686"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 687 - "Community 687"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 688 - "Community 688"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 689 - "Community 689"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 690 - "Community 690"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 691 - "Community 691"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 692 - "Community 692"
 Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 693 - "Community 693"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 694 - "Community 694"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 695 - "Community 695"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 696 - "Community 696"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 697 - "Community 697"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 698 - "Community 698"
 Cohesion: 0.67
@@ -4897,12 +4898,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 701 - "Community 701"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 702 - "Community 702"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 702 - "Community 702"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 703 - "Community 703"
 Cohesion: 0.67
@@ -4913,12 +4914,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 705 - "Community 705"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 706 - "Community 706"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 706 - "Community 706"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 707 - "Community 707"
 Cohesion: 0.67
@@ -4985,16 +4986,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 723 - "Community 723"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 724 - "Community 724"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 725 - "Community 725"
+### Community 724 - "Community 724"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 725 - "Community 725"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 726 - "Community 726"
 Cohesion: 1.0
@@ -5009,20 +5010,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 729 - "Community 729"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 730 - "Community 730"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 731 - "Community 731"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 732 - "Community 732"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 733 - "Community 733"
 Cohesion: 1.0
@@ -6146,11 +6147,11 @@ Nodes (0):
 
 ### Community 1013 - "Community 1013"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1014 - "Community 1014"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1015 - "Community 1015"
 Cohesion: 1.0
@@ -10312,372 +10313,376 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2055 - "Community 2055"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 732`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 733`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 734`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 735`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 736`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 737`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 738`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 739`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 740`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 741`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 742`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 743`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 744`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 745`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 746`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 747`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 748`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 749`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 750`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 751`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 752`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 753`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 754`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 755`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 756`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 757`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 758`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 759`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 760`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 761`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 762`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 763`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 764`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 765`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 766`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 767`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 768`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 769`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 770`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 771`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 772`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 773`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 774`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 775`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 776`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 777`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 778`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 779`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 780`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 781`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 782`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 783`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 784`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 785`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 786`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 787`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 788`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 789`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 790`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 791`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 792`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 793`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 794`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 795`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 796`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 797`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 798`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 799`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 800`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 801`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 802`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 803`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 804`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 805`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 806`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 807`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 808`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 809`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 810`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 811`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 812`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 813`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 814`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 815`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 816`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 817`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 818`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 819`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 820`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 821`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 822`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 823`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 824`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 825`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 826`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 827`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 828`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 829`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 830`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 831`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 832`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 833`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 834`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 835`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 836`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 837`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 838`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 839`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 840`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 841`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 842`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 843`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 844`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 845`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 846`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 847`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 848`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 849`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 850`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 851`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 852`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 853`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 854`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 855`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 856`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 857`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 858`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 859`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 860`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 861`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 862`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 863`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 864`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 865`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 866`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 867`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 868`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 869`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 870`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 871`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 872`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 873`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 874`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 875`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 876`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 877`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 878`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 879`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 880`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 881`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 882`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 883`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 884`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 885`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 886`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 887`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 888`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 889`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 890`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 891`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 892`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 893`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 894`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 895`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 896`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 897`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
+- **Thin community `Community 898`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 899`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 900`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 901`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 902`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 903`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 904`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 905`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 906`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 907`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 908`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 909`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 910`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 911`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 912`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
+- **Thin community `Community 913`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 914`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -10713,2287 +10718,2287 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 915`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 916`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 917`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 918`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 919`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 920`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 921`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 922`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 923`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 924`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
+- **Thin community `Community 925`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 926`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 927`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 928`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 929`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 930`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 931`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 932`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 933`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 934`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 935`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 936`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 937`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 938`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 939`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 940`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 941`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 942`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 943`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 944`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 945`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 946`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 947`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 948`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 949`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 950`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 951`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 952`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 953`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 954`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 955`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 956`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 957`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 958`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 959`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 960`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 961`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 962`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 963`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 964`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 965`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 966`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 967`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 968`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 969`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 970`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 971`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 972`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 973`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 974`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 975`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 976`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 977`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 978`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 979`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 980`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 981`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 982`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 983`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 984`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 985`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 986`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 987`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 988`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 989`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 990`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 991`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 992`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 993`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 994`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 995`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 996`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 997`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 998`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 999`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1000`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1001`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1002`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1003`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1004`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1005`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1006`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1007`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1008`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1009`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1010`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1011`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1012`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1013`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1014`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1015`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1016`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1017`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1018`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1019`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1020`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1021`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 1022`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1023`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1024`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1025`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1026`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1027`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1028`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1029`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1030`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1031`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1032`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1033`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
+- **Thin community `Community 1034`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1035`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1036`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1037`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1038`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
+- **Thin community `Community 1039`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1040`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1041`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1042`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1043`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1044`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1045`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1046`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1047`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1048`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1049`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1050`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1051`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `Index()`, `-index-route-view.tsx`
+- **Thin community `Community 1052`** (2 nodes): `Index()`, `-index-route-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1053`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1054`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1055`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1056`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1057`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1058`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1059`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1060`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1061`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
+- **Thin community `Community 1062`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1063`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1064`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1065`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1066`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1067`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1068`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1069`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1070`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1071`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1072`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1073`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1074`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1075`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1076`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1077`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1078`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1079`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1080`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1081`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1082`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1083`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1084`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1085`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1086`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1087`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1088`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1089`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1090`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1091`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1092`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1093`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1094`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1095`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1096`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1097`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1098`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1099`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1100`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1101`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1102`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1103`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1104`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1105`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1106`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1107`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1108`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1109`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1110`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1111`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1112`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1113`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1114`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1115`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1116`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1117`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1118`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1119`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1120`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1121`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1122`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1123`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1124`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1125`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1126`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1127`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1128`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1129`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1130`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1131`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1132`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1133`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1134`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1135`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1136`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1137`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1138`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1139`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1140`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1141`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1142`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1143`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1144`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1145`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1146`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1147`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1148`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1149`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1150`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1151`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1152`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1153`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1154`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1155`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1156`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1157`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1158`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1159`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1160`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1161`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1162`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1163`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1164`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1165`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1166`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1167`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1168`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1169`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1170`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1171`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1172`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1173`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1174`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1175`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1176`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1177`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1178`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1179`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1180`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1181`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1182`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1183`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1184`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1185`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1186`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1187`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1188`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1189`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1190`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1191`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1192`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1193`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1194`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1195`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1196`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1197`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1198`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1199`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1200`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1201`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1202`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1203`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1204`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1205`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `runGit()`, `pr-athena-delivery-run.test.ts`
+- **Thin community `Community 1206`** (2 nodes): `runGit()`, `pr-athena-delivery-run.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1207`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1208`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `api.js`
+- **Thin community `Community 1209`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1210`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1211`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `server.js`
+- **Thin community `Community 1212`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `app.ts`
+- **Thin community `Community 1213`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1214`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1215`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1216`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1217`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `auth.ts`
+- **Thin community `Community 1218`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1219`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1220`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1221`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `countries.ts`
+- **Thin community `Community 1222`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `email.ts`
+- **Thin community `Community 1223`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1224`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `payment.ts`
+- **Thin community `Community 1225`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `contextEvents.test.ts`
+- **Thin community `Community 1226`** (1 nodes): `contextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1227`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `types.ts`
+- **Thin community `Community 1228`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1229`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `crons.ts`
+- **Thin community `Community 1230`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1231`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `internal.ts`
+- **Thin community `Community 1232`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1233`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1234`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1235`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1236`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1237`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1238`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1239`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1240`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1241`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1242`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1243`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `env.ts`
+- **Thin community `Community 1244`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1245`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `auth.ts`
+- **Thin community `Community 1246`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1247`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `colors.ts`
+- **Thin community `Community 1248`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `index.ts`
+- **Thin community `Community 1249`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1250`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `products.ts`
+- **Thin community `Community 1251`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1252`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `stores.ts`
+- **Thin community `Community 1253`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1254`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `bag.ts`
+- **Thin community `Community 1255`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `guest.ts`
+- **Thin community `Community 1256`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1257`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `index.ts`
+- **Thin community `Community 1258`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `me.ts`
+- **Thin community `Community 1259`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `offers.ts`
+- **Thin community `Community 1260`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1261`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1262`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1263`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1264`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1265`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1266`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1267`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1268`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1269`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `user.ts`
+- **Thin community `Community 1270`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1271`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `index.ts`
+- **Thin community `Community 1272`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1273`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `http.ts`
+- **Thin community `Community 1274`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `access.ts`
+- **Thin community `Community 1275`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1276`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1277`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1278`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `index.ts`
+- **Thin community `Community 1279`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1280`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `types.ts`
+- **Thin community `Community 1281`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1282`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `categories.ts`
+- **Thin community `Community 1283`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `colors.ts`
+- **Thin community `Community 1284`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1285`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1286`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1287`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1288`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `pos.ts`
+- **Thin community `Community 1289`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1290`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1291`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1292`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1293`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1294`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1295`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1296`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1297`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1298`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1299`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1300`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1301`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1302`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1303`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1304`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1305`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1306`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `types.ts`
+- **Thin community `Community 1307`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1308`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1309`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1310`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1311`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1312`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1313`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `dto.ts`
+- **Thin community `Community 1314`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1315`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1316`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `searchCatalog.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `types.ts`
+- **Thin community `Community 1317`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1318`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1319`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1320`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1321`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `customers.ts`
+- **Thin community `Community 1322`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `register.test.ts`
+- **Thin community `Community 1323`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `register.ts`
+- **Thin community `Community 1324`** (1 nodes): `register.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `sync.ts`
+- **Thin community `Community 1325`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1326`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1327`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1328`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `schema.ts`
+- **Thin community `Community 1329`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `automation.ts`
+- **Thin community `Community 1330`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1331`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1332`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `index.ts`
+- **Thin community `Community 1333`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1334`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1335`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1336`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1337`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1338`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1339`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1340`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `category.ts`
+- **Thin community `Community 1341`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `color.ts`
+- **Thin community `Community 1342`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1343`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1344`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `index.ts`
+- **Thin community `Community 1345`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1346`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1347`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1348`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1349`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `organization.ts`
+- **Thin community `Community 1350`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1351`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `product.ts`
+- **Thin community `Community 1352`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1353`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1354`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1355`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `store.ts`
+- **Thin community `Community 1356`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1357`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `index.ts`
+- **Thin community `Community 1358`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1359`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1360`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1361`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1362`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1363`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1364`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1365`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `index.ts`
+- **Thin community `Community 1366`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1367`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1368`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1369`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1370`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1371`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1372`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1373`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1374`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1375`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1376`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1377`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `customer.ts`
+- **Thin community `Community 1378`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1379`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1380`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1381`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1382`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `index.ts`
+- **Thin community `Community 1383`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1384`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1385`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1386`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1387`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1388`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1389`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1390`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1391`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1392`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1393`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1394`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1395`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1396`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1397`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1398`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1399`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1400`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1401`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1402`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `index.ts`
+- **Thin community `Community 1403`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1404`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1405`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `index.ts`
+- **Thin community `Community 1406`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1407`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1408`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1409`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1410`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1411`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1412`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `index.ts`
+- **Thin community `Community 1413`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1414`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1415`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1416`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1417`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1418`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1419`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `bag.ts`
+- **Thin community `Community 1420`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1421`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1422`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1423`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `guest.ts`
+- **Thin community `Community 1424`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `index.ts`
+- **Thin community `Community 1425`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `offer.ts`
+- **Thin community `Community 1426`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1427`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1428`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `review.ts`
+- **Thin community `Community 1429`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1430`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1431`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1432`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1433`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1434`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1435`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1436`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1437`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1438`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `bag.ts`
+- **Thin community `Community 1439`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1440`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `customer.ts`
+- **Thin community `Community 1441`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `guest.ts`
+- **Thin community `Community 1442`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1443`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1444`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1445`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1446`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1447`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1448`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1449`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `users.ts`
+- **Thin community `Community 1450`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `payment.ts`
+- **Thin community `Community 1451`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1452`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1453`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1454`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1455`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1456`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1457`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1458`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `index.ts`
+- **Thin community `Community 1459`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1460`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1461`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1462`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1463`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `auth.ts`
+- **Thin community `Community 1464`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1465`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1466`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1467`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1468`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1469`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1470`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1471`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `index.ts`
+- **Thin community `Community 1472`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1473`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1474`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1475`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1476`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1477`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1478`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1479`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1480`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1481`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1482`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1483`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1484`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1485`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1486`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1487`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1488`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1489`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1490`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1491`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1492`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1493`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `constants.ts`
+- **Thin community `Community 1494`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1495`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1496`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1497`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `types.ts`
+- **Thin community `Community 1498`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1499`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1500`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1501`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1502`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1503`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1504`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1505`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1506`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1507`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1508`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1509`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1510`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1511`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1512`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1513`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1514`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1515`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1516`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1517`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1518`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `constants.ts`
+- **Thin community `Community 1519`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1520`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1521`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1522`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `data.ts`
+- **Thin community `Community 1523`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1524`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1525`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1526`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1527`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1528`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1529`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1530`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1531`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1532`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `constants.ts`
+- **Thin community `Community 1533`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1534`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1535`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1536`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `data.ts`
+- **Thin community `Community 1537`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1538`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1539`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1540`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1541`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1542`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1543`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1544`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1545`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1546`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1547`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1548`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1549`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `constants.ts`
+- **Thin community `Community 1550`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1551`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1552`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1553`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1554`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1555`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1556`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1557`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1558`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1559`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1560`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1561`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1562`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1563`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1564`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1565`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1566`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1567`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1568`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1569`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1570`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1571`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1572`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1573`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1574`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1575`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1576`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1577`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1578`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1579`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1580`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1581`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1582`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1583`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1584`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `constants.ts`
+- **Thin community `Community 1585`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1586`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1587`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1588`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `data.ts`
+- **Thin community `Community 1589`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1590`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1591`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `constants.ts`
+- **Thin community `Community 1592`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1593`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1594`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1595`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1596`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `data.ts`
+- **Thin community `Community 1597`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1598`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `constants.ts`
+- **Thin community `Community 1599`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1600`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1601`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1602`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1603`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `data.ts`
+- **Thin community `Community 1604`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1605`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1606`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1607`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1608`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1609`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1610`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1611`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1612`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1613`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1614`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1615`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1616`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1617`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1618`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1619`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1620`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1621`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1622`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1623`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1624`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1625`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1626`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1627`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1628`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1629`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1630`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1631`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1632`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `types.ts`
+- **Thin community `Community 1633`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1634`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1635`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1636`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1637`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1638`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1639`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1640`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1641`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 1642`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1643`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1644`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1645`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1646`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1647`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1648`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1649`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1650`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1651`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `data.ts`
+- **Thin community `Community 1652`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1653`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1654`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1655`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1656`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1657`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1658`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1659`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1660`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1661`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1662`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1663`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1664`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `constants.ts`
+- **Thin community `Community 1665`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1666`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1667`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1668`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `data.ts`
+- **Thin community `Community 1669`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `types.ts`
+- **Thin community `Community 1670`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1671`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1672`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1673`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1674`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1675`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `index.ts`
+- **Thin community `Community 1676`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1677`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1678`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1679`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1680`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `index.tsx`
+- **Thin community `Community 1681`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1682`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1683`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1684`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1685`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1686`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1687`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1688`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1689`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `index.tsx`
+- **Thin community `Community 1690`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1691`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1692`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1693`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `button.tsx`
+- **Thin community `Community 1694`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1695`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `card.tsx`
+- **Thin community `Community 1696`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1697`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1698`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `command.tsx`
+- **Thin community `Community 1699`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1700`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1701`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1702`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `form.tsx`
+- **Thin community `Community 1703`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1704`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1705`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `input.tsx`
+- **Thin community `Community 1706`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1707`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1708`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1709`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1710`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1711`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1712`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `select.tsx`
+- **Thin community `Community 1713`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1714`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1715`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1716`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1717`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `table.tsx`
+- **Thin community `Community 1718`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1719`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1720`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1721`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1722`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1723`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1724`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1725`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1726`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `constants.ts`
+- **Thin community `Community 1727`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1728`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1729`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1730`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `data.ts`
+- **Thin community `Community 1731`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1732`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1733`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1734`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1735`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1736`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1737`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1738`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1739`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1740`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1741`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `index.ts`
+- **Thin community `Community 1742`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1743`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1744`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1745`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 1746`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1747`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1748`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1749`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1750`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1751`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1752`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1753`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1754`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 1755`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 1756`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `index.ts`
+- **Thin community `Community 1757`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 1758`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `index.ts`
+- **Thin community `Community 1759`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 1760`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 1761`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `aws.ts`
+- **Thin community `Community 1762`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `constants.ts`
+- **Thin community `Community 1763`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `countries.ts`
+- **Thin community `Community 1764`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1765`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1766`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1767`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1768`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1769`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1770`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1771`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 1772`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `dto.ts`
+- **Thin community `Community 1773`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `ports.ts`
+- **Thin community `Community 1774`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `constants.ts`
+- **Thin community `Community 1775`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1776`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1777`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `index.ts`
+- **Thin community `Community 1778`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1779`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `types.ts`
+- **Thin community `Community 1780`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1781`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1782`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1783`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1784`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1785`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1786`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1787`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1788`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1789`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 1790`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 1791`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 1792`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 1793`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 1794`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1795`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1796`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1797`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1798`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `index.ts`
+- **Thin community `Community 1799`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1800`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `category.ts`
+- **Thin community `Community 1801`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `product.ts`
+- **Thin community `Community 1802`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `store.ts`
+- **Thin community `Community 1803`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1804`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `user.ts`
+- **Thin community `Community 1805`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1806`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1807`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1808`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1809`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1810`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `main.tsx`
+- **Thin community `Community 1811`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 1812`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1813`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1814`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1815`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1816`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1817`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `index.tsx`
+- **Thin community `Community 1818`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1819`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1820`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1821`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1822`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1823`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1824`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1825`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `index.tsx`
+- **Thin community `Community 1826`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1827`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1828`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1829`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `home.tsx`
+- **Thin community `Community 1830`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1831`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1832`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1833`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `index.tsx`
+- **Thin community `Community 1834`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `review.tsx`
+- **Thin community `Community 1835`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1836`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1837`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `index.tsx`
+- **Thin community `Community 1838`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1839`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1840`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1841`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `index.tsx`
+- **Thin community `Community 1842`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1843`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1844`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1845`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1846`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1847`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1848`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 1849`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `index.tsx`
+- **Thin community `Community 1850`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1851`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1852`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1853`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1854`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1855`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1856`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1857`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1858`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1859`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `index.tsx`
+- **Thin community `Community 1860`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1861`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `index.tsx`
+- **Thin community `Community 1862`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `new.tsx`
+- **Thin community `Community 1863`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `index.tsx`
+- **Thin community `Community 1864`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `new.tsx`
+- **Thin community `Community 1865`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1866`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1867`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `index.tsx`
+- **Thin community `Community 1868`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `new.tsx`
+- **Thin community `Community 1869`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `index.tsx`
+- **Thin community `Community 1870`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1871`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1872`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1873`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1874`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `index.tsx`
+- **Thin community `Community 1875`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1876`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1877`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1878`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `index.tsx`
+- **Thin community `Community 1879`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1880`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `_authed.tsx`
+- **Thin community `Community 1881`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1882`** (1 nodes): `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `index.tsx`
+- **Thin community `Community 1883`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1884`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1885`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1886`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 1887`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1888`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 1889`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1890`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 1891`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1892`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1893`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1894`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1895`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1896`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1897`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1898`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1899`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1900`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1901`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1902`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1903`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1904`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1905`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1906`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1907`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `setup.ts`
+- **Thin community `Community 1908`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1909`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `types.ts`
+- **Thin community `Community 1910`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1911`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1912`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1913`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1914`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1915`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1916`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1917`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `types.ts`
+- **Thin community `Community 1918`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1919`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1920`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1921`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1922`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1923`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1924`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1925`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1926`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `schema.ts`
+- **Thin community `Community 1927`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1928`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1929`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1930`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1931`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1932`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1933`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1934`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1935`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1936`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `types.ts`
+- **Thin community `Community 1937`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1938`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1939`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1940`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1941`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1942`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1943`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1944`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `constants.ts`
+- **Thin community `Community 1945`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1946`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `About.tsx`
+- **Thin community `Community 1947`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1948`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1949`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1950`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1951`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1952`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1953`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1954`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1955`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1956`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1957`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `types.ts`
+- **Thin community `Community 1958`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1959`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1960`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1961`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1962`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1963`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1964`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1965`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1966`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1967`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1968`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1969`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `button.tsx`
+- **Thin community `Community 1970`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `card.tsx`
+- **Thin community `Community 1971`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1972`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `command.tsx`
+- **Thin community `Community 1973`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1974`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1975`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1976`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `form.tsx`
+- **Thin community `Community 1977`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1978`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1979`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1980`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1981`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `input.tsx`
+- **Thin community `Community 1982`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `label.tsx`
+- **Thin community `Community 1983`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1984`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1985`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1986`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `index.ts`
+- **Thin community `Community 1987`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `types.ts`
+- **Thin community `Community 1988`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1989`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1990`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1991`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1992`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `select.tsx`
+- **Thin community `Community 1993`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1994`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1995`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `table.tsx`
+- **Thin community `Community 1996`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1997`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1998`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1999`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2000`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2001`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `config.ts`
+- **Thin community `Community 2002`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2003`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2004`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2005`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2006`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2007`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `constants.ts`
+- **Thin community `Community 2008`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `countries.ts`
+- **Thin community `Community 2009`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2010`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2011`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2012`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2013`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `index.ts`
+- **Thin community `Community 2014`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2015`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `store.ts`
+- **Thin community `Community 2016`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `bag.ts`
+- **Thin community `Community 2017`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2018`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `category.ts`
+- **Thin community `Community 2019`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `organization.ts`
+- **Thin community `Community 2020`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `product.ts`
+- **Thin community `Community 2021`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `store.ts`
+- **Thin community `Community 2022`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2023`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `user.ts`
+- **Thin community `Community 2024`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `states.ts`
+- **Thin community `Community 2025`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2026`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2027`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2028`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2029`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2030`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2031`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2032`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2033`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `index.tsx`
+- **Thin community `Community 2034`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2035`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `index.tsx`
+- **Thin community `Community 2036`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2037`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2038`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2039`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2040`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2041`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `index.tsx`
+- **Thin community `Community 2042`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2043`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2044`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2045`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2046`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2047`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `index.js`
+- **Thin community `Community 2048`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2049`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2050`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2051`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2052`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2053`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2054`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2055`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,17 +7,17 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2127
-- Graph nodes: 8002
-- Graph edges: 9400
-- Communities: 2055
+- Code files discovered: 2128
+- Graph nodes: 8032
+- Graph edges: 9450
+- Communities: 2056
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (89 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `harness-inferential-review.ts` (85 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `dailyClose.ts` (76 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `dailyOperations.ts` (63 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `projectLocalEvents.ts` (62 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `projectLocalEvents.ts` (63 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 - `terminalHealthPresentation.ts` (53 edges, Community 6) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `catalogImport.ts` (49 edges, Community 7) - [`packages/athena-webapp/convex/inventory/catalogImport.ts`](../../packages/athena-webapp/convex/inventory/catalogImport.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `DailyCloseView.tsx` (89 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (76 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `dailyOperations.ts` (63 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `projectLocalEvents.ts` (62 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `projectLocalEvents.ts` (63 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 
 ## Navigation

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -17,11 +17,11 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - [validation-map.json](../../../packages/storefront-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `storefrontJourneyEvents.ts` (45 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `createJourneyEvent()` (40 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 57) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storefrontJourneyEvents.ts` (45 edges, Community 10) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 10) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `getStoreConfigV2()` (17 edges, Community 56) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `storefrontContextEvents.ts` (17 edges, Community 77) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
-- `checkoutSession.ts` (14 edges, Community 91) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 92) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (15 edges, Community 92) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (15 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `app.test.js` (6 edges, Community 187) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 92) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossCluster()` (4 edges, Community 92) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossClusterWithPipeline()` (4 edges, Community 92) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisClient()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossCluster()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossClusterWithPipeline()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/_generated/api.d.ts
+++ b/packages/athena-webapp/convex/_generated/api.d.ts
@@ -203,6 +203,7 @@ import type * as pos_application_queries_storePulse from "../pos/application/que
 import type * as pos_application_queries_terminals from "../pos/application/queries/terminals.js";
 import type * as pos_application_sync_ingestLocalEvents from "../pos/application/sync/ingestLocalEvents.js";
 import type * as pos_application_sync_projectLocalEvents from "../pos/application/sync/projectLocalEvents.js";
+import type * as pos_application_sync_registerSessionCloseoutHolds from "../pos/application/sync/registerSessionCloseoutHolds.js";
 import type * as pos_application_sync_registerSessionSyncReview from "../pos/application/sync/registerSessionSyncReview.js";
 import type * as pos_application_sync_staffProof from "../pos/application/sync/staffProof.js";
 import type * as pos_application_sync_staffProofValidation from "../pos/application/sync/staffProofValidation.js";
@@ -616,6 +617,7 @@ declare const fullApi: ApiFromModules<{
   "pos/application/queries/terminals": typeof pos_application_queries_terminals;
   "pos/application/sync/ingestLocalEvents": typeof pos_application_sync_ingestLocalEvents;
   "pos/application/sync/projectLocalEvents": typeof pos_application_sync_projectLocalEvents;
+  "pos/application/sync/registerSessionCloseoutHolds": typeof pos_application_sync_registerSessionCloseoutHolds;
   "pos/application/sync/registerSessionSyncReview": typeof pos_application_sync_registerSessionSyncReview;
   "pos/application/sync/staffProof": typeof pos_application_sync_staffProof;
   "pos/application/sync/staffProofValidation": typeof pos_application_sync_staffProofValidation;

--- a/packages/athena-webapp/convex/cashControls/closeouts.test.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.test.ts
@@ -29,6 +29,158 @@ function getHandler(definition: unknown) {
   return (definition as { _handler: Function })._handler;
 }
 
+function createCloseoutMappingHoldCtx() {
+  const rowsByTable = new Map<string, Array<Record<string, unknown>>>(
+    Object.entries({
+      approvalRequest: [],
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_missing_mapping",
+          conflictType: "permission",
+          createdAt: 1,
+          details: {
+            localTransactionId: "local-transaction-1",
+          },
+          localEventId: "event_sale_1",
+          localRegisterSessionId: "local-register-1",
+          sequence: 3,
+          status: "needs_review",
+          storeId: "store-1",
+          summary: "Register session mapping is missing for synced POS history.",
+          terminalId: "terminal-1",
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_sale_1",
+          eventType: "sale_completed",
+          localEventId: "event_sale_1",
+          localRegisterSessionId: "local-register-1",
+          occurredAt: 2,
+          payload: {
+            localTransactionId: "local-transaction-1",
+            receiptNumber: "R-1001",
+          },
+          sequence: 3,
+          status: "conflicted",
+          storeId: "store-1",
+          submittedAt: 2,
+          terminalId: "terminal-1",
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "transaction_mapping_1",
+          cloudId: "transaction-1",
+          cloudTable: "posTransaction",
+          createdAt: 2,
+          localEventId: "event_sale_1",
+          localId: "local-transaction-1",
+          localIdKind: "transaction",
+          localRegisterSessionId: "local-register-1",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        },
+      ],
+      posTransaction: [
+        {
+          _id: "transaction-1",
+          completedAt: 2,
+          registerSessionId: "session-1",
+          status: "completed",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          total: 15000,
+          transactionNumber: "R-1001",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session-1",
+          countedCash: 30000,
+          expectedCash: 30000,
+          openedAt: 1,
+          organizationId: "org-1",
+          registerNumber: "A1",
+          status: "closing",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "manager-1",
+          linkedUserId: "manager-user-1",
+          organizationId: "org-1",
+          status: "active",
+          storeId: "store-1",
+        },
+      ],
+      staffRoleAssignment: [
+        {
+          _id: "role-1",
+          organizationId: "org-1",
+          role: "manager",
+          staffProfileId: "manager-1",
+          status: "active",
+          storeId: "store-1",
+        },
+      ],
+      store: [
+        {
+          _id: "store-1",
+          currency: "GHS",
+          organizationId: "org-1",
+        },
+      ],
+    }).map(([table, rows]) => [table, rows.map((row) => ({ ...row }))]),
+  );
+  const getRows = (tableName: string) => rowsByTable.get(tableName) ?? [];
+  const matches = (
+    row: Record<string, unknown>,
+    filters: Array<[string, unknown]>,
+  ) => filters.every(([field, value]) => row[field] === value);
+
+  return {
+    db: {
+      get: vi.fn(async (tableName: string, id: string) =>
+        getRows(tableName).find((row) => row._id === id) ?? null,
+      ),
+      insert: vi.fn(),
+      patch: vi.fn(),
+      query: vi.fn((tableName: string) => {
+        const filters: Array<[string, unknown]> = [];
+        const query = {
+          withIndex: vi.fn((_indexName: string, build: (q: any) => unknown) => {
+            const indexQuery = {
+              eq(field: string, value: unknown) {
+                filters.push([field, value]);
+                return indexQuery;
+              },
+            };
+            build(indexQuery);
+            return query;
+          }),
+          collect: vi.fn(async () =>
+            getRows(tableName).filter((row) => matches(row, filters)),
+          ),
+          take: vi.fn(async (limit: number) =>
+            getRows(tableName)
+              .filter((row) => matches(row, filters))
+              .slice(0, limit),
+          ),
+          unique: vi.fn(async () =>
+            getRows(tableName).find((row) => matches(row, filters)) ?? null,
+          ),
+        };
+        return query;
+      }),
+    },
+    runMutation: vi.fn(),
+    runQuery: vi.fn(async () => ({ _id: "store-1" })),
+  };
+}
+
 describe("cash control closeouts", () => {
   it("validates representative public closeout command results against exported return validators", () => {
     const validationError = {
@@ -1666,6 +1818,28 @@ describe("cash control closeouts", () => {
     expect(runMutation).not.toHaveBeenCalled();
   });
 
+  it("rejects closeout approval proof payloads while mapping repair holds exist", async () => {
+    const ctx = createCloseoutMappingHoldCtx();
+
+    const result = await getHandler(submitRegisterSessionCloseout)(ctx, {
+      actorStaffProfileId: "manager-1",
+      approvalProofId: "proof-1",
+      countedCash: 30000,
+      registerSessionId: "session-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message:
+          "Resolve pending register corrections before approving final closeout.",
+      },
+    });
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
   it("blocks final closeout while pending void approvals remain", async () => {
     const registerSession = {
       _id: "session-1",
@@ -1735,6 +1909,26 @@ describe("cash control closeouts", () => {
       },
     });
     expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("blocks final closeout while mapping repair holds remain", async () => {
+    const ctx = createCloseoutMappingHoldCtx();
+
+    const result = await getHandler(finalizeRegisterSessionCloseout)(ctx, {
+      actorStaffProfileId: "manager-1",
+      registerSessionId: "session-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message:
+          "Resolve pending register corrections before finalizing closeout.",
+      },
+    });
+    expect(ctx.runMutation).not.toHaveBeenCalled();
   });
 
   it("finalizes exact-match submitted closeouts without a variance approval proof", async () => {

--- a/packages/athena-webapp/convex/cashControls/closeouts.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.ts
@@ -19,6 +19,11 @@ import type { OperationalRole } from "../operations/staffRoles";
 import { commandResultValidator } from "../lib/commandResultValidators";
 import { toDisplayAmount } from "../lib/currency";
 import {
+  getCloseoutHoldOperatorMessage,
+  hasCashAffectingCloseoutHolds,
+  listRegisterSessionCloseoutHolds,
+} from "../pos/application/sync/registerSessionCloseoutHolds";
+import {
   requireAuthenticatedAthenaUserWithCtx,
   requireOrganizationMemberRoleWithCtx,
 } from "../lib/athenaUserAuth";
@@ -511,40 +516,6 @@ export function buildRegisterSessionVarianceApprovalRequirement(args: {
   };
 }
 
-async function countPendingVoidApprovalsForRegisterSession(
-  ctx: Pick<MutationCtx, "db">,
-  args: {
-    registerSessionId: Id<"registerSession">;
-    storeId: Id<"store">;
-  },
-) {
-  if (typeof ctx.db.query !== "function") {
-    return 0;
-  }
-
-  const query = ctx.db
-    .query("approvalRequest")
-    .withIndex("by_registerSessionId", (q) =>
-      q.eq("registerSessionId", args.registerSessionId),
-    );
-
-  if (typeof query.collect !== "function") {
-    return 0;
-  }
-
-  const approvalRequests =
-    // eslint-disable-next-line @convex-dev/no-collect-in-query -- Register-session scoped pending void approvals are bounded by manager-review workflow volume and must be checked before final closure.
-    await query.collect();
-
-  return approvalRequests.filter(
-    (approvalRequest) =>
-      approvalRequest.storeId === args.storeId &&
-      approvalRequest.status === "pending" &&
-      approvalRequest.requestType === "pos_transaction_void" &&
-      approvalRequest.subjectType === "pos_transaction",
-  ).length;
-}
-
 function submittedCloseoutPendingVoidsResult(args: {
   closeoutReview: RegisterSessionCloseoutReview;
   pendingVoidApprovalCount: number;
@@ -927,17 +898,22 @@ export const submitRegisterSessionCloseout = mutation({
       config,
       expectedCash: registerSession.expectedCash,
     });
+    const closeoutHolds = await listRegisterSessionCloseoutHolds(ctx, {
+      registerSessionId: registerSession._id,
+      storeId: args.storeId,
+    });
     const pendingVoidApprovalCount =
-      await countPendingVoidApprovalsForRegisterSession(ctx, {
-        registerSessionId: registerSession._id,
-        storeId: args.storeId,
-      });
+      closeoutHolds.find(
+        (hold) => hold.kind === "pending_completed_sale_void_approvals",
+      )?.count ?? 0;
+    const hasFinalCloseoutHold = hasCashAffectingCloseoutHolds(closeoutHolds);
 
-    if (pendingVoidApprovalCount > 0 && args.approvalProofId) {
+    if (hasFinalCloseoutHold && args.approvalProofId) {
       return userError({
         code: "precondition_failed",
         message:
-          "Resolve pending void approvals before approving final closeout.",
+          getCloseoutHoldOperatorMessage(closeoutHolds, "approve") ??
+          "Resolve pending register corrections before approving final closeout.",
       });
     }
     const latestReopenedCloseout = getLatestReopenedCloseoutRecord(registerSession);
@@ -1044,7 +1020,7 @@ export const submitRegisterSessionCloseout = mutation({
     if (
       closeoutReview.requiresApproval &&
       args.approvalProofId &&
-      pendingVoidApprovalCount === 0
+      !hasFinalCloseoutHold
     ) {
       if (!registerSession.organizationId) {
         return userError({
@@ -1089,7 +1065,7 @@ export const submitRegisterSessionCloseout = mutation({
     if (
       closeoutReview.requiresApproval &&
       !args.approvalProofId &&
-      pendingVoidApprovalCount === 0 &&
+      !hasFinalCloseoutHold &&
       closeoutSubmitActorStaffProfileId &&
       !approvedByStaffProfileId &&
       registerSession.organizationId
@@ -1151,7 +1127,7 @@ export const submitRegisterSessionCloseout = mutation({
       workflowTraceId: registerSession.workflowTraceId,
     });
 
-    if (pendingVoidApprovalCount > 0) {
+    if (hasFinalCloseoutHold) {
       return submittedCloseoutPendingVoidsResult({
         closeoutReview,
         pendingVoidApprovalCount,
@@ -1476,16 +1452,17 @@ export const finalizeRegisterSessionCloseout = mutation({
       });
     }
 
-    const pendingVoidApprovalCount =
-      await countPendingVoidApprovalsForRegisterSession(ctx, {
-        registerSessionId: registerSession._id,
-        storeId: args.storeId,
-      });
+    const closeoutHolds = await listRegisterSessionCloseoutHolds(ctx, {
+      registerSessionId: registerSession._id,
+      storeId: args.storeId,
+    });
 
-    if (pendingVoidApprovalCount > 0) {
+    if (hasCashAffectingCloseoutHolds(closeoutHolds)) {
       return userError({
         code: "precondition_failed",
-        message: "Resolve pending void approvals before finalizing closeout.",
+        message:
+          getCloseoutHoldOperatorMessage(closeoutHolds, "finalize") ??
+          "Resolve pending register corrections before finalizing closeout.",
       });
     }
 
@@ -2200,13 +2177,12 @@ export const reviewRegisterSessionCloseout = mutation({
         });
       }
 
-      const pendingVoidApprovalCount =
-        await countPendingVoidApprovalsForRegisterSession(ctx, {
-          registerSessionId: registerSession._id,
-          storeId: args.storeId,
-        });
+      const closeoutHolds = await listRegisterSessionCloseoutHolds(ctx, {
+        registerSessionId: registerSession._id,
+        storeId: args.storeId,
+      });
 
-      if (pendingVoidApprovalCount > 0) {
+      if (hasCashAffectingCloseoutHolds(closeoutHolds)) {
         return ok({
           action: "approved" as const,
           approvalRequest: reviewedApprovalRequest,

--- a/packages/athena-webapp/convex/cashControls/deposits.test.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.test.ts
@@ -299,6 +299,169 @@ function createAuthorizedRegisterDepositCtx(
   });
 }
 
+function createMissingMappingRepairSeed(
+  options: {
+    existingRegisterMappingCloudId?: string;
+    localTransactionId?: string;
+    registerSessionStatus?: string;
+    saleSequence?: number;
+    transactionRegisterSessionId?: string;
+    transactionStatus?: string;
+    withCloseoutBeforeSale?: boolean;
+  } = {},
+) {
+  const localTransactionId =
+    options.localTransactionId === undefined
+      ? "local-transaction-1"
+      : options.localTransactionId;
+  const saleSequence = options.saleSequence ?? 3;
+  const mappings: Record<string, unknown>[] = [
+    ...(localTransactionId
+      ? [
+          {
+            _id: "transaction_mapping_1",
+            storeId: "store_1",
+            terminalId: "terminal_1",
+            localRegisterSessionId: "local-register-1",
+            localEventId: "event_sale_1",
+            localIdKind: "transaction",
+            localId: localTransactionId,
+            cloudTable: "posTransaction",
+            cloudId: "transaction_1",
+            createdAt: 2,
+          },
+        ]
+      : []),
+  ];
+  if (options.existingRegisterMappingCloudId) {
+    mappings.push({
+      _id: "register_mapping_1",
+      storeId: "store_1",
+      terminalId: "terminal_1",
+      localRegisterSessionId: "local-register-1",
+      localEventId: "event_open_1",
+      localIdKind: "registerSession",
+      localId: "local-register-1",
+      cloudTable: "registerSession",
+      cloudId: options.existingRegisterMappingCloudId,
+      createdAt: 1,
+    });
+  }
+
+  return {
+    operationalEvent: [],
+    posLocalSyncConflict: [
+      {
+        _id: "sync_conflict_missing_mapping",
+        storeId: "store_1",
+        terminalId: "terminal_1",
+        localRegisterSessionId: "local-register-1",
+        localEventId: "event_sale_1",
+        sequence: saleSequence,
+        conflictType: "permission",
+        status: "needs_review",
+        summary: "Register session mapping is missing for synced POS history.",
+        details: {
+          ...(localTransactionId ? { localTransactionId } : {}),
+        },
+        createdAt: 1,
+      },
+    ],
+    posLocalSyncEvent: [
+      ...(options.withCloseoutBeforeSale
+        ? [
+            {
+              _id: "sync_event_closeout_1",
+              storeId: "store_1",
+              terminalId: "terminal_1",
+              localRegisterSessionId: "local-register-1",
+              localEventId: "event_closeout_1",
+              sequence: saleSequence - 1,
+              eventType: "register_closed",
+              occurredAt: 1,
+              payload: {},
+              status: "projected",
+              submittedAt: 1,
+            },
+          ]
+        : []),
+      {
+        _id: "sync_event_sale_1",
+        storeId: "store_1",
+        terminalId: "terminal_1",
+        localRegisterSessionId: "local-register-1",
+        localEventId: "event_sale_1",
+        sequence: saleSequence,
+        eventType: "sale_completed",
+        occurredAt: 2,
+        staffProfileId: "staff_1",
+        payload: {
+          ...(localTransactionId ? { localTransactionId } : {}),
+          receiptNumber: "R-1001",
+          totals: {
+            total: 15000,
+          },
+        },
+        status: "conflicted",
+        submittedAt: 2,
+      },
+    ],
+    posLocalSyncMapping: mappings,
+    posTransaction: [
+      {
+        _id: "transaction_1",
+        completedAt: 2,
+        registerSessionId:
+          options.transactionRegisterSessionId ?? "session_open",
+        status: options.transactionStatus ?? "completed",
+        storeId: "store_1",
+        terminalId: "terminal_1",
+        total: 15000,
+        transactionNumber: "R-1001",
+      },
+    ],
+    registerSession: [
+      {
+        _id: "session_open",
+        closeoutRecords: [],
+        expectedCash: 50000,
+        openedAt: 1,
+        openingFloat: 50000,
+        organizationId: "org_1",
+        registerNumber: "1",
+        status: options.registerSessionStatus ?? "active",
+        storeId: "store_1",
+        terminalId: "terminal_1",
+      },
+    ],
+    staffProfile: [
+      {
+        _id: "manager_1",
+        linkedUserId: "athena_user_1",
+        organizationId: "org_1",
+        status: "active",
+        storeId: "store_1",
+      },
+      {
+        _id: "staff_1",
+        organizationId: "org_1",
+        status: "active",
+        storeId: "store_1",
+      },
+    ],
+    staffRoleAssignment: [
+      {
+        _id: "role_1",
+        organizationId: "org_1",
+        role: "manager",
+        staffProfileId: "manager_1",
+        status: "active",
+        storeId: "store_1",
+      },
+    ],
+  };
+}
+
 describe("cash control deposits", () => {
   beforeEach(() => {
     mockedAuthServer.getAuthUserId.mockResolvedValue("auth_user_1");
@@ -360,6 +523,19 @@ describe("cash control deposits", () => {
       actionPolicy: "apply_or_reject",
       conflictType: "inventory",
       reviewKind: "inventory_review",
+    });
+    expect(
+      classifyRegisterSessionSyncReview({
+        conflictType: "permission",
+        details: {},
+        localEventId: "event-sale-missing-register",
+        status: "needs_review",
+        summary: "Register session mapping is missing for synced POS history.",
+      }),
+    ).toEqual({
+      actionPolicy: "apply_or_reject",
+      conflictType: "permission",
+      reviewKind: "missing_register_session_mapping",
     });
   });
 
@@ -772,6 +948,99 @@ describe("cash control deposits", () => {
     );
   });
 
+  it("maps repairable missing register-session mapping conflicts through the completed sale", async () => {
+    const ctx = createQueryCtx({
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_missing_mapping",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale_1",
+          sequence: 3,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Register session mapping is missing for synced POS history.",
+          details: {
+            localTransactionId: "local-transaction-1",
+          },
+          createdAt: 1,
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_sale_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale_1",
+          sequence: 3,
+          eventType: "sale_completed",
+          occurredAt: 2,
+          staffProfileId: "staff_1",
+          payload: {
+            localTransactionId: "local-transaction-1",
+            receiptNumber: "R-1001",
+          },
+          status: "conflicted",
+          submittedAt: 2,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "transaction_mapping_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale_1",
+          localIdKind: "transaction",
+          localId: "local-transaction-1",
+          cloudTable: "posTransaction",
+          cloudId: "transaction_1",
+          createdAt: 2,
+        },
+      ],
+      posTransaction: [
+        {
+          _id: "transaction_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          registerSessionId: "session_open",
+          status: "completed",
+          transactionNumber: "R-1001",
+          total: 15000,
+          completedAt: 2,
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_open",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          status: "active",
+        },
+      ],
+    });
+
+    await expect(
+      listOpenLocalSyncConflictsByRegisterSession(
+        ctx as never,
+        "store_1" as Id<"store">,
+      ),
+    ).resolves.toEqual(
+      new Map([
+        [
+          "session_open",
+          [
+            expect.objectContaining({
+              _id: "sync_conflict_missing_mapping",
+            }),
+          ],
+        ],
+      ]),
+    );
+  });
+
   it("hides duplicate closeout shadows while the variance closeout review is open", async () => {
     const ctx = createQueryCtx({
       posLocalSyncConflict: [
@@ -1099,6 +1368,454 @@ describe("cash control deposits", () => {
         }),
       ]),
     );
+  });
+
+  it("repairs missing register-session mappings for completed synced sales", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      operationalEvent: [],
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_missing_mapping",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale_1",
+          sequence: 3,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Register session mapping is missing for synced POS history.",
+          details: {
+            localTransactionId: "local-transaction-1",
+          },
+          createdAt: 1,
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_sale_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale_1",
+          sequence: 3,
+          eventType: "sale_completed",
+          occurredAt: 2,
+          staffProfileId: "staff_1",
+          payload: {
+            localTransactionId: "local-transaction-1",
+            receiptNumber: "R-1001",
+            totals: {
+              total: 15000,
+            },
+          },
+          status: "conflicted",
+          submittedAt: 2,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "transaction_mapping_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale_1",
+          localIdKind: "transaction",
+          localId: "local-transaction-1",
+          cloudTable: "posTransaction",
+          cloudId: "transaction_1",
+          createdAt: 2,
+        },
+      ],
+      posTransaction: [
+        {
+          _id: "transaction_1",
+          completedAt: 2,
+          registerSessionId: "session_open",
+          status: "completed",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          total: 15000,
+          transactionNumber: "R-1001",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_open",
+          closeoutRecords: [],
+          expectedCash: 50000,
+          openedAt: 1,
+          openingFloat: 50000,
+          organizationId: "org_1",
+          registerNumber: "1",
+          status: "active",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "manager_1",
+          linkedUserId: "athena_user_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "staff_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      staffRoleAssignment: [
+        {
+          _id: "role_1",
+          organizationId: "org_1",
+          role: "manager",
+          staffProfileId: "manager_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+    });
+
+    const result = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        reviewConflictIds: ["sync_conflict_missing_mapping"],
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual(
+      ok({
+        action: "resolved",
+        projectedCount: 1,
+        registerSession: expect.objectContaining({
+          _id: "session_open",
+          status: "active",
+        }),
+        resolvedCount: 1,
+      }),
+    );
+    expect(ctx.tables.get("posLocalSyncMapping")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          cloudId: "session_open",
+          cloudTable: "registerSession",
+          localEventId: "event_sale_1",
+          localId: "local-register-1",
+          localIdKind: "registerSession",
+          localRegisterSessionId: "local-register-1",
+        }),
+      ]),
+    );
+    expect(ctx.tables.get("posLocalSyncEvent")).toEqual([
+      expect.objectContaining({
+        _id: "sync_event_sale_1",
+        projectedAt: expect.any(Number),
+        status: "projected",
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncConflict")).toEqual([
+      expect.objectContaining({
+        _id: "sync_conflict_missing_mapping",
+        resolvedByStaffProfileId: "manager_1",
+        status: "resolved",
+      }),
+    ]);
+  });
+
+  it("associates and repairs missing register mapping reviews for open register sessions", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx(
+      createMissingMappingRepairSeed({ registerSessionStatus: "open" }),
+    );
+
+    await expect(
+      listOpenLocalSyncConflictsByRegisterSession(
+        ctx as never,
+        "store_1" as Id<"store">,
+      ),
+    ).resolves.toEqual(
+      new Map([
+        [
+          "session_open",
+          [
+            expect.objectContaining({
+              _id: "sync_conflict_missing_mapping",
+            }),
+          ],
+        ],
+      ]),
+    );
+
+    const result = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        reviewConflictIds: ["sync_conflict_missing_mapping"],
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual(
+      ok({
+        action: "resolved",
+        projectedCount: 1,
+        registerSession: expect.objectContaining({
+          _id: "session_open",
+          status: "open",
+        }),
+        resolvedCount: 1,
+      }),
+    );
+    expect(ctx.tables.get("posLocalSyncMapping")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          cloudId: "session_open",
+          cloudTable: "registerSession",
+          localIdKind: "registerSession",
+        }),
+      ]),
+    );
+  });
+
+  it("repairs missing register mapping reviews while the register is closing", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx(
+      createMissingMappingRepairSeed({ registerSessionStatus: "closing" }),
+    );
+
+    const result = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        reviewConflictIds: ["sync_conflict_missing_mapping"],
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual(
+      ok({
+        action: "resolved",
+        projectedCount: 1,
+        registerSession: expect.objectContaining({
+          _id: "session_open",
+          status: "closing",
+        }),
+        resolvedCount: 1,
+      }),
+    );
+  });
+
+  it("rejects missing register mapping repair after the local closeout event", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx(
+      createMissingMappingRepairSeed({
+        registerSessionStatus: "closing",
+        withCloseoutBeforeSale: true,
+      }),
+    );
+
+    await expect(
+      getHandler(resolveRegisterSessionSyncReview)(ctx as never, {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        reviewConflictIds: ["sync_conflict_missing_mapping"],
+        storeId: "store_1" as Id<"store">,
+      }),
+    ).resolves.toEqual(
+      userError({
+        code: "precondition_failed",
+        message:
+          "This synced sale can no longer be repaired for this closeout.",
+      }),
+    );
+  });
+
+  it("rejects missing register mapping repair once the register is closed", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx(
+      createMissingMappingRepairSeed({
+        existingRegisterMappingCloudId: "session_open",
+        registerSessionStatus: "closed",
+      }),
+    );
+
+    await expect(
+      getHandler(resolveRegisterSessionSyncReview)(ctx as never, {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        reviewConflictIds: ["sync_conflict_missing_mapping"],
+        storeId: "store_1" as Id<"store">,
+      }),
+    ).resolves.toEqual(
+      userError({
+        code: "precondition_failed",
+        message:
+          "This synced sale can only be repaired before the register session is closed.",
+      }),
+    );
+  });
+
+  it("rejects missing register mapping repair when the completed sale cannot be matched", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx(
+      createMissingMappingRepairSeed({
+        existingRegisterMappingCloudId: "session_open",
+        transactionStatus: "void",
+      }),
+    );
+
+    await expect(
+      getHandler(resolveRegisterSessionSyncReview)(ctx as never, {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        reviewConflictIds: ["sync_conflict_missing_mapping"],
+        storeId: "store_1" as Id<"store">,
+      }),
+    ).resolves.toEqual(
+      userError({
+        code: "precondition_failed",
+        message:
+          "This synced sale could not be matched to a completed sale for this register session.",
+      }),
+    );
+  });
+
+  it("rejects automatic missing register mapping repair", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx(
+      createMissingMappingRepairSeed({
+        existingRegisterMappingCloudId: "session_open",
+      }),
+    );
+
+    await expect(
+      getHandler(resolveRegisterSessionSyncReview)(ctx as never, {
+        registerSessionId: "session_open" as Id<"registerSession">,
+        reviewConflictIds: ["sync_conflict_missing_mapping"],
+        storeId: "store_1" as Id<"store">,
+      }),
+    ).resolves.toEqual(
+      userError({
+        code: "precondition_failed",
+        message:
+          "This register review is not eligible for automatic sync repair.",
+      }),
+    );
+  });
+
+  it("rejects missing register mapping repair when the local drawer already has a conflicting mapping", async () => {
+    const seed = createMissingMappingRepairSeed();
+    const ctx = createAuthorizedRegisterDepositCtx({
+      ...seed,
+      posLocalSyncMapping: [
+        ...(seed.posLocalSyncMapping as Record<string, unknown>[]),
+        {
+          _id: "corrupt_register_mapping",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_open_1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "posTransaction",
+          cloudId: "transaction_other",
+          createdAt: 1,
+        },
+      ],
+    });
+
+    await expect(
+      getHandler(resolveRegisterSessionSyncReview)(ctx as never, {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        reviewConflictIds: ["sync_conflict_missing_mapping"],
+        storeId: "store_1" as Id<"store">,
+      }),
+    ).resolves.toEqual(
+      userError({
+        code: "precondition_failed",
+        message:
+          "This synced sale is already mapped to a different register session.",
+      }),
+    );
+  });
+
+  it("keeps the source sync event conflicted when a sibling conflict remains open", async () => {
+    const seed = createMissingMappingRepairSeed();
+    const ctx = createAuthorizedRegisterDepositCtx({
+      ...seed,
+      posLocalSyncConflict: [
+        ...(seed.posLocalSyncConflict as Record<string, unknown>[]),
+        {
+          _id: "sync_conflict_inventory",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale_1",
+          sequence: 3,
+          conflictType: "inventory",
+          status: "needs_review",
+          summary: "Inventory needs manager review for a synced offline sale.",
+          details: {
+            productSkuId: "product_sku_1",
+            requestedQuantity: 2,
+          },
+          createdAt: 2,
+        },
+      ],
+      posLocalSyncMapping: [
+        ...(seed.posLocalSyncMapping as Record<string, unknown>[]),
+        {
+          _id: "register_mapping_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_open_1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "registerSession",
+          cloudId: "session_open",
+          createdAt: 1,
+        },
+      ],
+    });
+
+    const result = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        reviewConflictIds: ["sync_conflict_missing_mapping"],
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual(
+      ok({
+        action: "resolved",
+        projectedCount: 1,
+        registerSession: expect.objectContaining({ _id: "session_open" }),
+        resolvedCount: 1,
+      }),
+    );
+    expect(ctx.tables.get("posLocalSyncEvent")).toEqual([
+      expect.objectContaining({
+        _id: "sync_event_sale_1",
+        status: "conflicted",
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncConflict")).toEqual([
+      expect.objectContaining({
+        _id: "sync_conflict_missing_mapping",
+        status: "resolved",
+      }),
+      expect.objectContaining({
+        _id: "sync_conflict_inventory",
+        status: "needs_review",
+      }),
+    ]);
   });
 
   it("rejects synced register review when the manager actor belongs to another user", async () => {
@@ -4473,6 +5190,50 @@ describe("cash control deposits", () => {
     );
   });
 
+  it("sanitizes internal sync metadata from register-session timelines", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      operationalEvent: [
+        {
+          _id: "event_sync_review",
+          actorStaffProfileId: "staff_1",
+          createdAt: 10,
+          eventType: "register_session_sync_review_resolved",
+          metadata: {
+            conflictIds: ["sync_conflict_missing_mapping"],
+            decision: "approved",
+            localEventIds: ["event_sale_1"],
+            managerOverride: false,
+            originalStatuses: ["conflicted"],
+            projectedTransactionIds: ["transaction_1"],
+            sequences: [3],
+          },
+          message: "Applied reviewed synced register sale.",
+          registerSessionId: "session_open",
+          storeId: "store_1",
+        },
+      ],
+    });
+
+    await expect(
+      getHandler(getRegisterSessionSnapshot)(ctx as never, {
+        registerSessionId: "session_open" as Id<"registerSession">,
+        storeId: "store_1" as Id<"store">,
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        timeline: [
+          expect.objectContaining({
+            _id: "event_sync_review",
+            metadata: {
+              decision: "approved",
+              managerOverride: false,
+            },
+          }),
+        ],
+      }),
+    );
+  });
+
   it("includes void status details on linked register-session transactions", async () => {
     const voidedAt = new Date("2026-04-21T17:45:00.000Z").getTime();
     const ctx = createAuthorizedRegisterDepositCtx({
@@ -4723,6 +5484,104 @@ describe("cash control deposits", () => {
       error: {
         code: "precondition_failed",
         message: "Resolve pending void approvals before recording a deposit.",
+      },
+    });
+
+    expect(ctx.tables.get("paymentAllocation")).toEqual([]);
+  });
+
+  it("rejects new deposits while repairable register mapping reviews are pending", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_missing_mapping",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale_1",
+          sequence: 3,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Register session mapping is missing for synced POS history.",
+          details: {
+            localTransactionId: "local-transaction-1",
+          },
+          createdAt: 1,
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_sale_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale_1",
+          sequence: 3,
+          eventType: "sale_completed",
+          occurredAt: 2,
+          staffProfileId: "staff_1",
+          payload: {
+            localTransactionId: "local-transaction-1",
+            receiptNumber: "R-1001",
+          },
+          status: "conflicted",
+          submittedAt: 2,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "transaction_mapping_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale_1",
+          localIdKind: "transaction",
+          localId: "local-transaction-1",
+          cloudTable: "posTransaction",
+          cloudId: "transaction_1",
+          createdAt: 2,
+        },
+      ],
+      posTransaction: [
+        {
+          _id: "transaction_1",
+          completedAt: 2,
+          registerSessionId: "session_open",
+          status: "completed",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          total: 15000,
+          transactionNumber: "R-1001",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_open",
+          expectedCash: 50000,
+          openedAt: 1,
+          openingFloat: 10000,
+          organizationId: "org_1",
+          registerNumber: "1",
+          status: "open",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+        },
+      ],
+    });
+
+    await expect(
+      getHandler(recordRegisterSessionDeposit)(ctx as never, {
+        actorStaffProfileId: "staff_1" as Id<"staffProfile">,
+        amount: 100,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        storeId: "store_1" as Id<"store">,
+        submissionKey: "deposit-1",
+      }),
+    ).resolves.toEqual({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Resolve pending register corrections before recording a deposit.",
       },
     });
 

--- a/packages/athena-webapp/convex/cashControls/deposits.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.ts
@@ -31,7 +31,15 @@ import {
 } from "../pos/application/sync/registerSessionSyncReview";
 import { createConvexLocalSyncRepository } from "../pos/infrastructure/repositories/localSyncRepository";
 import { parseStoredLocalSyncEvent } from "../pos/application/sync/ingestLocalEvents";
-import { projectLocalSyncEvent } from "../pos/application/sync/projectLocalEvents";
+import {
+  createOrReuseRegisterSessionRepairMapping,
+  projectLocalSyncEvent,
+} from "../pos/application/sync/projectLocalEvents";
+import {
+  getCloseoutHoldOperatorMessage,
+  hasCashAffectingCloseoutHolds,
+  listRegisterSessionCloseoutHolds,
+} from "../pos/application/sync/registerSessionCloseoutHolds";
 import {
   requireAuthenticatedAthenaUserWithCtx,
   requireOrganizationMemberRoleWithCtx,
@@ -256,10 +264,47 @@ function numberDetail(
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
+function stringDetail(
+  details: Record<string, unknown> | undefined,
+  key: string,
+) {
+  const value = details?.[key];
+
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
 function recordDetail(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null;
+}
+
+function sanitizeCashControlTimelineMetadata(
+  metadata?: Record<string, unknown> | null,
+) {
+  if (!metadata) {
+    return null;
+  }
+
+  const safeMetadata: Record<string, unknown> = {};
+  for (const key of [
+    "amount",
+    "countedCash",
+    "decision",
+    "expectedCash",
+    "managerOverride",
+    "managerOverrideCount",
+    "projectedCloseoutCount",
+    "reference",
+    "syncOrigin",
+    "variance",
+  ]) {
+    if (metadata[key] !== undefined) {
+      safeMetadata[key] = metadata[key];
+    }
+  }
+
+  return Object.keys(safeMetadata).length > 0 ? safeMetadata : null;
 }
 
 function arrayDetail(value: unknown): Record<string, unknown>[] {
@@ -340,6 +385,109 @@ function buildReviewedSaleProjectionEvent(syncEvent: StoredLocalSyncEvent) {
     ...syncEvent,
     payload: normalizeReviewedNonCashOverpaymentPayload(syncEvent.payload),
   };
+}
+
+function isRepairableRegisterSessionStatus(status?: string | null) {
+  return status === "open" || status === "active" || status === "closing";
+}
+
+async function getCompletedTransactionForRegisterMappingRepair(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  localSyncRepository: ReturnType<typeof createConvexLocalSyncRepository>,
+  args: {
+    conflict: RegisterSessionSyncConflict;
+    registerSessionId: Id<"registerSession">;
+    syncEvent: StoredLocalSyncEvent;
+    terminalId: Id<"posTerminal">;
+  },
+) {
+  const payload = recordDetail(args.syncEvent.payload) ?? {};
+  const localTransactionId =
+    stringDetail(args.conflict.details, "localTransactionId") ??
+    stringDetail(payload, "localTransactionId");
+
+  if (localTransactionId) {
+    const transactionMapping = await localSyncRepository.findMapping({
+      storeId: args.syncEvent.storeId,
+      terminalId: args.terminalId,
+      localRegisterSessionId: args.syncEvent.localRegisterSessionId,
+      localIdKind: "transaction",
+      localId: localTransactionId,
+    });
+    if (transactionMapping?.cloudTable === "posTransaction") {
+      const transaction = await ctx.db.get(
+        "posTransaction",
+        transactionMapping.cloudId as Id<"posTransaction">,
+      );
+      if (
+        transaction?.status === "completed" &&
+        transaction.storeId === args.syncEvent.storeId &&
+        transaction.terminalId === args.terminalId &&
+        transaction.registerSessionId === args.registerSessionId
+      ) {
+        return transaction;
+      }
+    }
+  }
+
+  const receiptNumbers = new Set(
+    [
+      stringDetail(payload, "receiptNumber"),
+      stringDetail(payload, "localReceiptNumber"),
+      args.conflict.sale?.receiptNumber ?? null,
+      args.conflict.sale?.localReceiptNumber ?? null,
+    ].filter((value): value is string => Boolean(value)),
+  );
+  if (receiptNumbers.size === 0) {
+    return null;
+  }
+
+  const totals = recordDetail(payload.totals);
+  const total = totals ? numberDetail(totals, "total") : null;
+  const candidates = await ctx.db
+    .query("posTransaction")
+    .withIndex("by_storeId_status_registerSessionId_completedAt", (q) =>
+      q
+        .eq("storeId", args.syncEvent.storeId)
+        .eq("status", "completed")
+        .eq("registerSessionId", args.registerSessionId),
+    )
+    .take(100);
+  const matches = candidates.filter((transaction) => {
+    if (transaction.terminalId !== args.terminalId) {
+      return false;
+    }
+    if (!receiptNumbers.has(transaction.transactionNumber)) {
+      return false;
+    }
+    return total === null || transaction.total === total;
+  });
+
+  return matches.length === 1 ? matches[0] : null;
+}
+
+async function salePrecedesLocalCloseoutIfPresent(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  args: {
+    storeId: Id<"store">;
+    syncEvent: StoredLocalSyncEvent;
+    terminalId: Id<"posTerminal">;
+  },
+) {
+  const localCloseoutEvents = await ctx.db
+    .query("posLocalSyncEvent")
+    .withIndex("by_store_terminal_register_sequence", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("terminalId", args.terminalId)
+        .eq("localRegisterSessionId", args.syncEvent.localRegisterSessionId),
+    )
+    .take(100);
+  const closeoutEvent = localCloseoutEvents
+    .filter((event) => event.eventType === "register_closed")
+    .sort((left, right) => left.sequence - right.sequence)[0];
+
+  return !closeoutEvent || args.syncEvent.sequence < closeoutEvent.sequence;
 }
 
 async function staffProfileCanResolveSyncReview(
@@ -1137,7 +1285,7 @@ export const getRegisterSessionSnapshot = query({
           : null,
         createdAt: event.createdAt,
         eventType: event.eventType,
-        metadata: event.metadata ?? null,
+        metadata: sanitizeCashControlTimelineMetadata(event.metadata),
         message: event.message,
         reason: event.reason,
       })),
@@ -1255,18 +1403,17 @@ export const recordRegisterSessionDeposit = mutation({
       });
     }
 
-    const pendingVoidApprovals = await listPendingVoidApprovalsForRegisterSession(
-      ctx,
-      {
-        registerSessionId: registerSession._id,
-        storeId: args.storeId,
-      },
-    );
+    const closeoutHolds = await listRegisterSessionCloseoutHolds(ctx, {
+      registerSessionId: registerSession._id,
+      storeId: args.storeId,
+    });
 
-    if (pendingVoidApprovals.length > 0) {
+    if (hasCashAffectingCloseoutHolds(closeoutHolds)) {
       return userError({
         code: "precondition_failed",
-        message: "Resolve pending void approvals before recording a deposit.",
+        message:
+          getCloseoutHoldOperatorMessage(closeoutHolds, "deposit") ??
+          "Resolve pending register corrections before recording a deposit.",
       });
     }
 
@@ -1625,6 +1772,114 @@ export const resolveRegisterSessionSyncReview = mutation({
           review.reviewKind === "register_closeout_variance") ||
         (shouldApplyManagerOverride &&
           syncEvent.eventType === "register_closed");
+      const shouldRepairMissingRegisterSessionMapping =
+        syncEvent.eventType === "sale_completed" &&
+        matchesLocalRegisterSession &&
+        review.reviewKind === "missing_register_session_mapping";
+
+      if (shouldRepairMissingRegisterSessionMapping) {
+        if (isAutomaticResolution) {
+          return userError({
+            code: "precondition_failed",
+            message:
+              "This register review is not eligible for automatic sync repair.",
+          });
+        }
+
+        if (!isRepairableRegisterSessionStatus(registerSession.status)) {
+          return userError({
+            code: "precondition_failed",
+            message:
+              "This synced sale can only be repaired before the register session is closed.",
+          });
+        }
+
+        if (registerSession.status === "closing") {
+          const closeoutHolds = await listRegisterSessionCloseoutHolds(ctx, {
+            registerSessionId: registerSession._id,
+            storeId: args.storeId,
+          });
+          const hasMappingRepairHold = closeoutHolds.some(
+            (hold) =>
+              hold.kind === "repairable_missing_register_session_mapping_sales" &&
+              hold.count > 0,
+          );
+          const salePrecedesCloseout = await salePrecedesLocalCloseoutIfPresent(
+            ctx,
+            {
+              storeId: args.storeId,
+              syncEvent,
+              terminalId,
+            },
+          );
+          if (!hasMappingRepairHold || !salePrecedesCloseout) {
+            return userError({
+              code: "precondition_failed",
+              message:
+                "This synced sale can no longer be repaired for this closeout.",
+            });
+          }
+        }
+
+        const completedTransaction =
+          await getCompletedTransactionForRegisterMappingRepair(
+            ctx,
+            localSyncRepository,
+            {
+              conflict,
+              registerSessionId: args.registerSessionId,
+              syncEvent,
+              terminalId,
+            },
+          );
+        if (!completedTransaction) {
+          return userError({
+            code: "precondition_failed",
+            message:
+              "This synced sale could not be matched to a completed sale for this register session.",
+          });
+        }
+
+        try {
+          await createOrReuseRegisterSessionRepairMapping(localSyncRepository, {
+            localEventId: syncEvent.localEventId,
+            localRegisterSessionId: syncEvent.localRegisterSessionId,
+            now: resolvedAt,
+            registerSessionId: args.registerSessionId,
+            storeId: args.storeId,
+            terminalId,
+          });
+        } catch {
+          return userError({
+            code: "precondition_failed",
+            message:
+              "This synced sale is already mapped to a different register session.",
+          });
+        }
+
+        const hasUnselectedOpenConflictForEvent =
+          requestedConflictIds.size > 0 &&
+          allConflicts.some(
+            (candidate) =>
+              candidate.localEventId === syncEvent.localEventId &&
+              candidate.terminalId === terminalId &&
+              candidate.conflictType !== conflict.conflictType &&
+              candidate.status === "needs_review" &&
+              !requestedConflictIds.has(candidate._id) &&
+              !requestedConflictIds.has(candidate.localEventId),
+          );
+        if (!hasUnselectedOpenConflictForEvent) {
+          await localSyncRepository.patchEvent(syncEvent._id, {
+            status: "projected",
+            projectedAt: resolvedAt,
+          });
+        }
+        if (hasConflictRecord) {
+          resolvedConflictIds.add(conflict._id as Id<"posLocalSyncConflict">);
+        }
+        projectedTransactionIds.push(completedTransaction._id);
+        continue;
+      }
 
       if (isAutomaticResolution && !shouldApplyProoflessStaffAccessEvent) {
         return userError({

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import type { Id } from "../../../_generated/dataModel";
-import { projectLocalSyncEvent } from "./projectLocalEvents";
+import {
+  createOrReuseRegisterSessionRepairMapping,
+  projectLocalSyncEvent,
+} from "./projectLocalEvents";
 import type {
   LocalSyncConflictRecord,
   LocalSyncMappingRecord,
@@ -98,6 +101,45 @@ describe("projectLocalSyncEvent", () => {
       }),
     ]);
     expect(repository.createdPendingCheckoutItems).toHaveLength(1);
+  });
+
+  it("reuses an existing register-session repair mapping for the same cloud drawer", async () => {
+    const repository = createProjectionRepository();
+
+    const mapping = await createOrReuseRegisterSessionRepairMapping(repository, {
+      localEventId: "event-register-opened-1",
+      localRegisterSessionId: "local-register-1",
+      now: 100,
+      registerSessionId: "register-session-1" as Id<"registerSession">,
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+    });
+
+    expect(mapping).toEqual(
+      expect.objectContaining({
+        _id: "mapping-register",
+        cloudId: "register-session-1",
+        localId: "local-register-1",
+      }),
+    );
+    expect(repository.mappings).toHaveLength(1);
+  });
+
+  it("rejects register-session repair when the local drawer maps elsewhere", async () => {
+    const repository = createProjectionRepository();
+
+    await expect(
+      createOrReuseRegisterSessionRepairMapping(repository, {
+        localEventId: "event-sale-1",
+        localRegisterSessionId: "local-register-1",
+        now: 100,
+        registerSessionId: "other-register-session" as Id<"registerSession">,
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+      }),
+    ).rejects.toThrow(
+      "POS local sync register-session mapping already belongs to another projection.",
+    );
   });
 
   it("resolves offline pending sale lines through the pending item mapping before validating provisional anchors", async () => {
@@ -4123,6 +4165,52 @@ describe("projectLocalSyncEvent", () => {
     expect(repository.createdOperationalEvents).toEqual([]);
   });
 
+  it("keeps synced register closeout unresolved when repairable mapping holds exist", async () => {
+    const repository = createProjectionRepository({
+      closeoutHolds: [
+        {
+          kind: "repairable_missing_register_session_mapping_sales",
+          cashAffecting: true,
+          count: 1,
+        },
+      ],
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-closed-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 3,
+        eventType: "register_closed",
+        occurredAt: 30,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: {
+          countedCash: 90,
+          notes: "Closed drawer with pending sale mapping repair",
+        },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("projected");
+    expect(repository.registerSessionPatches).toEqual([
+      {
+        registerSessionId: "register-session-1",
+        patch: expect.objectContaining({
+          status: "closing",
+          countedCash: 90,
+          notes: "Closed drawer with pending sale mapping repair",
+          variance: -10,
+        }),
+      },
+    ]);
+    expect(repository.createdOperationalEvents).toEqual([]);
+  });
+
   it("conflicts non-zero offline closeout variance for manager review", async () => {
     const repository = createProjectionRepository();
 
@@ -5637,6 +5725,13 @@ function createProjectionRepository(
       | boolean
       | ((args: Parameters<SyncProjectionRepository["hasActivePosRole"]>[0]) => boolean);
     pendingVoidApprovalCount: number;
+    closeoutHolds: Array<{
+      cashAffecting: boolean;
+      count: number;
+      kind:
+        | "pending_completed_sale_void_approvals"
+        | "repairable_missing_register_session_mapping_sales";
+    }>;
     validStaffProof: boolean;
   }> = {},
 ): SyncProjectionRepository & {
@@ -5930,8 +6025,20 @@ function createProjectionRepository(
         ? (registerSession as never)
         : null;
     },
-    async countPendingVoidApprovalsForRegisterSession() {
-      return overrides.pendingVoidApprovalCount ?? 0;
+    async listCloseoutHoldsForRegisterSession() {
+      if (overrides.closeoutHolds) {
+        return overrides.closeoutHolds;
+      }
+      const count = overrides.pendingVoidApprovalCount ?? 0;
+      return count > 0
+        ? [
+            {
+              kind: "pending_completed_sale_void_approvals" as const,
+              cashAffecting: true,
+              count,
+            },
+          ]
+        : [];
     },
     async getActiveHeldQuantity(args) {
       if (args.excludeSessionId && overrides.existingPosSession?._id === args.excludeSessionId) {

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -49,6 +49,15 @@ type ProjectEventArgs = {
   };
 };
 
+export type RegisterSessionRepairMappingArgs = {
+  localEventId: string;
+  localRegisterSessionId: string;
+  now: number;
+  registerSessionId: Id<"registerSession">;
+  storeId: Id<"store">;
+  terminalId: Id<"posTerminal">;
+};
+
 type SaleCompletedArgs = ProjectEventArgsFor<"sale_completed">;
 type SaleClearedArgs = ProjectEventArgsFor<"sale_cleared">;
 type ExpenseRecordedArgs = ProjectEventArgsFor<"expense_recorded">;
@@ -265,6 +274,43 @@ export async function projectLocalSyncEvent(
   }
 
   assertNever(args.event);
+}
+
+export async function createOrReuseRegisterSessionRepairMapping(
+  repository: SyncProjectionRepository,
+  args: RegisterSessionRepairMappingArgs,
+) {
+  const existing = await repository.findMapping({
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+    localRegisterSessionId: args.localRegisterSessionId,
+    localIdKind: "registerSession",
+    localId: args.localRegisterSessionId,
+  });
+  if (existing) {
+    if (
+      existing.cloudTable === "registerSession" &&
+      existing.cloudId === args.registerSessionId
+    ) {
+      return existing;
+    }
+
+    throw new Error(
+      "POS local sync register-session mapping already belongs to another projection.",
+    );
+  }
+
+  return repository.createMapping({
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+    localRegisterSessionId: args.localRegisterSessionId,
+    localEventId: args.localEventId,
+    localIdKind: "registerSession",
+    localId: args.localRegisterSessionId,
+    cloudTable: "registerSession",
+    cloudId: args.registerSessionId,
+    createdAt: args.now,
+  });
 }
 
 async function projectExpenseRecorded(
@@ -3506,13 +3552,15 @@ async function projectRegisterClosed(
     return { status: "conflicted", mappings: [], conflicts: [conflict] };
   }
 
-  const pendingVoidApprovalCount =
-    (await repository.countPendingVoidApprovalsForRegisterSession?.({
+  const closeoutHolds =
+    (await repository.listCloseoutHoldsForRegisterSession?.({
       registerSessionId: registerSession._id,
       storeId: args.storeId,
-    })) ?? 0;
+    })) ?? [];
 
-  if (pendingVoidApprovalCount > 0) {
+  if (
+    closeoutHolds.some((hold) => hold.cashAffecting && hold.count > 0)
+  ) {
     await repository.patchRegisterSession(registerSession._id, {
       status: "closing",
       countedCash,

--- a/packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts
@@ -1,0 +1,166 @@
+import type { Doc, Id } from "../../../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../../../_generated/server";
+import {
+  classifyRegisterSessionSyncReview,
+  listOpenLocalSyncConflictsByRegisterSession,
+} from "./registerSessionSyncReview";
+
+export type RegisterSessionCloseoutHoldKind =
+  | "pending_completed_sale_void_approvals"
+  | "repairable_missing_register_session_mapping_sales";
+
+export type RegisterSessionCloseoutHold = {
+  kind: RegisterSessionCloseoutHoldKind;
+  cashAffecting: boolean;
+  count: number;
+  conflictIds?: string[];
+  localEventIds?: string[];
+  approvalRequestIds?: Array<Id<"approvalRequest">>;
+};
+
+export function hasCashAffectingCloseoutHolds(
+  holds: RegisterSessionCloseoutHold[],
+) {
+  return holds.some((hold) => hold.cashAffecting && hold.count > 0);
+}
+
+async function listPendingCompletedSaleVoidApprovals(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  args: {
+    registerSessionId: Id<"registerSession">;
+    storeId: Id<"store">;
+  },
+) {
+  if (typeof ctx.db.query !== "function") {
+    return [];
+  }
+
+  const query = ctx.db
+    .query("approvalRequest")
+    .withIndex("by_registerSessionId", (q) =>
+      q.eq("registerSessionId", args.registerSessionId),
+    );
+  if (typeof query.collect !== "function") {
+    return [];
+  }
+
+  const approvalRequests =
+    // eslint-disable-next-line @convex-dev/no-collect-in-query -- Register-session scoped manager-review queues are bounded by operational review volume and must not be truncated before final closeout.
+    await query.collect();
+
+  return approvalRequests.filter(
+    (approvalRequest): approvalRequest is Doc<"approvalRequest"> =>
+      approvalRequest.storeId === args.storeId &&
+      approvalRequest.status === "pending" &&
+      approvalRequest.requestType === "pos_transaction_void" &&
+      approvalRequest.subjectType === "pos_transaction",
+  );
+}
+
+function canListRegisterSessionSyncConflicts(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  storeId: Id<"store">,
+) {
+  if (typeof ctx.db.query !== "function") {
+    return false;
+  }
+
+  let query;
+  try {
+    query = ctx.db
+      .query("posLocalSyncConflict")
+      .withIndex("by_store_status", (q) =>
+        q.eq("storeId", storeId).eq("status", "needs_review"),
+      );
+  } catch {
+    return false;
+  }
+
+  return typeof query.take === "function";
+}
+
+export async function listRegisterSessionCloseoutHolds(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  args: {
+    registerSessionId: Id<"registerSession">;
+    storeId: Id<"store">;
+  },
+): Promise<RegisterSessionCloseoutHold[]> {
+  const holds: RegisterSessionCloseoutHold[] = [];
+
+  const pendingVoidApprovals = await listPendingCompletedSaleVoidApprovals(
+    ctx,
+    args,
+  );
+  if (pendingVoidApprovals.length > 0) {
+    holds.push({
+      kind: "pending_completed_sale_void_approvals",
+      cashAffecting: true,
+      count: pendingVoidApprovals.length,
+      approvalRequestIds: pendingVoidApprovals.map(
+        (approvalRequest) => approvalRequest._id,
+      ),
+    });
+  }
+
+  const conflictsBySessionId = canListRegisterSessionSyncConflicts(
+    ctx,
+    args.storeId,
+  )
+    ? await listOpenLocalSyncConflictsByRegisterSession(ctx, args.storeId)
+    : new Map<Id<"registerSession">, []>();
+  const repairableConflicts = (
+    conflictsBySessionId.get(args.registerSessionId) ?? []
+  ).filter(
+    (conflict) =>
+      classifyRegisterSessionSyncReview(conflict).reviewKind ===
+      "missing_register_session_mapping",
+  );
+
+  if (repairableConflicts.length > 0) {
+    holds.push({
+      kind: "repairable_missing_register_session_mapping_sales",
+      cashAffecting: true,
+      count: repairableConflicts.length,
+      conflictIds: repairableConflicts.map((conflict) => conflict._id),
+      localEventIds: repairableConflicts.map(
+        (conflict) => conflict.localEventId,
+      ),
+    });
+  }
+
+  return holds;
+}
+
+export function getCloseoutHoldOperatorMessage(
+  holds: RegisterSessionCloseoutHold[],
+  action: "approve" | "deposit" | "finalize",
+) {
+  const cashAffectingHolds = holds.filter(
+    (hold) => hold.cashAffecting && hold.count > 0,
+  );
+  if (cashAffectingHolds.length === 0) {
+    return null;
+  }
+
+  if (
+    cashAffectingHolds.length === 1 &&
+    cashAffectingHolds[0].kind === "pending_completed_sale_void_approvals"
+  ) {
+    if (action === "deposit") {
+      return "Resolve pending void approvals before recording a deposit.";
+    }
+    if (action === "approve") {
+      return "Resolve pending void approvals before approving final closeout.";
+    }
+    return "Resolve pending void approvals before finalizing closeout.";
+  }
+
+  if (action === "deposit") {
+    return "Resolve pending register corrections before recording a deposit.";
+  }
+  if (action === "approve") {
+    return "Resolve pending register corrections before approving final closeout.";
+  }
+  return "Resolve pending register corrections before finalizing closeout.";
+}

--- a/packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts
@@ -19,6 +19,8 @@ export const CLOSED_REGISTER_SYNCED_CLOSEOUT_SUMMARY =
   "Register session is not open for synced POS closeout.";
 export const INVENTORY_SYNC_REVIEW_SUMMARY =
   "Inventory needs manager review for a synced offline sale.";
+export const MISSING_REGISTER_SESSION_MAPPING_SYNC_REVIEW_SUMMARY =
+  "Register session mapping is missing for synced POS history.";
 
 export type RegisterSessionSyncReviewActionPolicy =
   | "apply_or_reject"
@@ -29,6 +31,7 @@ export type RegisterSessionSyncReviewKind =
   | "duplicate_register_closeout"
   | "register_closeout_variance"
   | "register_not_open_sale"
+  | "missing_register_session_mapping"
   | "server_rejected"
   | "service_customer_attribution"
   | "inventory_review"
@@ -168,6 +171,14 @@ export function classifyRegisterSessionSyncReview(
       actionPolicy: "apply_or_reject",
       conflictType: conflict.conflictType,
       reviewKind: "register_closeout_variance",
+    };
+  }
+
+  if (summary === MISSING_REGISTER_SESSION_MAPPING_SYNC_REVIEW_SUMMARY) {
+    return {
+      actionPolicy: "apply_or_reject",
+      conflictType: conflict.conflictType,
+      reviewKind: "missing_register_session_mapping",
     };
   }
 
@@ -456,6 +467,65 @@ async function findTransactionIdForSyncEvent(
     : null;
 }
 
+async function findProjectedRegisterSessionIdForRepairableMissingMapping(
+  ctx: Pick<QueryCtx, "db">,
+  conflict: RegisterSessionSyncConflict,
+) {
+  if (
+    classifyRegisterSessionSyncReview(conflict).reviewKind !==
+      "missing_register_session_mapping" ||
+    !conflict.terminalId
+  ) {
+    return null;
+  }
+
+  const syncEvent = await ctx.db
+    .query("posLocalSyncEvent")
+    .withIndex("by_store_terminal_localEvent", (q) =>
+      q
+        .eq("storeId", conflict.storeId!)
+        .eq("terminalId", conflict.terminalId!)
+        .eq("localEventId", conflict.localEventId),
+    )
+    .unique();
+  if (syncEvent?.eventType !== "sale_completed") {
+    return null;
+  }
+
+  const transactionId = await findTransactionIdForSyncEvent(ctx, syncEvent);
+  if (!transactionId) {
+    return null;
+  }
+
+  const transaction = await ctx.db.get("posTransaction", transactionId);
+  if (
+    !transaction ||
+    transaction.storeId !== syncEvent.storeId ||
+    transaction.terminalId !== syncEvent.terminalId ||
+    transaction.status !== "completed" ||
+    !transaction.registerSessionId
+  ) {
+    return null;
+  }
+
+  const registerSession = await ctx.db.get(
+    "registerSession",
+    transaction.registerSessionId,
+  );
+  if (
+    !registerSession ||
+    registerSession.storeId !== syncEvent.storeId ||
+    registerSession.terminalId !== syncEvent.terminalId ||
+    (registerSession.status !== "open" &&
+      registerSession.status !== "active" &&
+      registerSession.status !== "closing")
+  ) {
+    return null;
+  }
+
+  return registerSession._id;
+}
+
 export function buildRegisterSessionLocalSyncStatus(
   conflicts: RegisterSessionSyncConflict[],
   options: { staffNamesById?: Map<Id<"staffProfile">, string> } = {},
@@ -731,6 +801,15 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
         ) {
           return [cloudRegisterSessionId, conflict] as const;
         }
+      }
+
+      const repairableRegisterSessionId =
+        await findProjectedRegisterSessionIdForRepairableMissingMapping(ctx, {
+          ...conflict,
+          storeId: conflictStoreId,
+        });
+      if (repairableRegisterSessionId) {
+        return [repairableRegisterSessionId, conflict] as const;
       }
 
       return null;

--- a/packages/athena-webapp/convex/pos/application/sync/types.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/types.ts
@@ -5,6 +5,7 @@ import type {
   PosLocalSyncEventStatus,
   PosLocalSyncEventType,
 } from "../../../../shared/posLocalSyncContract";
+import type { RegisterSessionCloseoutHold } from "./registerSessionCloseoutHolds";
 
 export type { PosLocalSyncEventStatus, PosLocalSyncEventType };
 
@@ -312,10 +313,10 @@ export type SyncProjectionRepository = {
   getRegisterSession(
     registerSessionId: Id<"registerSession">,
   ): Promise<Doc<"registerSession"> | null>;
-  countPendingVoidApprovalsForRegisterSession?(args: {
+  listCloseoutHoldsForRegisterSession?(args: {
     registerSessionId: Id<"registerSession">;
     storeId: Id<"store">;
-  }): Promise<number>;
+  }): Promise<RegisterSessionCloseoutHold[]>;
   getCustomerProfile(
     customerProfileId: Id<"customerProfile">,
   ): Promise<Doc<"customerProfile"> | null>;

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
@@ -27,6 +27,7 @@ import type {
   LocalSyncRepository,
   PosSyncOperationalRole,
 } from "../../application/sync/types";
+import { listRegisterSessionCloseoutHolds } from "../../application/sync/registerSessionCloseoutHolds";
 import { validatePosLocalStaffProofWithCtx } from "../../application/sync/staffProofValidation";
 
 export function createConvexLocalSyncRepository(
@@ -150,23 +151,8 @@ export function createConvexLocalSyncRepository(
     getRegisterSession(registerSessionId) {
       return ctx.db.get("registerSession", registerSessionId);
     },
-    async countPendingVoidApprovalsForRegisterSession(args) {
-      const approvalRequests =
-        // eslint-disable-next-line @convex-dev/no-collect-in-query -- Register-session scoped pending void approvals are bounded by manager-review workflow volume and must be checked before synced closeout projection.
-        await ctx.db
-          .query("approvalRequest")
-          .withIndex("by_registerSessionId", (q) =>
-            q.eq("registerSessionId", args.registerSessionId),
-          )
-          .collect();
-
-      return approvalRequests.filter(
-        (approvalRequest) =>
-          approvalRequest.storeId === args.storeId &&
-          approvalRequest.status === "pending" &&
-          approvalRequest.requestType === "pos_transaction_void" &&
-          approvalRequest.subjectType === "pos_transaction",
-      ).length;
+    async listCloseoutHoldsForRegisterSession(args) {
+      return listRegisterSessionCloseoutHolds(ctx, args);
     },
     async getActiveHeldQuantity(args) {
       const holds = await ctx.db

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 16 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, cycleCountDrafts.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 8 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCaseTracing.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 19 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 597 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 598 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 9 file(s); key children: README.md, SUMMARY.md, pos, prod.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -1360,6 +1360,116 @@ describe("RegisterSessionViewContent", () => {
     });
   });
 
+  it("shows repair copy for completed sale register mapping reviews", async () => {
+    const user = userEvent.setup();
+    const onAuthenticateStaff = vi.fn().mockResolvedValue(
+      ok({
+        activeRoles: ["manager"],
+        staffProfile: { fullName: "Ato Kofi" },
+        staffProfileId: "manager-1",
+      }),
+    );
+    const onResolveSyncReview = vi
+      .fn()
+      .mockResolvedValue(
+        ok({ action: "resolved", projectedCount: 1, resolvedCount: 1 }),
+      );
+
+    render(
+      <RegisterSessionViewContent
+        currency="GHS"
+        isLoading={false}
+        onRecordDeposit={vi.fn()}
+        {...closeoutHandlers}
+        onAuthenticateStaff={onAuthenticateStaff}
+        onResolveSyncReview={onResolveSyncReview}
+        orgUrlSlug="wigclub"
+        registerSessionSnapshot={{
+          ...baseSnapshot,
+          registerSession: {
+            ...baseSnapshot.registerSession,
+            localSyncStatus: {
+              status: "needs_review",
+              reconciliationItems: [
+                {
+                  actionPolicy: "apply_or_reject",
+                  id: "sync_conflict_missing_mapping",
+                  localEventId: "event_sale_1",
+                  reviewKind: "missing_register_session_mapping",
+                  sale: {
+                    cashAmount: 3500,
+                    itemCount: 1,
+                    occurredAt: Date.parse("2026-06-23T03:38:00Z"),
+                    paymentMethods: ["cash"],
+                    receiptNumber: "003078",
+                    staffName: "Ato K.",
+                    total: 3500,
+                    totalPaid: 3500,
+                  },
+                  sequence: 2,
+                  status: "needs_review",
+                  summary:
+                    "Register session mapping is missing for synced POS history.",
+                  type: "permission",
+                },
+              ],
+            },
+          },
+        }}
+        storeUrlSlug="wigclub"
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Manager sign-in repairs the completed sale link to this register session so the drawer can be settled.",
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /Receipt #003078/i,
+      }),
+    );
+
+    expect(screen.getByText("Repair sale mapping")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Completed sale needs its register-session link repaired before this drawer can be settled.",
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Repair sale mapping" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm staff for Repair sale mapping",
+      }),
+    );
+
+    expect(onResolveSyncReview).toHaveBeenNthCalledWith(1, {
+      actorStaffProfileId: "manager-1",
+      decision: "approved",
+      registerSessionId: "session-1",
+      reviewConflictIds: ["sync_conflict_missing_mapping"],
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Reject sale mapping review" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm staff for Reject sale mapping review",
+      }),
+    );
+
+    expect(onResolveSyncReview).toHaveBeenNthCalledWith(2, {
+      actorStaffProfileId: "manager-1",
+      decision: "rejected",
+      registerSessionId: "session-1",
+      reviewConflictIds: ["sync_conflict_missing_mapping"],
+    });
+  });
+
   it("shows only the duplicate rejection decision for duplicate synced sale reviews", async () => {
     const user = userEvent.setup();
     const onAuthenticateStaff = vi.fn().mockResolvedValue(

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -88,6 +88,8 @@ const CLOSED_REGISTER_SYNCED_CLOSEOUT_SUMMARY =
   "register session is not open for synced pos closeout";
 const REGISTER_NOT_OPEN_SYNC_REVIEW_SUMMARY =
   "Register was not open before this sale synced.";
+const MISSING_REGISTER_SESSION_MAPPING_SYNC_REVIEW_SUMMARY =
+  "Register session mapping is missing for synced POS history.";
 const STAFF_ACCESS_SYNC_REVIEW_SUMMARY =
   "Staff access changed before this POS history synced.";
 const SERVICE_CUSTOMER_ATTRIBUTION_SYNC_REVIEW_SUMMARY =
@@ -1568,6 +1570,10 @@ function getCombinedReviewNextStep(items: PosReconciliationItem[]) {
     return "This synced activity needs correction before it can be applied. Reject it to clear this review, then correct the sale from the appropriate workflow if needed.";
   }
 
+  if (items.some(isMissingRegisterSessionMappingReviewItem)) {
+    return "Manager sign-in repairs the completed sale link to this register session so the drawer can be settled.";
+  }
+
   if (
     items.some(
       (item) =>
@@ -1587,6 +1593,15 @@ function isInventoryRegisterSyncReviewItem(item: PosReconciliationItem) {
     item.reviewKind === "inventory_review" ||
     item.type === "inventory" ||
     item.type === "inventory_conflict"
+  );
+}
+
+function isMissingRegisterSessionMappingReviewItem(
+  item: PosReconciliationItem,
+) {
+  return (
+    item.reviewKind === "missing_register_session_mapping" ||
+    item.summary?.trim() === MISSING_REGISTER_SESSION_MAPPING_SYNC_REVIEW_SUMMARY
   );
 }
 
@@ -1626,6 +1641,13 @@ function getRegisterSyncReviewItemActionLabels(item: PosReconciliationItem) {
     };
   }
 
+  if (isMissingRegisterSessionMappingReviewItem(item)) {
+    return {
+      approveLabel: "Repair sale mapping",
+      rejectLabel: "Reject sale mapping review",
+    };
+  }
+
   return {
     approveLabel: "Apply review item",
     rejectLabel: "Reject review item",
@@ -1639,6 +1661,10 @@ function getRegisterSyncReviewItemSummary(item: PosReconciliationItem) {
 
   if (isInventoryRegisterSyncReviewItem(item)) {
     return "Inventory needs manager review before this synced sale can be applied.";
+  }
+
+  if (isMissingRegisterSessionMappingReviewItem(item)) {
+    return "Completed sale needs its register-session link repaired before this drawer can be settled.";
   }
 
   if (item.reviewKind === "register_closeout_variance") {
@@ -1680,6 +1706,10 @@ function getRegisterSyncReviewDecisionScope(item: PosReconciliationItem) {
 
   if (isInventoryRegisterSyncReviewItem(item)) {
     return "inventory";
+  }
+
+  if (isMissingRegisterSessionMappingReviewItem(item)) {
+    return "missing_register_session_mapping";
   }
 
   if (isRegisterCloseoutReviewItem(item)) {

--- a/packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts
@@ -19,6 +19,7 @@ export type PosReconciliationItem = {
     | "duplicate_register_closeout"
     | "register_closeout_variance"
     | "register_not_open_sale"
+    | "missing_register_session_mapping"
     | "server_rejected"
     | "service_customer_attribution"
     | "inventory_review"


### PR DESCRIPTION
## Summary
- classify missing register-session mapping sync reviews as repairable instead of reject-only
- add manager-approved repair that reuses the completed-sale projection and creates/reuses the local register-session mapping
- generalize closeout hold mechanics so void approvals and repairable mapping conflicts share the same cash-affecting hold boundary
- expose Cash Controls repair/reject actions and document the approved plan/solution

## Review
- Correctness reviewer: approved
- Data integrity reviewer: approved
- Security reviewer: approved
- Testing reviewer: approved

## Validation
- `bunx vitest run packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts --reporter=dot`
- `bunx vitest run packages/athena-webapp/convex/cashControls/deposits.test.ts packages/athena-webapp/convex/cashControls/closeouts.test.ts --reporter=dot`
- `bun run --cwd packages/athena-webapp typecheck`
- `bun run pr:athena`
