### PR TITLE
Preserve EOD carry-forward automation

### DIFF
--- a/docs/plans/2026-06-26-001-feat-eod-carry-forward-auto-complete-plan.html
+++ b/docs/plans/2026-06-26-001-feat-eod-carry-forward-auto-complete-plan.html
@@ -1,0 +1,296 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Plan: Preserve Carry-Forward Work During EOD Auto-Completion</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f8fafc;
+      --paper: #ffffff;
+      --ink: #172033;
+      --muted: #667085;
+      --line: #d9e2ec;
+      --accent: #0f766e;
+      --accent-soft: #e6f4f1;
+      --warn-soft: #fff7e6;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 32px 20px 56px;
+    }
+    header, section {
+      background: var(--paper);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 24px;
+      margin-bottom: 18px;
+    }
+    h1, h2, h3 {
+      line-height: 1.2;
+      margin: 0 0 12px;
+    }
+    h1 { font-size: 2rem; }
+    h2 { font-size: 1.35rem; border-bottom: 1px solid var(--line); padding-bottom: 8px; }
+    h3 { font-size: 1.05rem; margin-top: 20px; }
+    p { margin: 0 0 12px; }
+    ul { margin: 0 0 0 1.2rem; padding: 0; }
+    li { margin: 0.35rem 0; }
+    a { color: var(--accent); text-decoration-thickness: 1px; }
+    code {
+      background: #eef2f7;
+      border-radius: 4px;
+      padding: 0.1rem 0.3rem;
+      font-size: 0.92em;
+    }
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 12px 0;
+      font-size: 0.95rem;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 10px;
+      vertical-align: top;
+      text-align: left;
+    }
+    th { background: #f1f5f9; }
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 16px;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+    .pill {
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 4px 10px;
+      background: #fbfdff;
+    }
+    .callout {
+      background: var(--accent-soft);
+      border-left: 4px solid var(--accent);
+      padding: 14px 16px;
+      border-radius: 6px;
+      margin: 14px 0;
+    }
+    .warning {
+      background: var(--warn-soft);
+      border-left-color: #b45309;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 14px;
+    }
+    .unit {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px;
+      background: #fbfdff;
+    }
+    .unit h3 { margin-top: 0; }
+    .small { color: var(--muted); font-size: 0.94rem; }
+    @media (max-width: 700px) {
+      header, section { padding: 18px; }
+      h1 { font-size: 1.55rem; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>Preserve Carry-Forward Work During EOD Auto-Completion</h1>
+      <p>Extend EOD auto-completion so Athena can close blocker-free EOD Reviews with supported review evidence and carry-forward work, while preserving unresolved work for Opening Handoff.</p>
+      <div class="meta">
+        <span class="pill">Type: feat</span>
+        <span class="pill">Status: active</span>
+        <span class="pill">Date: 2026-06-26</span>
+        <span class="pill">Source: <a href="2026-06-26-001-feat-eod-carry-forward-auto-complete-plan.md">Markdown plan</a></span>
+      </div>
+    </header>
+
+    <section>
+      <h2>Scope</h2>
+      <div class="callout">
+        <p><strong>Core shift:</strong> carry-forward is no longer a hard EOD auto-completion blocker by itself. Athena may complete the EOD Review when blockers are zero and review policy passes, but carry-forward remains unresolved and visible for Opening.</p>
+      </div>
+      <ul>
+        <li>Keep blockers strict.</li>
+        <li>Keep supported review categories limited to <code>cash_variance</code> and <code>voided_sale</code>.</li>
+        <li>Preserve carry-forward work item IDs, counts, and snapshot evidence.</li>
+        <li>Do not create new carry-forward work items from automation.</li>
+        <li>Do not treat carry-forward as policy-reviewed review evidence.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Key Decisions</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Decision</th>
+            <th>Rationale</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Replace carry-forward skip with preserved evidence.</td>
+            <td>Carry-forward is already durable handoff work and should not block closing when the day has zero blockers.</td>
+          </tr>
+          <tr>
+            <td>Keep review and carry-forward semantics separate.</td>
+            <td><code>policyReviewedItemKeys</code> should only mean review evidence checked by policy, not work resolution.</td>
+          </tr>
+          <tr>
+            <td>Let command-time re-read win.</td>
+            <td>Daily Close is a store-day command boundary; the final server snapshot and policy check prevent races from closing blocked or over-threshold days.</td>
+          </tr>
+          <tr>
+            <td>Preserve IDs, stored snapshot evidence, and applied run evidence.</td>
+            <td>Opening Handoff needs durable IDs, history needs immutable report evidence, and the automation ledger must match the completed close.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Copy Direction</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>State</th>
+            <th>Approved direction</th>
+            <th>Avoid</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Settings capability</td>
+            <td>Athena can complete blocker-free EOD Reviews under store policy. Carry-forward work stays open for Opening Handoff.</td>
+            <td>Resolved, approved, clean-only capability wording.</td>
+          </tr>
+          <tr>
+            <td>Completed with carry-forward</td>
+            <td>Carry-forward work was preserved for Opening Handoff.</td>
+            <td>Cleared, completed, resolved.</td>
+          </tr>
+          <tr>
+            <td>Opening Handoff</td>
+            <td>Carry-forward work from the prior EOD Review remains open for this opening.</td>
+            <td>Any implication that the close resolved the work item.</td>
+          </tr>
+          <tr>
+            <td>Redacted attribution</td>
+            <td>Restricted close evidence is hidden for this account.</td>
+            <td>Variance totals, void totals, raw backend codes.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Implementation Units</h2>
+      <div class="grid">
+        <article class="unit">
+          <h3>U1. Eligibility Policy</h3>
+          <p>Update <code>dailyOperationsAutomation.ts</code> and run-ledger evidence so carry-forward is observed/preserved evidence, not an ineligible classification.</p>
+          <p class="small">Primary tests: <code>dailyOperationsAutomation.test.ts</code></p>
+        </article>
+        <article class="unit">
+          <h3>U2. Completion Persistence</h3>
+          <p>Update <code>dailyClose.ts</code> so automation-completed closes persist carry-forward IDs, counts, return payloads, and report snapshot items.</p>
+          <p class="small">Primary tests: <code>dailyClose.test.ts</code></p>
+        </article>
+        <article class="unit">
+          <h3>U3. Read Models and History</h3>
+          <p>Keep completed lifecycle primary, preserve stored-history rendering, and verify redaction for broad readers.</p>
+          <p class="small">Primary tests: <code>dailyOperations.test.ts</code>, <code>dailyClose.test.ts</code></p>
+        </article>
+        <article class="unit">
+          <h3>U4. Operator Copy</h3>
+          <p>Update POS settings, Daily Close, Daily Operations, history, and Opening Handoff copy so Athena completion does not imply manager approval or carry-forward resolution.</p>
+          <p class="small">Primary tests: component tests for settings and operations views</p>
+        </article>
+        <article class="unit">
+          <h3>U5. Opening Handoff</h3>
+          <p>Prove Opening consumes carry-forward IDs from an Athena-completed prior close and keeps acknowledgement semantics unchanged.</p>
+          <p class="small">Primary tests: <code>dailyOpening.test.ts</code>, <code>DailyOpeningView.test.tsx</code></p>
+        </article>
+        <article class="unit">
+          <h3>U6. Knowledge and Validation</h3>
+          <p>Update durable solution guidance and validation metadata if implementation changes generated harness artifacts.</p>
+          <p class="small">Primary docs: EOD automation solution note</p>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <h2>Critical Test Themes</h2>
+      <ul>
+        <li>Clean day plus carry-forward completes when clean-day policy is enabled.</li>
+        <li>Low-risk review plus carry-forward completes inside thresholds.</li>
+        <li>Unsupported review, mixed unsupported review, blockers, and threshold failures still skip.</li>
+        <li>Automation completion stores carry-forward IDs, counts, snapshot items, and Athena attribution.</li>
+        <li>Applied automation evidence matches the command-time completed close/report snapshot.</li>
+        <li>Wrong-store, wrong-organization, terminal, duplicate, missing, or unmappable carry-forward items fail closed.</li>
+        <li>Broad readers see safe attribution and carry-forward shells/counts but not restricted financial or review metadata.</li>
+        <li>Opening Handoff surfaces carry-forward work from an Athena-completed prior close.</li>
+        <li>Dry-run, skipped, redacted, no-carry-forward, and carry-forward-present copy states stay distinct.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Risks</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Risk</th>
+            <th>Mitigation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Automation appears to resolve carry-forward work.</td>
+            <td>Keep copy and data model explicit: preserved for Opening, not resolved.</td>
+          </tr>
+          <tr>
+            <td>Opening loses carry-forward handoff.</td>
+            <td>Persist <code>carryForwardWorkItemIds</code> and test Opening context.</td>
+          </tr>
+          <tr>
+            <td>Restricted evidence leaks.</td>
+            <td>Keep redaction boundaries and add broad-reader tests.</td>
+          </tr>
+          <tr>
+            <td>A race closes a newly blocked day.</td>
+            <td>Command-time snapshot re-read wins and skips if blockers or unsupported review appear.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>References</h2>
+      <ul>
+        <li><a href="../brainstorms/2026-05-07-daily-operations-lifecycle-requirements.md">Daily Operations Lifecycle requirements</a></li>
+        <li><a href="2026-06-22-004-feat-eod-review-automation-plan.md">Prior EOD automation plan</a></li>
+        <li><a href="../solutions/architecture/athena-eod-review-automation-completion-2026-06-22.md">EOD automation solution note</a></li>
+        <li><a href="../solutions/logic-errors/athena-daily-close-store-day-boundary-2026-05-07.md">Daily Close store-day boundary</a></li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-06-26-001-feat-eod-carry-forward-auto-complete-plan.md
+++ b/docs/plans/2026-06-26-001-feat-eod-carry-forward-auto-complete-plan.md
@@ -1,0 +1,473 @@
+---
+title: "feat: Preserve Carry-Forward Work During EOD Auto-Completion"
+type: feat
+status: active
+date: 2026-06-26
+origin: docs/brainstorms/2026-05-07-daily-operations-lifecycle-requirements.md
+---
+
+# feat: Preserve Carry-Forward Work During EOD Auto-Completion
+
+## Summary
+
+Extend the delivered EOD auto-completion path so Athena can complete blocker-free EOD Reviews that contain supported review evidence and carry-forward work. The implementation keeps blockers and unsupported review categories strict, preserves unresolved carry-forward work into the completed close and next Opening Handoff, and updates operator copy so automation never sounds like manager approval or work resolution.
+
+---
+
+## Problem Frame
+
+The previous EOD automation rollout intentionally skipped any day with carry-forward evidence. That was safe for the first completion boundary, but it now leaves Athena unable to close otherwise eligible operating days where follow-up work should simply remain visible tomorrow. Daily Close already treats carry-forward as durable store-day handoff evidence, so the next iteration should let automation close the operating-day boundary while preserving that unresolved work.
+
+---
+
+## Requirements
+
+- R1. EOD auto-completion may apply only when the command-time Daily Close snapshot has zero blocker items.
+- R2. Supported review evidence remains limited to `cash_variance` and `voided_sale`, and each supported review item must pass existing policy thresholds before automation can complete.
+- R3. Unsupported review categories, mixed supported-plus-unsupported review sets, threshold failures, invalid operating ranges, and reopened or superseded close lifecycle states must still skip automation completion.
+- R4. Carry-forward work must no longer be a hard EOD auto-completion blocker when R1 and R2 are satisfied.
+- R5. Athena must preserve carry-forward as unresolved work, not resolve, approve, complete, or hide it.
+- R6. Automated completion must persist carry-forward work item IDs, carry-forward counts, report snapshot carry-forward items, source subjects, Athena attribution, automation run ID, policy version, and decision reason.
+- R7. Opening Handoff must continue to surface carry-forward work from an Athena-completed prior close.
+- R8. Manual EOD completion and reopen flows must keep the existing manager approval proof contract.
+- R9. EOD automation remains policy-evidence based; it must not create fake manager approval, fake staff attribution, or manager-approved copy.
+- R10. Broad readers may see safe Athena attribution and neutral carry-forward shells/counts, but raw carry-forward work item IDs, source subject IDs, link params, decision evidence, policy-reviewed keys, restricted financial/review evidence, and sensitive metadata must keep existing redaction boundaries.
+- R11. POS settings, Daily Close, Daily Operations, Daily Close History, and Opening Handoff copy must describe the new behavior calmly: Athena completed the EOD Review under policy and preserved carry-forward work for Opening.
+
+**Origin actors:** A1 Operator, A2 Owner or manager, A4 Athena
+**Origin flows:** F1 Daily close readiness review, F2 Exception review and carry-forward, F3 Close completion and daily summary, F4 Future opening handoff
+**Origin acceptance examples:** AE2, AE3, AE4
+
+---
+
+## Scope Boundaries
+
+- This plan does not add new low-risk review categories beyond `cash_variance` and `voided_sale`.
+- This plan does not soften blocker categories such as open/closing registers, pending approvals, unresolved POS sessions, invalid dates, or reopened/superseded close lifecycle conflicts.
+- This plan does not create new carry-forward work items from automation. Athena should preserve existing durable work item IDs from the snapshot.
+- This plan does not let policy-reviewed review keys represent carry-forward resolution. `policyReviewedItemKeys` stays scoped to review items checked by policy.
+- This plan does not change manual manager approval requirements for completing or reopening an EOD Review.
+- This plan does not add external notifications, intelligence-layer recommendations, or a new automation history surface.
+
+### Deferred to Follow-Up Work
+
+- Broader low-risk category policy beyond `cash_variance` and `voided_sale`.
+- Dedicated automation history drill-down for policy evidence.
+- Data-driven recommendations for tuning review thresholds.
+- Support for automation-created carry-forward work from operator draft text.
+- Scheduler-ledger cleanup for routine pre-window EOD checks.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts` owns `eod.auto_complete`, low-risk categories, thresholds, timing, decision evidence, and the current carry-forward skip.
+- `packages/athena-webapp/convex/operations/dailyClose.ts` owns the authoritative Daily Close snapshot and completion mutation. It currently rejects carry-forward for automation and writes empty carry-forward IDs/items for automation-completed closes.
+- `packages/athena-webapp/convex/automation/runLedger.ts` and `packages/athena-webapp/convex/schemas/automation.ts` own policy config and structured `automationRun.decisionEvidence`.
+- `packages/athena-webapp/convex/schemas/operations/dailyClose.ts` already supports completed-close attribution, `policyReviewedItemKeys`, and `carryForwardWorkItemIds`.
+- `packages/athena-webapp/convex/operations/dailyOpening.ts` consumes prior close `carryForwardWorkItemIds` for Opening Handoff.
+- `packages/athena-webapp/convex/operations/dailyOperations.ts` projects automation status and redacts restricted EOD evidence for broad readers.
+- `packages/athena-webapp/src/components/operations/DailyCloseView.tsx`, `DailyOperationsView.tsx`, and `DailyCloseHistoryView.tsx` render Athena attribution and policy detail copy.
+- `packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx` exposes EOD completion automation policy copy and controls.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-eod-review-automation-completion-2026-06-22.md`: EOD completion must stay a distinct `eod.auto_complete` action with policy evidence, Athena attribution, command-time revalidation, and redaction.
+- `docs/solutions/architecture/athena-store-day-auto-start-review-2026-06-11.md`: automation may advance lifecycle state when policy allows it, but unresolved evidence must be preserved for manager review.
+- `docs/solutions/logic-errors/athena-daily-close-store-day-boundary-2026-05-07.md`: Daily Close is a store-day command boundary and completion must re-read the server snapshot.
+- `docs/solutions/logic-errors/athena-daily-close-history-snapshots-2026-05-09.md`: historical close detail must render the stored report snapshot, not recompute from live source records.
+- `docs/product-copy-tone.md`: operator-facing copy should stay calm, clear, restrained, operational, and normalized.
+
+### External References
+
+- None. Local Athena automation, Daily Close, Opening Handoff, and redaction patterns are the source of truth.
+
+---
+
+## Key Technical Decisions
+
+- **Replace carry-forward skip with preserved evidence:** Carry-forward is no longer a completion blocker by itself. It is stored as unresolved handoff work on the completed close.
+- **Keep review and carry-forward semantics separate:** `policyReviewedItemKeys` represents review evidence checked by policy. Carry-forward remains represented by work item IDs, carry-forward counts, and report snapshot items.
+- **Preserve existing durable work items only:** Automation should link work item IDs already present in `snapshot.carryForwardItems`; it should not create new carry-forward work items.
+- **Let command-time re-read win:** If the apply-time snapshot gains blockers, unsupported review evidence, or threshold-exceeding supported review evidence, automation skips. If only the carry-forward set changes and blockers/review policy still pass, automation completes with the final re-read evidence.
+- **Make applied run evidence match the completed close:** The final `automationRun.decisionEvidence` for an applied run must reflect the command-time snapshot that produced the close, including carry-forward IDs/keys/counts, source subjects, preserved status, and a completed close reference.
+- **Keep completion lifecycle primary in read models:** A completed Athena close remains the primary state; stale skipped or dry-run automation rows must not override the completed close.
+- **Redact identifiers and details, not attribution:** Broad readers can see safe Athena attribution and neutral carry-forward shells/counts, while raw IDs, source subjects, link params, decision evidence, policy keys, financial/review details, and sensitive metadata remain restricted.
+- **Update the prior solution doc during implementation:** The June 22 solution doc currently says carry-forward stays human-only in v1; implementation should update that learning after this plan lands.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should carry-forward items be created by automation?** No. Preserve existing durable work item IDs from the snapshot only.
+- **Should low-risk review completion require `cleanDayAutoCompleteEnabled`?** No. The clean-day toggle gates zero-review days. Low-risk review days use their existing review threshold policy.
+- **What happens if carry-forward changes between eligibility and apply?** The command-time snapshot wins. Complete with the final carry-forward set if blockers remain zero and review policy still passes.
+- **What happens if a blocker, unsupported review, or threshold-exceeding supported review appears between eligibility and apply?** Skip with precondition evidence; do not complete.
+- **What should history show?** Athena completion attribution plus preserved carry-forward evidence for Opening Handoff, with existing redaction for restricted review/financial details.
+
+### Deferred to Implementation
+
+- Whether the final implementation uses an existing helper or a new small helper to derive work item IDs from `snapshot.carryForwardItems`.
+- Whether generated Convex validators need widening after the final return payload and public read model changes are known.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  Policy["Store EOD policy"] --> Decision["eod.auto_complete decision"]
+  Decision --> Snapshot["Daily Close snapshot"]
+  Snapshot --> Gates{"Blockers zero and review policy passes?"}
+  Gates -->|No| Skip["Record skipped evidence"]
+  Gates -->|Dry run| Dry["Record would-preserve evidence"]
+  Gates -->|Yes, enabled| Apply["Automation completion helper"]
+  Apply --> ReRead["Command-time snapshot re-read"]
+  ReRead -->|Blocker or unsupported review| ApplySkip["Skip without close mutation"]
+  ReRead -->|Still eligible| Persist["Persist completed close"]
+  Persist --> Carry["Store carryForwardWorkItemIds and snapshot items"]
+  Carry --> History["Daily Close History uses stored snapshot"]
+  Carry --> Opening["Opening Handoff consumes carry-forward IDs"]
+```
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 Eligibility policy"] --> U2["U2 Completion persistence"]
+  U2 --> U3["U3 Read models and history"]
+  U3 --> U4["U4 Operator copy and settings"]
+  U2 --> U5["U5 Opening handoff regression"]
+  U1 --> U6["U6 Knowledge and validation updates"]
+  U2 --> U6
+  U3 --> U6
+  U4 --> U6
+  U5 --> U6
+```
+
+- U1. **Update EOD Auto-Complete Eligibility**
+
+**Goal:** Change the automation decision so carry-forward work is preserved evidence rather than an ineligible classification when blockers are zero and review policy passes.
+
+**Requirements:** R1, R2, R3, R4, R5, R9
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts`
+- Modify: `packages/athena-webapp/convex/automation/runLedger.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts`
+
+**Approach:**
+- Remove the carry-forward hard skip from the decision path.
+- Keep `cash_variance` and `voided_sale` as the only supported review categories.
+- Keep blockers, unsupported review categories, threshold failures, invalid operating windows, and lifecycle conflicts strict.
+- Add decision evidence that makes carry-forward observed/preserved status explicit without turning it into a threshold gate.
+- Define applied-run evidence so it can be rebuilt from the command-time snapshot and patched onto the run after completion: carry-forward work item IDs, carry-forward item keys, counts, source subjects, preserved-vs-skipped status, and the completed close reference.
+- Keep dry-run behavior mutation-free while recording what carry-forward would have been preserved.
+- Preserve existing local completion-window behavior; scheduler-ledger cleanup is outside this carry-forward capability.
+
+**Execution note:** Start with failing eligibility tests that replace the current hard-skip expectation.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts`
+- `packages/athena-webapp/convex/automation/runLedger.ts`
+
+**Test scenarios:**
+- Happy path: clean day with carry-forward and zero blockers completes when clean-day policy is enabled.
+- Happy path: low-risk `cash_variance` within threshold plus carry-forward is eligible and applies.
+- Happy path: low-risk `voided_sale` within count/total thresholds plus carry-forward is eligible and applies.
+- Edge case: carry-forward evidence appears in decision evidence as preserved evidence, not as `classification: "carry_forward"`.
+- Edge case: applied run evidence references the same carry-forward IDs/items and source subjects as the completed close/report snapshot.
+- Edge case: unsupported review category plus carry-forward skips the whole close.
+- Edge case: one supported review item plus one unsupported review item skips the whole close.
+- Edge case: threshold-exceeded supported review plus carry-forward skips.
+- Edge case: blocker plus carry-forward skips because blockers remain hard stops.
+- Edge case: outside completion window plus carry-forward does not mutate and preserves current timing-gate behavior.
+- Edge case: dry-run plus carry-forward records would-preserve evidence and does not mutate Daily Close.
+- Integration: `eod.prepare` remains preparation-only and is not conflated with completion.
+
+**Verification:**
+- Automation eligibility explains carry-forward as preserved evidence while keeping blocker and unsupported-review outcomes strict.
+
+---
+
+- U2. **Persist Carry-Forward During Automation Completion**
+
+**Goal:** Change the command-time completion helper so Athena-completed closes retain carry-forward IDs, counts, and report snapshot evidence.
+
+**Requirements:** R1, R4, R5, R6, R7, R8, R9
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/dailyClose.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyClose.test.ts`
+
+**Approach:**
+- Remove the automation-only rejection of `snapshot.carryForwardItems`.
+- Reuse the EOD auto-complete eligibility evaluator or an equivalent shared policy helper against the command-time snapshot and current policy config before mutating.
+- Reject unless the final command-time snapshot is still eligible as `clean_day` or `low_risk_review`.
+- Derive existing operational work item IDs from carry-forward snapshot items whose subject is an operational work item.
+- Require every command-time carry-forward item to map one-to-one to an existing, same-store, same-organization, non-terminal operational work item.
+- Reject automation completion if any carry-forward item is missing, duplicated ambiguously, wrong-store, wrong-organization, terminal, or not mappable to a durable work item ID.
+- Persist the final command-time work item IDs to `dailyClose.carryForwardWorkItemIds`.
+- Preserve `readiness.carryForwardCount`, `summary.carryForwardWorkItemCount`, and `reportSnapshot.carryForwardItems` based on the command-time evidence.
+- Patch the final applied `automationRun.decisionEvidence` so it matches the command-time close/report snapshot rather than the earlier eligibility snapshot.
+- Do not create new work items and do not include carry-forward keys in `policyReviewedItemKeys`.
+- Keep command-time rejection for blockers, unreviewed policy review items, unsupported review items, reopened/superseded lifecycle states, and human-completed closes.
+
+**Execution note:** Add command-boundary tests before changing the completion helper.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/operations/dailyClose.ts`
+- `packages/athena-webapp/convex/schemas/operations/dailyClose.ts`
+
+**Test scenarios:**
+- Happy path: automation completion persists existing carry-forward work item IDs.
+- Happy path: automation completion stores carry-forward items in `reportSnapshot.carryForwardItems`.
+- Happy path: automation completion preserves carry-forward counts in readiness and summary instead of zeroing them.
+- Happy path: automation completion returns carry-forward work items in the command result.
+- Edge case: carry-forward set changes between eligibility and apply; command-time set is persisted if blockers remain zero and review policy passes.
+- Edge case: supported review threshold changes between eligibility and apply; command-time policy revalidation skips without daily close mutation.
+- Edge case: command-time final evidence differs from the eligibility snapshot; applied run evidence matches the completed close/report snapshot.
+- Error path: a blocker appears at command time; automation skips without daily close mutation.
+- Error path: unsupported or unreviewed review evidence appears at command time; automation skips without daily close mutation.
+- Error path: carry-forward subject references a missing or wrong-store work item; automation returns a validation failure without completing.
+- Error path: carry-forward subject references a wrong-organization, terminal, duplicate, or unmappable work item; automation returns a validation failure without completing.
+- Error path: reopened or superseded close state rejects automation.
+- Integration: automation completion has Athena attribution and no fake manager proof, staff profile, or approval event.
+- Integration: reopening an Athena-completed close preserves the historical carry-forward report snapshot.
+
+**Verification:**
+- An Athena-completed close is a trustworthy store-day record whose unresolved carry-forward work survives as both audit evidence and future handoff input.
+
+---
+
+- U3. **Preserve Read Models, History, and Redaction**
+
+**Goal:** Ensure Daily Operations, Daily Close detail, and Daily Close History expose safe Athena completion attribution with preserved carry-forward evidence.
+
+**Requirements:** R6, R7, R9, R10, R11
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/dailyOperations.ts`
+- Modify: `packages/athena-webapp/convex/operations/dailyClose.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyOperations.test.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyClose.test.ts`
+
+**Approach:**
+- Keep completed lifecycle state primary over stale skipped, dry-run, or eligible automation rows.
+- Confirm redaction keeps raw `carryForwardWorkItemIds`, source subject IDs, link params, decision evidence, policy-reviewed keys, financial/review details, and sensitive metadata restricted while allowing safe Athena attribution and neutral carry-forward shells/counts.
+- Require explicit parity across Daily Operations, Daily Close detail, Daily Close History, and any widened return payloads.
+- Make historical detail render the stored report snapshot carry-forward items, not live recomputation.
+- Confirm `policyReviewedItemKeys` remains hidden or redacted for broad readers according to existing rules.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/operations/dailyOperations.ts`
+- `packages/athena-webapp/convex/operations/dailyClose.ts`
+
+**Test scenarios:**
+- Happy path: Daily Operations shows closed lifecycle for an Athena-completed EOD Review with carry-forward work.
+- Happy path: manager/evidence reader can inspect safe automation and carry-forward evidence.
+- Edge case: broad reader sees Athena attribution and neutral carry-forward shells/counts but not raw carry-forward IDs, source subjects, link params, decision evidence, policy-reviewed keys, or restricted variance/void metadata.
+- Edge case: full-admin/evidence reader can inspect carry-forward IDs/source subjects and policy evidence where the existing permission model allows it.
+- Edge case: source work item changes after completion; historical detail still renders the stored close snapshot.
+- Edge case: stale skipped/dry-run automation rows do not override completed close state.
+- Integration: completed close detail keeps policy-reviewed review keys separate from carry-forward work IDs.
+
+**Verification:**
+- Read models preserve the distinction between completed lifecycle, unresolved carry-forward work, policy-reviewed evidence, and redacted detail.
+
+---
+
+- U4. **Update Operator Copy and Settings**
+
+**Goal:** Update operator-facing copy so admins and managers understand that Athena can complete blocker-free EOD Reviews while preserving carry-forward work.
+
+**Requirements:** R5, R9, R10, R11
+
+**Dependencies:** U3
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/DailyCloseView.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/DailyOperationsView.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`
+- Test: `packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx`
+- Test: `packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx`
+- Test: `packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx`
+- Test: `packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx`
+- Test: `packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx`
+
+**Approach:**
+- Replace narrow "clean-day" language with blocker-free/policy-completion language where the control describes overall capability.
+- Keep the clean-day toggle semantics if it still gates zero-review days, but clarify that carry-forward work can be preserved for Opening.
+- Replace generic applied-status copy like "Athena updated EOD Review" with completion-specific copy when the applied lane is EOD completion.
+- Broaden attribution detail from "Policy checked low-risk review evidence" to mention preserved carry-forward work when present.
+- Confirm Opening Handoff copy remains accurate when a prior close was completed by Athena: the work is carried forward from a completed EOD Review and remains unresolved until handled or acknowledged.
+- Avoid copy that implies Athena resolved carry-forward work, manager-approved the day, or made a judgement outside policy.
+
+**Copy matrix:**
+
+| Surface / state | Approved direction | Avoid |
+| --- | --- | --- |
+| POS settings capability | "Athena can complete blocker-free EOD Reviews under store policy. Carry-forward work stays open for Opening Handoff." | "clean only" as the overall capability, "resolved", "approved" |
+| POS settings clean-day toggle | "Allow Athena to complete days with no review items." | implying the toggle controls carry-forward preservation |
+| Daily Close applied EOD automation | "Athena completed EOD Review under store policy." | "Athena updated EOD Review" for completion, "manager reviewed" |
+| Daily Close with carry-forward | "Carry-forward work was preserved for Opening Handoff." | "cleared", "completed", "resolved" |
+| Daily Operations completed lane | "Athena completed EOD Review under store policy." | generic update copy, manager approval language |
+| Daily Close History | "Athena completed this EOD Review under store policy. Carry-forward work remains in the stored close record." | live recomputation language, resolved-work wording |
+| Opening Handoff | "Carry-forward work from the prior EOD Review remains open for this opening." | implying Opening work was resolved by the close |
+| Redacted attribution | "Restricted close evidence is hidden for this account." | exposing variance totals, void totals, threshold details, or raw backend codes |
+| Dry-run / would-preserve | "Athena checked EOD Review in dry run. No workflow changes were made." | implying the close was completed or carry-forward was linked |
+| Skipped / failed check | "Athena could not finish the EOD Review automation check. Review the close before completing the store day." | raw exception text or backend classification names |
+
+**Patterns to follow:**
+- `docs/product-copy-tone.md`
+- Existing Athena attribution copy in `DailyOpeningView.tsx`
+
+**Test scenarios:**
+- Happy path: POS settings tells full admins that carry-forward work is preserved for Opening Handoff.
+- Happy path: Daily Close shows Athena completion under store policy and preserved carry-forward detail.
+- Happy path: Daily Operations shows completion-specific automation copy for applied EOD completion.
+- Happy path: Daily Close History shows historical Athena attribution plus carry-forward handoff copy.
+- Happy path: Opening Handoff labels prior Athena-completed carry-forward work as unresolved handoff work, not automation-resolved work.
+- Edge case: no-carry-forward Athena completion keeps existing low-risk policy attribution copy without mentioning Opening Handoff.
+- Edge case: carry-forward-present Athena completion includes preserved-for-Opening copy.
+- Edge case: dry-run/would-preserve copy states that no workflow changes were made.
+- Edge case: skipped automation copy directs operators to review the close without leaking backend classification names.
+- Edge case: redacted users see safe attribution without restricted review/financial detail.
+- Error path: settings save failures continue to show normalized operational copy.
+
+**Verification:**
+- Operator copy is calm and explicit: Athena completed the close under policy, and unresolved work remains for Opening Handoff.
+
+---
+
+- U5. **Protect Opening Handoff Continuity**
+
+**Goal:** Prove an Athena-completed prior close still feeds carry-forward work into the next Opening Handoff.
+
+**Requirements:** R5, R6, R7, R11
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/dailyOpening.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyOpening.test.ts`
+- Test: `packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx`
+
+**Approach:**
+- Prefer characterization coverage first; implementation may not need changes if preserving `carryForwardWorkItemIds` in U2 is sufficient.
+- Verify Opening reads the prior Athena-completed close's carry-forward IDs and displays unresolved work as carry-forward evidence.
+- Coordinate with U4 so any Opening Handoff copy touched here states that carry-forward remains unresolved after Athena completed the prior EOD Review.
+- Keep Opening acknowledgement semantics unchanged: acknowledging carry-forward does not resolve the underlying work item.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/operations/dailyOpening.ts`
+- `packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`
+
+**Test scenarios:**
+- Happy path: prior Athena-completed EOD Review with carry-forward work creates Opening carry-forward items.
+- Edge case: report snapshot has carry-forward item copies but missing work item IDs; Opening does not silently fabricate handoff work.
+- Edge case: Opening acknowledgement keeps the work item unresolved.
+- Integration: Daily Close completion, history snapshot, and Opening context agree on carry-forward count and work item identity.
+
+**Verification:**
+- Closing by automation does not break the next day's operational handoff.
+
+---
+
+- U6. **Refresh Knowledge and Validation Coverage**
+
+**Goal:** Update durable learning and repo sensors so future agents preserve the new carry-forward automation boundary.
+
+**Requirements:** R1, R3, R5, R10, R11
+
+**Dependencies:** U1, U2, U3, U4, U5
+
+**Files:**
+- Modify: `docs/solutions/architecture/athena-eod-review-automation-completion-2026-06-22.md`
+- Modify: `packages/athena-webapp/docs/agent/validation-map.json` if generated by harness changes
+- Modify: `packages/athena-webapp/docs/agent/validation-guide.md` if generated by harness changes
+- Test: `packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyClose.test.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyOperations.test.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyOpening.test.ts`
+- Test: `packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx`
+- Test: `packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx`
+- Test: `packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx`
+- Test: `packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx`
+
+**Approach:**
+- Update the June 22 solution doc to supersede the "carry-forward stays human-only in v1" rule with the new preserved-evidence rule.
+- Confirm validation-map coverage still points at Daily Operations, Daily Close, Opening, and POS settings when those files change.
+- Refresh generated artifacts only through the repo-supported commands if implementation changes schemas, generated API refs, validation-map docs, or Graphify.
+
+**Patterns to follow:**
+- `packages/athena-webapp/docs/agent/testing.md`
+- `docs/solutions/architecture/athena-eod-review-automation-completion-2026-06-22.md`
+
+**Test scenarios:**
+- Test expectation: none for the solution-doc prose itself; executable coverage is carried by U1-U5 tests.
+
+**Verification:**
+- The repo's durable guidance and validation metadata no longer teach future agents that carry-forward must hard-skip EOD auto-completion.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Daily Operations automation, Daily Close completion, Daily Close history, Daily Operations read model, POS settings, and Opening Handoff all participate in this boundary.
+- **Error propagation:** Automation eligibility skips are expected business outcomes; command-time precondition failures should record skipped evidence where possible, not generic failed automation, unless the command fails unexpectedly.
+- **State lifecycle risks:** The apply-time snapshot must be authoritative so races cannot close a newly blocked day. Carry-forward IDs must be persisted or Opening loses the handoff.
+- **API surface parity:** Public Convex return validators and generated client refs may need refresh if return shapes widen for carry-forward evidence.
+- **Integration coverage:** Unit tests must be paired with cross-boundary tests proving automation-completed closes appear in history and feed Opening Handoff.
+- **Unchanged invariants:** Manual manager approval, blocker strictness, unsupported category skips, redaction boundaries, and `eod.prepare` semantics do not change.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Automation sounds like it resolved carry-forward work | Use explicit preserved-for-Opening copy and keep carry-forward out of `policyReviewedItemKeys`. |
+| Opening loses carry-forward work | Persist `dailyClose.carryForwardWorkItemIds` and add Opening regression coverage. |
+| Applied run evidence drifts from the completed close | Patch applied decision evidence from the command-time snapshot and assert it matches the completed close/report snapshot. |
+| A race closes a newly blocked or over-threshold day | Re-run EOD eligibility against the command-time snapshot and current policy config. |
+| Carry-forward identity silently drops or links wrong work | Require one-to-one same-store/same-organization non-terminal work item mapping and fail closed on gaps. |
+| Restricted review, financial, source, or work item identifiers leak through automation evidence | Keep existing redaction boundaries and add broad-reader tests for raw IDs, source subjects, link params, decision evidence, and policy keys. |
+| Historical detail drifts after source work changes | Render stored `reportSnapshot.carryForwardItems` in history tests. |
+
+---
+
+## Documentation / Operational Notes
+
+- Update the prior EOD automation solution doc after implementation so it no longer documents carry-forward as a hard v1 skip.
+- The operator-facing behavior should be described as "completed under store policy" and "carry-forward work preserved for Opening Handoff."
+- Run Graphify rebuild after code changes in this repo, per `AGENTS.md`.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-07-daily-operations-lifecycle-requirements.md](../brainstorms/2026-05-07-daily-operations-lifecycle-requirements.md)
+- Prior plan: [docs/plans/2026-06-22-004-feat-eod-review-automation-plan.md](2026-06-22-004-feat-eod-review-automation-plan.md)
+- Related solution: [docs/solutions/architecture/athena-eod-review-automation-completion-2026-06-22.md](../solutions/architecture/athena-eod-review-automation-completion-2026-06-22.md)
+- Related solution: [docs/solutions/architecture/athena-store-day-auto-start-review-2026-06-11.md](../solutions/architecture/athena-store-day-auto-start-review-2026-06-11.md)
+- Related solution: [docs/solutions/logic-errors/athena-daily-close-store-day-boundary-2026-05-07.md](../solutions/logic-errors/athena-daily-close-store-day-boundary-2026-05-07.md)
+- Related solution: [docs/solutions/logic-errors/athena-daily-close-history-snapshots-2026-05-09.md](../solutions/logic-errors/athena-daily-close-history-snapshots-2026-05-09.md)
+- Product copy: [docs/product-copy-tone.md](../product-copy-tone.md)

--- a/docs/solutions/architecture/athena-eod-review-automation-completion-2026-06-22.md
+++ b/docs/solutions/architecture/athena-eod-review-automation-completion-2026-06-22.md
@@ -41,34 +41,45 @@ Model EOD completion as its own Daily Operations action:
 
 The action is disabled by default. Enabled policies can complete only after the
 configured store-local completion window opens. Clean days require zero
-blockers, zero review items, and zero carry-forward items. Low-risk days require
-every review item to be an allowlisted category inside configured thresholds.
+blockers and zero review items. Low-risk days require every review item to be an
+allowlisted category inside configured thresholds. Carry-forward work is not a
+completion approval signal: automation may complete the EOD boundary only when
+the blockers/review gates pass, and it must preserve carry-forward work as
+unresolved Opening Handoff evidence.
 
 ## Safety Boundary
 
-Carry-forward stays human-only in v1. Any existing carry-forward item or
-non-zero carry-forward count skips automation completion, even when the day is
-otherwise ready.
-
 Automation re-reads the command-time Daily Close snapshot before mutating. If a
-blocker, carry-forward item, unreviewed item, reopened/superseded lifecycle
-state, or already-human-completed close appears, the automation path fails safe
-or records a no-op without overwriting human attribution.
+blocker, unsupported review item, threshold-exceeding review item, unreviewed
+policy item, reopened/superseded lifecycle state, or already-human-completed
+close appears, the automation path fails safe or records a no-op without
+overwriting human attribution.
 
-Read models may expose safe Athena attribution broadly, but restricted
-financial/review evidence keeps the existing manager and financial-detail
-access boundary. Cash variance amounts, voided sale totals, threshold
-summaries, item snapshots, and source evidence must be redacted before reaching
-users without access.
+Carry-forward remains unresolved operational work. Automation must not create,
+resolve, approve, or hide it. The command-time snapshot must map every
+carry-forward item one-to-one to an existing same-store, same-organization,
+non-terminal `operationalWorkItem`; otherwise completion fails closed. Applied
+runs patch final `automationRun.decisionEvidence` from the command-time
+snapshot so the run, completed close, report snapshot, and Opening Handoff all
+describe the same preserved work.
+
+Read models may expose safe Athena attribution and neutral carry-forward counts
+broadly, but restricted financial/review evidence and raw carry-forward
+identifiers keep the existing manager/evidence access boundary. Cash variance
+amounts, voided sale totals, threshold summaries, policy-reviewed keys, raw
+work-item IDs, source-subject IDs, link parameters, decision evidence, item
+metadata, and source evidence must be redacted before reaching users without
+access.
 
 ## Prevention
 
 - Add completion automation as a distinct action; do not overload preparation.
 - Persist structured decision evidence on the run before patching terminal
-  outcomes, including applied outcomes.
+  outcomes, and replace it with command-time evidence for applied outcomes.
 - Keep event taxonomy stable and use actor metadata for automation attribution.
 - Test clean completion, low-risk completion, full hard-blocker matrix,
-  local-time window boundaries, idempotent retries, human attribution
-  preservation, and read-side redaction together.
+  preserved carry-forward work, local-time window boundaries, idempotent
+  retries, human attribution preservation, Opening Handoff continuity, and
+  read-side redaction together.
 - Refresh generated Convex APIs and Graphify whenever schema, backend API, or
   read-model surfaces change.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8032 nodes · 9450 edges · 2056 communities detected
+- 8040 nodes · 9462 edges · 2056 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2072,7 +2072,7 @@
 2. `buildDailyCloseSnapshotWithCtx()` - 33 edges
 3. `collectConvexQueryWriteBoundaryFindings()` - 28 edges
 4. `projectLocalRegisterReadModel()` - 26 edges
-5. `buildDailyOpeningSnapshotWithCtx()` - 17 edges
+5. `buildDailyOpeningSnapshotWithCtx()` - 18 edges
 6. `buildDailyOperationsSnapshotWithCtx()` - 17 edges
 7. `getStoreConfigV2()` - 17 edges
 8. `submitTerminalRuntimeStatus()` - 16 edges
@@ -2103,7 +2103,7 @@ Nodes (84): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShad
 
 ### Community 2 - "Community 2"
 Cohesion: 0.05
-Nodes (67): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildApprovalRequestsById(), buildDailyCloseApprovalSubject() (+59 more)
+Nodes (70): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildApprovalRequestsById(), buildDailyCloseApprovalSubject() (+62 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.07
@@ -2162,16 +2162,16 @@ Cohesion: 0.08
 Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
 
 ### Community 17 - "Community 17"
+Cohesion: 0.11
+Nodes (33): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+25 more)
+
+### Community 18 - "Community 18"
 Cohesion: 0.12
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.14
 Nodes (34): asRecord(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale() (+26 more)
-
-### Community 19 - "Community 19"
-Cohesion: 0.12
-Nodes (32): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+24 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.16
@@ -2762,116 +2762,116 @@ Cohesion: 0.39
 Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 167 - "Community 167"
-Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
+Cohesion: 0.25
+Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
 ### Community 168 - "Community 168"
 Cohesion: 0.39
-Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 169 - "Community 169"
 Cohesion: 0.39
-Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
+Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
 ### Community 170 - "Community 170"
+Cohesion: 0.39
+Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
+
+### Community 171 - "Community 171"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.33
 Nodes (6): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), saveProduct(), updateVariantSku()
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.28
 Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.28
 Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.25
 Nodes (2): isValidMessageBlocker(), isValidPriority()
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
-### Community 181 - "Community 181"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
 ### Community 182 - "Community 182"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
-### Community 183 - "Community 183"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 184 - "Community 184"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 185 - "Community 185"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
+### Community 183 - "Community 183"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
+
+### Community 184 - "Community 184"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
+### Community 185 - "Community 185"
+Cohesion: 0.22
+Nodes (0):
+
 ### Community 186 - "Community 186"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 187 - "Community 187"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
-
-### Community 194 - "Community 194"
-Cohesion: 0.29
-Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
 ### Community 195 - "Community 195"
 Cohesion: 0.36

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,14 +8,14 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2128
-- Graph nodes: 8032
-- Graph edges: 9450
+- Graph nodes: 8040
+- Graph edges: 9462
 - Communities: 2056
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (89 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `harness-inferential-review.ts` (85 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `dailyClose.ts` (76 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (82 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `dailyOperations.ts` (63 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `projectLocalEvents.ts` (63 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -18,7 +18,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (89 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `dailyClose.ts` (76 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (82 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `dailyOperations.ts` (63 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `projectLocalEvents.ts` (63 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (15 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 187) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 188) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/automation/automationFoundation.ts
+++ b/packages/athena-webapp/convex/automation/automationFoundation.ts
@@ -29,6 +29,7 @@ type EvaluateAutomationActionArgs = {
   apply?: (args: {
     run: Doc<"automationRun">;
   }) => Promise<{
+    decisionEvidence?: AutomationDecisionEvidence;
     eventIds?: Id<"operationalEvent">[];
     outcome?: "applied" | "prepared" | "skipped" | "failed";
     error?: { code: string; message: string };
@@ -196,7 +197,8 @@ export async function evaluateAutomationActionWithCtx(
       applied.outcome === "applied" || !applied.outcome
         ? Date.now()
         : undefined,
-    decisionEvidence: args.adapterDecision.decisionEvidence,
+    decisionEvidence:
+      applied.decisionEvidence ?? args.adapterDecision.decisionEvidence,
     error: applied.error,
     eventIds: applied.eventIds,
     outcome: applied.outcome ?? "applied",

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -8,6 +8,7 @@ import {
   completeDailyCloseWithCtx,
   getCompletedDailyCloseHistoryDetailWithCtx,
   getDailyCloseSnapshot,
+  getDailyCloseOpeningContext,
   getDailyCloseOpeningContextWithCtx,
   listCompletedDailyCloseHistoryWithCtx,
   reopenDailyClose,
@@ -223,6 +224,13 @@ const store = {
   name: "Accra",
   organizationId: "org-1",
   slug: "accra",
+};
+
+const eodAutoCompletePolicy = {
+  cleanDayAutoCompleteEnabled: true,
+  maxAbsoluteCashVariance: 500,
+  maxVoidedSaleCount: 2,
+  maxVoidedSaleTotal: 1000,
 };
 
 function dailyCloseSummary(overrides: Record<string, unknown> = {}) {
@@ -1014,7 +1022,7 @@ describe("end-of-day review backend foundation", () => {
     );
   });
 
-  it("keeps active register blocker metadata on the exported snapshot query", async () => {
+  it("redacts active register blocker metadata on the exported snapshot query", async () => {
     const { db } = createDb({
       posTerminal: [
         {
@@ -1056,21 +1064,136 @@ describe("end-of-day review backend foundation", () => {
     expect(snapshot.blockers).toHaveLength(1);
     expect(snapshot.blockers[0]).toMatchObject({
       category: "register_session",
-      link: {
-        label: "View session",
-        params: { sessionId: "register-open" },
-        to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId",
-      },
-      metadata: {
-        expectedCash: 10000,
-        openedAt: Date.UTC(2026, 4, 7, 10),
-        operatingScope: "Opened today",
-        register: "Register A1",
-        status: "open",
-        terminal: "terminal-1",
+      key: "blocker:register_session:0",
+      subject: {
+        id: "redacted",
+        label: "Register A1",
+        type: "register_session",
       },
       title: "Register session is still open",
     });
+    expect(snapshot.blockers[0]).not.toHaveProperty("link");
+    expect(snapshot.blockers[0]).not.toHaveProperty("metadata");
+  });
+
+  it("redacts completed automation review evidence on the exported snapshot query", async () => {
+    const reportSnapshot = completedDailyCloseSnapshot({
+      closeMetadata: {
+        ...completedDailyCloseSnapshot().closeMetadata,
+        actorType: "automation",
+        automationDecisionReason: "Policy reviewed low-risk review evidence.",
+        automationPolicyVersion: "daily-close-auto-complete.v1",
+        automationRunId: "automation-run-1",
+        carryForwardWorkItemIds: ["work-1"],
+        policyReviewedItemKeys: ["pos_transaction:txn-void:void"],
+      },
+      readiness: {
+        blockerCount: 0,
+        carryForwardCount: 1,
+        readyCount: 0,
+        reviewCount: 1,
+        status: "ready",
+      },
+      reviewedItems: [
+        {
+          key: "pos_transaction:txn-void:void",
+          severity: "review",
+          category: "voided_sale",
+          title: "Voided sale",
+          message: "Voided transaction reviewed by policy.",
+          subject: {
+            id: "txn-void",
+            label: "TXN-VOID",
+            type: "pos_transaction",
+          },
+          metadata: {
+            total: 500,
+            voidedAt: Date.UTC(2026, 4, 7, 15),
+          },
+        },
+      ],
+      carryForwardItems: [
+        {
+          key: "operational_work_item:work-1:carry_forward",
+          severity: "carry_forward",
+          category: "operational_work_item",
+          title: "Call customer tomorrow",
+          message: "Carry-forward work remains open.",
+          subject: {
+            id: "work-1",
+            label: "Call customer tomorrow",
+            type: "operational_work_item",
+          },
+          metadata: {
+            workItemId: "work-1",
+          },
+        },
+      ],
+      readyItems: [],
+      sourceSubjects: [
+        {
+          id: "txn-void",
+          label: "TXN-VOID",
+          type: "pos_transaction",
+        },
+      ],
+    });
+    const { db } = createDb({
+      dailyClose: [
+        completedDailyCloseRow({
+          actorType: "automation",
+          automationDecisionReason:
+            "Policy reviewed low-risk review evidence.",
+          automationPolicyVersion: "daily-close-auto-complete.v1",
+          automationRunId: "automation-run-1",
+          carryForwardWorkItemIds: ["work-1"],
+          policyReviewedItemKeys: ["pos_transaction:txn-void:void"],
+          readiness: reportSnapshot.readiness,
+          reportSnapshot,
+          sourceSubjects: reportSnapshot.sourceSubjects,
+          summary: reportSnapshot.summary,
+        }),
+      ],
+      store: [store],
+    });
+    const handler = getHandler<
+      {
+        operatingDate: string;
+        storeId: Id<"store">;
+      },
+      Promise<Awaited<ReturnType<typeof buildDailyCloseSnapshotWithCtx>>>
+    >(getDailyCloseSnapshot);
+
+    const snapshot = await handler(
+      { db } as unknown as QueryCtx,
+      {
+        operatingDate: "2026-05-07",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(snapshot.completedClose).toMatchObject({
+      actorType: "automation",
+      restrictedDetailsRedacted: true,
+    });
+    expect(snapshot.completedClose).not.toHaveProperty(
+      "policyReviewedItemKeys",
+    );
+    expect(snapshot.reviewItems).toEqual([
+      expect.objectContaining({
+        key: "review:voided_sale:0",
+        subject: expect.objectContaining({ id: "redacted" }),
+      }),
+    ]);
+    expect(snapshot.reviewItems[0]).not.toHaveProperty("metadata");
+    expect(snapshot.carryForwardItems).toEqual([
+      expect.objectContaining({
+        key: "carry_forward:operational_work_item:0",
+        subject: expect.objectContaining({ id: "redacted" }),
+      }),
+    ]);
+    expect(snapshot.carryForwardItems[0]).not.toHaveProperty("metadata");
+    expect(snapshot.sourceSubjects).toEqual([]);
   });
 
   it("surfaces review-only closeouts as blockers without active or closed totals", async () => {
@@ -1977,10 +2100,10 @@ describe("end-of-day review backend foundation", () => {
           payments: [],
           status: "void",
           storeId: "store-1",
-          subtotal: 5000,
+          subtotal: 500,
           tax: 0,
-          total: 5000,
-          totalPaid: 5000,
+          total: 500,
+          totalPaid: 500,
           transactionNumber: "TXN-2",
         },
       ],
@@ -2256,13 +2379,14 @@ describe("end-of-day review backend foundation", () => {
 
     const result = await completeDailyCloseForAutomationWithCtx(
       { db } as unknown as MutationCtx,
-      {
-        automationDecisionReason: "EOD Review passed policy checks.",
-        automationPolicyVersion: "daily-close-auto-complete.v1",
-        automationRunId: "automation-run-1" as Id<"automationRun">,
-        operatingDate: "2026-05-07",
-        policyReviewedItemKeys: [],
-        storeId: "store-1" as Id<"store">,
+        {
+          automationDecisionReason: "EOD Review passed policy checks.",
+          automationPolicyVersion: "daily-close-auto-complete.v1",
+          automationRunId: "automation-run-1" as Id<"automationRun">,
+          eodAutoCompletePolicy,
+          operatingDate: "2026-05-07",
+          policyReviewedItemKeys: [],
+          storeId: "store-1" as Id<"store">,
       },
     );
 
@@ -2339,10 +2463,10 @@ describe("end-of-day review backend foundation", () => {
           payments: [],
           status: "void",
           storeId: "store-1",
-          subtotal: 5000,
+          subtotal: 500,
           tax: 0,
-          total: 5000,
-          totalPaid: 5000,
+          total: 500,
+          totalPaid: 500,
           transactionNumber: "TXN-2",
         },
       ],
@@ -2355,6 +2479,7 @@ describe("end-of-day review backend foundation", () => {
         automationDecisionReason: "Policy reviewed voided-sale evidence.",
         automationPolicyVersion: "daily-close-auto-complete.v1",
         automationRunId: "automation-run-1" as Id<"automationRun">,
+        eodAutoCompletePolicy,
         operatingDate: "2026-05-07",
         policyReviewedItemKeys: [reviewKey],
         storeId: "store-1" as Id<"store">,
@@ -2390,13 +2515,14 @@ describe("end-of-day review backend foundation", () => {
 
     const result = await completeDailyCloseForAutomationWithCtx(
       { db } as unknown as MutationCtx,
-      {
-        automationDecisionReason: "Retry after timeout.",
-        automationPolicyVersion: "daily-close-auto-complete.v1",
-        automationRunId: "automation-run-retry" as Id<"automationRun">,
-        operatingDate: "2026-05-07",
-        policyReviewedItemKeys: [],
-        storeId: "store-1" as Id<"store">,
+        {
+          automationDecisionReason: "Retry after timeout.",
+          automationPolicyVersion: "daily-close-auto-complete.v1",
+          automationRunId: "automation-run-retry" as Id<"automationRun">,
+          eodAutoCompletePolicy,
+          operatingDate: "2026-05-07",
+          policyReviewedItemKeys: [],
+          storeId: "store-1" as Id<"store">,
       },
     );
 
@@ -2423,7 +2549,35 @@ describe("end-of-day review backend foundation", () => {
     expect(inserts).toEqual([]);
   });
 
-  it("fails automation completion when command-time blockers, carry-forward, or unreviewed items remain", async () => {
+  it("requires policy evidence before automation completes an open close", async () => {
+    const { db, inserts } = createDb({
+      store: [store],
+    });
+
+    const result = await completeDailyCloseForAutomationWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        automationDecisionReason: "Policy evidence was not supplied.",
+        automationPolicyVersion: "daily-close-auto-complete.v1",
+        automationRunId: "automation-run-missing-policy" as Id<"automationRun">,
+        operatingDate: "2026-05-07",
+        policyReviewedItemKeys: [],
+        storeId: "store-1" as Id<"store">,
+      } as unknown as Parameters<typeof completeDailyCloseForAutomationWithCtx>[1],
+    );
+
+    expect(result).toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message:
+          "EOD Review automation requires policy evidence before completion.",
+      },
+    });
+    expect(inserts).toEqual([]);
+  });
+
+  it("fails automation completion when command-time blockers or unreviewed items remain", async () => {
     const blockerDb = createDb({
       registerSession: [
         {
@@ -2440,13 +2594,14 @@ describe("end-of-day review backend foundation", () => {
     await expect(
       completeDailyCloseForAutomationWithCtx(
         { db: blockerDb.db } as unknown as MutationCtx,
-        {
-          automationDecisionReason: "Policy saw no blockers earlier.",
-          automationPolicyVersion: "daily-close-auto-complete.v1",
-          automationRunId: "automation-run-blocker" as Id<"automationRun">,
-          operatingDate: "2026-05-07",
-          policyReviewedItemKeys: [],
-          storeId: "store-1" as Id<"store">,
+          {
+            automationDecisionReason: "Policy saw no blockers earlier.",
+            automationPolicyVersion: "daily-close-auto-complete.v1",
+            automationRunId: "automation-run-blocker" as Id<"automationRun">,
+            eodAutoCompletePolicy,
+            operatingDate: "2026-05-07",
+            policyReviewedItemKeys: [],
+            storeId: "store-1" as Id<"store">,
         },
       ),
     ).resolves.toMatchObject({
@@ -2457,43 +2612,6 @@ describe("end-of-day review backend foundation", () => {
       },
     });
     expect(blockerDb.inserts).toEqual([]);
-
-    const carryForwardDb = createDb({
-      operationalWorkItem: [
-        {
-          _id: "work-1",
-          approvalState: "not_required",
-          createdAt: 4,
-          organizationId: "org-1",
-          priority: "normal",
-          status: "open",
-          storeId: "store-1",
-          title: "Call customer tomorrow",
-          type: "customer_follow_up",
-        },
-      ],
-      store: [store],
-    });
-    await expect(
-      completeDailyCloseForAutomationWithCtx(
-        { db: carryForwardDb.db } as unknown as MutationCtx,
-        {
-          automationDecisionReason: "Policy saw no carry-forward earlier.",
-          automationPolicyVersion: "daily-close-auto-complete.v1",
-          automationRunId: "automation-run-carry-forward" as Id<"automationRun">,
-          operatingDate: "2026-05-07",
-          policyReviewedItemKeys: [],
-          storeId: "store-1" as Id<"store">,
-        },
-      ),
-    ).resolves.toMatchObject({
-      kind: "user_error",
-      error: {
-        code: "precondition_failed",
-        metadata: { carryForwardCount: 1 },
-      },
-    });
-    expect(carryForwardDb.inserts).toEqual([]);
 
     const reviewDb = createDb({
       posTransaction: [
@@ -2515,13 +2633,14 @@ describe("end-of-day review backend foundation", () => {
     await expect(
       completeDailyCloseForAutomationWithCtx(
         { db: reviewDb.db } as unknown as MutationCtx,
-        {
-          automationDecisionReason: "Policy saw no review items earlier.",
-          automationPolicyVersion: "daily-close-auto-complete.v1",
-          automationRunId: "automation-run-review" as Id<"automationRun">,
-          operatingDate: "2026-05-07",
-          policyReviewedItemKeys: [],
-          storeId: "store-1" as Id<"store">,
+          {
+            automationDecisionReason: "Policy saw no review items earlier.",
+            automationPolicyVersion: "daily-close-auto-complete.v1",
+            automationRunId: "automation-run-review" as Id<"automationRun">,
+            eodAutoCompletePolicy,
+            operatingDate: "2026-05-07",
+            policyReviewedItemKeys: [],
+            storeId: "store-1" as Id<"store">,
         },
       ),
     ).resolves.toMatchObject({
@@ -2567,13 +2686,14 @@ describe("end-of-day review backend foundation", () => {
     await expect(
       completeDailyCloseForAutomationWithCtx(
         { db: reopenedDb.db } as unknown as MutationCtx,
-        {
-          automationDecisionReason: "Policy saw a reopened day as ready.",
-          automationPolicyVersion: "daily-close-auto-complete.v1",
-          automationRunId: "automation-run-reopened" as Id<"automationRun">,
-          operatingDate: "2026-05-07",
-          policyReviewedItemKeys: [],
-          storeId: "store-1" as Id<"store">,
+          {
+            automationDecisionReason: "Policy saw a reopened day as ready.",
+            automationPolicyVersion: "daily-close-auto-complete.v1",
+            automationRunId: "automation-run-reopened" as Id<"automationRun">,
+            eodAutoCompletePolicy,
+            operatingDate: "2026-05-07",
+            policyReviewedItemKeys: [],
+            storeId: "store-1" as Id<"store">,
         },
       ),
     ).resolves.toMatchObject({
@@ -2586,6 +2706,434 @@ describe("end-of-day review backend foundation", () => {
       },
     });
     expect(reopenedDb.inserts).toEqual([]);
+  });
+
+  it("fails automation completion when command-time review evidence exceeds policy thresholds", async () => {
+    const reviewKey = "pos_transaction:txn-void:void";
+    const { db, inserts } = createDb({
+      posTransaction: [
+        {
+          _id: "txn-void",
+          completedAt: Date.UTC(2026, 4, 7, 15),
+          payments: [],
+          status: "void",
+          storeId: "store-1",
+          subtotal: 1500,
+          tax: 0,
+          total: 1500,
+          totalPaid: 1500,
+          transactionNumber: "TXN-2",
+        },
+      ],
+      store: [store],
+    });
+
+    const result = await completeDailyCloseForAutomationWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        automationDecisionReason: "Policy reviewed voided-sale evidence.",
+        automationPolicyVersion: "daily-close-auto-complete.v1",
+        automationRunId: "automation-run-threshold" as Id<"automationRun">,
+        eodAutoCompletePolicy,
+        operatingDate: "2026-05-07",
+        policyReviewedItemKeys: [reviewKey],
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        metadata: {
+          thresholdFailures: ["voided_sale_total"],
+          voidedSaleCount: 1,
+          voidedSaleTotal: 1500,
+        },
+      },
+    });
+    expect(inserts).toEqual([]);
+  });
+
+  it("rejects carry-forward work that cannot be safely mapped at command time", async () => {
+    const openWorkItem = {
+      _id: "work-1",
+      approvalState: "not_required",
+      createdAt: 4,
+      organizationId: "org-1",
+      priority: "normal",
+      status: "open",
+      storeId: "store-1",
+      title: "Call customer tomorrow",
+      type: "customer_follow_up",
+    };
+    const createCommandArgs = () => ({
+      automationDecisionReason: "EOD Review passed policy checks.",
+      automationPolicyVersion: "daily-close-auto-complete.v1",
+      automationRunId: "automation-run-carry-forward" as Id<"automationRun">,
+      eodAutoCompletePolicy,
+      operatingDate: "2026-05-07",
+      policyReviewedItemKeys: [],
+      storeId: "store-1" as Id<"store">,
+    });
+
+    const missingDb = createDb({
+      operationalWorkItem: [openWorkItem],
+      store: [store],
+    });
+    const dbWithMissingWorkItem = {
+      ...missingDb.db,
+      async get(tableOrId: string, maybeId?: string) {
+        if (
+          (tableOrId === "operationalWorkItem" && maybeId === "work-1") ||
+          tableOrId === "work-1"
+        ) {
+          return null;
+        }
+
+        return missingDb.db.get(tableOrId, maybeId);
+      },
+    };
+    await expect(
+      completeDailyCloseForAutomationWithCtx(
+        { db: dbWithMissingWorkItem } as unknown as MutationCtx,
+        createCommandArgs(),
+      ),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message:
+          "EOD Review automation cannot preserve missing carry-forward work.",
+        metadata: { workItemId: "work-1" },
+      },
+    });
+    expect(missingDb.inserts).toEqual([]);
+
+    const duplicateDb = createDb({
+      operationalWorkItem: [openWorkItem],
+      store: [store],
+    });
+    const dbWithDuplicatedWorkItem = {
+      ...duplicateDb.db,
+      query(table: TableName) {
+        const chain = duplicateDb.db.query(table);
+
+        if (table !== "operationalWorkItem") {
+          return chain;
+        }
+
+        return {
+          ...chain,
+          withIndex(
+            index: string,
+            applyIndex: Parameters<typeof chain.withIndex>[1],
+          ) {
+            const indexedChain = chain.withIndex(index, applyIndex);
+
+            return {
+              ...indexedChain,
+              take: async (limit: number) => {
+                const rows = await indexedChain.take(limit);
+
+                return rows.length > 0
+                  ? [rows[0], rows[0], ...rows.slice(1)]
+                  : rows;
+              },
+            };
+          },
+        };
+      },
+    };
+    await expect(
+      completeDailyCloseForAutomationWithCtx(
+        { db: dbWithDuplicatedWorkItem } as unknown as MutationCtx,
+        createCommandArgs(),
+      ),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message:
+          "EOD Review automation cannot preserve unmapped or duplicated carry-forward work.",
+        metadata: {
+          carryForwardCount: 2,
+          mappedWorkItemCount: 1,
+        },
+      },
+    });
+    expect(duplicateDb.inserts).toEqual([]);
+
+    const wrongOrgDb = createDb({
+      operationalWorkItem: [
+        {
+          ...openWorkItem,
+          organizationId: "org-other",
+        },
+      ],
+      store: [store],
+    });
+    await expect(
+      completeDailyCloseForAutomationWithCtx(
+        { db: wrongOrgDb.db } as unknown as MutationCtx,
+        createCommandArgs(),
+      ),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message:
+          "EOD Review automation cannot preserve carry-forward work outside this store.",
+        metadata: { workItemId: "work-1" },
+      },
+    });
+    expect(wrongOrgDb.inserts).toEqual([]);
+
+    const terminalDb = createDb({
+      operationalWorkItem: [openWorkItem],
+      store: [store],
+    });
+    const dbWithTerminalWorkItem = {
+      ...terminalDb.db,
+      async get(tableOrId: string, maybeId?: string) {
+        const row = await terminalDb.db.get(tableOrId, maybeId);
+
+        if (
+          row &&
+          ((tableOrId === "operationalWorkItem" && maybeId === "work-1") ||
+            tableOrId === "work-1")
+        ) {
+          return { ...row, status: "completed" };
+        }
+
+        return row;
+      },
+    };
+    await expect(
+      completeDailyCloseForAutomationWithCtx(
+        { db: dbWithTerminalWorkItem } as unknown as MutationCtx,
+        createCommandArgs(),
+      ),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message:
+          "EOD Review automation cannot preserve terminal carry-forward work.",
+        metadata: {
+          status: "completed",
+          workItemId: "work-1",
+        },
+      },
+    });
+    expect(terminalDb.inserts).toEqual([]);
+  });
+
+  it("preserves command-time carry-forward work when automation completes an otherwise ready day", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 7, 22));
+    const { db, inserts } = createDb({
+      operationalWorkItem: [
+        {
+          _id: "work-1",
+          approvalState: "not_required",
+          createdAt: 4,
+          organizationId: "org-1",
+          priority: "normal",
+          status: "open",
+          storeId: "store-1",
+          title: "Call customer tomorrow",
+          type: "customer_follow_up",
+        },
+      ],
+      store: [store],
+    });
+
+    const result = await completeDailyCloseForAutomationWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        automationDecisionReason: "EOD Review passed policy checks.",
+        automationPolicyVersion: "daily-close-auto-complete.v1",
+        automationRunId: "automation-run-carry-forward" as Id<"automationRun">,
+        eodAutoCompletePolicy: {
+          cleanDayAutoCompleteEnabled: true,
+          maxAbsoluteCashVariance: 500,
+          maxVoidedSaleCount: 2,
+          maxVoidedSaleTotal: 1000,
+        },
+        operatingDate: "2026-05-07",
+        policyReviewedItemKeys: [],
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "completed",
+        automationDecisionEvidence: {
+          classification: "clean_day",
+          eligible: true,
+          observed: {
+            carryForwardCount: 1,
+            carryForwardItemKeys: [
+              "operational_work_item:work-1:carry_forward",
+            ],
+            carryForwardPreserved: true,
+          },
+        },
+        carryForwardWorkItems: [
+          {
+            _id: "work-1",
+            status: "open",
+          },
+        ],
+        dailyClose: {
+          actorType: "automation",
+          carryForwardWorkItemIds: ["work-1"],
+          readiness: {
+            carryForwardCount: 1,
+          },
+          summary: {
+            carryForwardWorkItemCount: 1,
+          },
+        },
+      },
+    });
+    const dailyClose = result.kind === "ok" ? result.data.dailyClose : null;
+    expect(dailyClose?.reportSnapshot).toMatchObject({
+      carryForwardItems: [
+        {
+          key: "operational_work_item:work-1:carry_forward",
+          subject: {
+            id: "work-1",
+            type: "operational_work_item",
+          },
+        },
+      ],
+      closeMetadata: {
+        actorType: "automation",
+        carryForwardWorkItemIds: ["work-1"],
+      },
+    });
+    expect(inserts.map((insert) => insert.table)).toEqual([
+      "dailyClose",
+      "operationalEvent",
+    ]);
+    expect(
+      inserts.find(
+        (insert) =>
+          insert.table === "operationalEvent" &&
+          insert.value.eventType === "daily_close_completed",
+      )?.value,
+    ).toMatchObject({
+      actorType: "automation",
+      metadata: {
+        readiness: {
+          carryForwardCount: 1,
+        },
+      },
+    });
+  });
+
+  it("preserves carry-forward work for Opening when automation completes low-risk review evidence", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 7, 22));
+    const reviewKey = "pos_transaction:txn-void:void";
+    const { db } = createDb({
+      operationalWorkItem: [
+        {
+          _id: "work-1",
+          approvalState: "not_required",
+          createdAt: 4,
+          organizationId: "org-1",
+          priority: "normal",
+          status: "open",
+          storeId: "store-1",
+          title: "Call customer tomorrow",
+          type: "customer_follow_up",
+        },
+      ],
+      posTransaction: [
+        {
+          _id: "txn-void",
+          completedAt: Date.UTC(2026, 4, 7, 15),
+          payments: [],
+          status: "void",
+          storeId: "store-1",
+          subtotal: 500,
+          tax: 0,
+          total: 500,
+          totalPaid: 500,
+          transactionNumber: "TXN-2",
+        },
+      ],
+      store: [store],
+    });
+
+    const result = await completeDailyCloseForAutomationWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        automationDecisionReason:
+          "EOD Review has only low-risk review evidence within policy thresholds.",
+        automationPolicyVersion: "daily-close-auto-complete.v1",
+        automationRunId: "automation-run-low-risk-carry" as Id<"automationRun">,
+        eodAutoCompletePolicy,
+        operatingDate: "2026-05-07",
+        policyReviewedItemKeys: [reviewKey],
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "completed",
+        automationDecisionEvidence: {
+          classification: "low_risk_review",
+          eligible: true,
+          observed: {
+            carryForwardCount: 1,
+            carryForwardPreserved: true,
+            reviewCount: 1,
+            voidedSaleCount: 1,
+            voidedSaleTotal: 500,
+          },
+          policy: eodAutoCompletePolicy,
+        },
+        dailyClose: {
+          actorType: "automation",
+          automationRunId: "automation-run-low-risk-carry",
+          carryForwardWorkItemIds: ["work-1"],
+          policyReviewedItemKeys: [reviewKey],
+        },
+      },
+    });
+    const dailyClose = result.kind === "ok" ? result.data.dailyClose : null;
+    expect(dailyClose?.reportSnapshot).toMatchObject({
+      carryForwardItems: [
+        {
+          key: "operational_work_item:work-1:carry_forward",
+        },
+      ],
+      closeMetadata: {
+        carryForwardWorkItemIds: ["work-1"],
+        policyReviewedItemKeys: [reviewKey],
+      },
+      reviewedItems: [
+        {
+          key: reviewKey,
+        },
+      ],
+    });
+
+    const openingContext = await getDailyCloseOpeningContextWithCtx(
+      { db } as unknown as QueryCtx,
+      { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(openingContext.priorClose?._id).toBe(dailyClose?._id);
+    expect(openingContext.carryForwardWorkItems.map((item) => item._id)).toEqual([
+      "work-1",
+    ]);
   });
 
   it("requires manager approval and a reason before reopening a completed daily close", async () => {
@@ -3221,6 +3769,7 @@ describe("end-of-day review backend foundation", () => {
           "EOD Review has only low-risk review evidence within policy thresholds.",
         automationPolicyVersion: "daily-operations.v1",
         automationRunId: "automation-run-1",
+        carryForwardWorkItemIds: ["work-1" as Id<"operationalWorkItem">],
         completedAt: Date.UTC(2026, 4, 7, 22),
         operatingDate: "2026-05-07",
         organizationId: "org-1",
@@ -3249,6 +3798,33 @@ describe("end-of-day review backend foundation", () => {
           },
         },
       ],
+      carryForwardItems: [
+        {
+          key: "operational_work_item:work-1:carry_forward",
+          severity: "carry_forward",
+          category: "open_work",
+          title: "Call customer tomorrow",
+          message:
+            "Open operational work will carry forward after the end of day review.",
+          subject: {
+            id: "work-1",
+            label: "Call customer tomorrow",
+            type: "operational_work_item",
+          },
+          metadata: {
+            priority: "normal",
+            status: "open",
+            type: "customer_follow_up",
+          },
+        },
+      ],
+      readiness: {
+        blockerCount: 0,
+        carryForwardCount: 1,
+        readyCount: 1,
+        reviewCount: 1,
+        status: "needs_review",
+      },
       sourceSubjects: [
         {
           id: "txn-void",
@@ -3305,7 +3881,7 @@ describe("end-of-day review backend foundation", () => {
             "EOD Review has only low-risk review evidence within policy thresholds.",
           automationPolicyVersion: "daily-operations.v1",
           automationRunId: "automation-run-1",
-          carryForwardWorkItemIds: [],
+          carryForwardWorkItemIds: ["work-1"],
           completedAt: Date.UTC(2026, 4, 7, 22),
           createdAt: Date.UTC(2026, 4, 7, 22),
           isCurrent: true,
@@ -3359,6 +3935,14 @@ describe("end-of-day review backend foundation", () => {
     expect(broadSnapshot.priorClose).toBeNull();
     expect(broadSnapshot.sourceSubjects).toEqual([]);
     expect(broadSnapshot.reviewItems[0]).not.toHaveProperty("metadata");
+    expect(broadSnapshot.carryForwardItems[0]).toMatchObject({
+      key: "carry_forward:open_work:0",
+      subject: {
+        id: "redacted",
+        type: "operational_work_item",
+      },
+    });
+    expect(broadSnapshot.carryForwardItems[0]).not.toHaveProperty("metadata");
 
     const trustedDetail = await getCompletedDailyCloseHistoryDetailWithCtx(
       { db } as unknown as QueryCtx,
@@ -3391,6 +3975,19 @@ describe("end-of-day review backend foundation", () => {
     });
     expect(broadDetail?.reportSnapshot.closeMetadata).not.toHaveProperty(
       "policyReviewedItemKeys",
+    );
+    expect(
+      broadDetail?.reportSnapshot.closeMetadata.carryForwardWorkItemIds,
+    ).toEqual([]);
+    expect(broadDetail?.reportSnapshot.carryForwardItems[0]).toMatchObject({
+      key: "carry_forward:open_work:0",
+      subject: {
+        id: "redacted",
+        type: "operational_work_item",
+      },
+    });
+    expect(broadDetail?.reportSnapshot.carryForwardItems[0]).not.toHaveProperty(
+      "metadata",
     );
     expect(broadDetail?.reportSnapshot.summary).toMatchObject({
       registerVarianceCount: 0,
@@ -3510,5 +4107,106 @@ describe("end-of-day review backend foundation", () => {
     expect(context.carryForwardWorkItems.map((item) => item._id)).toEqual([
       "work-1",
     ]);
+  });
+
+  it("redacts prior close and carry-forward identifiers on the exported opening context query", async () => {
+    const humanSnapshot = completedDailyCloseSnapshot({
+      carryForwardItems: [
+        {
+          key: "operational_work_item:work-1:carry_forward",
+          severity: "carry_forward",
+          category: "open_work",
+          title: "Carry forward",
+          message: "Carry forward work remains open.",
+          subject: {
+            id: "work-1",
+            label: "Carry forward",
+            type: "operational_work_item",
+          },
+          metadata: {
+            workItemId: "work-1",
+          },
+        },
+      ],
+      closeMetadata: {
+        ...completedDailyCloseSnapshot().closeMetadata,
+        carryForwardWorkItemIds: ["work-1"],
+      },
+      readiness: {
+        blockerCount: 0,
+        carryForwardCount: 1,
+        readyCount: 1,
+        reviewCount: 0,
+        status: "ready",
+      },
+    });
+    const { db } = createDb({
+      dailyClose: [
+        completedDailyCloseRow({
+          carryForwardWorkItemIds: ["work-1"],
+          readiness: humanSnapshot.readiness,
+          reportSnapshot: humanSnapshot,
+          sourceSubjects: humanSnapshot.sourceSubjects,
+          summary: humanSnapshot.summary,
+        }),
+      ],
+      operationalWorkItem: [
+        {
+          _id: "work-1",
+          approvalState: "not_required",
+          createdAt: 4,
+          metadata: {
+            source: "manager_note",
+          },
+          organizationId: "org-1",
+          priority: "normal",
+          status: "open",
+          storeId: "store-1",
+          title: "Carry forward",
+          type: "daily_close_carry_forward",
+        },
+      ],
+      store: [store],
+    });
+    const handler = getHandler<
+      {
+        operatingDate: string;
+        storeId: Id<"store">;
+      },
+      Promise<{
+        priorClose: Record<string, unknown> | null;
+        carryForwardWorkItems: Array<Record<string, unknown>>;
+      }>
+    >(getDailyCloseOpeningContext);
+
+    const context = await handler(
+      { db } as unknown as QueryCtx,
+      { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(context.priorClose).toMatchObject({
+      completedAt: Date.UTC(2026, 4, 7, 22),
+      operatingDate: "2026-05-07",
+      status: "completed",
+    });
+    expect(context.priorClose).not.toHaveProperty("_id");
+    expect(context.priorClose).not.toHaveProperty("carryForwardWorkItemIds");
+    expect(context.priorClose).not.toHaveProperty("organizationId");
+    expect(context.priorClose).not.toHaveProperty("storeId");
+    expect(context.carryForwardWorkItems).toEqual([
+      {
+        approvalState: "not_required",
+        priority: "normal",
+        status: "open",
+        title: "Carry forward",
+        type: "daily_close_carry_forward",
+      },
+    ]);
+    expect(context.carryForwardWorkItems[0]).not.toHaveProperty("_id");
+    expect(context.carryForwardWorkItems[0]).not.toHaveProperty("metadata");
+    expect(context.carryForwardWorkItems[0]).not.toHaveProperty(
+      "organizationId",
+    );
+    expect(context.carryForwardWorkItems[0]).not.toHaveProperty("storeId");
   });
 });

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -27,6 +27,7 @@ import {
   type DailyOperationsAutomationStatus,
 } from "./dailyOperationsAutomation";
 import { buildPaymentTotals, transactionCashDelta } from "./paymentTotals";
+import type { AutomationDecisionEvidence } from "../automation/runLedger";
 
 const DAILY_CLOSE_QUERY_LIMIT = 200;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -35,6 +36,10 @@ const DAILY_CLOSE_SUBJECT_TYPE = "daily_close";
 const DAILY_CLOSE_CARRY_FORWARD_TYPE = "daily_close_carry_forward";
 const TERMINAL_WORK_ITEM_STATUSES = new Set(["completed", "cancelled"]);
 const OPEN_OPERATIONAL_WORK_ITEM_STATUSES = ["open", "in_progress"] as const;
+const EOD_AUTO_COMPLETE_LOW_RISK_REVIEW_CATEGORIES = new Set([
+  "cash_variance",
+  "voided_sale",
+]);
 const ACTIVE_REGISTER_STATUSES = ["open", "active", "closing"] as const;
 const REVIEW_ONLY_REGISTER_CLOSEOUT_STATUSES = ["closeout_rejected"] as const;
 const OPEN_POS_SESSION_STATUSES = ["active", "held"] as const;
@@ -375,6 +380,12 @@ type CompleteDailyCloseForAutomationArgs = {
   automationDecisionReason: string;
   automationPolicyVersion: string;
   automationRunId: Id<"automationRun">;
+  eodAutoCompletePolicy: {
+    cleanDayAutoCompleteEnabled: boolean;
+    maxAbsoluteCashVariance: number;
+    maxVoidedSaleCount: number;
+    maxVoidedSaleTotal: number;
+  };
   endAt?: number;
   operatingDate: string;
   organizationId?: Id<"organization">;
@@ -386,6 +397,7 @@ type CompleteDailyCloseForAutomationArgs = {
 type CompleteDailyCloseResult = ApprovalCommandResult<{
   action: "completed" | "already_completed";
   dailyClose: Doc<"dailyClose">;
+  automationDecisionEvidence?: AutomationDecisionEvidence;
   carryForwardWorkItems: Array<Doc<"operationalWorkItem">>;
   operationalEventId?: Id<"operationalEvent">;
 }>;
@@ -1494,6 +1506,154 @@ function buildDailyCloseReportSnapshot(args: {
   };
 }
 
+function numberFromMetadata(
+  record: Record<string, unknown> | undefined,
+  key: string,
+) {
+  const value = record?.[key];
+
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function buildEodAutomationDecisionEvidence(args: {
+  classification: string;
+  eligible: boolean;
+  policy: CompleteDailyCloseForAutomationArgs["eodAutoCompletePolicy"];
+  snapshot: DailyCloseSnapshot;
+}): AutomationDecisionEvidence {
+  const voidedSaleTotal = args.snapshot.reviewItems
+    .filter((item) => item.category === "voided_sale")
+    .reduce((sum, item) => sum + numberFromMetadata(item.metadata, "total"), 0);
+  const disqualifyingCategories = Array.from(
+    new Set([
+      ...args.snapshot.blockers.map((item) => item.category),
+      ...args.snapshot.reviewItems
+        .map((item) => item.category)
+        .filter(
+          (category) =>
+            !EOD_AUTO_COMPLETE_LOW_RISK_REVIEW_CATEGORIES.has(category),
+        ),
+    ]),
+  ).sort();
+
+  return {
+    kind: "eod_auto_complete",
+    classification: args.classification,
+    eligible: args.eligible,
+    observed: {
+      absoluteCashVariance: Math.abs(args.snapshot.summary.netCashVariance),
+      blockerCount: args.snapshot.readiness.blockerCount,
+      carryForwardCount: args.snapshot.readiness.carryForwardCount,
+      carryForwardItemKeys: args.snapshot.carryForwardItems.map(
+        (item) => item.key,
+      ),
+      carryForwardPreserved:
+        args.snapshot.carryForwardItems.length > 0 ||
+        args.snapshot.readiness.carryForwardCount > 0,
+      disqualifyingCategories,
+      reviewCount: args.snapshot.readiness.reviewCount,
+      voidedSaleCount: args.snapshot.summary.voidedTransactionCount,
+      voidedSaleTotal,
+    },
+    policy: {
+      cleanDayAutoCompleteEnabled: args.policy.cleanDayAutoCompleteEnabled,
+      maxAbsoluteCashVariance: args.policy.maxAbsoluteCashVariance,
+      maxVoidedSaleCount: args.policy.maxVoidedSaleCount,
+      maxVoidedSaleTotal: args.policy.maxVoidedSaleTotal,
+    },
+  };
+}
+
+function validateEodAutomationPolicyForSnapshot(args: {
+  policy: CompleteDailyCloseForAutomationArgs["eodAutoCompletePolicy"];
+  reviewedItemKeys: Set<string>;
+  snapshot: DailyCloseSnapshot;
+}) {
+  const unsupportedReviewCategories = Array.from(
+    new Set(
+      args.snapshot.reviewItems
+        .map((item) => item.category)
+        .filter(
+          (category) =>
+            !EOD_AUTO_COMPLETE_LOW_RISK_REVIEW_CATEGORIES.has(category),
+        ),
+    ),
+  );
+  const disqualifyingCategories = Array.from(
+    new Set([
+      ...args.snapshot.blockers.map((item) => item.category),
+      ...unsupportedReviewCategories,
+    ]),
+  ).sort();
+
+  if (disqualifyingCategories.length > 0) {
+    return {
+      classification: "blocked",
+      message:
+        "EOD Review automation cannot complete while blockers or unsupported review evidence remain.",
+      metadata: { disqualifyingCategories },
+    };
+  }
+
+  if (args.snapshot.reviewItems.length === 0) {
+    return args.policy.cleanDayAutoCompleteEnabled
+      ? null
+      : {
+          classification: "clean_day",
+          message:
+            "EOD Review automation cannot complete clean days while clean-day auto-complete is disabled.",
+          metadata: { cleanDayAutoCompleteEnabled: false },
+        };
+  }
+
+  const unreviewedItemKeys = args.snapshot.reviewItems
+    .map((item) => item.key)
+    .filter((key) => !args.reviewedItemKeys.has(key));
+
+  if (unreviewedItemKeys.length > 0) {
+    return {
+      classification: "review_unreviewed",
+      message:
+        "EOD Review automation cannot complete while review items are unreviewed by policy.",
+      metadata: {
+        reviewItemCount: args.snapshot.reviewItems.length,
+        unreviewedItemKeys,
+      },
+    };
+  }
+
+  const absoluteCashVariance = Math.abs(args.snapshot.summary.netCashVariance);
+  const voidedSaleTotal = args.snapshot.reviewItems
+    .filter((item) => item.category === "voided_sale")
+    .reduce((sum, item) => sum + numberFromMetadata(item.metadata, "total"), 0);
+  const thresholdFailures = [
+    absoluteCashVariance > args.policy.maxAbsoluteCashVariance
+      ? "absolute_cash_variance"
+      : null,
+    args.snapshot.summary.voidedTransactionCount >
+    args.policy.maxVoidedSaleCount
+      ? "voided_sale_count"
+      : null,
+    voidedSaleTotal > args.policy.maxVoidedSaleTotal
+      ? "voided_sale_total"
+      : null,
+  ].filter(Boolean);
+
+  return thresholdFailures.length === 0
+    ? null
+    : {
+        classification: "review_threshold_exceeded",
+        message:
+          "EOD Review automation cannot complete while review evidence exceeds policy thresholds.",
+        metadata: {
+          absoluteCashVariance,
+          thresholdFailures,
+          voidedSaleCount: args.snapshot.summary.voidedTransactionCount,
+          voidedSaleTotal,
+        },
+      };
+}
+
 function snapshotReviewedItems(
   snapshot: DailyCloseSnapshot,
   reviewedItemKeys?: string[],
@@ -1533,14 +1693,21 @@ function completionAttributionForDailyClose(
   };
 }
 
-function redactDailyCloseItemForBroadView(item: DailyCloseItem): DailyCloseItem {
+function redactDailyCloseItemForBroadView(
+  item: DailyCloseItem,
+  index = 0,
+): DailyCloseItem {
   return {
-    key: item.key,
+    key: `${item.severity}:${item.category}:${index}`,
     severity: item.severity,
     category: item.category,
     title: item.title,
     message: item.message,
-    subject: item.subject,
+    subject: {
+      type: item.subject.type,
+      id: "redacted",
+      label: item.subject.label,
+    },
   };
 }
 
@@ -1580,7 +1747,7 @@ function redactDailyCloseReportSnapshotForBroadView(
       automationPolicyVersion: snapshot.closeMetadata.automationPolicyVersion,
       automationDecisionReason: snapshot.closeMetadata.automationDecisionReason,
       notes: snapshot.closeMetadata.notes,
-      carryForwardWorkItemIds: snapshot.closeMetadata.carryForwardWorkItemIds,
+      carryForwardWorkItemIds: [],
     },
     readiness: snapshot.readiness,
     summary: redactDailyCloseSummaryForBroadView(snapshot.summary),
@@ -2704,6 +2871,89 @@ async function validateCarryForwardWorkItemIds(
   };
 }
 
+function carryForwardWorkItemIdFromItem(
+  item: DailyCloseItem,
+): Id<"operationalWorkItem"> | null {
+  if (item.subject.type !== "operational_work_item") {
+    return null;
+  }
+
+  return item.subject.id as Id<"operationalWorkItem">;
+}
+
+async function validateAutomationCarryForwardWorkItems(
+  ctx: Pick<MutationCtx, "db">,
+  args: {
+    organizationId: Id<"organization">;
+    snapshot: DailyCloseSnapshot;
+    storeId: Id<"store">;
+  },
+) {
+  const workItemIds = args.snapshot.carryForwardItems
+    .map(carryForwardWorkItemIdFromItem)
+    .filter(Boolean) as Id<"operationalWorkItem">[];
+  const uniqueWorkItemIds = Array.from(new Set(workItemIds));
+
+  if (
+    workItemIds.length !== args.snapshot.carryForwardItems.length ||
+    uniqueWorkItemIds.length !== workItemIds.length
+  ) {
+    return {
+      ok: false as const,
+      message:
+        "EOD Review automation cannot preserve unmapped or duplicated carry-forward work.",
+      metadata: {
+        carryForwardCount: args.snapshot.carryForwardItems.length,
+        mappedWorkItemCount: uniqueWorkItemIds.length,
+      },
+    };
+  }
+
+  const workItems: Array<Doc<"operationalWorkItem">> = [];
+
+  for (const workItemId of uniqueWorkItemIds) {
+    const workItem = await ctx.db.get("operationalWorkItem", workItemId);
+
+    if (!workItem) {
+      return {
+        ok: false as const,
+        message:
+          "EOD Review automation cannot preserve missing carry-forward work.",
+        metadata: { workItemId },
+      };
+    }
+
+    if (
+      workItem.storeId !== args.storeId ||
+      workItem.organizationId !== args.organizationId
+    ) {
+      return {
+        ok: false as const,
+        message:
+          "EOD Review automation cannot preserve carry-forward work outside this store.",
+        metadata: { workItemId },
+      };
+    }
+
+    if (TERMINAL_WORK_ITEM_STATUSES.has(workItem.status)) {
+      return {
+        ok: false as const,
+        message:
+          "EOD Review automation cannot preserve terminal carry-forward work.",
+        metadata: { status: workItem.status, workItemId },
+      };
+    }
+
+    workItems.push(workItem);
+  }
+
+  return {
+    ok: true as const,
+    workItemIds: uniqueWorkItemIds,
+    workItems,
+  };
+}
+
 async function createCarryForwardWorkItems(
   ctx: MutationCtx,
   args: {
@@ -3165,6 +3415,14 @@ export async function completeDailyCloseForAutomationWithCtx(
     });
   }
 
+  if (!args.eodAutoCompletePolicy) {
+    return userError({
+      code: "precondition_failed",
+      message:
+        "EOD Review automation requires policy evidence before completion.",
+    });
+  }
+
   if (!snapshot.existingClose) {
     const nonActiveClose = await getNonActiveDailyCloseForDate(ctx, {
       operatingDate: args.operatingDate,
@@ -3212,18 +3470,21 @@ export async function completeDailyCloseForAutomationWithCtx(
     });
   }
 
-  if (snapshot.carryForwardItems.length > 0) {
+  const reviewedItemKeys = new Set(args.policyReviewedItemKeys);
+  const policyError = validateEodAutomationPolicyForSnapshot({
+    policy: args.eodAutoCompletePolicy,
+    reviewedItemKeys,
+    snapshot,
+  });
+
+  if (policyError) {
     return userError({
       code: "precondition_failed",
-      message:
-        "EOD Review automation cannot complete while carry-forward items remain.",
-      metadata: {
-        carryForwardCount: snapshot.carryForwardItems.length,
-      },
+      message: policyError.message,
+      metadata: policyError.metadata,
     });
   }
 
-  const reviewedItemKeys = new Set(args.policyReviewedItemKeys);
   const unreviewedItemKeys = snapshot.reviewItems
     .map((item) => item.key)
     .filter((key) => !reviewedItemKeys.has(key));
@@ -3240,15 +3501,38 @@ export async function completeDailyCloseForAutomationWithCtx(
     });
   }
 
+  const carryForwardResult = await validateAutomationCarryForwardWorkItems(ctx, {
+    organizationId: store.organizationId,
+    snapshot,
+    storeId: args.storeId,
+  });
+
+  if (!carryForwardResult.ok) {
+    return userError({
+      code: "precondition_failed",
+      message: carryForwardResult.message,
+      metadata: carryForwardResult.metadata,
+    });
+  }
+
   const now = Date.now();
+  const carryForwardWorkItemIds = carryForwardResult.workItemIds;
+  const carryForwardWorkItems = carryForwardResult.workItems;
   const readiness = {
     ...snapshot.readiness,
-    carryForwardCount: 0,
+    carryForwardCount: carryForwardWorkItemIds.length,
   };
   const summary = {
     ...snapshot.summary,
-    carryForwardWorkItemCount: 0,
+    carryForwardWorkItemCount: carryForwardWorkItemIds.length,
   };
+  const automationDecisionEvidence = buildEodAutomationDecisionEvidence({
+    classification:
+      snapshot.reviewItems.length > 0 ? "low_risk_review" : "clean_day",
+    eligible: true,
+    policy: args.eodAutoCompletePolicy,
+    snapshot,
+  });
   const closeFields = {
     storeId: args.storeId,
     organizationId: store.organizationId,
@@ -3264,8 +3548,8 @@ export async function completeDailyCloseForAutomationWithCtx(
       automationDecisionReason: args.automationDecisionReason,
       automationPolicyVersion: args.automationPolicyVersion,
       automationRunId: args.automationRunId,
-      carryForwardWorkItemIds: [],
-      carryForwardWorkItems: [],
+      carryForwardWorkItemIds,
+      carryForwardWorkItems,
       completedAt: now,
       policyReviewedItemKeys: args.policyReviewedItemKeys,
       readiness,
@@ -3273,7 +3557,7 @@ export async function completeDailyCloseForAutomationWithCtx(
       snapshot,
       summary,
     }),
-    carryForwardWorkItemIds: [],
+    carryForwardWorkItemIds,
     reviewedItemKeys: args.policyReviewedItemKeys,
     actorType: "automation" as const,
     automationRunId: args.automationRunId,
@@ -3333,8 +3617,9 @@ export async function completeDailyCloseForAutomationWithCtx(
 
   return ok({
     action: "completed",
+    automationDecisionEvidence,
     dailyClose,
-    carryForwardWorkItems: [],
+    carryForwardWorkItems,
     operationalEventId: operationalEvent?._id,
   });
 }
@@ -3569,6 +3854,31 @@ export async function getDailyCloseOpeningContextWithCtx(
   };
 }
 
+function redactDailyCloseOpeningContextForBroadView(
+  context: Awaited<ReturnType<typeof getDailyCloseOpeningContextWithCtx>>,
+) {
+  return {
+    priorClose: context.priorClose
+      ? {
+          actorType: context.priorClose.actorType,
+          automationPolicyVersion: context.priorClose.automationPolicyVersion,
+          completedAt: context.priorClose.completedAt,
+          lifecycleStatus: context.priorClose.lifecycleStatus,
+          operatingDate: context.priorClose.operatingDate,
+          status: context.priorClose.status,
+        }
+      : null,
+    carryForwardWorkItems: context.carryForwardWorkItems.map((workItem) => ({
+      approvalState: workItem.approvalState,
+      ...(workItem.dueAt ? { dueAt: workItem.dueAt } : {}),
+      priority: workItem.priority,
+      status: workItem.status,
+      title: workItem.title,
+      type: workItem.type,
+    })),
+  };
+}
+
 export async function listCompletedDailyCloseHistoryWithCtx(
   ctx: Pick<QueryCtx, "db">,
   args: {
@@ -3682,7 +3992,11 @@ export const getDailyCloseSnapshot = query({
     startAt: v.optional(v.number()),
     storeId: v.id("store"),
   },
-  handler: (ctx, args) => buildDailyCloseSnapshotWithCtx(ctx, args),
+  handler: (ctx, args) =>
+    buildDailyCloseSnapshotWithCtx(ctx, {
+      ...args,
+      includeManagerReviewEvidence: false,
+    }),
 });
 
 export const completeDailyClose = mutation({
@@ -3720,6 +4034,12 @@ export const completeDailyCloseForAutomation = internalMutation({
     automationDecisionReason: v.string(),
     automationPolicyVersion: v.string(),
     automationRunId: v.id("automationRun"),
+    eodAutoCompletePolicy: v.object({
+      cleanDayAutoCompleteEnabled: v.boolean(),
+      maxAbsoluteCashVariance: v.number(),
+      maxVoidedSaleCount: v.number(),
+      maxVoidedSaleTotal: v.number(),
+    }),
     endAt: v.optional(v.number()),
     operatingDate: v.string(),
     organizationId: v.optional(v.id("organization")),
@@ -3750,7 +4070,10 @@ export const getDailyCloseOpeningContext = query({
     operatingDate: v.string(),
     storeId: v.id("store"),
   },
-  handler: (ctx, args) => getDailyCloseOpeningContextWithCtx(ctx, args),
+  handler: async (ctx, args) =>
+    redactDailyCloseOpeningContextForBroadView(
+      await getDailyCloseOpeningContextWithCtx(ctx, args),
+    ),
 });
 
 export const listCompletedDailyCloseHistory = query({

--- a/packages/athena-webapp/convex/operations/dailyOpening.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOpening.test.ts
@@ -3,8 +3,10 @@ import type { Id } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
 import {
   buildDailyOpeningSnapshotWithCtx,
+  startStoreDay,
   startStoreDayWithCtx,
 } from "./dailyOpening";
+import { assertConformsToExportedReturns } from "../lib/returnValidatorContract";
 
 type TableName =
   | "approvalRequest"
@@ -219,6 +221,35 @@ describe("daily opening backend foundation", () => {
     vi.restoreAllMocks();
   });
 
+  it("keeps daily opening command results aligned with exported return validators", () => {
+    expect(() =>
+      assertConformsToExportedReturns(startStoreDay, {
+        kind: "user_error",
+        error: {
+          code: "precondition_failed",
+          message:
+            "Opening Handoff cannot start while items still need attention.",
+        },
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      assertConformsToExportedReturns(startStoreDay, {
+        kind: "ok",
+        data: {
+          action: "started",
+          dailyOpening: {
+            _id: "daily-opening-1",
+            storeId: "store-1",
+            operatingDate: "2026-05-08",
+            status: "started",
+          },
+          operationalEventId: "operational-event-1",
+        },
+      }),
+    ).not.toThrow();
+  });
+
   it("returns a ready snapshot when the prior EOD Review completed cleanly", async () => {
     const { db } = createDb({
       dailyClose: [completedDailyClose()],
@@ -257,6 +288,203 @@ describe("daily opening backend foundation", () => {
         type: "daily_close",
       },
     ]);
+  });
+
+  it("redacts prior close carry-forward work for broad opening snapshot readers", async () => {
+    const { db } = createDb({
+      dailyClose: [
+        completedDailyClose({
+          carryForwardWorkItemIds: ["work-1"],
+          readiness: {
+            blockerCount: 0,
+            carryForwardCount: 1,
+            readyCount: 1,
+            reviewCount: 0,
+            status: "ready",
+          },
+        }),
+      ],
+      operationalWorkItem: [
+        {
+          _id: "work-1",
+          approvalState: "not_required",
+          createdAt: 4,
+          metadata: {
+            source: "manager_note",
+          },
+          organizationId: "org-1",
+          priority: "normal",
+          status: "open",
+          storeId: "store-1",
+          title: "Call customer tomorrow",
+          type: "customer_follow_up",
+        },
+      ],
+      store: [store],
+    });
+
+    const snapshot = await buildDailyOpeningSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      {
+        includeManagerReviewEvidence: false,
+        operatingDate: "2026-05-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(snapshot.carryForwardItems).toEqual([
+      {
+        key: "carry_forward:0",
+        severity: "carry_forward",
+        category: "carry_forward",
+        title: "Call customer tomorrow",
+        message:
+          "This unresolved carry-forward item remains open and must be acknowledged for Opening.",
+        subject: {
+          type: "operational_work_item",
+          id: "redacted",
+          label: "Call customer tomorrow",
+        },
+      },
+    ]);
+    expect(snapshot.sourceSubjects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "redacted",
+          type: "operational_work_item",
+        }),
+      ]),
+    );
+    expect(snapshot.carryForwardItems[0]).not.toHaveProperty("link");
+    expect(snapshot.carryForwardItems[0]).not.toHaveProperty("metadata");
+    expect(snapshot.readyItems).toEqual([
+      expect.objectContaining({
+        key: "prior_close:completed",
+        subject: {
+          type: "daily_close",
+          id: "redacted",
+          label: "EOD Review 2026-05-07",
+        },
+      }),
+    ]);
+    expect(snapshot.readyItems[0]).not.toHaveProperty("metadata");
+    expect(snapshot.priorClose).toMatchObject({
+      completedAt: Date.UTC(2026, 4, 7, 22),
+      operatingDate: "2026-05-07",
+      status: "completed",
+    });
+    expect(snapshot.priorClose).not.toHaveProperty("_id");
+    expect(snapshot.priorClose).not.toHaveProperty("carryForwardWorkItemIds");
+    expect(snapshot.priorClose).not.toHaveProperty("organizationId");
+    expect(snapshot.priorClose).not.toHaveProperty("reportSnapshot");
+    expect(snapshot.priorClose).not.toHaveProperty("sourceSubjects");
+    expect(snapshot.priorClose).not.toHaveProperty("storeId");
+  });
+
+  it("keeps prior close carry-forward evidence for trusted opening snapshot readers", async () => {
+    const { db } = createDb({
+      dailyClose: [
+        completedDailyClose({
+          carryForwardWorkItemIds: ["work-1"],
+          readiness: {
+            blockerCount: 0,
+            carryForwardCount: 1,
+            readyCount: 1,
+            reviewCount: 0,
+            status: "ready",
+          },
+        }),
+      ],
+      operationalWorkItem: [
+        {
+          _id: "work-1",
+          approvalState: "not_required",
+          createdAt: 4,
+          metadata: {
+            source: "manager_note",
+          },
+          organizationId: "org-1",
+          priority: "normal",
+          status: "open",
+          storeId: "store-1",
+          title: "Call customer tomorrow",
+          type: "customer_follow_up",
+        },
+      ],
+      store: [store],
+    });
+
+    const snapshot = await buildDailyOpeningSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      {
+        includeManagerReviewEvidence: true,
+        operatingDate: "2026-05-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(snapshot.carryForwardItems[0]).toMatchObject({
+      key: "operational_work_item:work-1:carry_forward",
+      subject: {
+        id: "work-1",
+        type: "operational_work_item",
+      },
+      link: {
+        label: "View open work",
+      },
+      metadata: {
+        priority: "normal",
+        status: "open",
+        type: "customer_follow_up",
+      },
+    });
+  });
+
+  it("redacts missing carry-forward blockers for broad opening snapshot readers", async () => {
+    const { db } = createDb({
+      dailyClose: [
+        completedDailyClose({
+          carryForwardWorkItemIds: ["work-missing"],
+          readiness: {
+            blockerCount: 0,
+            carryForwardCount: 1,
+            readyCount: 1,
+            reviewCount: 0,
+            status: "ready",
+          },
+        }),
+      ],
+      store: [store],
+    });
+
+    const snapshot = await buildDailyOpeningSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      {
+        includeManagerReviewEvidence: false,
+        operatingDate: "2026-05-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(snapshot.blockers).toEqual([
+      expect.objectContaining({
+        key: "carry_forward:missing",
+        subject: {
+          type: "operational_work_item",
+          id: "redacted",
+          label: "Missing carry-forward work",
+        },
+      }),
+    ]);
+    expect(snapshot.blockers[0]).not.toHaveProperty("metadata");
+    expect(snapshot.sourceSubjects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "redacted",
+          type: "operational_work_item",
+        }),
+      ]),
+    );
   });
 
   it("includes the latest Opening automation status when present", async () => {

--- a/packages/athena-webapp/convex/operations/dailyOpening.ts
+++ b/packages/athena-webapp/convex/operations/dailyOpening.ts
@@ -71,6 +71,18 @@ type DailyOpeningReadiness = {
   readyCount: number;
 };
 
+type DailyOpeningPriorClose =
+  | Doc<"dailyClose">
+  | {
+      _id?: Id<"dailyClose">;
+      actorType?: "human" | "automation";
+      automationPolicyVersion?: string;
+      completedAt?: number;
+      lifecycleStatus?: string;
+      operatingDate: string;
+      status: string;
+    };
+
 type DailyOpeningSnapshot = {
   endAt: number;
   operatingDate: string;
@@ -78,7 +90,7 @@ type DailyOpeningSnapshot = {
   organizationId: Id<"organization"> | null;
   automationStatus?: DailyOperationsAutomationStatus | null;
   existingOpening: Doc<"dailyOpening"> | null;
-  priorClose: Doc<"dailyClose"> | null;
+  priorClose: DailyOpeningPriorClose | null;
   status: DailyOpeningReadinessStatus | "started";
   blockers: DailyOpeningItem[];
   reviewItems: DailyOpeningItem[];
@@ -466,9 +478,26 @@ function invalidOperatingDateItem(operatingDate: string): DailyOpeningItem {
 }
 
 function missingCarryForwardItem(args: {
+  includeManagerReviewEvidence?: boolean;
   priorClose: Doc<"dailyClose">;
   workItemId: Id<"operationalWorkItem">;
 }): DailyOpeningItem {
+  if (args.includeManagerReviewEvidence === false) {
+    return {
+      key: "carry_forward:missing",
+      severity: "blocker",
+      category: "carry_forward",
+      title: "Carry-forward work is missing",
+      message:
+        "A carry-forward item referenced by the prior end of day review could not be loaded. Resolve the missing handoff before Opening Handoff can be acknowledged.",
+      subject: {
+        type: "operational_work_item",
+        id: "redacted",
+        label: "Missing carry-forward work",
+      },
+    };
+  }
+
   return {
     key: `operational_work_item:${args.workItemId}:missing`,
     severity: "blocker",
@@ -488,7 +517,34 @@ function missingCarryForwardItem(args: {
   };
 }
 
-function priorCloseReadyItem(priorClose: Doc<"dailyClose">): DailyOpeningItem {
+function priorCloseReadyItem(
+  priorClose: Doc<"dailyClose">,
+  options: {
+    includeManagerReviewEvidence?: boolean;
+  } = {},
+): DailyOpeningItem {
+  if (options.includeManagerReviewEvidence === false) {
+    return {
+      key: "prior_close:completed",
+      severity: "ready",
+      category: "prior_close",
+      title: "Prior EOD Review completed",
+      message: "The prior store day has a completed end of day review.",
+      subject: {
+        type: DAILY_CLOSE_SUBJECT_TYPE,
+        id: "redacted",
+        label: `EOD Review ${priorClose.operatingDate}`,
+      },
+      link: {
+        label: "View EOD Review",
+        search: {
+          operatingDate: priorClose.operatingDate,
+        },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
+      },
+    };
+  }
+
   return {
     key: `daily_close:${priorClose._id}:completed`,
     severity: "ready",
@@ -514,7 +570,35 @@ function priorCloseReadyItem(priorClose: Doc<"dailyClose">): DailyOpeningItem {
   };
 }
 
-function priorCloseReopenedItem(priorClose: Doc<"dailyClose">): DailyOpeningItem {
+function priorCloseReopenedItem(
+  priorClose: Doc<"dailyClose">,
+  options: {
+    includeManagerReviewEvidence?: boolean;
+  } = {},
+): DailyOpeningItem {
+  if (options.includeManagerReviewEvidence === false) {
+    return {
+      key: "prior_close:reopened",
+      severity: "review",
+      category: "prior_close",
+      title: "Prior EOD Review reopened",
+      message:
+        "The prior store day was reopened. Complete the revised end of day review before treating the prior close as clean.",
+      subject: {
+        type: DAILY_CLOSE_SUBJECT_TYPE,
+        id: "redacted",
+        label: `EOD Review ${priorClose.operatingDate}`,
+      },
+      link: {
+        label: "Review EOD Review",
+        search: {
+          operatingDate: priorClose.operatingDate,
+        },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
+      },
+    };
+  }
+
   return {
     key: `daily_close:${priorClose._id}:reopened`,
     severity: "review",
@@ -569,7 +653,27 @@ function priorCloseNotesItem(priorClose: Doc<"dailyClose">): DailyOpeningItem | 
 
 function carryForwardItem(
   workItem: Doc<"operationalWorkItem">,
+  options: {
+    includeManagerReviewEvidence?: boolean;
+    index?: number;
+  } = {},
 ): DailyOpeningItem {
+  if (options.includeManagerReviewEvidence === false) {
+    return {
+      key: `carry_forward:${options.index ?? 0}`,
+      severity: "carry_forward",
+      category: "carry_forward",
+      title: workItem.title,
+      message:
+        "This unresolved carry-forward item remains open and must be acknowledged for Opening.",
+      subject: {
+        type: "operational_work_item",
+        id: "redacted",
+        label: workItem.title,
+      },
+    };
+  }
+
   return {
     key: `operational_work_item:${workItem._id}:carry_forward`,
     severity: "carry_forward",
@@ -591,6 +695,21 @@ function carryForwardItem(
       status: workItem.status,
       type: workItem.type,
     },
+  };
+}
+
+function redactPriorCloseForBroadOpeningSnapshot(
+  priorClose: Doc<"dailyClose"> | null,
+): DailyOpeningPriorClose | null {
+  if (!priorClose) return null;
+
+  return {
+    actorType: priorClose.actorType,
+    automationPolicyVersion: priorClose.automationPolicyVersion,
+    completedAt: priorClose.completedAt,
+    lifecycleStatus: priorClose.lifecycleStatus,
+    operatingDate: priorClose.operatingDate,
+    status: priorClose.status,
   };
 }
 
@@ -652,6 +771,9 @@ function managerReviewEvidenceFromSnapshot(
 async function getMissingCarryForwardItems(
   ctx: Pick<QueryCtx, "db">,
   priorClose: Doc<"dailyClose">,
+  options: {
+    includeManagerReviewEvidence?: boolean;
+  } = {},
 ) {
   const carryForwardWorkItems = await Promise.all(
     priorClose.carryForwardWorkItemIds.map(async (workItemId) => ({
@@ -662,7 +784,13 @@ async function getMissingCarryForwardItems(
 
   return carryForwardWorkItems
     .filter(({ workItem }) => !workItem)
-    .map(({ workItemId }) => missingCarryForwardItem({ priorClose, workItemId }));
+    .map(({ workItemId }) =>
+      missingCarryForwardItem({
+        includeManagerReviewEvidence: options.includeManagerReviewEvidence,
+        priorClose,
+        workItemId,
+      }),
+    );
 }
 
 async function resolveOpeningActor(
@@ -823,22 +951,40 @@ export async function buildDailyOpeningSnapshotWithCtx(
     (await getPriorDailyCloseForOpeningReview(ctx, args));
 
   const blockers: DailyOpeningItem[] = openingContext.priorClose
-    ? await getMissingCarryForwardItems(ctx, openingContext.priorClose)
+    ? await getMissingCarryForwardItems(ctx, openingContext.priorClose, {
+        includeManagerReviewEvidence: args.includeManagerReviewEvidence,
+      })
     : [];
   const reviewItems: DailyOpeningItem[] = [];
   const carryForwardItems = openingContext.carryForwardWorkItems
     .filter((workItem) => !TERMINAL_WORK_ITEM_STATUSES.has(workItem.status))
-    .map(carryForwardItem);
+    .map((workItem, index) =>
+      carryForwardItem(workItem, {
+        includeManagerReviewEvidence: args.includeManagerReviewEvidence,
+        index,
+      }),
+    );
   const readyItems: DailyOpeningItem[] = [];
 
   if (priorClose) {
     if (priorClose.lifecycleStatus === "reopened") {
-      reviewItems.push(priorCloseReopenedItem(priorClose));
+      reviewItems.push(
+        priorCloseReopenedItem(priorClose, {
+          includeManagerReviewEvidence: args.includeManagerReviewEvidence,
+        }),
+      );
     } else {
-      readyItems.push(priorCloseReadyItem(priorClose));
+      readyItems.push(
+        priorCloseReadyItem(priorClose, {
+          includeManagerReviewEvidence: args.includeManagerReviewEvidence,
+        }),
+      );
     }
 
-    const notesItem = priorCloseNotesItem(priorClose);
+    const notesItem =
+      args.includeManagerReviewEvidence === false
+        ? null
+        : priorCloseNotesItem(priorClose);
 
     if (notesItem) {
       reviewItems.push(notesItem);
@@ -869,7 +1015,10 @@ export async function buildDailyOpeningSnapshotWithCtx(
     organizationId: store?.organizationId ?? null,
     automationStatus,
     existingOpening,
-    priorClose,
+    priorClose:
+      args.includeManagerReviewEvidence === false
+        ? redactPriorCloseForBroadOpeningSnapshot(priorClose)
+        : priorClose,
     status: existingOpening ? "started" : readiness.status,
     blockers,
     reviewItems,

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -2176,7 +2176,12 @@ export async function buildDailyOperationsSnapshotWithCtx(
   return {
     automationStatuses,
     attentionItems,
-    completedClose: closeSnapshot.completedClose,
+    completedClose: closeSnapshot.completedClose
+      ? {
+          ...closeSnapshot.completedClose,
+          carryForwardCount: closeSnapshot.readiness?.carryForwardCount ?? 0,
+        }
+      : closeSnapshot.completedClose,
     closeSummary,
     currency: store?.currency ?? "GHS",
     endAt: range.endAt,

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
@@ -1266,8 +1266,8 @@ describe("daily operations automation adapter", () => {
     });
   });
 
-  it("hard-skips EOD auto-complete when v1 carry-forward evidence is present", async () => {
-    const { db } = createDb({
+  it("auto-completes blocker-free EOD reviews while preserving carry-forward work", async () => {
+    const { db, inserts } = createDb({
       automationPolicy: [
         policy("eod.auto_complete", "enabled", {
           eodCleanDayAutoCompleteEnabled: true,
@@ -1281,12 +1281,16 @@ describe("daily operations automation adapter", () => {
       operationalWorkItem: [
         {
           _id: "work-1",
+          approvalState: "not_required",
           createdAt: Date.UTC(2026, 5, 8, 12),
+          organizationId: "org-1",
+          priority: "normal",
           status: "open",
           storeId: "store-1",
           subjectId: "cycle-count-1",
           subjectType: "stock_adjustment",
           title: "Cycle count follow-up",
+          type: "stock_adjustment_follow_up",
         },
       ],
       posTransaction: [completedTransaction()],
@@ -1304,12 +1308,45 @@ describe("daily operations automation adapter", () => {
 
     expect(result.run).toMatchObject({
       decisionEvidence: {
-        classification: "carry_forward",
-        eligible: false,
+        classification: "clean_day",
+        eligible: true,
+        observed: {
+          carryForwardCount: 1,
+          carryForwardItemKeys: [
+            "operational_work_item:work-1:carry_forward",
+          ],
+          carryForwardPreserved: true,
+        },
       },
-      decisionReason:
-        "EOD Review has carry-forward evidence; v1 auto-complete requires human review.",
-      outcome: "skipped",
+      outcome: "applied",
+    });
+    const dailyClose = inserts.find(
+      (insert) => insert.table === "dailyClose",
+    )?.value;
+    expect(dailyClose).toMatchObject({
+      actorType: "automation",
+      carryForwardWorkItemIds: ["work-1"],
+      readiness: {
+        carryForwardCount: 1,
+      },
+      status: "completed",
+      summary: {
+        carryForwardWorkItemCount: 1,
+      },
+    });
+    expect(dailyClose?.reportSnapshot).toMatchObject({
+      carryForwardItems: [
+        {
+          key: "operational_work_item:work-1:carry_forward",
+          subject: {
+            id: "work-1",
+            type: "operational_work_item",
+          },
+        },
+      ],
+      closeMetadata: {
+        carryForwardWorkItemIds: ["work-1"],
+      },
     });
   });
 

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
@@ -371,7 +371,11 @@ function eodAutoCompleteDecision(
   const observed = {
     absoluteCashVariance,
     blockerCount: snapshot.readiness.blockerCount,
+    carryForwardItemKeys: snapshot.carryForwardItems.map((item) => item.key),
     carryForwardCount: snapshot.readiness.carryForwardCount,
+    carryForwardPreserved:
+      snapshot.readiness.carryForwardCount > 0 ||
+      snapshot.carryForwardItems.length > 0,
     disqualifyingCategories,
     reviewCount: snapshot.readiness.reviewCount,
     voidedSaleCount: snapshot.summary.voidedTransactionCount,
@@ -429,20 +433,6 @@ function eodAutoCompleteDecision(
     return decision({
       classification: "completed",
       decisionReason: "EOD Review is already completed for this store day.",
-      eligible: false,
-      outcome: "skipped",
-    });
-  }
-
-  if (
-    snapshot.status === "carry_forward" ||
-    snapshot.readiness.carryForwardCount > 0 ||
-    snapshot.carryForwardItems.length > 0
-  ) {
-    return decision({
-      classification: "carry_forward",
-      decisionReason:
-        "EOD Review has carry-forward evidence; v1 auto-complete requires human review.",
       eligible: false,
       outcome: "skipped",
     });
@@ -661,6 +651,13 @@ export async function runDailyCloseAutoCompleteEligibilityWithCtx(
           run.decisionReason ?? "EOD Review completed by automation policy.",
         automationPolicyVersion: run.policyVersion,
         automationRunId: run._id,
+        eodAutoCompletePolicy: {
+          cleanDayAutoCompleteEnabled:
+            policyConfig.cleanDayAutoCompleteEnabled,
+          maxAbsoluteCashVariance: policyConfig.maxAbsoluteCashVariance,
+          maxVoidedSaleCount: policyConfig.maxVoidedSaleCount,
+          maxVoidedSaleTotal: policyConfig.maxVoidedSaleTotal,
+        },
         endAt: args.endAt,
         operatingDate: args.operatingDate,
         organizationId: snapshot.organizationId ?? undefined,
@@ -692,6 +689,7 @@ export async function runDailyCloseAutoCompleteEligibilityWithCtx(
         eventIds: result.data.operationalEventId
           ? [result.data.operationalEventId]
           : [],
+        decisionEvidence: result.data.automationDecisionEvidence,
         outcome:
           result.data.action === "already_completed"
             ? ("skipped" as const)

--- a/packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx
@@ -333,6 +333,7 @@ describe("DailyCloseHistoryView", () => {
       historyRecord({
         completedByStaffName: null,
         reportSnapshot: snapshot({
+          carryForwardItems: [],
           completedClose: {
             actorType: "automation",
             automationDecisionReason:
@@ -340,6 +341,13 @@ describe("DailyCloseHistoryView", () => {
             automationPolicyVersion: "daily-close-auto-complete.v1",
             completedAt: Date.UTC(2026, 4, 8, 22, 30),
             notes: "Policy close.",
+          },
+          readiness: {
+            blockerCount: 0,
+            carryForwardCount: 0,
+            readyCount: 2,
+            reviewCount: 1,
+            status: "ready",
           },
         }),
       }),
@@ -359,7 +367,48 @@ describe("DailyCloseHistoryView", () => {
         "Policy checked low-risk review evidence before completion.",
       ),
     ).toBeInTheDocument();
+    expect(
+      within(detail).queryByText(
+        "Policy checked low-risk review evidence and preserved carry-forward work for Opening.",
+      ),
+    ).not.toBeInTheDocument();
     expect(within(detail).queryByText(/manager approved/i)).not.toBeInTheDocument();
+  });
+
+  it("renders historical Athena carry-forward preservation copy when present", () => {
+    mockQueries([
+      historyRecord({
+        completedByStaffName: null,
+        reportSnapshot: snapshot({
+          completedClose: {
+            actorType: "automation",
+            automationDecisionReason:
+              "EOD Review has only low-risk review evidence within policy thresholds.",
+            automationPolicyVersion: "daily-close-auto-complete.v1",
+            completedAt: Date.UTC(2026, 4, 8, 22, 30),
+          },
+          readiness: {
+            blockerCount: 0,
+            carryForwardCount: 1,
+            readyCount: 0,
+            reviewCount: 1,
+            status: "ready",
+          },
+        }),
+      }),
+    ]);
+
+    render(<DailyCloseHistoryView />);
+
+    const detail = screen.getByRole("region", {
+      name: "Historical Daily Close detail",
+    });
+
+    expect(
+      within(detail).getByText(
+        "Policy checked low-risk review evidence and preserved carry-forward work for Opening.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("uses safe historical Athena attribution when restricted evidence is redacted", () => {
@@ -392,7 +441,7 @@ describe("DailyCloseHistoryView", () => {
     ).toBeInTheDocument();
     expect(
       within(detail).queryByText(
-        "Policy checked low-risk review evidence before completion.",
+        "Policy checked low-risk review evidence and preserved carry-forward work for Opening.",
       ),
     ).not.toBeInTheDocument();
   });

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -683,8 +683,40 @@ describe("DailyCloseViewContent", () => {
         "Policy checked low-risk review evidence before completion.",
       ),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Policy checked low-risk review evidence and preserved carry-forward work for Opening.",
+      ),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText(/manager approved/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/resolved review/i)).not.toBeInTheDocument();
+  });
+
+  it("mentions preserved carry-forward work when Athena completed with carry-forward", () => {
+    renderContent({
+      ...readySnapshot,
+      completedClose: {
+        actorType: "automation",
+        automationDecisionReason:
+          "EOD Review has only low-risk review evidence within policy thresholds.",
+        completedAt: Date.UTC(2026, 4, 7, 22, 30),
+        policyReviewedItemKeys: ["pos_transaction:txn-void:void"],
+      },
+      readiness: {
+        blockerCount: 0,
+        carryForwardCount: 1,
+        readyCount: 1,
+        reviewCount: 1,
+        status: "ready",
+      },
+      status: "completed",
+    });
+
+    expect(
+      screen.getByText(
+        "Policy checked low-risk review evidence and preserved carry-forward work for Opening.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("does not add Athena attribution to human-completed closes", () => {
@@ -726,7 +758,7 @@ describe("DailyCloseViewContent", () => {
     ).toBeInTheDocument();
     expect(
       screen.queryByText(
-        "Policy checked low-risk review evidence before completion.",
+        "Policy checked low-risk review evidence and preserved carry-forward work for Opening.",
       ),
     ).not.toBeInTheDocument();
   });

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -569,6 +569,7 @@ export type DailyCloseCompletionAttribution = NonNullable<
 
 export function getDailyCloseCompletionAttributionDetail(
   completedClose?: DailyCloseCompletionAttribution | null,
+  carryForwardCount = 0,
 ) {
   if (completedClose?.actorType !== "automation") {
     return null;
@@ -578,11 +579,14 @@ export function getDailyCloseCompletionAttributionDetail(
     return "Restricted close evidence is hidden for this account.";
   }
 
+  const hasCarryForward = carryForwardCount > 0;
   if (
     completedClose.policyReviewedItemKeys &&
     completedClose.policyReviewedItemKeys.length > 0
   ) {
-    return "Policy checked low-risk review evidence before completion.";
+    return hasCarryForward
+      ? "Policy checked low-risk review evidence and preserved carry-forward work for Opening."
+      : "Policy checked low-risk review evidence before completion.";
   }
 
   if (
@@ -590,15 +594,21 @@ export function getDailyCloseCompletionAttributionDetail(
       ?.toLowerCase()
       .includes("low-risk review")
   ) {
-    return "Policy checked low-risk review evidence before completion.";
+    return hasCarryForward
+      ? "Policy checked low-risk review evidence and preserved carry-forward work for Opening."
+      : "Policy checked low-risk review evidence before completion.";
   }
 
-  return "Policy checked the close before completion.";
+  return hasCarryForward
+    ? "Policy checked the close and preserved carry-forward work for Opening."
+    : "Policy checked the close before completion.";
 }
 
 export function DailyCloseCompletionAttributionNotice({
+  carryForwardCount,
   completedClose,
 }: {
+  carryForwardCount?: number | null;
   completedClose?: DailyCloseCompletionAttribution | null;
 }) {
   if (completedClose?.actorType !== "automation") {
@@ -611,7 +621,10 @@ export function DailyCloseCompletionAttributionNotice({
         Athena completed EOD Review under store policy.
       </p>
       <p className="mt-1 text-muted-foreground">
-        {getDailyCloseCompletionAttributionDetail(completedClose)}
+        {getDailyCloseCompletionAttributionDetail(
+          completedClose,
+          carryForwardCount ?? 0,
+        )}
       </p>
     </div>
   );
@@ -2653,6 +2666,7 @@ export function DailyCloseReadOnlyReport({
       </section>
 
       <DailyCloseCompletionAttributionNotice
+        carryForwardCount={displaySnapshot.readiness?.carryForwardCount ?? 0}
         completedClose={displaySnapshot.completedClose}
       />
 
@@ -2936,6 +2950,7 @@ function CompletionRail({
               {formatDailyCloseCompletedAt(snapshot.completedClose.completedAt)}
             </p>
             <DailyCloseCompletionAttributionNotice
+              carryForwardCount={snapshot.readiness?.carryForwardCount ?? 0}
               completedClose={snapshot.completedClose}
             />
             {snapshot.completedClose.notes ? (

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -1193,7 +1193,31 @@ describe("DailyOperationsViewContent", () => {
     expect(
       screen.getByText("Policy checked low-risk review evidence before completion."),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Policy checked low-risk review evidence and preserved carry-forward work for Opening.",
+      ),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText(/manager approved/i)).not.toBeInTheDocument();
+  });
+
+  it("shows preserved carry-forward copy when the completed close has carry-forward", () => {
+    renderContent({
+      ...closedSnapshot,
+      completedClose: {
+        actorType: "automation",
+        automationDecisionReason:
+          "EOD Review has only low-risk review evidence within policy thresholds.",
+        carryForwardCount: 1,
+        completedAt: Date.UTC(2026, 4, 8, 22),
+      },
+    } as DailyOperationsSnapshot);
+
+    expect(
+      screen.getByText(
+        "Policy checked low-risk review evidence and preserved carry-forward work for Opening.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("shows safe Athena completion attribution when details are redacted", () => {
@@ -1213,7 +1237,7 @@ describe("DailyOperationsViewContent", () => {
       screen.getByText("Restricted close evidence is hidden for this account."),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText("Policy checked low-risk review evidence before completion."),
+      screen.queryByText("Policy checked low-risk review evidence and preserved carry-forward work for Opening."),
     ).not.toBeInTheDocument();
   });
 

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -171,6 +171,7 @@ type DailyOperationsScheduledRunSummary = {
 type DailyOperationsCompletedCloseAttribution = {
   actorType?: "human" | "automation";
   automationDecisionReason?: string | null;
+  carryForwardCount?: number | null;
   completedAt?: number | null;
   policyReviewedItemKeys?: string[] | null;
   restrictedDetailsRedacted?: boolean | null;
@@ -1180,6 +1181,7 @@ function AutomationStatusPanel({
 
 function getDailyOperationsCompletionAttributionDetail(
   completedClose?: DailyOperationsCompletedCloseAttribution | null,
+  carryForwardCount = completedClose?.carryForwardCount ?? 0,
 ) {
   if (completedClose?.actorType !== "automation") {
     return null;
@@ -1189,21 +1191,28 @@ function getDailyOperationsCompletionAttributionDetail(
     return "Restricted close evidence is hidden for this account.";
   }
 
+  const hasCarryForward = carryForwardCount > 0;
   if (
     completedClose.policyReviewedItemKeys?.length ||
     completedClose.automationDecisionReason
       ?.toLowerCase()
       .includes("low-risk review")
   ) {
-    return "Policy checked low-risk review evidence before completion.";
+    return hasCarryForward
+      ? "Policy checked low-risk review evidence and preserved carry-forward work for Opening."
+      : "Policy checked low-risk review evidence before completion.";
   }
 
-  return "Policy checked the close before completion.";
+  return hasCarryForward
+    ? "Policy checked the close and preserved carry-forward work for Opening."
+    : "Policy checked the close before completion.";
 }
 
 function DailyOperationsCompletionAttributionNotice({
+  carryForwardCount,
   completedClose,
 }: {
+  carryForwardCount?: number | null;
   completedClose?: DailyOperationsCompletedCloseAttribution | null;
 }) {
   if (completedClose?.actorType !== "automation") {
@@ -1216,7 +1225,10 @@ function DailyOperationsCompletionAttributionNotice({
         Athena completed EOD Review under store policy.
       </p>
       <p className="mt-1 text-muted-foreground">
-        {getDailyOperationsCompletionAttributionDetail(completedClose)}
+        {getDailyOperationsCompletionAttributionDetail(
+          completedClose,
+          carryForwardCount ?? completedClose.carryForwardCount ?? 0,
+        )}
       </p>
     </div>
   );
@@ -2266,6 +2278,7 @@ export function DailyOperationsViewContent({
                     snapshot={snapshot}
                   />
                   <DailyOperationsCompletionAttributionNotice
+                    carryForwardCount={snapshot.completedClose?.carryForwardCount}
                     completedClose={snapshot.completedClose}
                   />
                 </PageWorkspaceMain>

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
@@ -515,7 +515,7 @@ describe("registerAndProvisionPosTerminal", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Dry run EOD completion")).toBeChecked();
-    expect(screen.getByLabelText("Enable clean-day completion")).toBeChecked();
+    expect(screen.getByLabelText("Enable blocker-free completion")).toBeChecked();
     expect(screen.getByRole("combobox", { name: "EOD completion hour" }))
       .toHaveTextContent("06");
     expect(screen.getByRole("combobox", { name: "EOD completion minute" }))
@@ -540,7 +540,7 @@ describe("registerAndProvisionPosTerminal", () => {
       expect(screen.getByLabelText("Dry run EOD completion")).toBeChecked(),
     );
     fireEvent.click(screen.getByLabelText("Enable EOD completion"));
-    fireEvent.click(screen.getByLabelText("Enable clean-day completion"));
+    fireEvent.click(screen.getByLabelText("Enable blocker-free completion"));
     fireEvent.change(screen.getByLabelText("Cash variance threshold"), {
       target: { value: "750" },
     });
@@ -551,7 +551,7 @@ describe("registerAndProvisionPosTerminal", () => {
       target: { value: "9000" },
     });
     expect(screen.getByLabelText("Enable EOD completion")).toBeChecked();
-    expect(screen.getByLabelText("Enable clean-day completion")).not.toBeChecked();
+    expect(screen.getByLabelText("Enable blocker-free completion")).not.toBeChecked();
     expect(screen.getByLabelText("Cash variance threshold")).toHaveValue(750);
     expect(screen.getByLabelText("Voided sale count threshold")).toHaveValue(2);
     expect(screen.getByLabelText("Voided sale total threshold")).toHaveValue(9000);

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
@@ -716,7 +716,7 @@ function EodCompletionAutomationAdminPanel({
         <div className="grid gap-layout-md lg:grid-cols-[minmax(0,1fr)_14rem]">
           <label className="flex min-h-[5rem] items-start gap-layout-sm rounded-md border border-border bg-background p-layout-sm text-sm">
             <Checkbox
-              aria-label="Enable clean-day completion"
+              aria-label="Enable blocker-free completion"
               checked={cleanDayAutoCompleteEnabled}
               className="mt-1"
               onCheckedChange={(checked) =>
@@ -725,11 +725,11 @@ function EodCompletionAutomationAdminPanel({
             />
             <span>
               <span className="block font-medium text-foreground">
-                Enable clean-day completion
+                Enable blocker-free completion
               </span>
               <span className="mt-1 block leading-5 text-muted-foreground">
-                Athena can complete days with no blockers, carry-forward items,
-                or review evidence when automation is enabled.
+                Athena can complete blocker-free days and preserve
+                carry-forward work for Opening when automation is enabled.
               </span>
             </span>
           </label>


### PR DESCRIPTION
## Summary
- Allow EOD automation to auto-complete blocker-free operating days while preserving non-zero review and carry-forward items for Opening.
- Add redacted broad read models for preserved carry-forward evidence and safe carry-forward counts in Daily Operations UI projections.
- Update operator copy, automation documentation, graphify artifacts, and include the approved delivery plan artifacts.

## Plan Artifacts
- `docs/plans/2026-06-26-001-feat-eod-carry-forward-auto-complete-plan.md`
- `docs/plans/2026-06-26-001-feat-eod-carry-forward-auto-complete-plan.html`

## Validation
- `bun run pr:athena`
- Focused Convex tests for daily close/opening/operations/automation paths
- Focused UI tests for Daily Close, Daily Operations, close history, and POS settings
- Reviewer loop: correctness, data integrity, security, testing, frontend, and architecture all approved
