### PR TITLE
Repair register sync reconciliation

### DIFF
--- a/docs/solutions/logic-errors/athena-pos-register-sync-repair-and-runtime-reconciliation-2026-06-26.md
+++ b/docs/solutions/logic-errors/athena-pos-register-sync-repair-and-runtime-reconciliation-2026-06-26.md
@@ -1,0 +1,76 @@
+---
+title: Athena POS Register Sync Repair and Runtime Reconciliation
+date: 2026-06-26
+category: logic-errors
+module: athena-webapp
+problem_type: logic_error
+component: pos-register-sync
+symptoms:
+  - "Synced register review could only reject completed sales even when the business record should be retained"
+  - "Cash Controls could show review items without a visible completed-sale mapping"
+  - "The POS register could keep showing the open-drawer gate while the cloud terminal had an active register session"
+root_cause: review_state_without_repairable_mapping_or_runtime_reconciliation
+resolution_type: code_fix
+severity: high
+tags:
+  - pos
+  - cash-controls
+  - register-session
+  - local-sync
+  - terminal-runtime
+---
+
+# Athena POS Register Sync Repair and Runtime Reconciliation
+
+## Problem
+
+Register sync conflicts are business-record problems, not just queue problems.
+When a synced sale belongs to a completed POS transaction but is missing the
+register-session mapping, rejecting the event loses the operational intent. The
+manager needs a repair path that links the completed sale to the drawer and lets
+the register totals settle.
+
+The same boundary appears in the terminal runtime. A browser can have stale
+local register history while the cloud terminal session is already active. If
+the register view only trusts the stale local read model, the cashier sees the
+open-drawer gate even though Cash Controls and the cloud terminal agree that the
+drawer is active.
+
+## Solution
+
+Keep the repair bounded and evidence-driven:
+
+- Register review actions should repair completed-sale mappings when the cloud
+  sale exists and matches the reviewed local event. Reject remains available for
+  genuinely invalid synced activity, but it is not the only manager path.
+- Applying reviewed activity should hold closeout settlement behind a generic
+  closeout-hold mechanism so future review types can block settlement without
+  duplicating closeout-specific control flow.
+- The POS heartbeat can return an active-register directive when local runtime
+  status reports no usable drawer but the cloud terminal has a sale-usable
+  register session.
+- Runtime directive repair should append through the local command gateway, not
+  mutate the event store directly. It must keep drawer-authority and terminal
+  integrity checks, and it must not overwrite a different local drawer that is
+  already operable.
+- Debug state should show the heartbeat drawer, local read model, and repair
+  seed result so support can see whether the mismatch is cloud state, local
+  projection, or gateway rejection.
+
+## Prevention
+
+- Test the manager repair command at the Convex boundary and the Cash Controls
+  UI boundary: visible review rows, per-item repair, batch apply, and linked
+  transaction totals.
+- Test local runtime reconciliation at three layers: the command gateway
+  allowing only directive-scoped repair over stale history, the heartbeat hook
+  recording repair diagnostics, and the register view model passing runtime
+  state into the debug panel.
+- Add a stale-directive regression whenever runtime reconciliation changes: a
+  cloud directive must not seed over a different local drawer that can already
+  sell.
+- Keep the cashier hot path local-first. Cloud reads for reconciliation belong
+  in the POS heartbeat/runtime channel, not inside sale-entry interactions.
+- Treat future terminal-local state repair as event-model work. Do not patch
+  IndexedDB records manually or hide stale local history by bypassing the read
+  model.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8040 nodes · 9462 edges · 2056 communities detected
+- 8055 nodes · 9481 edges · 2056 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2074,8 +2074,8 @@
 4. `projectLocalRegisterReadModel()` - 26 edges
 5. `buildDailyOpeningSnapshotWithCtx()` - 18 edges
 6. `buildDailyOperationsSnapshotWithCtx()` - 17 edges
-7. `getStoreConfigV2()` - 17 edges
-8. `submitTerminalRuntimeStatus()` - 16 edges
+7. `submitTerminalRuntimeStatus()` - 17 edges
+8. `getStoreConfigV2()` - 17 edges
 9. `createConflict()` - 16 edges
 10. `DataTableViewOptions()` - 16 edges
 
@@ -2134,20 +2134,20 @@ Cohesion: 0.06
 Nodes (26): asRecord(), createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), getExpenseLocalSessionId(), getUploadSequenceScopeId(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeLocalEventPayload() (+18 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.09
-Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
-
-### Community 11 - "Community 11"
 Cohesion: 0.06
 Nodes (21): assertPosLocalStoreOk(), buildRuntimeAppUpdateInput(), clearAcceptedTerminalIntegrityState(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus() (+13 more)
 
+### Community 11 - "Community 11"
+Cohesion: 0.09
+Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
+
 ### Community 12 - "Community 12"
-Cohesion: 0.06
-Nodes (22): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+14 more)
+Cohesion: 0.09
+Nodes (35): annotateTerminalSyncEvidenceReviewTargets(), buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalRecoveryActions(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryManualReview(), buildTerminalRecoveryPreview() (+27 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.09
-Nodes (34): annotateTerminalSyncEvidenceReviewTargets(), buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalRecoveryActions(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryManualReview(), buildTerminalRecoveryPreview() (+26 more)
+Cohesion: 0.06
+Nodes (22): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+14 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.07
@@ -2234,160 +2234,160 @@ Cohesion: 0.13
 Nodes (23): automationErrorMessage(), automationIdempotencyKey(), eodAutoCompleteDecision(), eodAutoCompleteLocalTiming(), eodAutoCompletePolicyCronWindow(), eodDecision(), getLatestDailyOperationsAutomationStatusWithCtx(), getOpeningAutoStartPolicyForApi() (+15 more)
 
 ### Community 35 - "Community 35"
+Cohesion: 0.19
+Nodes (23): assertRegisterNumberIsAvailable(), buildRuntimeActiveRegisterSessionDirective(), buildRuntimeDrawerAuthorityDirective(), cleanActiveRegisterSession(), cleanAppSessionRecovery(), cleanAppShell(), cleanAppUpdate(), cleanBrowserInfo() (+15 more)
+
+### Community 36 - "Community 36"
 Cohesion: 0.09
 Nodes (6): getConversionRequestId(), handleClick(), handleFinalize(), isSkuReserved(), normalizeCommandMessage(), shouldDisable()
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.1
 Nodes (15): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+7 more)
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.12
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.15
 Nodes (21): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+13 more)
 
-### Community 39 - "Community 39"
+### Community 40 - "Community 40"
 Cohesion: 0.16
 Nodes (19): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), pendingCheckoutItemMatchesLine(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding() (+11 more)
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.09
 Nodes (5): listCompletedTransactionsForDay(), listCompletedTransactionsForRange(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 41 - "Community 41"
+### Community 42 - "Community 42"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 42 - "Community 42"
+### Community 43 - "Community 43"
 Cohesion: 0.19
 Nodes (23): assertCompoundSolutionCheck(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSourceLineChanges(), countFileLines(), extractFrontmatter() (+15 more)
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.21
 Nodes (23): buildCartChange(), buildLegacyContextPayload(), buildLegacyProductId(), compactPayload(), compileLegacyStorefrontAnalyticsRow(), compileLegacyStorefrontAnalyticsRows(), compileLegacyStorefrontAnalyticsRowsWithReport(), containsSensitiveText() (+15 more)
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.19
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
 Cohesion: 0.18
 Nodes (23): buildEventMessage(), buildNextEvidence(), buildNextSaleEvidence(), buildReviewPriority(), buildWorkItemPriority(), createOrReusePendingCheckoutItem(), createProvisionalCatalogAnchors(), findMatchingPendingCheckoutItem() (+15 more)
 
-### Community 47 - "Community 47"
-Cohesion: 0.22
-Nodes (21): assertRegisterNumberIsAvailable(), buildRuntimeDrawerAuthorityDirective(), cleanActiveRegisterSession(), cleanAppSessionRecovery(), cleanAppShell(), cleanAppUpdate(), cleanBrowserInfo(), cleanDiagnosticMessage() (+13 more)
-
 ### Community 48 - "Community 48"
+Cohesion: 0.09
+Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
+
+### Community 49 - "Community 49"
 Cohesion: 0.12
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
 
-### Community 49 - "Community 49"
+### Community 50 - "Community 50"
 Cohesion: 0.17
 Nodes (21): buildHomepageSnapshotV1(), hydrateCategory(), hydrateFeaturedItem(), hydrateProduct(), hydrateSubcategory(), hydrateTargetProducts(), isCustomerVisibleProduct(), isCustomerVisibleSku() (+13 more)
 
-### Community 50 - "Community 50"
+### Community 51 - "Community 51"
 Cohesion: 0.17
 Nodes (19): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady(), mapSyncStatus() (+11 more)
 
-### Community 51 - "Community 51"
+### Community 52 - "Community 52"
 Cohesion: 0.16
 Nodes (17): asRecord(), buildSnapshotHash(), buildStoreInsightsPromptFromContextBundle(), buildStoreInsightsPromptFromContextEvents(), buildUserInsightsPromptFromContextBundle(), buildUserInsightsPromptFromContextEvents(), compactContextEventsForPrompt(), compactEnvironmentForPrompt() (+9 more)
 
-### Community 52 - "Community 52"
+### Community 53 - "Community 53"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 53 - "Community 53"
+### Community 54 - "Community 54"
 Cohesion: 0.15
 Nodes (16): findLatestOpenOperatingDay(), getTodaySummary(), getTransactionById(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile() (+8 more)
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
+Cohesion: 0.12
+Nodes (12): getLatestRuntimeStatusForTerminal(), getTerminalByFingerprint(), getTerminalSyncEvidence(), isActionableRejectedSyncEvent(), isActionableTerminalReviewSyncEvent(), mapTerminalRecord(), mergeRuntimeStatusPatch(), omitUndefined() (+4 more)
+
+### Community 56 - "Community 56"
 Cohesion: 0.21
 Nodes (21): detectFormat(), extractJsonRows(), flattenJsonRows(), inferProductName(), isRecord(), looksLikeLabel(), normalizeKey(), normalizeLegacyRow() (+13 more)
 
-### Community 55 - "Community 55"
+### Community 57 - "Community 57"
 Cohesion: 0.25
 Nodes (21): asRecord(), errorFor(), getLocalExpenseSessionId(), getOrCreateSession(), isExpenseEvent(), itemSource(), itemSourceKey(), numberField() (+13 more)
 
-### Community 56 - "Community 56"
+### Community 58 - "Community 58"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 57 - "Community 57"
+### Community 59 - "Community 59"
 Cohesion: 0.18
 Nodes (18): assertValidEodLocalCompletionWindowMinutes(), assertValidEodThreshold(), assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getEodAutoCompletePolicyConfigWithCtx() (+10 more)
 
-### Community 58 - "Community 58"
+### Community 60 - "Community 60"
 Cohesion: 0.11
 Nodes (6): asBoolean(), asNumber(), asRecord(), buildRegisterCloseoutVarianceTimelineMessage(), formatCloseoutVarianceAmount(), getCashControlsConfig()
 
-### Community 59 - "Community 59"
+### Community 61 - "Community 61"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
-### Community 60 - "Community 60"
-Cohesion: 0.13
-Nodes (12): getLatestRuntimeStatusForTerminal(), getTerminalByFingerprint(), getTerminalSyncEvidence(), isActionableRejectedSyncEvent(), isActionableTerminalReviewSyncEvent(), mapTerminalRecord(), mergeRuntimeStatusPatch(), omitUndefined() (+4 more)
-
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.21
 Nodes (18): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), formatRecoveryCode(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode() (+10 more)
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.1
 Nodes (4): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onStartRemoteAssist()
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.13
 Nodes (9): asCloudOperableSession(), countPendingSyncableLocalEventsForStaff(), hasSyncedSaleLocalEventsForStaff(), hasUploadedLocalEventsForStaff(), isCloudOperableSession(), isEmptyLocalSaleShell(), selectPassiveCloseoutBlockedRegisterSession(), trimOptional() (+1 more)
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.27
 Nodes (18): assertConformsToExportedReturns(), collectReturnValidatorIssues(), decodeSerializedFloat64(), decodeSerializedInt64(), decodeSerializedLiteralValue(), describeValue(), formatReturnValidatorIssues(), isConvexValue() (+10 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.2
 Nodes (17): acknowledgeTerminalRecoveryCommand(), buildExecutionId(), claimTerminalRecoveryCommand(), containsSecretLikeField(), getRuntimeAppUpdateEvidence(), isActiveCommand(), isEquivalentCommand(), issueTerminalRecoveryCommand() (+9 more)
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.22
 Nodes (18): assertPrAthenaProofReady(), classifySnapshotError(), collectFilesUnder(), collectProofSnapshot(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof() (+10 more)
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.17
 Nodes (13): buildProviderRegistry(), createIntelligenceRun(), defaultFakeOutput(), failedGenerationResult(), getStoreInsightsSnapshotFallback(), isActivityTrend(), isDeviceDistribution(), isInsightGenerationInProgressError() (+5 more)
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.16
 Nodes (10): buildProductSkuSearchProjection(), buildSearchText(), hydrateCanonicalProjection(), normalizeAttributes(), normalizeLookup(), projectionsEqual(), requireProductSkuSearchAccess(), requireProductSkuSearchAdmin() (+2 more)
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.25
 Nodes (17): getRegisterCatalogPrice(), isActiveProvisionalImportSkuForStore(), isDraftAllowedInTrustedRegisterCatalog(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailability(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogAvailabilitySkus() (+9 more)
-
-### Community 73 - "Community 73"
-Cohesion: 0.12
-Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
 
 ### Community 74 - "Community 74"
 Cohesion: 0.11
@@ -2414,40 +2414,40 @@ Cohesion: 0.22
 Nodes (14): assertActorMatchesStore(), buildCompiledContextBundle(), buildStoreInsightsContextBundleFromContextEvents(), buildUserInsightsContextBundleFromContextEvents(), compileContextEvent(), compileContextEventsWithReport(), getDataWindow(), getStoreFrontActorById() (+6 more)
 
 ### Community 80 - "Community 80"
+Cohesion: 0.24
+Nodes (13): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), classifyRegisterSessionSyncReview(), findProjectedRegisterSessionIdForRepairableMissingMapping(), findTransactionIdForSyncEvent(), hasInventoryReviewWorkItemForProjectedSale(), isNonSaleMissingRegisterSessionMappingConflict() (+5 more)
+
+### Community 81 - "Community 81"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.13
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.15
 Nodes (5): buildMissingDraftResult(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.14
 Nodes (5): getBlockedPosTerminalShellCopy(), getPosHubRouteParams(), getRouteParamsForPattern(), getStoreWorkspaceRouteParams(), PosTerminalBlockedShell()
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.23
 Nodes (13): buildAbusePartitionKey(), buildServerContextTrackingEnvelope(), deriveBrowserFamily(), deriveContextEnvironment(), deriveOsFamily(), derivePrimarySubject(), isAcceptedSyntheticContext(), isRecord() (+5 more)
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.19
 Nodes (10): buildLatestRunDebugPayload(), getBoundedDebugRunsByCapability(), getLatestDebugRunByCapability(), getLatestDebugRunBySubject(), isActiveRunStale(), isActiveRunStatus(), selectLatestDebugRunFromCandidates(), shouldRecoverActiveRun() (+2 more)
-
-### Community 88 - "Community 88"
-Cohesion: 0.25
-Nodes (12): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), classifyRegisterSessionSyncReview(), findProjectedRegisterSessionIdForRepairableMissingMapping(), findTransactionIdForSyncEvent(), hasInventoryReviewWorkItemForProjectedSale(), listOpenLocalSyncConflictsByRegisterSession() (+4 more)
 
 ### Community 89 - "Community 89"
 Cohesion: 0.27
@@ -2610,712 +2610,712 @@ Cohesion: 0.2
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
 ### Community 129 - "Community 129"
+Cohesion: 0.26
+Nodes (9): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), canProjectRegisterOpenForTerminalCloudRepair(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), getRepairOpenRegisterCloseoutReviewState(), isDuplicateRegisterOpenConflict(), normalizeRepairString() (+1 more)
+
+### Community 130 - "Community 130"
 Cohesion: 0.2
 Nodes (4): formatProductLineMeta(), formatServiceLabel(), formatServiceLineMeta(), formatStoredAmount()
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.21
 Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.24
 Nodes (6): blocked(), evaluateLocalPosReadiness(), hasSettledLocalCloseout(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.18
 Nodes (2): expenseItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.29
 Nodes (8): isFiniteNumber(), isPointInsideViewport(), isPositiveFiniteNumber(), isRecord(), isValidViewport(), validateKeyEvent(), validatePointerEvent(), validateRemoteAssistControlEvent()
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.2
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.25
 Nodes (7): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus()
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.33
 Nodes (7): createAthenaProviderError(), createProviderFailureResult(), getProviderFailureDiagnostic(), invokeStructuredTextProvider(), isJsonObject(), isJsonValue(), sanitizeDiagnostic()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.27
 Nodes (5): clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), runProcess(), writePrAthenaProviderEvidence()
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.39
 Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.25
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.39
 Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.33
 Nodes (6): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), saveProduct(), updateVariantSku()
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.28
 Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.28
 Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.25
 Nodes (2): isValidMessageBlocker(), isValidPriority()
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.22
 Nodes (0):
-
-### Community 186 - "Community 186"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 187 - "Community 187"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 188 - "Community 188"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 189 - "Community 189"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.5
 Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 200 - "Community 200"
-Cohesion: 0.36
-Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
 
 ### Community 201 - "Community 201"
 Cohesion: 0.36
-Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
 
 ### Community 202 - "Community 202"
+Cohesion: 0.36
+Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+
+### Community 203 - "Community 203"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.29
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 205 - "Community 205"
+### Community 206 - "Community 206"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.29
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
-### Community 209 - "Community 209"
+### Community 210 - "Community 210"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 210 - "Community 210"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 211 - "Community 211"
 Cohesion: 0.39
-Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 212 - "Community 212"
+Cohesion: 0.39
+Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+
+### Community 213 - "Community 213"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 213 - "Community 213"
+### Community 214 - "Community 214"
 Cohesion: 0.29
 Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
 
-### Community 214 - "Community 214"
+### Community 215 - "Community 215"
 Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
-### Community 215 - "Community 215"
+### Community 216 - "Community 216"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 216 - "Community 216"
+### Community 217 - "Community 217"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.38
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 227 - "Community 227"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 228 - "Community 228"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 229 - "Community 229"
-Cohesion: 0.48
-Nodes (6): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), isDuplicateRegisterOpenConflict(), skipped()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 230 - "Community 230"
 Cohesion: 0.48
-Nodes (5): canRepairProjectRegisterOpen(), getRepairOpenRegisterCloseoutReviewState(), normalizeRepairString(), resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
-
-### Community 231 - "Community 231"
-Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 232 - "Community 232"
+### Community 231 - "Community 231"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 233 - "Community 233"
+### Community 232 - "Community 232"
 Cohesion: 0.33
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 234 - "Community 234"
+### Community 233 - "Community 233"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 235 - "Community 235"
+### Community 234 - "Community 234"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 236 - "Community 236"
+### Community 235 - "Community 235"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 237 - "Community 237"
+### Community 236 - "Community 236"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 238 - "Community 238"
+### Community 237 - "Community 237"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 239 - "Community 239"
+### Community 238 - "Community 238"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 240 - "Community 240"
+### Community 239 - "Community 239"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 241 - "Community 241"
+### Community 240 - "Community 240"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 242 - "Community 242"
+### Community 241 - "Community 241"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 243 - "Community 243"
+### Community 242 - "Community 242"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 244 - "Community 244"
+### Community 243 - "Community 243"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
+
+### Community 244 - "Community 244"
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 245 - "Community 245"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 246 - "Community 246"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 247 - "Community 247"
 Cohesion: 0.33
 Nodes (2): handlePinChange(), normalizeOtpCode()
 
-### Community 248 - "Community 248"
+### Community 247 - "Community 247"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 249 - "Community 249"
+### Community 248 - "Community 248"
 Cohesion: 0.33
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+
+### Community 249 - "Community 249"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
 
 ### Community 250 - "Community 250"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
 ### Community 251 - "Community 251"
-Cohesion: 0.29
-Nodes (1): ResizeObserverStub
-
-### Community 252 - "Community 252"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 253 - "Community 253"
+### Community 252 - "Community 252"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 254 - "Community 254"
+### Community 253 - "Community 253"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 255 - "Community 255"
+### Community 254 - "Community 254"
 Cohesion: 0.52
 Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
-### Community 256 - "Community 256"
+### Community 255 - "Community 255"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 257 - "Community 257"
+### Community 256 - "Community 256"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 258 - "Community 258"
+### Community 257 - "Community 257"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 259 - "Community 259"
+### Community 258 - "Community 258"
 Cohesion: 0.38
 Nodes (3): getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusSignature()
 
-### Community 260 - "Community 260"
+### Community 259 - "Community 259"
 Cohesion: 0.33
 Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
+
+### Community 260 - "Community 260"
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 261 - "Community 261"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 262 - "Community 262"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 263 - "Community 263"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 264 - "Community 264"
+### Community 263 - "Community 263"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 265 - "Community 265"
+### Community 264 - "Community 264"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 266 - "Community 266"
+### Community 265 - "Community 265"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 267 - "Community 267"
+### Community 266 - "Community 266"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 268 - "Community 268"
+### Community 267 - "Community 267"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 269 - "Community 269"
+### Community 268 - "Community 268"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 270 - "Community 270"
+### Community 269 - "Community 269"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 271 - "Community 271"
+### Community 270 - "Community 270"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 272 - "Community 272"
+### Community 271 - "Community 271"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
 
-### Community 273 - "Community 273"
+### Community 272 - "Community 272"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 274 - "Community 274"
+### Community 273 - "Community 273"
 Cohesion: 0.47
 Nodes (3): canListRegisterSessionSyncConflicts(), listPendingCompletedSaleVoidApprovals(), listRegisterSessionCloseoutHolds()
 
-### Community 275 - "Community 275"
+### Community 274 - "Community 274"
 Cohesion: 0.4
 Nodes (2): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository()
 
-### Community 276 - "Community 276"
+### Community 275 - "Community 275"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 277 - "Community 277"
+### Community 276 - "Community 276"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 278 - "Community 278"
+### Community 277 - "Community 277"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 279 - "Community 279"
+### Community 278 - "Community 278"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 280 - "Community 280"
+### Community 279 - "Community 279"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 281 - "Community 281"
+### Community 280 - "Community 280"
 Cohesion: 0.6
 Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
-### Community 282 - "Community 282"
+### Community 281 - "Community 281"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 283 - "Community 283"
+### Community 282 - "Community 282"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 284 - "Community 284"
+### Community 283 - "Community 283"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 285 - "Community 285"
+### Community 284 - "Community 284"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 286 - "Community 286"
+### Community 285 - "Community 285"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 287 - "Community 287"
+### Community 286 - "Community 286"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 288 - "Community 288"
+### Community 287 - "Community 287"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 289 - "Community 289"
+### Community 288 - "Community 288"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 290 - "Community 290"
+### Community 289 - "Community 289"
 Cohesion: 0.4
 Nodes (2): moveBestSeller(), saveOrder()
 
-### Community 291 - "Community 291"
+### Community 290 - "Community 290"
 Cohesion: 0.4
 Nodes (2): moveFeaturedItem(), saveOrder()
 
-### Community 292 - "Community 292"
+### Community 291 - "Community 291"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 293 - "Community 293"
+### Community 292 - "Community 292"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 294 - "Community 294"
+### Community 293 - "Community 293"
 Cohesion: 0.4
 Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
-### Community 295 - "Community 295"
+### Community 294 - "Community 294"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 296 - "Community 296"
+### Community 295 - "Community 295"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 297 - "Community 297"
+### Community 296 - "Community 296"
 Cohesion: 0.4
 Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
-### Community 298 - "Community 298"
+### Community 297 - "Community 297"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
+
+### Community 298 - "Community 298"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 299 - "Community 299"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 300 - "Community 300"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 301 - "Community 301"
 Cohesion: 0.47
 Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
 
-### Community 302 - "Community 302"
+### Community 301 - "Community 301"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 303 - "Community 303"
+### Community 302 - "Community 302"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 304 - "Community 304"
+### Community 303 - "Community 303"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
+### Community 304 - "Community 304"
+Cohesion: 0.33
+Nodes (0):
+
 ### Community 305 - "Community 305"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 306 - "Community 306"
 Cohesion: 0.33
@@ -3326,204 +3326,204 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 308 - "Community 308"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 309 - "Community 309"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 310 - "Community 310"
-Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 311 - "Community 311"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 312 - "Community 312"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 313 - "Community 313"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 314 - "Community 314"
+### Community 312 - "Community 312"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 315 - "Community 315"
+### Community 313 - "Community 313"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 316 - "Community 316"
+### Community 314 - "Community 314"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 315 - "Community 315"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 316 - "Community 316"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 317 - "Community 317"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 318 - "Community 318"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 319 - "Community 319"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 320 - "Community 320"
+### Community 318 - "Community 318"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 321 - "Community 321"
+### Community 319 - "Community 319"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 322 - "Community 322"
+### Community 320 - "Community 320"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 321 - "Community 321"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 322 - "Community 322"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 323 - "Community 323"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 324 - "Community 324"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 325 - "Community 325"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 326 - "Community 326"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 327 - "Community 327"
+### Community 326 - "Community 326"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 328 - "Community 328"
+### Community 327 - "Community 327"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 329 - "Community 329"
+### Community 328 - "Community 328"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 330 - "Community 330"
+### Community 329 - "Community 329"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 331 - "Community 331"
+### Community 330 - "Community 330"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 332 - "Community 332"
+### Community 331 - "Community 331"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 333 - "Community 333"
+### Community 332 - "Community 332"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
-### Community 334 - "Community 334"
+### Community 333 - "Community 333"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 335 - "Community 335"
+### Community 334 - "Community 334"
 Cohesion: 0.6
 Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
-### Community 336 - "Community 336"
+### Community 335 - "Community 335"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 337 - "Community 337"
+### Community 336 - "Community 336"
 Cohesion: 0.5
 Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
-### Community 338 - "Community 338"
+### Community 337 - "Community 337"
 Cohesion: 0.5
 Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
-### Community 339 - "Community 339"
+### Community 338 - "Community 338"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 340 - "Community 340"
+### Community 339 - "Community 339"
 Cohesion: 0.5
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 341 - "Community 341"
+### Community 340 - "Community 340"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 342 - "Community 342"
+### Community 341 - "Community 341"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 343 - "Community 343"
+### Community 342 - "Community 342"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 344 - "Community 344"
+### Community 343 - "Community 343"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
+
+### Community 344 - "Community 344"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 345 - "Community 345"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 346 - "Community 346"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 347 - "Community 347"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+
+### Community 347 - "Community 347"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 348 - "Community 348"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 349 - "Community 349"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 350 - "Community 350"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 351 - "Community 351"
+### Community 350 - "Community 350"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 352 - "Community 352"
+### Community 351 - "Community 351"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 353 - "Community 353"
+### Community 352 - "Community 352"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 354 - "Community 354"
+### Community 353 - "Community 353"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 355 - "Community 355"
+### Community 354 - "Community 354"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 356 - "Community 356"
+### Community 355 - "Community 355"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 357 - "Community 357"
+### Community 356 - "Community 356"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
+
+### Community 357 - "Community 357"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 358 - "Community 358"
 Cohesion: 0.4
@@ -3534,12 +3534,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 360 - "Community 360"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 361 - "Community 361"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 361 - "Community 361"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 362 - "Community 362"
 Cohesion: 0.4
@@ -3554,20 +3554,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 365 - "Community 365"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 366 - "Community 366"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 367 - "Community 367"
+### Community 366 - "Community 366"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 368 - "Community 368"
+### Community 367 - "Community 367"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+
+### Community 368 - "Community 368"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 369 - "Community 369"
 Cohesion: 0.4
@@ -3586,84 +3586,84 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 373 - "Community 373"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 374 - "Community 374"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 375 - "Community 375"
+### Community 374 - "Community 374"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 376 - "Community 376"
+### Community 375 - "Community 375"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 377 - "Community 377"
+### Community 376 - "Community 376"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 378 - "Community 378"
+### Community 377 - "Community 377"
 Cohesion: 0.5
 Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
-### Community 379 - "Community 379"
+### Community 378 - "Community 378"
 Cohesion: 0.5
 Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
-### Community 380 - "Community 380"
+### Community 379 - "Community 379"
 Cohesion: 0.5
 Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
 
-### Community 381 - "Community 381"
+### Community 380 - "Community 380"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 382 - "Community 382"
+### Community 381 - "Community 381"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 383 - "Community 383"
+### Community 382 - "Community 382"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 384 - "Community 384"
+### Community 383 - "Community 383"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 385 - "Community 385"
+### Community 384 - "Community 384"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 386 - "Community 386"
+### Community 385 - "Community 385"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 387 - "Community 387"
+### Community 386 - "Community 386"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 388 - "Community 388"
+### Community 387 - "Community 387"
 Cohesion: 0.6
 Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
-### Community 389 - "Community 389"
+### Community 388 - "Community 388"
 Cohesion: 0.6
 Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
-### Community 390 - "Community 390"
+### Community 389 - "Community 389"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 391 - "Community 391"
+### Community 390 - "Community 390"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 392 - "Community 392"
+### Community 391 - "Community 391"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
+
+### Community 392 - "Community 392"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 393 - "Community 393"
 Cohesion: 0.4
@@ -3674,132 +3674,132 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 395 - "Community 395"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 396 - "Community 396"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 397 - "Community 397"
+### Community 396 - "Community 396"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 398 - "Community 398"
+### Community 397 - "Community 397"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 399 - "Community 399"
+### Community 398 - "Community 398"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 400 - "Community 400"
+### Community 399 - "Community 399"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 401 - "Community 401"
+### Community 400 - "Community 400"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
-### Community 402 - "Community 402"
+### Community 401 - "Community 401"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 403 - "Community 403"
+### Community 402 - "Community 402"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 404 - "Community 404"
+### Community 403 - "Community 403"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 405 - "Community 405"
+### Community 404 - "Community 404"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+
+### Community 405 - "Community 405"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 406 - "Community 406"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 407 - "Community 407"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 408 - "Community 408"
 Cohesion: 0.6
 Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
 
-### Community 409 - "Community 409"
+### Community 408 - "Community 408"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 410 - "Community 410"
+### Community 409 - "Community 409"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 411 - "Community 411"
+### Community 410 - "Community 410"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 412 - "Community 412"
+### Community 411 - "Community 411"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 413 - "Community 413"
+### Community 412 - "Community 412"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 414 - "Community 414"
+### Community 413 - "Community 413"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 415 - "Community 415"
+### Community 414 - "Community 414"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 416 - "Community 416"
+### Community 415 - "Community 415"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 417 - "Community 417"
+### Community 416 - "Community 416"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 418 - "Community 418"
+### Community 417 - "Community 417"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
+
+### Community 418 - "Community 418"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 419 - "Community 419"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 420 - "Community 420"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 421 - "Community 421"
 Cohesion: 0.67
 Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
+
+### Community 421 - "Community 421"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 422 - "Community 422"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 423 - "Community 423"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 424 - "Community 424"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 425 - "Community 425"
+### Community 424 - "Community 424"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 426 - "Community 426"
+### Community 425 - "Community 425"
 Cohesion: 0.67
 Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
+
+### Community 426 - "Community 426"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 427 - "Community 427"
 Cohesion: 0.5
@@ -3818,92 +3818,92 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 431 - "Community 431"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 432 - "Community 432"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 433 - "Community 433"
+### Community 432 - "Community 432"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 434 - "Community 434"
+### Community 433 - "Community 433"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 435 - "Community 435"
+### Community 434 - "Community 434"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 436 - "Community 436"
+### Community 435 - "Community 435"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 436 - "Community 436"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 437 - "Community 437"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 438 - "Community 438"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 439 - "Community 439"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 440 - "Community 440"
+### Community 439 - "Community 439"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 441 - "Community 441"
+### Community 440 - "Community 440"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 442 - "Community 442"
+### Community 441 - "Community 441"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 443 - "Community 443"
+### Community 442 - "Community 442"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 444 - "Community 444"
+### Community 443 - "Community 443"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 445 - "Community 445"
+### Community 444 - "Community 444"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 446 - "Community 446"
+### Community 445 - "Community 445"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+
+### Community 446 - "Community 446"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 447 - "Community 447"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 448 - "Community 448"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 449 - "Community 449"
 Cohesion: 0.67
 Nodes (2): buildCtx(), buildQueryCtx()
 
-### Community 450 - "Community 450"
+### Community 449 - "Community 449"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 451 - "Community 451"
+### Community 450 - "Community 450"
 Cohesion: 0.67
 Nodes (2): buildRepository(), buildSession()
 
-### Community 452 - "Community 452"
+### Community 451 - "Community 451"
 Cohesion: 0.67
 Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+
+### Community 452 - "Community 452"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 453 - "Community 453"
 Cohesion: 0.5
@@ -3918,36 +3918,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 456 - "Community 456"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 457 - "Community 457"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 458 - "Community 458"
+### Community 457 - "Community 457"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
+
+### Community 458 - "Community 458"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 459 - "Community 459"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 460 - "Community 460"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 461 - "Community 461"
 Cohesion: 0.83
 Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
-### Community 462 - "Community 462"
+### Community 461 - "Community 461"
 Cohesion: 0.83
 Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
-### Community 463 - "Community 463"
+### Community 462 - "Community 462"
 Cohesion: 0.83
 Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+
+### Community 463 - "Community 463"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 464 - "Community 464"
 Cohesion: 0.5
@@ -3958,32 +3958,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 466 - "Community 466"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 467 - "Community 467"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 468 - "Community 468"
+### Community 467 - "Community 467"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 469 - "Community 469"
+### Community 468 - "Community 468"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
-### Community 470 - "Community 470"
+### Community 469 - "Community 469"
 Cohesion: 0.67
 Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
-### Community 471 - "Community 471"
+### Community 470 - "Community 470"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
-### Community 472 - "Community 472"
+### Community 471 - "Community 471"
 Cohesion: 0.67
 Nodes (2): getPosRouteScope(), Login()
+
+### Community 472 - "Community 472"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 473 - "Community 473"
 Cohesion: 0.5
@@ -4014,12 +4014,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 480 - "Community 480"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 481 - "Community 481"
 Cohesion: 0.67
 Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+
+### Community 481 - "Community 481"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 482 - "Community 482"
 Cohesion: 0.5
@@ -4030,12 +4030,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 484 - "Community 484"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 485 - "Community 485"
 Cohesion: 1.0
 Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
+
+### Community 485 - "Community 485"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 486 - "Community 486"
 Cohesion: 0.5
@@ -4046,124 +4046,124 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 488 - "Community 488"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 489 - "Community 489"
 Cohesion: 0.67
 Nodes (2): applyCommandResult(), handleCreateCase()
+
+### Community 489 - "Community 489"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 490 - "Community 490"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 491 - "Community 491"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 492 - "Community 492"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 493 - "Community 493"
+### Community 492 - "Community 492"
 Cohesion: 0.67
 Nodes (2): useGetArchivedProducts(), useGetProducts()
 
-### Community 494 - "Community 494"
+### Community 493 - "Community 493"
 Cohesion: 0.67
 Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
-### Community 495 - "Community 495"
+### Community 494 - "Community 494"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 496 - "Community 496"
+### Community 495 - "Community 495"
 Cohesion: 0.67
 Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
-### Community 497 - "Community 497"
+### Community 496 - "Community 496"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 498 - "Community 498"
+### Community 497 - "Community 497"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 499 - "Community 499"
+### Community 498 - "Community 498"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 500 - "Community 500"
+### Community 499 - "Community 499"
 Cohesion: 0.67
 Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
-### Community 501 - "Community 501"
+### Community 500 - "Community 500"
 Cohesion: 0.67
 Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+
+### Community 501 - "Community 501"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 502 - "Community 502"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 503 - "Community 503"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 504 - "Community 504"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 505 - "Community 505"
+### Community 504 - "Community 504"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 506 - "Community 506"
+### Community 505 - "Community 505"
 Cohesion: 0.83
 Nodes (3): completedEvent(), event(), item()
 
-### Community 507 - "Community 507"
+### Community 506 - "Community 506"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 508 - "Community 508"
+### Community 507 - "Community 507"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 509 - "Community 509"
+### Community 508 - "Community 508"
 Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
-### Community 510 - "Community 510"
+### Community 509 - "Community 509"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+
+### Community 510 - "Community 510"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 511 - "Community 511"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 512 - "Community 512"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 513 - "Community 513"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 514 - "Community 514"
+### Community 513 - "Community 513"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 515 - "Community 515"
+### Community 514 - "Community 514"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 516 - "Community 516"
+### Community 515 - "Community 515"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 517 - "Community 517"
+### Community 516 - "Community 516"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+
+### Community 517 - "Community 517"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 518 - "Community 518"
 Cohesion: 0.5
@@ -4194,63 +4194,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 525 - "Community 525"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 526 - "Community 526"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 527 - "Community 527"
+### Community 526 - "Community 526"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 528 - "Community 528"
+### Community 527 - "Community 527"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 529 - "Community 529"
+### Community 528 - "Community 528"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 530 - "Community 530"
+### Community 529 - "Community 529"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 531 - "Community 531"
+### Community 530 - "Community 530"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 532 - "Community 532"
+### Community 531 - "Community 531"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 533 - "Community 533"
+### Community 532 - "Community 532"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 534 - "Community 534"
+### Community 533 - "Community 533"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 535 - "Community 535"
+### Community 534 - "Community 534"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 536 - "Community 536"
+### Community 535 - "Community 535"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 537 - "Community 537"
+### Community 536 - "Community 536"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
+
+### Community 537 - "Community 537"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 538 - "Community 538"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 539 - "Community 539"
-Cohesion: 0.5
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 540 - "Community 540"
@@ -4258,12 +4258,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 541 - "Community 541"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 542 - "Community 542"
 Cohesion: 1.0
 Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+
+### Community 542 - "Community 542"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 543 - "Community 543"
 Cohesion: 0.67
@@ -4322,16 +4322,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 557 - "Community 557"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 558 - "Community 558"
 Cohesion: 1.0
 Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
-### Community 559 - "Community 559"
+### Community 558 - "Community 558"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 559 - "Community 559"
+Cohesion: 1.0
+Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 560 - "Community 560"
 Cohesion: 1.0

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2128
-- Graph nodes: 8040
-- Graph edges: 9462
+- Graph nodes: 8055
+- Graph edges: 9481
 - Communities: 2056
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -17,9 +17,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - [validation-map.json](../../../packages/storefront-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `storefrontJourneyEvents.ts` (45 edges, Community 10) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `createJourneyEvent()` (40 edges, Community 10) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 56) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storefrontJourneyEvents.ts` (45 edges, Community 11) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 11) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `getStoreConfigV2()` (17 edges, Community 58) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `storefrontContextEvents.ts` (17 edges, Community 77) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
 - `checkoutSession.ts` (14 edges, Community 92) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (15 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 188) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 189) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/cashControls/deposits.test.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.test.ts
@@ -308,6 +308,8 @@ function createMissingMappingRepairSeed(
     transactionRegisterSessionId?: string;
     transactionStatus?: string;
     withCloseoutBeforeSale?: boolean;
+    withCloudTransaction?: boolean;
+    withTransactionMapping?: boolean;
   } = {},
 ) {
   const localTransactionId =
@@ -316,7 +318,7 @@ function createMissingMappingRepairSeed(
       : options.localTransactionId;
   const saleSequence = options.saleSequence ?? 3;
   const mappings: Record<string, unknown>[] = [
-    ...(localTransactionId
+    ...(localTransactionId && options.withTransactionMapping !== false
       ? [
           {
             _id: "transaction_mapping_1",
@@ -331,7 +333,7 @@ function createMissingMappingRepairSeed(
             createdAt: 2,
           },
         ]
-      : []),
+        : []),
   ];
   if (options.existingRegisterMappingCloudId) {
     mappings.push({
@@ -397,27 +399,81 @@ function createMissingMappingRepairSeed(
         staffProfileId: "staff_1",
         payload: {
           ...(localTransactionId ? { localTransactionId } : {}),
+          localPosSessionId: "local-pos-session-1",
+          localReceiptNumber: "local-receipt-1",
           receiptNumber: "R-1001",
+          registerNumber: "1",
           totals: {
+            subtotal: 15000,
+            tax: 0,
             total: 15000,
           },
+          items: [
+            {
+              localTransactionItemId: "local-item-1",
+              productId: "product_1",
+              productName: "Test product",
+              productSku: "SKU-1",
+              productSkuId: "product_sku_1",
+              quantity: 1,
+              unitPrice: 15000,
+            },
+          ],
+          payments: [
+            {
+              amount: 15000,
+              localPaymentId: "local-payment-1",
+              method: "cash",
+              timestamp: 2,
+            },
+          ],
         },
         status: "conflicted",
         submittedAt: 2,
       },
     ],
     posLocalSyncMapping: mappings,
-    posTransaction: [
+    posTransaction:
+      options.withCloudTransaction === false
+        ? []
+        : [
+            {
+              _id: "transaction_1",
+              completedAt: 2,
+              registerSessionId:
+                options.transactionRegisterSessionId ?? "session_open",
+              status: options.transactionStatus ?? "completed",
+              storeId: "store_1",
+              terminalId: "terminal_1",
+              total: 15000,
+              transactionNumber: "R-1001",
+            },
+          ],
+    posTerminal: [
       {
-        _id: "transaction_1",
-        completedAt: 2,
-        registerSessionId:
-          options.transactionRegisterSessionId ?? "session_open",
-        status: options.transactionStatus ?? "completed",
+        _id: "terminal_1",
+        registerNumber: "1",
+        registeredByUserId: "athena_user_1",
+        status: "active",
         storeId: "store_1",
-        terminalId: "terminal_1",
-        total: 15000,
-        transactionNumber: "R-1001",
+      },
+    ],
+    product: [
+      {
+        _id: "product_1",
+        storeId: "store_1",
+      },
+    ],
+    productSku: [
+      {
+        _id: "product_sku_1",
+        images: [],
+        inventoryCount: 10,
+        price: 15000,
+        productId: "product_1",
+        quantityAvailable: 10,
+        sku: "SKU-1",
+        storeId: "store_1",
       },
     ],
     registerSession: [
@@ -455,6 +511,14 @@ function createMissingMappingRepairSeed(
         organizationId: "org_1",
         role: "manager",
         staffProfileId: "manager_1",
+        status: "active",
+        storeId: "store_1",
+      },
+      {
+        _id: "role_2",
+        organizationId: "org_1",
+        role: "cashier",
+        staffProfileId: "staff_1",
         status: "active",
         storeId: "store_1",
       },
@@ -1041,6 +1105,74 @@ describe("cash control deposits", () => {
     );
   });
 
+  it("does not surface missing register-session mapping conflicts for non-sale sync events", async () => {
+    const ctx = createQueryCtx({
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_closeout_missing_mapping",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_closeout_1",
+          sequence: 4,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Register session mapping is missing for synced POS history.",
+          details: {
+            localRegisterSessionId: "local-register-1",
+          },
+          createdAt: 1,
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_closeout_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_closeout_1",
+          sequence: 4,
+          eventType: "register_closed",
+          occurredAt: 2,
+          payload: {
+            countedCash: 359000,
+          },
+          status: "conflicted",
+          submittedAt: 2,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "sync_mapping_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_open_1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "registerSession",
+          cloudId: "session_closing",
+          createdAt: 2,
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_closing",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          status: "closing",
+        },
+      ],
+    });
+
+    await expect(
+      listOpenLocalSyncConflictsByRegisterSession(
+        ctx as never,
+        "store_1" as Id<"store">,
+      ),
+    ).resolves.toEqual(new Map());
+  });
+
   it("hides duplicate closeout shadows while the variance closeout review is open", async () => {
     const ctx = createQueryCtx({
       posLocalSyncConflict: [
@@ -1370,6 +1502,99 @@ describe("cash control deposits", () => {
     );
   });
 
+  it("repairs missing register-session mappings with an inline manager approval proof", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      ...createMissingMappingRepairSeed(),
+      approvalProof: [
+        {
+          _id: "approval_proof_1",
+          actionKey: "cash_controls.register_session.resolve_sync_review",
+          approvedByCredentialId: "credential_manager_1",
+          approvedByStaffProfileId: "manager_1",
+          createdAt: 1,
+          expiresAt: Date.now() + 60_000,
+          requestedByStaffProfileId: "staff_1",
+          requiredRole: "manager",
+          storeId: "store_1",
+          subjectId: "session_open",
+          subjectLabel: "1",
+          subjectType: "register_session",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "manager_1",
+          linkedUserId: "athena_user_2",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "staff_1",
+          linkedUserId: "athena_user_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+    });
+
+    const result = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        approvalProofId: "approval_proof_1" as Id<"approvalProof">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        requestedByStaffProfileId: "staff_1" as Id<"staffProfile">,
+        reviewConflictIds: ["sync_conflict_missing_mapping"],
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual(
+      ok({
+        action: "resolved",
+        projectedCount: 1,
+        registerSession: expect.objectContaining({ _id: "session_open" }),
+        resolvedCount: 1,
+      }),
+    );
+    expect(ctx.tables.get("approvalProof")).toEqual([
+      expect.objectContaining({
+        _id: "approval_proof_1",
+        consumedAt: expect.any(Number),
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncConflict")).toEqual([
+      expect.objectContaining({
+        _id: "sync_conflict_missing_mapping",
+        resolvedByStaffProfileId: "manager_1",
+        status: "resolved",
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncMapping")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          cloudId: "session_open",
+          cloudTable: "registerSession",
+          localIdKind: "registerSession",
+        }),
+      ]),
+    );
+    expect(ctx.tables.get("operationalEvent")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          actorStaffProfileId: "manager_1",
+          eventType: "register_session_sync_review_resolved",
+          metadata: expect.objectContaining({
+            approvalProofId: "approval_proof_1",
+            conflictIds: ["sync_conflict_missing_mapping"],
+          }),
+        }),
+      ]),
+    );
+  });
+
   it("repairs missing register-session mappings for completed synced sales", async () => {
     const ctx = createAuthorizedRegisterDepositCtx({
       operationalEvent: [],
@@ -1509,6 +1734,74 @@ describe("cash control deposits", () => {
           localId: "local-register-1",
           localIdKind: "registerSession",
           localRegisterSessionId: "local-register-1",
+        }),
+      ]),
+    );
+    expect(ctx.tables.get("posLocalSyncEvent")).toEqual([
+      expect.objectContaining({
+        _id: "sync_event_sale_1",
+        projectedAt: expect.any(Number),
+        status: "projected",
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncConflict")).toEqual([
+      expect.objectContaining({
+        _id: "sync_conflict_missing_mapping",
+        resolvedByStaffProfileId: "manager_1",
+        status: "resolved",
+      }),
+    ]);
+  });
+
+  it("projects an unprojected sale after repairing its missing register mapping", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx(
+      createMissingMappingRepairSeed({
+        existingRegisterMappingCloudId: "session_open",
+        withCloudTransaction: false,
+        withTransactionMapping: false,
+      }),
+    );
+
+    const result = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        reviewConflictIds: ["sync_conflict_missing_mapping"],
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual(
+      ok({
+        action: "resolved",
+        projectedCount: 1,
+        registerSession: expect.objectContaining({
+          _id: "session_open",
+          expectedCash: 65000,
+          status: "active",
+        }),
+        resolvedCount: 1,
+      }),
+    );
+    expect(ctx.tables.get("posTransaction")).toEqual([
+      expect.objectContaining({
+        registerSessionId: "session_open",
+        total: 15000,
+        transactionNumber: "R-1001",
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncMapping")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          cloudId: "session_open",
+          cloudTable: "registerSession",
+          localIdKind: "registerSession",
+        }),
+        expect.objectContaining({
+          cloudTable: "posTransaction",
+          localId: "local-transaction-1",
+          localIdKind: "transaction",
         }),
       ]),
     );

--- a/packages/athena-webapp/convex/cashControls/deposits.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.ts
@@ -17,6 +17,7 @@ import {
   rejectRegisterSessionCloseoutWithCtx,
 } from "../operations/registerSessions";
 import { recordRegisterSessionTraceBestEffort } from "../operations/registerSessionTracing";
+import { consumeApprovalProofWithCtx } from "../operations/approvalProofs";
 import { toPesewas } from "../lib/currency";
 import {
   listCompletedTransactions,
@@ -52,6 +53,8 @@ export { listOpenLocalSyncConflictsByRegisterSession } from "../pos/application/
 
 const CASH_DEPOSIT_ALLOCATION_TYPE = "cash_deposit";
 const CASH_DEPOSIT_SUBJECT_TYPE = "register_cash_deposit";
+const REGISTER_SESSION_SYNC_REVIEW_APPROVAL_ACTION_KEY =
+  "cash_controls.register_session.resolve_sync_review";
 const RECENT_DEPOSIT_LIMIT = 10;
 const SESSION_LIMIT = 100;
 const STAFF_ROLE_LOOKUP_LIMIT = 20;
@@ -400,11 +403,16 @@ async function getCompletedTransactionForRegisterMappingRepair(
     syncEvent: StoredLocalSyncEvent;
     terminalId: Id<"posTerminal">;
   },
-) {
+): Promise<
+  | { kind: "matched"; transaction: Doc<"posTransaction"> }
+  | { kind: "unprojected" }
+  | { kind: "mismatch" }
+> {
   const payload = recordDetail(args.syncEvent.payload) ?? {};
   const localTransactionId =
     stringDetail(args.conflict.details, "localTransactionId") ??
     stringDetail(payload, "localTransactionId");
+  let sawTransactionMapping = false;
 
   if (localTransactionId) {
     const transactionMapping = await localSyncRepository.findMapping({
@@ -414,6 +422,7 @@ async function getCompletedTransactionForRegisterMappingRepair(
       localIdKind: "transaction",
       localId: localTransactionId,
     });
+    sawTransactionMapping = Boolean(transactionMapping);
     if (transactionMapping?.cloudTable === "posTransaction") {
       const transaction = await ctx.db.get(
         "posTransaction",
@@ -425,8 +434,9 @@ async function getCompletedTransactionForRegisterMappingRepair(
         transaction.terminalId === args.terminalId &&
         transaction.registerSessionId === args.registerSessionId
       ) {
-        return transaction;
+        return { kind: "matched", transaction };
       }
+      return { kind: "mismatch" };
     }
   }
 
@@ -439,7 +449,7 @@ async function getCompletedTransactionForRegisterMappingRepair(
     ].filter((value): value is string => Boolean(value)),
   );
   if (receiptNumbers.size === 0) {
-    return null;
+    return { kind: "unprojected" };
   }
 
   const totals = recordDetail(payload.totals);
@@ -463,7 +473,11 @@ async function getCompletedTransactionForRegisterMappingRepair(
     return total === null || transaction.total === total;
   });
 
-  return matches.length === 1 ? matches[0] : null;
+  if (matches.length === 1) {
+    return { kind: "matched", transaction: matches[0] };
+  }
+
+  return { kind: sawTransactionMapping ? "mismatch" : "unprojected" };
 }
 
 async function salePrecedesLocalCloseoutIfPresent(
@@ -1496,8 +1510,10 @@ export const recordRegisterSessionDeposit = mutation({
 export const resolveRegisterSessionSyncReview = mutation({
   args: {
     actorStaffProfileId: v.optional(v.id("staffProfile")),
+    approvalProofId: v.optional(v.id("approvalProof")),
     decision: v.optional(v.union(v.literal("approved"), v.literal("rejected"))),
     registerSessionId: v.id("registerSession"),
+    requestedByStaffProfileId: v.optional(v.id("staffProfile")),
     reviewConflictIds: v.optional(v.array(v.string())),
     storeId: v.id("store"),
   },
@@ -1531,7 +1547,26 @@ export const resolveRegisterSessionSyncReview = mutation({
           "Automatic sync repair can only apply eligible register activity.",
       });
     }
-    if (args.actorStaffProfileId) {
+    if (args.approvalProofId) {
+      const approvalProof = await consumeApprovalProofWithCtx(ctx, {
+        actionKey: REGISTER_SESSION_SYNC_REVIEW_APPROVAL_ACTION_KEY,
+        approvalProofId: args.approvalProofId,
+        requestedByStaffProfileId: args.requestedByStaffProfileId,
+        requiredRole: "manager",
+        storeId: args.storeId,
+        subject: {
+          id: args.registerSessionId,
+          label: registerSession.registerNumber,
+          type: "register_session",
+        },
+      });
+
+      if (approvalProof.kind !== "ok") {
+        return approvalProof;
+      }
+
+      reviewActorStaffProfileId = approvalProof.data.approvedByStaffProfileId;
+    } else if (args.actorStaffProfileId) {
       try {
         reviewActorStaffProfileId = await resolveDepositActorStaffProfileId(ctx, {
           athenaUserId: athenaUser._id,
@@ -1832,7 +1867,7 @@ export const resolveRegisterSessionSyncReview = mutation({
               terminalId,
             },
           );
-        if (!completedTransaction) {
+        if (completedTransaction.kind === "mismatch") {
           return userError({
             code: "precondition_failed",
             message:
@@ -1868,17 +1903,26 @@ export const resolveRegisterSessionSyncReview = mutation({
               !requestedConflictIds.has(candidate._id) &&
               !requestedConflictIds.has(candidate.localEventId),
           );
-        if (!hasUnselectedOpenConflictForEvent) {
-          await localSyncRepository.patchEvent(syncEvent._id, {
-            status: "projected",
-            projectedAt: resolvedAt,
-          });
+        if (completedTransaction.kind === "matched") {
+          if (!hasUnselectedOpenConflictForEvent) {
+            await localSyncRepository.patchEvent(syncEvent._id, {
+              status: "projected",
+              projectedAt: resolvedAt,
+            });
+          }
+          if (hasConflictRecord) {
+            resolvedConflictIds.add(conflict._id as Id<"posLocalSyncConflict">);
+          }
+          projectedTransactionIds.push(completedTransaction.transaction._id);
+          continue;
         }
-        if (hasConflictRecord) {
-          resolvedConflictIds.add(conflict._id as Id<"posLocalSyncConflict">);
+
+        if (hasUnselectedOpenConflictForEvent) {
+          if (hasConflictRecord) {
+            resolvedConflictIds.add(conflict._id as Id<"posLocalSyncConflict">);
+          }
+          continue;
         }
-        projectedTransactionIds.push(completedTransaction._id);
-        continue;
       }
 
       if (isAutomaticResolution && !shouldApplyProoflessStaffAccessEvent) {
@@ -1892,7 +1936,8 @@ export const resolveRegisterSessionSyncReview = mutation({
       if (
         !shouldApplyReviewedSale &&
         !shouldApplyReviewedCloseout &&
-        !shouldApplyProoflessStaffAccessEvent
+        !shouldApplyProoflessStaffAccessEvent &&
+        !shouldRepairMissingRegisterSessionMapping
       ) {
         if (
           syncEvent.eventType === "register_closed" &&
@@ -1942,6 +1987,8 @@ export const resolveRegisterSessionSyncReview = mutation({
         !parsedEvent.ok ||
         (shouldApplyReviewedSale &&
           parsedEvent.event.eventType !== "sale_completed") ||
+        (shouldRepairMissingRegisterSessionMapping &&
+          parsedEvent.event.eventType !== "sale_completed") ||
         (shouldApplyProoflessStaffAccessEvent &&
           parsedEvent.event.eventType !== "register_opened" &&
           parsedEvent.event.eventType !== "sale_completed") ||
@@ -1964,6 +2011,8 @@ export const resolveRegisterSessionSyncReview = mutation({
         now: resolvedAt,
         options: {
           allowClosedRegisterSaleProjection: true,
+          allowReviewedClosingRegisterSaleProjection:
+            shouldRepairMissingRegisterSessionMapping,
           applyExpectedTotalForReviewedNonCashOverpayment:
             shouldApplyManagerOverride || shouldApplyReviewedSale,
           allowReviewedInventorySaleProjection:
@@ -2096,6 +2145,9 @@ export const resolveRegisterSessionSyncReview = mutation({
                 ? "Applied reviewed synced register sale."
                 : `Applied ${projectedTransactionIds.length} reviewed synced register sales.`,
       metadata: {
+        ...(args.approvalProofId
+          ? { approvalProofId: args.approvalProofId }
+          : {}),
         conflictIds: conflicts.map((conflict) => conflict._id),
         conflictTypes: conflicts.map((conflict) => conflict.conflictType),
         decision,

--- a/packages/athena-webapp/convex/pos/application/commands/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/terminals.ts
@@ -369,6 +369,18 @@ type DrawerAuthorityDirective = {
   status: DrawerAuthorityStatus;
 };
 
+type ActiveRegisterSessionDirective = {
+  cloudRegisterSessionId: string;
+  expectedCash: number;
+  localRegisterSessionId: string;
+  observedAt: number;
+  openedAt: number;
+  openingFloat: number;
+  registerNumber?: string;
+  staffProfileId?: Id<"staffProfile">;
+  status: "active";
+};
+
 type AppSessionRecoveryStatus =
   | "ready"
   | "recovering"
@@ -431,6 +443,7 @@ export async function submitTerminalRuntimeStatus(
   },
 ): Promise<
   CommandResult<{
+    activeRegisterSessionDirective?: ActiveRegisterSessionDirective;
     drawerAuthorityDirective?: DrawerAuthorityDirective;
     terminalId: Id<"posTerminal">;
     reportedAt: number;
@@ -539,13 +552,126 @@ export async function submitTerminalRuntimeStatus(
       receivedAt,
       storeId: args.storeId,
     });
+  const activeRegisterSessionDirective =
+    await buildRuntimeActiveRegisterSessionDirective(ctx, {
+      activeRegisterSession,
+      receivedAt,
+      runtimeStatus: args.status,
+      storeId: args.storeId,
+      terminal,
+    });
 
   return ok({
-    ...omitUndefined({ drawerAuthorityDirective }),
+    ...omitUndefined({
+      activeRegisterSessionDirective,
+      drawerAuthorityDirective,
+    }),
     terminalId: args.terminalId,
     reportedAt,
     receivedAt,
   });
+}
+
+async function buildRuntimeActiveRegisterSessionDirective(
+  ctx: MutationCtx,
+  args: {
+    activeRegisterSession:
+      | ReturnType<typeof cleanActiveRegisterSession>
+      | undefined;
+    receivedAt: number;
+    runtimeStatus: TerminalRuntimeStatusInput;
+    storeId: Id<"store">;
+    terminal: Doc<"posTerminal">;
+  },
+): Promise<ActiveRegisterSessionDirective | undefined> {
+  if (
+    args.activeRegisterSession ||
+    !args.runtimeStatus.localStore.available ||
+    !args.runtimeStatus.localStore.terminalSeedReady
+  ) {
+    return undefined;
+  }
+  if (!ctx.db || typeof (ctx.db as { query?: unknown }).query !== "function") {
+    return undefined;
+  }
+
+  const cloudRegisterSession = await getSaleUsableRegisterSessionForTerminal(ctx, {
+    registerNumber: args.terminal.registerNumber,
+    storeId: args.storeId,
+    terminalId: args.terminal._id,
+  });
+  if (!cloudRegisterSession) {
+    return undefined;
+  }
+
+  return omitUndefined({
+    cloudRegisterSessionId: cloudRegisterSession._id,
+    expectedCash: cloudRegisterSession.expectedCash,
+    localRegisterSessionId: cloudRegisterSession._id,
+    observedAt: args.receivedAt,
+    openedAt: cloudRegisterSession.openedAt,
+    openingFloat: cloudRegisterSession.openingFloat,
+    registerNumber: cloudRegisterSession.registerNumber,
+    staffProfileId: cloudRegisterSession.openedByStaffProfileId,
+    status: "active" as const,
+  });
+}
+
+async function getSaleUsableRegisterSessionForTerminal(
+  ctx: MutationCtx,
+  args: {
+    registerNumber?: string | null;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+): Promise<Doc<"registerSession"> | null> {
+  const recentByTerminal = await ctx.db
+    .query("registerSession")
+    .withIndex("by_terminalId", (q) => q.eq("terminalId", args.terminalId))
+    .order("desc")
+    .take(25);
+  const directMatch = recentByTerminal.find((session) =>
+    isSaleUsableRegisterSessionForRuntimeTerminal(session, args),
+  );
+  if (directMatch) return directMatch;
+
+  const registerNumber = args.registerNumber?.trim();
+  if (!registerNumber) {
+    return null;
+  }
+
+  const recentByRegisterNumber = await ctx.db
+    .query("registerSession")
+    .withIndex("by_storeId_registerNumber", (q) =>
+      q.eq("storeId", args.storeId).eq("registerNumber", registerNumber),
+    )
+    .order("desc")
+    .take(25);
+
+  return (
+    recentByRegisterNumber.find((session) =>
+      isSaleUsableRegisterSessionForRuntimeTerminal(session, args),
+    ) ?? null
+  );
+}
+
+function isSaleUsableRegisterSessionForRuntimeTerminal(
+  session: Doc<"registerSession">,
+  args: {
+    registerNumber?: string | null;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+) {
+  const registerNumber = args.registerNumber?.trim();
+  return (
+    session.storeId === args.storeId &&
+    session.terminalId === args.terminalId &&
+    (!registerNumber ||
+      !session.registerNumber ||
+      session.registerNumber === registerNumber) &&
+    isRegisterSessionSaleUsable(session)
+  );
 }
 
 async function buildRuntimeDrawerAuthorityDirective(
@@ -820,6 +946,7 @@ const activeRegisterSessionStatuses = new Set([
   "open",
   "active",
   "closing",
+  "closeout_rejected",
   "closed",
 ]);
 

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { Doc, Id } from "../../../_generated/dataModel";
 import type { QueryCtx } from "../../../_generated/server";
+import { REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY } from "../../../../shared/registerSessionLifecyclePolicy";
 import {
   getTerminalHealthSummary,
   listTerminalHealthSummaries,
@@ -52,6 +53,53 @@ describe("terminal health queries", () => {
     expect(summary?.recoveryPreview?.readiness).toBe("healthy_idle");
     expect(summary?.recoveryPreview?.terminalActions).toEqual([]);
   });
+
+  it.each(["closing", "closeout_rejected"] as const)(
+    "treats a %s cloud drawer authority as ready for replacement",
+    async (status) => {
+      const ctx = buildQueryCtx({
+        posTerminal: [buildTerminal()],
+        posTerminalRuntimeStatus: [
+          buildRuntimeStatus({
+            drawerAuthority: {
+              cloudRegisterSessionId: "register-1",
+              localRegisterSessionId: "local-register-1",
+              observedAt: now - 2_000,
+              reason: "cloud_closed",
+              status: "blocked",
+            },
+            saleAuthority: {
+              observedAt: now - 1_000,
+              status: "ready",
+              transactionMode: "products_and_services",
+            },
+          }),
+        ],
+        registerSession: [
+          buildRegisterSession({
+            _id: "register-1" as Id<"registerSession">,
+            closeoutRecords: [],
+            closedAt: undefined,
+            status,
+          }),
+        ],
+      });
+
+      const summary = await getTerminalHealthSummary(ctx, {
+        now,
+        storeId,
+        terminalId,
+      });
+
+      expect(summary?.health).toBe("online");
+      expect(summary?.runtimeStatus?.drawerAuthority).toBeUndefined();
+      expect(summary?.attentionReasons.map((reason) => reason.type)).not.toContain(
+        "drawer_authority_blocked",
+      );
+      expect(summary?.recoveryPreview?.readiness).toBe("healthy_idle");
+      expect(summary?.recoveryPreview?.terminalActions).toEqual([]);
+    },
+  );
 
   it("includes latest terminal recovery command lifecycle metadata in the health preview", async () => {
     const ctx = buildQueryCtx({
@@ -502,6 +550,107 @@ describe("terminal health queries", () => {
     );
   });
 
+  it("offers cloud repair preview for a replacement open after submitted closeout review", async () => {
+    const duplicateOpenConflict = buildConflict({
+      _id: "duplicate-open-conflict" as Id<"posLocalSyncConflict">,
+      localEventId: "event-open-replacement",
+      localRegisterSessionId: "register-replacement",
+      sequence: 3,
+    });
+    const closeoutVarianceConflict = buildConflict({
+      _id: "closeout-conflict" as Id<"posLocalSyncConflict">,
+      conflictType: "permission",
+      details: {
+        countedCash: 95,
+        expectedCash: 100,
+        variance: -5,
+      },
+      localEventId: "event-register-closed",
+      localRegisterSessionId: "register-prior",
+      sequence: 2,
+      summary: REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY,
+    });
+    const ctx = buildQueryCtx({
+      posLocalSyncConflict: [closeoutVarianceConflict, duplicateOpenConflict],
+      posLocalSyncEvent: [
+        buildEvent({
+          _id: "event-open-replacement-id" as Id<"posLocalSyncEvent">,
+          localEventId: "event-open-replacement",
+          localRegisterSessionId: "register-replacement",
+          sequence: 3,
+        }),
+      ],
+      posTerminal: [buildTerminal({ registerNumber: "A1" })],
+      posTerminalRuntimeStatus: [buildRuntimeStatus()],
+      registerSession: [
+        buildRegisterSession({
+          _id: "register-prior" as Id<"registerSession">,
+          closedAt: undefined,
+          registerNumber: "A1",
+          status: "closing",
+        }),
+      ],
+      staffProfile: [buildStaffProfile()],
+      staffRoleAssignment: [buildStaffRoleAssignment()],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.recoveryPreview?.cloudRepair.safeConflictIds).toEqual([
+      duplicateOpenConflict._id,
+    ]);
+    expect(summary?.recoveryPreview?.cloudRepair.skippedConflictIds).toEqual([
+      closeoutVarianceConflict._id,
+    ]);
+  });
+
+  it("does not offer cloud repair preview for duplicate open blocked by an active drawer", async () => {
+    const duplicateOpenConflict = buildConflict({
+      _id: "duplicate-active-open-conflict" as Id<"posLocalSyncConflict">,
+      localEventId: "event-open-replacement",
+      localRegisterSessionId: "register-replacement",
+      sequence: 2,
+    });
+    const ctx = buildQueryCtx({
+      posLocalSyncConflict: [duplicateOpenConflict],
+      posLocalSyncEvent: [
+        buildEvent({
+          _id: "event-open-replacement-id" as Id<"posLocalSyncEvent">,
+          localEventId: "event-open-replacement",
+          localRegisterSessionId: "register-replacement",
+          sequence: 2,
+        }),
+      ],
+      posTerminal: [buildTerminal({ registerNumber: "A1" })],
+      posTerminalRuntimeStatus: [buildRuntimeStatus()],
+      registerSession: [
+        buildRegisterSession({
+          _id: "register-active" as Id<"registerSession">,
+          closedAt: undefined,
+          registerNumber: "A1",
+          status: "active",
+        }),
+      ],
+      staffProfile: [buildStaffProfile()],
+      staffRoleAssignment: [buildStaffRoleAssignment()],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.recoveryPreview?.cloudRepair.safeConflictIds).toEqual([]);
+    expect(summary?.recoveryPreview?.cloudRepair.skippedConflictIds).toEqual([
+      duplicateOpenConflict._id,
+    ]);
+  });
+
   it("keeps terminal health roster and detail recovery preview in parity", async () => {
     const ctx = buildQueryCtx({
       posTerminal: [buildTerminal()],
@@ -795,10 +944,13 @@ type TestTable =
   | "posLocalSyncConflict"
   | "posLocalSyncCursor"
   | "posLocalSyncEvent"
+  | "posLocalSyncMapping"
   | "posTerminal"
   | "posTerminalRecoveryCommand"
   | "posTerminalRuntimeStatus"
-  | "registerSession";
+  | "registerSession"
+  | "staffProfile"
+  | "staffRoleAssignment";
 
 function buildQueryCtx(
   records: Partial<Record<TestTable, Array<Record<string, unknown>>>>,
@@ -809,6 +961,9 @@ function buildQueryCtx(
         return Promise.resolve(
           records[table]?.find((record) => record._id === id) ?? null,
         );
+      },
+      normalizeId(table: TestTable, id: string) {
+        return records[table]?.some((record) => record._id === id) ? id : null;
       },
       query(table: TestTable) {
         return buildQuery(records[table] ?? []);
@@ -900,6 +1055,74 @@ function buildRegisterSession(
     terminalId,
     ...overrides,
   };
+}
+
+function buildStaffProfile(
+  overrides: Partial<Doc<"staffProfile">> = {},
+): Doc<"staffProfile"> {
+  return {
+    _id: "staff-1" as Id<"staffProfile">,
+    _creationTime: now - 50_000,
+    status: "active",
+    storeId,
+    ...overrides,
+  } as Doc<"staffProfile">;
+}
+
+function buildStaffRoleAssignment(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: "role-1",
+    _creationTime: now - 50_000,
+    role: "cashier",
+    staffProfileId: "staff-1",
+    status: "active",
+    storeId,
+    ...overrides,
+  };
+}
+
+function buildConflict(
+  overrides: Partial<Doc<"posLocalSyncConflict">> = {},
+): Doc<"posLocalSyncConflict"> {
+  return {
+    _id: "conflict-1" as Id<"posLocalSyncConflict">,
+    _creationTime: now - 20 * 60 * 1000,
+    conflictType: "duplicate_local_id",
+    createdAt: now - 20 * 60 * 1000,
+    details: { reason: "duplicate_register_opened" },
+    localEventId: "event-1",
+    localRegisterSessionId: "register-1",
+    sequence: 1,
+    status: "needs_review",
+    storeId,
+    summary: "Duplicate register-open attempt for an already opened drawer.",
+    terminalId,
+    ...overrides,
+  } as Doc<"posLocalSyncConflict">;
+}
+
+function buildEvent(
+  overrides: Partial<Doc<"posLocalSyncEvent">> = {},
+): Doc<"posLocalSyncEvent"> {
+  return {
+    _id: "event-1-id" as Id<"posLocalSyncEvent">,
+    _creationTime: now - 20 * 60 * 1000,
+    eventType: "register_opened",
+    localEventId: "event-1",
+    localRegisterSessionId: "register-1",
+    occurredAt: now - 20 * 60 * 1000,
+    payload: {
+      openingFloat: 100,
+      registerNumber: "A1",
+    },
+    sequence: 1,
+    staffProfileId: "staff-1" as Id<"staffProfile">,
+    status: "conflicted",
+    storeId,
+    submittedAt: now - 19 * 60 * 1000,
+    terminalId,
+    ...overrides,
+  } as Doc<"posLocalSyncEvent">;
 }
 
 function buildQuery(records: Array<Record<string, unknown>>) {

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.ts
@@ -1,6 +1,12 @@
 import type { Doc, Id } from "../../../_generated/dataModel";
 import type { QueryCtx } from "../../../_generated/server";
-import { isPosUsableRegisterSessionStatus } from "../../../../shared/registerSessionStatus";
+import {
+  isPosUsableRegisterSessionStatus,
+  isRegisterSessionConflictBlockingStatus,
+} from "../../../../shared/registerSessionStatus";
+import {
+  isRegisterSessionReplacementBlocking,
+} from "../../../../shared/registerSessionLifecyclePolicy";
 
 import {
   getLatestRuntimeStatusForTerminal,
@@ -19,8 +25,17 @@ import {
 } from "../../infrastructure/repositories/terminalRecoveryRepository";
 import {
   buildTerminalCloudRepairPreview,
+  canProjectRegisterOpenForTerminalCloudRepair,
   classifyTerminalCloudRepairConflict,
+  skipTerminalCloudRepairConflict,
+  type TerminalCloudRepairConflictClassification,
+  type TerminalCloudRepairProjectionEligibilityRepository,
 } from "../terminalRecovery/cloudRepairPolicy";
+import { parseStoredLocalSyncEvent } from "../sync/ingestLocalEvents";
+import type {
+  LocalSyncIngestionRepository,
+  LocalSyncMappingRecord,
+} from "../sync/types";
 import type {
   TerminalRecoveryCommandPayload,
   TerminalRecoveryCommandType,
@@ -302,11 +317,16 @@ async function isCleanlyClosedDrawerAuthority(
   }
 
   const registerSession = await db.get("registerSession", registerSessionId);
-  return (
-    registerSession?.storeId === args.terminal.storeId &&
-    registerSession.terminalId === args.terminal._id &&
-    registerSession.status === "closed"
-  );
+  if (
+    registerSession?.storeId !== args.terminal.storeId ||
+    registerSession.terminalId !== args.terminal._id
+  ) {
+    return false;
+  }
+  return !isRegisterSessionReplacementBlocking({
+    hasSubmittedCloseout: registerSession.status === "closing",
+    session: registerSession,
+  });
 }
 
 async function buildTerminalHealthSummary(
@@ -851,20 +871,46 @@ async function buildTerminalRecoveryCloudRepairPreview(
     storeId: args.storeId,
     terminalId: args.terminalId,
   });
+  const repository = createTerminalCloudRepairQueryRepository(ctx);
   const classified = await Promise.all(
-    conflicts.map(async (conflict) =>
-      classifyTerminalCloudRepairConflict({
-        conflict,
-        now: args.now,
-        sourceEvent: await getTerminalRecoverySourceEvent(ctx, {
-          storeId: args.storeId,
-          terminalId: args.terminalId,
-          localEventId: conflict.localEventId,
-        }),
+    conflicts.map(async (conflict): Promise<TerminalCloudRepairConflictClassification> => {
+      const sourceEvent = await getTerminalRecoverySourceEvent(ctx, {
         storeId: args.storeId,
         terminalId: args.terminalId,
-      }),
-    ),
+        localEventId: conflict.localEventId,
+      });
+      const classification = classifyTerminalCloudRepairConflict({
+        conflict,
+        now: args.now,
+        sourceEvent,
+        storeId: args.storeId,
+        terminalId: args.terminalId,
+      });
+      if (classification.kind !== "safe_duplicate_register_opened") {
+        return classification;
+      }
+      if (!sourceEvent) {
+        return classification;
+      }
+
+      const parsed = parseStoredLocalSyncEvent(
+        repository as unknown as LocalSyncIngestionRepository,
+        sourceEvent,
+      );
+      if (
+        !parsed.ok ||
+        !(await canProjectRegisterOpenForTerminalCloudRepair(repository, {
+          event: parsed.event,
+          now: sourceEvent.acceptedAt ?? args.now,
+          storeId: args.storeId,
+          terminalId: args.terminalId,
+        }))
+      ) {
+        return skipTerminalCloudRepairConflict(classification, "not_projection_safe");
+      }
+
+      return classification;
+    }),
   );
   const preview = buildTerminalCloudRepairPreview({
     classified,
@@ -876,6 +922,171 @@ async function buildTerminalRecoveryCloudRepairPreview(
     preconditionHash: preview.preconditionHash,
     safeConflictIds: preview.safeConflictIds,
     skippedConflictIds: preview.skipped.map((item) => item.conflictId),
+  };
+}
+
+function createTerminalCloudRepairQueryRepository(
+  ctx: QueryCtx,
+): TerminalCloudRepairProjectionEligibilityRepository {
+  const normalizeCloudId = <TableName extends string>(
+    tableName: TableName,
+    value: string,
+  ) => {
+    const normalizeId = (
+      ctx.db as unknown as {
+        normalizeId?: (tableName: string, value: string) => unknown;
+      }
+    ).normalizeId;
+    if (typeof normalizeId !== "function") return null;
+    const normalized = normalizeId.call(ctx.db, tableName, value);
+    return typeof normalized === "string" ? normalized : null;
+  };
+
+  return {
+    async findBlockingRegisterSession(args) {
+      const terminalRows = await ctx.db
+        .query("registerSession")
+        .withIndex("by_terminalId", (q) => q.eq("terminalId", args.terminalId))
+        .order("desc")
+        .take(20);
+      const latestByTerminal = terminalRows
+        .filter(
+          (session) =>
+            session.storeId === args.storeId &&
+            session.terminalId === args.terminalId,
+        )
+        .sort((left, right) => right._creationTime - left._creationTime)[0];
+      if (
+        latestByTerminal &&
+        isRegisterSessionConflictBlockingStatus(latestByTerminal.status)
+      ) {
+        return latestByTerminal;
+      }
+
+      if (!args.registerNumber) {
+        return null;
+      }
+
+      const registerRows = await ctx.db
+        .query("registerSession")
+        .withIndex("by_storeId_registerNumber", (q) =>
+          q.eq("storeId", args.storeId).eq("registerNumber", args.registerNumber),
+        )
+        .order("desc")
+        .take(20);
+      const latestByRegisterNumber = registerRows
+        .filter(
+          (session) =>
+            session.storeId === args.storeId &&
+            session.registerNumber === args.registerNumber,
+        )
+        .sort((left, right) => right._creationTime - left._creationTime)[0];
+      return latestByRegisterNumber &&
+        isRegisterSessionConflictBlockingStatus(latestByRegisterNumber.status)
+        ? latestByRegisterNumber
+        : null;
+    },
+    getRegisterSession(registerSessionId) {
+      return ctx.db.get("registerSession", registerSessionId);
+    },
+    getStaffProfile(staffProfileId) {
+      return ctx.db.get("staffProfile", staffProfileId);
+    },
+    getTerminal(terminalId) {
+      return ctx.db.get("posTerminal", terminalId);
+    },
+    async hasActivePosRole(args) {
+      const assignments = await ctx.db
+        .query("staffRoleAssignment")
+        .withIndex("by_staffProfileId", (q) =>
+          q.eq("staffProfileId", args.staffProfileId),
+        )
+        .take(50);
+      return assignments.some(
+        (assignment) =>
+          assignment.storeId === args.storeId &&
+          assignment.status === "active" &&
+          (assignment.role === "cashier" || assignment.role === "manager") &&
+          args.allowedRoles.includes(assignment.role),
+      );
+    },
+    async listOpenRegisterReviewConflictFacts(args) {
+      const registerSessionMappings = await ctx.db
+        .query("posLocalSyncMapping")
+        .withIndex("by_store_terminal_cloud", (q) =>
+          q
+            .eq("storeId", args.storeId)
+            .eq("terminalId", args.terminalId)
+            .eq("cloudTable", "registerSession")
+            .eq("cloudId", args.registerSessionId),
+        )
+        .take(100);
+      const scopedMappings = registerSessionMappings.filter(
+        (mapping) =>
+          mapping.storeId === args.storeId &&
+          mapping.terminalId === args.terminalId &&
+          mapping.cloudTable === "registerSession" &&
+          mapping.cloudId === args.registerSessionId,
+      ) as LocalSyncMappingRecord[];
+      const mappingByLocalId = new Map(
+        scopedMappings.map((mapping) => [mapping.localRegisterSessionId, mapping]),
+      );
+      const localRegisterSessionIds = new Set<string>([
+        args.registerSessionId,
+        ...scopedMappings.map((mapping) => mapping.localRegisterSessionId),
+      ]);
+      const facts = [];
+      for (const localRegisterSessionId of localRegisterSessionIds) {
+        const conflicts = await ctx.db
+          .query("posLocalSyncConflict")
+          .withIndex("by_store_terminal_register_status_type", (q) =>
+            q
+              .eq("storeId", args.storeId)
+              .eq("terminalId", args.terminalId)
+              .eq("localRegisterSessionId", localRegisterSessionId)
+              .eq("status", "needs_review")
+              .eq("conflictType", "permission"),
+          )
+          .take(100);
+        for (const conflict of conflicts) {
+          if (
+            conflict.storeId !== args.storeId ||
+            conflict.terminalId !== args.terminalId ||
+            conflict.localRegisterSessionId !== localRegisterSessionId ||
+            conflict.status !== "needs_review" ||
+            conflict.conflictType !== "permission"
+          ) {
+            continue;
+          }
+
+          const directRegisterSessionId = normalizeCloudId(
+            "registerSession",
+            conflict.localRegisterSessionId,
+          ) as Id<"registerSession"> | null;
+          const directRegisterSession = directRegisterSessionId
+            ? await ctx.db.get("registerSession", directRegisterSessionId)
+            : null;
+          facts.push({
+            conflict,
+            directRegisterSession:
+              directRegisterSession &&
+              directRegisterSession.storeId === args.storeId &&
+              directRegisterSession.terminalId === args.terminalId
+                ? {
+                    _id: directRegisterSession._id,
+                    storeId: directRegisterSession.storeId,
+                    terminalId: directRegisterSession.terminalId,
+                  }
+                : null,
+            registerSessionMapping:
+              mappingByLocalId.get(conflict.localRegisterSessionId) ?? null,
+          });
+        }
+      }
+
+      return facts;
+    },
+    normalizeCloudId: normalizeCloudId as never,
   };
 }
 

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -3657,7 +3657,7 @@ describe("projectLocalSyncEvent", () => {
     ]);
   });
 
-  it("maps duplicate register opens to the terminal's existing active drawer", async () => {
+  it("conflicts duplicate register opens that do not match the existing drawer identity", async () => {
     const repository = createProjectionRepository({
       blockingRegisterSession: {
         _id: "register-session-open",
@@ -3690,16 +3690,19 @@ describe("projectLocalSyncEvent", () => {
       now: 100,
     });
 
-    expect(result.status).toBe("projected");
-    expect(result.conflicts).toEqual([]);
-    expect(result.mappings).toEqual([
+    expect(result.status).toBe("conflicted");
+    expect(result.conflicts).toEqual([
       expect.objectContaining({
-        localIdKind: "registerSession",
-        localId: "local-register-2",
-        cloudTable: "registerSession",
-        cloudId: "register-session-open",
+        conflictType: "permission",
+        summary: "A register session is already open for this terminal.",
+        details: expect.objectContaining({
+          blockingRegisterSessionId: "register-session-open",
+          localRegisterSessionId: "local-register-2",
+        }),
       }),
     ]);
+    expect(result.mappings).toEqual([]);
+    expect(repository.createdRegisterSessions).toEqual([]);
   });
 
   it("conflicts a stale register open when the active drawer has a newer closeout review", async () => {
@@ -3790,6 +3793,58 @@ describe("projectLocalSyncEvent", () => {
       expect.objectContaining({
         localIdKind: "registerSession",
         localId: "local-register-2",
+        cloudTable: "registerSession",
+        cloudId: "register-session-1",
+      }),
+    ]);
+    expect(repository.createdRegisterSessions).toEqual([
+      expect.objectContaining({
+        expectedCash: 250,
+        openingFloat: 250,
+        registerNumber: "1",
+      }),
+    ]);
+  });
+
+  it("creates a new register open when the blocking drawer already submitted closeout", async () => {
+    const repository = createProjectionRepository({
+      blockingRegisterSession: {
+        _id: "register-session-closing",
+        expectedCash: 100,
+        closeoutRecords: [],
+        registerNumber: "1",
+        status: "closing",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-opened-after-closeout",
+        localRegisterSessionId: "local-register-after-closeout",
+        sequence: 1,
+        eventType: "register_opened",
+        occurredAt: 10,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: {
+          openingFloat: 250,
+          registerNumber: "1",
+        },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("projected");
+    expect(result.conflicts).toEqual([]);
+    expect(result.mappings).toEqual([
+      expect.objectContaining({
+        localIdKind: "registerSession",
+        localId: "local-register-after-closeout",
         cloudTable: "registerSession",
         cloudId: "register-session-1",
       }),

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -40,6 +40,7 @@ type ProjectEventArgs = {
   now: number;
   options?: {
     allowClosedRegisterSaleProjection?: boolean;
+    allowReviewedClosingRegisterSaleProjection?: boolean;
     applyExpectedTotalForReviewedNonCashOverpayment?: boolean;
     allowReviewedInventorySaleProjection?: boolean;
     allowRegisterCloseoutVarianceProjection?: boolean;
@@ -856,7 +857,13 @@ async function canReuseCloudRegisterSessionForLocalOpen(
   return canReuseCloudRegisterSessionForLocalOpenPolicy({
     hasOpenRegisterCloseoutReview:
       hasOpenRegisterCloseoutReview.hasOpenRegisterCloseoutReview,
-    registerSession,
+    localRegisterSessionId: args.event.localRegisterSessionId,
+    registerSession: registerSession
+      ? {
+          ...registerSession,
+          cloudRegisterSessionId: registerSession._id,
+        }
+      : registerSession,
     storeId: args.storeId,
     terminalId: args.terminalId,
   });
@@ -1484,8 +1491,13 @@ async function resolveSaleRegisterAndSession(
     return conflictResult(conflict);
   }
 
+  const registerSessionSaleUsable = isRegisterSessionSaleUsable(registerSession);
+  const reviewedClosingRegisterSaleAllowed =
+    args.options?.allowReviewedClosingRegisterSaleProjection === true &&
+    registerSession.status === "closing";
+
   if (
-    isRegisterSessionSaleUsable(registerSession) &&
+    registerSessionSaleUsable &&
     (
       await getOpenRegisterCloseoutReviewState(repository, args, {
         registerSessionId: registerSession._id,
@@ -1504,7 +1516,7 @@ async function resolveSaleRegisterAndSession(
     return conflictResult(conflict);
   }
 
-  if (!isRegisterSessionSaleUsable(registerSession)) {
+  if (!registerSessionSaleUsable && !reviewedClosingRegisterSaleAllowed) {
     const conflict = await createConflict(repository, args, {
       conflictType: "permission",
       summary: "Register was not open before this sale synced.",
@@ -2539,7 +2551,9 @@ async function persistPaymentAllocations(
 
   if (
     payments.expectedCashDelta > 0 &&
-    isRegisterSessionSaleUsable(session.registerSession)
+    (isRegisterSessionSaleUsable(session.registerSession) ||
+      (args.options?.allowReviewedClosingRegisterSaleProjection === true &&
+        session.registerSession.status === "closing"))
   ) {
     const expectedCash =
       session.registerSession.expectedCash + payments.expectedCashDelta;

--- a/packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts
@@ -311,6 +311,32 @@ async function hasInventoryReviewWorkItemForProjectedSale(
   });
 }
 
+async function isNonSaleMissingRegisterSessionMappingConflict(
+  ctx: Pick<QueryCtx, "db">,
+  storeId: Id<"store">,
+  conflict: Doc<"posLocalSyncConflict">,
+) {
+  if (
+    classifyRegisterSessionSyncReview(conflict).reviewKind !==
+      "missing_register_session_mapping" ||
+    !conflict.terminalId
+  ) {
+    return false;
+  }
+
+  const syncEvent = await ctx.db
+    .query("posLocalSyncEvent")
+    .withIndex("by_store_terminal_localEvent", (q) =>
+      q
+        .eq("storeId", conflict.storeId ?? storeId)
+        .eq("terminalId", conflict.terminalId!)
+        .eq("localEventId", conflict.localEventId),
+    )
+    .unique();
+
+  return Boolean(syncEvent && syncEvent.eventType !== "sale_completed");
+}
+
 function recordDetail(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -621,8 +647,22 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
   const activeNeedsReviewConflicts = projectedInventoryReviewResults
     .filter((result) => !result.hasInventoryWorkItem)
     .map((result) => result.conflict);
+  const activeRegisterReviewResults = await Promise.all(
+    activeNeedsReviewConflicts.map(async (conflict) => ({
+      conflict,
+      isNonSaleMissingRegisterSessionMapping:
+        await isNonSaleMissingRegisterSessionMappingConflict(
+          ctx,
+          storeId,
+          conflict,
+        ),
+    })),
+  );
+  const activeRegisterReviewConflicts = activeRegisterReviewResults
+    .filter((result) => !result.isNonSaleMissingRegisterSessionMapping)
+    .map((result) => result.conflict);
   const varianceCloseoutEventKeys = new Set(
-    activeNeedsReviewConflicts
+    activeRegisterReviewConflicts
       .filter(
         (conflict) =>
           classifyRegisterSessionSyncReview(conflict).reviewKind ===
@@ -630,7 +670,7 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
       )
       .map(syncConflictEventKey),
   );
-  const reviewableNeedsReviewConflicts = activeNeedsReviewConflicts.filter(
+  const reviewableNeedsReviewConflicts = activeRegisterReviewConflicts.filter(
     (conflict) =>
       !(
         classifyRegisterSessionSyncReview(conflict).reviewKind ===
@@ -662,6 +702,14 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
         .unique();
 
       if (syncEvent?.status === "conflicted") {
+        if (
+          classifyRegisterSessionSyncReview(conflict).reviewKind ===
+            "missing_register_session_mapping" &&
+          syncEvent.eventType !== "sale_completed"
+        ) {
+          return null;
+        }
+
         return { ...conflict, status: "needs_review" };
       }
 

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts
@@ -1,4 +1,14 @@
 import type { Doc, Id } from "../../../_generated/dataModel";
+import {
+  canReuseCloudRegisterSessionForLocalOpen as canReuseCloudRegisterSessionForLocalOpenPolicy,
+  canSupersedeReviewedRegisterSessionForLocalOpen as canSupersedeReviewedRegisterSessionForLocalOpenPolicy,
+  isRegisterCloseoutReviewConflict,
+} from "../../../../shared/registerSessionLifecyclePolicy";
+import type {
+  LocalSyncRegisterReviewConflictFact,
+  ParsedPosLocalSyncEventInput,
+  SyncProjectionRepository,
+} from "../sync/types";
 
 const STALE_DUPLICATE_REGISTER_OPEN_MS = 5 * 60 * 1000;
 const BUSINESS_FACT_KEYS = [
@@ -35,6 +45,7 @@ export type SkippedTerminalCloudRepairConflict = {
     | "missing_source_event"
     | "not_duplicate_register_opened"
     | "not_needs_review"
+    | "not_projection_safe"
     | "not_register_opened"
     | "not_stale"
     | "store_or_terminal_mismatch";
@@ -118,6 +129,17 @@ export function buildTerminalCloudRepairPreview(args: {
   };
 }
 
+export function skipTerminalCloudRepairConflict(
+  conflict: SafeTerminalCloudRepairConflict,
+  reason: SkippedTerminalCloudRepairConflict["reason"],
+): SkippedTerminalCloudRepairConflict {
+  return {
+    conflictId: conflict.conflictId,
+    kind: "skipped",
+    reason,
+  };
+}
+
 export function buildTerminalCloudRepairPreconditionHash(args: {
   safeConflictIds: Array<Id<"posLocalSyncConflict">>;
   storeId: Id<"store">;
@@ -129,6 +151,145 @@ export function buildTerminalCloudRepairPreconditionHash(args: {
     args.terminalId,
     ...args.safeConflictIds,
   ].join(":");
+}
+
+export type TerminalCloudRepairProjectionEligibilityRepository = Pick<
+  SyncProjectionRepository,
+  | "findBlockingRegisterSession"
+  | "getRegisterSession"
+  | "getStaffProfile"
+  | "getTerminal"
+  | "hasActivePosRole"
+  | "listOpenRegisterReviewConflictFacts"
+  | "normalizeCloudId"
+>;
+
+export async function canProjectRegisterOpenForTerminalCloudRepair(
+  repository: TerminalCloudRepairProjectionEligibilityRepository,
+  args: {
+    event: ParsedPosLocalSyncEventInput;
+    now: number;
+    storeId: Parameters<SyncProjectionRepository["getStore"]>[0];
+    terminalId: Parameters<SyncProjectionRepository["getTerminal"]>[0];
+  },
+) {
+  if (args.event.eventType !== "register_opened") return false;
+
+  const terminal = await repository.getTerminal(args.terminalId);
+  const staff = await repository.getStaffProfile(args.event.staffProfileId);
+  const terminalRegisterNumber = normalizeRepairString(terminal?.registerNumber);
+  const payloadRegisterNumber = normalizeRepairString(args.event.payload.registerNumber);
+  if (
+    !terminal ||
+    terminal.storeId !== args.storeId ||
+    terminal.status !== "active" ||
+    !terminalRegisterNumber ||
+    (payloadRegisterNumber && payloadRegisterNumber !== terminalRegisterNumber)
+  ) {
+    return false;
+  }
+
+  const hasActiveOpenRole = staff
+    ? await repository.hasActivePosRole({
+        staffProfileId: args.event.staffProfileId,
+        storeId: args.storeId,
+        allowedRoles: ["cashier", "manager"],
+      })
+    : false;
+  if (
+    !staff ||
+    staff.storeId !== args.storeId ||
+    staff.status !== "active" ||
+    !hasActiveOpenRole
+  ) {
+    return false;
+  }
+
+  const directRegisterSessionId = repository.normalizeCloudId(
+    "registerSession",
+    args.event.localRegisterSessionId,
+  );
+  if (directRegisterSessionId) {
+    const registerSession = await repository.getRegisterSession(directRegisterSessionId);
+    return canReuseCloudRegisterSessionForLocalOpenPolicy({
+      hasOpenRegisterCloseoutReview: false,
+      localRegisterSessionId: args.event.localRegisterSessionId,
+      registerSession: registerSession
+        ? {
+            ...registerSession,
+            cloudRegisterSessionId: registerSession._id,
+          }
+        : registerSession,
+      storeId: args.storeId,
+      terminalId: args.terminalId,
+    });
+  }
+
+  const blockingRegisterSession = await repository.findBlockingRegisterSession({
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+    registerNumber: terminalRegisterNumber,
+  });
+  if (!blockingRegisterSession) return true;
+
+  const reviewState = await getRepairOpenRegisterCloseoutReviewState(repository, {
+    registerSessionId: blockingRegisterSession._id,
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+  });
+
+  return canSupersedeReviewedRegisterSessionForLocalOpenPolicy({
+    hasOpenRegisterCloseoutReview: reviewState.hasOpenRegisterCloseoutReview,
+    replacementLocalRegisterSessionId: args.event.localRegisterSessionId,
+    replacementSequence: args.event.sequence,
+    registerSession: blockingRegisterSession,
+    reviewSequence: reviewState.latestReviewSequence ?? null,
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+  });
+}
+
+async function getRepairOpenRegisterCloseoutReviewState(
+  repository: TerminalCloudRepairProjectionEligibilityRepository,
+  args: {
+    registerSessionId: Parameters<
+      SyncProjectionRepository["listOpenRegisterReviewConflictFacts"]
+    >[0]["registerSessionId"];
+    storeId: Parameters<SyncProjectionRepository["getStore"]>[0];
+    terminalId: Parameters<SyncProjectionRepository["getTerminal"]>[0];
+  },
+) {
+  const conflicts = (await repository.listOpenRegisterReviewConflictFacts(args))
+    .filter((fact) =>
+      repairFactMatchesRegisterSessionCloseoutReview(fact, args.registerSessionId),
+    )
+    .map((fact) => fact.conflict);
+
+  return {
+    hasOpenRegisterCloseoutReview: conflicts.length > 0,
+    latestReviewSequence: conflicts.reduce<number | undefined>(
+      (latest, conflict) =>
+        latest === undefined ? conflict.sequence : Math.max(latest, conflict.sequence),
+      undefined,
+    ),
+  };
+}
+
+function repairFactMatchesRegisterSessionCloseoutReview(
+  fact: LocalSyncRegisterReviewConflictFact,
+  registerSessionId: Parameters<
+    SyncProjectionRepository["listOpenRegisterReviewConflictFacts"]
+  >[0]["registerSessionId"],
+) {
+  if (!isRegisterCloseoutReviewConflict(fact.conflict)) return false;
+  if (
+    fact.registerSessionMapping?.cloudTable === "registerSession" &&
+    fact.registerSessionMapping.cloudId === registerSessionId
+  ) {
+    return true;
+  }
+
+  return fact.directRegisterSession?._id === registerSessionId;
 }
 
 function skipped(
@@ -181,4 +342,10 @@ function containsBusinessFacts(value: unknown): boolean {
       ) || containsBusinessFacts(entry)
     );
   });
+}
+
+function normalizeRepairString(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
 }

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.ts
@@ -6,18 +6,11 @@ import {
   type CommandResult,
 } from "../../../../shared/commandResult";
 import {
-  canReuseCloudRegisterSessionForLocalOpen as canReuseCloudRegisterSessionForLocalOpenPolicy,
-  canSupersedeReviewedRegisterSessionForLocalOpen as canSupersedeReviewedRegisterSessionForLocalOpenPolicy,
-  isRegisterCloseoutReviewConflict,
-} from "../../../../shared/registerSessionLifecyclePolicy";
+  canProjectRegisterOpenForTerminalCloudRepair,
+} from "./cloudRepairPolicy";
 import { createConvexLocalSyncRepository } from "../../infrastructure/repositories/localSyncRepository";
 import { parseStoredLocalSyncEvent } from "../sync/ingestLocalEvents";
 import { projectLocalSyncEvent } from "../sync/projectLocalEvents";
-import type {
-  LocalSyncRegisterReviewConflictFact,
-  ParsedPosLocalSyncEventInput,
-  SyncProjectionRepository,
-} from "../sync/types";
 import {
   buildTerminalCloudRepairPreview,
   classifyTerminalCloudRepairConflict,
@@ -119,7 +112,7 @@ export async function resolveTerminalCloudRepair(
       });
     }
     if (
-      !(await canRepairProjectRegisterOpen(localSyncRepository, {
+      !(await canProjectRegisterOpenForTerminalCloudRepair(localSyncRepository, {
         event: parsed.event,
         now: sourceEvent.acceptedAt ?? args.now,
         storeId: args.storeId,
@@ -204,134 +197,4 @@ function selectLatestSafeDuplicateOpenConflict(
       right.sequence - left.sequence ||
       String(right.conflictId).localeCompare(String(left.conflictId)),
   )[0];
-}
-
-async function canRepairProjectRegisterOpen(
-  repository: SyncProjectionRepository,
-  args: {
-    event: ParsedPosLocalSyncEventInput;
-    now: number;
-    storeId: Parameters<SyncProjectionRepository["getStore"]>[0];
-    terminalId: Parameters<SyncProjectionRepository["getTerminal"]>[0];
-  },
-) {
-  if (args.event.eventType !== "register_opened") return false;
-
-  const terminal = await repository.getTerminal(args.terminalId);
-  const staff = await repository.getStaffProfile(args.event.staffProfileId);
-  const terminalRegisterNumber = normalizeRepairString(terminal?.registerNumber);
-  const payloadRegisterNumber = normalizeRepairString(args.event.payload.registerNumber);
-  if (
-    !terminal ||
-    terminal.storeId !== args.storeId ||
-    terminal.status !== "active" ||
-    !terminalRegisterNumber ||
-    (payloadRegisterNumber && payloadRegisterNumber !== terminalRegisterNumber)
-  ) {
-    return false;
-  }
-
-  const hasActiveOpenRole = staff
-    ? await repository.hasActivePosRole({
-        staffProfileId: args.event.staffProfileId,
-        storeId: args.storeId,
-        allowedRoles: ["cashier", "manager"],
-      })
-    : false;
-  if (
-    !staff ||
-    staff.storeId !== args.storeId ||
-    staff.status !== "active" ||
-    !hasActiveOpenRole
-  ) {
-    return false;
-  }
-
-  const directRegisterSessionId = repository.normalizeCloudId(
-    "registerSession",
-    args.event.localRegisterSessionId,
-  );
-  if (directRegisterSessionId) {
-    const registerSession = await repository.getRegisterSession(directRegisterSessionId);
-    return canReuseCloudRegisterSessionForLocalOpenPolicy({
-      hasOpenRegisterCloseoutReview: false,
-      registerSession,
-      storeId: args.storeId,
-      terminalId: args.terminalId,
-    });
-  }
-
-  const blockingRegisterSession = await repository.findBlockingRegisterSession({
-    storeId: args.storeId,
-    terminalId: args.terminalId,
-    registerNumber: terminalRegisterNumber,
-  });
-  if (!blockingRegisterSession) return true;
-
-  const reviewState = await getRepairOpenRegisterCloseoutReviewState(repository, {
-    registerSessionId: blockingRegisterSession._id,
-    storeId: args.storeId,
-    terminalId: args.terminalId,
-  });
-
-  return canSupersedeReviewedRegisterSessionForLocalOpenPolicy({
-    hasOpenRegisterCloseoutReview: reviewState.hasOpenRegisterCloseoutReview,
-    replacementLocalRegisterSessionId: args.event.localRegisterSessionId,
-    replacementSequence: args.event.sequence,
-    registerSession: blockingRegisterSession,
-    reviewSequence: reviewState.latestReviewSequence ?? null,
-    storeId: args.storeId,
-    terminalId: args.terminalId,
-  });
-}
-
-async function getRepairOpenRegisterCloseoutReviewState(
-  repository: SyncProjectionRepository,
-  args: {
-    registerSessionId: Parameters<
-      SyncProjectionRepository["listOpenRegisterReviewConflictFacts"]
-    >[0]["registerSessionId"];
-    storeId: Parameters<SyncProjectionRepository["getStore"]>[0];
-    terminalId: Parameters<SyncProjectionRepository["getTerminal"]>[0];
-  },
-) {
-  const conflicts = (
-    await repository.listOpenRegisterReviewConflictFacts(args)
-  )
-    .filter((fact) =>
-      repairFactMatchesRegisterSessionCloseoutReview(fact, args.registerSessionId),
-    )
-    .map((fact) => fact.conflict);
-
-  return {
-    hasOpenRegisterCloseoutReview: conflicts.length > 0,
-    latestReviewSequence: conflicts.reduce<number | undefined>(
-      (latest, conflict) =>
-        latest === undefined ? conflict.sequence : Math.max(latest, conflict.sequence),
-      undefined,
-    ),
-  };
-}
-
-function repairFactMatchesRegisterSessionCloseoutReview(
-  fact: LocalSyncRegisterReviewConflictFact,
-  registerSessionId: Parameters<
-    SyncProjectionRepository["listOpenRegisterReviewConflictFacts"]
-  >[0]["registerSessionId"],
-) {
-  if (!isRegisterCloseoutReviewConflict(fact.conflict)) return false;
-  if (
-    fact.registerSessionMapping?.cloudTable === "registerSession" &&
-    fact.registerSessionMapping.cloudId === registerSessionId
-  ) {
-    return true;
-  }
-
-  return fact.directRegisterSession?._id === registerSessionId;
-}
-
-function normalizeRepairString(value: unknown) {
-  return typeof value === "string" && value.trim().length > 0
-    ? value.trim()
-    : undefined;
 }

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -436,6 +436,40 @@ describe("submitTerminalRuntimeStatus", () => {
     );
   });
 
+  it("preserves closeout-rejected active register status in runtime status", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
+      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    );
+
+    await submitTerminalRuntimeStatus(
+      { db: null as never } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        status: {
+          ...buildRuntimeStatus(),
+          activeRegisterSession: {
+            cloudRegisterSessionId: "cloud-register-1",
+            localRegisterSessionId: "local-register-1",
+            observedAt: 112,
+            status: "closeout_rejected",
+          },
+        } as never,
+      },
+    );
+
+    expect(vi.mocked(upsertLatestRuntimeStatus)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        activeRegisterSession: expect.objectContaining({
+          localRegisterSessionId: "local-register-1",
+          status: "closeout_rejected",
+        }),
+      }),
+    );
+  });
+
   it("persists support-safe app-session recovery status in runtime status", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
     vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
@@ -516,6 +550,76 @@ describe("submitTerminalRuntimeStatus", () => {
           reason: "cloud_closed",
           registerNumber: "8",
           status: "blocked",
+        },
+      }),
+    });
+  });
+
+  it("returns an active register session directive when cloud has a usable drawer but runtime does not", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
+      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    );
+    const registerSessions = [
+      {
+        _creationTime: 300,
+        _id: "cloud-register-closed",
+        expectedCash: 0,
+        openedAt: 300,
+        openingFloat: 0,
+        registerNumber: "A1",
+        status: "closed",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      },
+      {
+        _creationTime: 200,
+        _id: "cloud-register-1",
+        expectedCash: 13_000,
+        openedAt: 100,
+        openingFloat: 13_000,
+        openedByStaffProfileId: "staff-1",
+        registerNumber: "A1",
+        status: "active",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      },
+    ];
+    const db = {
+      query: vi.fn(() => buildTerminalHealthQuery(registerSessions)),
+    };
+
+    const result = await submitTerminalRuntimeStatus(
+      { db } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        status: {
+          ...buildRuntimeStatus(),
+          activeRegisterSession: undefined,
+          localStore: {
+            available: true,
+            schemaVersion: 1,
+            terminalSeedReady: true,
+          },
+        },
+      },
+    );
+
+    expect(db.query).toHaveBeenCalledWith("registerSession");
+    expect(result).toEqual({
+      kind: "ok",
+      data: expect.objectContaining({
+        activeRegisterSessionDirective: {
+          cloudRegisterSessionId: "cloud-register-1",
+          expectedCash: 13_000,
+          localRegisterSessionId: "cloud-register-1",
+          observedAt: 200,
+          openedAt: 100,
+          openingFloat: 13_000,
+          registerNumber: "A1",
+          staffProfileId: "staff-1",
+          status: "active",
         },
       }),
     });
@@ -1883,7 +1987,30 @@ describe("terminal health summaries", () => {
     );
 
     const result = await getTerminalHealthSummary(
-      { db: null as never } as never,
+      {
+        db: buildTerminalHealthDb({
+          posTerminal: [existingTerminal],
+          registerSession: [],
+          staffProfile: [
+            {
+              _id: "staff-1" as Id<"staffProfile">,
+              _creationTime: 100,
+              status: "active",
+              storeId: "store-1" as Id<"store">,
+            } as Doc<"staffProfile">,
+          ],
+          staffRoleAssignment: [
+            {
+              _id: "role-1",
+              _creationTime: 100,
+              role: "cashier",
+              staffProfileId: "staff-1",
+              status: "active",
+              storeId: "store-1",
+            },
+          ],
+        }),
+      } as never,
       {
         storeId: "store-1" as Id<"store">,
         terminalId: "terminal-1" as Id<"posTerminal">,
@@ -2016,8 +2143,54 @@ function buildSyncEvent(
       openingFloat: 100,
       registerNumber: "A1",
     },
+    sequence: 1,
     status: "conflicted",
     submittedAt: 110,
     ...overrides,
   } as Doc<"posLocalSyncEvent">;
+}
+
+function buildTerminalHealthDb(
+  records: Partial<Record<string, Array<Record<string, unknown>>>>,
+) {
+  return {
+    get: vi.fn(async (tableName: string, id: string) => {
+      return records[tableName]?.find((record) => record._id === id) ?? null;
+    }),
+    normalizeId: vi.fn((tableName: string, value: string) => {
+      return records[tableName]?.some((record) => record._id === value)
+        ? value
+        : null;
+    }),
+    query: vi.fn((tableName: string) => buildTerminalHealthQuery(records[tableName] ?? [])),
+  };
+}
+
+function buildTerminalHealthQuery(records: Array<Record<string, unknown>>) {
+  let currentRecords = [...records];
+  const chain = {
+    first: vi.fn(async () => currentRecords[0] ?? null),
+    order: vi.fn((direction: "asc" | "desc") => {
+      currentRecords = [...currentRecords].sort((left, right) => {
+        const leftTime = Number(left._creationTime ?? 0);
+        const rightTime = Number(right._creationTime ?? 0);
+        return direction === "desc" ? rightTime - leftTime : leftTime - rightTime;
+      });
+      return chain;
+    }),
+    take: vi.fn(async (count: number) => currentRecords.slice(0, count)),
+    withIndex: vi.fn((_indexName: string, build: (q: {
+      eq: (field: string, value: unknown) => unknown;
+    }) => unknown) => {
+      const q = {
+        eq: vi.fn((field: string, value: unknown) => {
+          currentRecords = currentRecords.filter((record) => record[field] === value);
+          return q;
+        }),
+      };
+      build(q);
+      return chain;
+    }),
+  };
+  return chain;
 }

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
@@ -416,6 +416,33 @@ describe("terminalRepository active register-session evidence", () => {
     ).resolves.toBe(true);
   });
 
+  it("finds an older active register session when newer terminal history is closed", async () => {
+    const ctx = buildCtx({
+      registerSession: [
+        buildRegisterSession({
+          _creationTime: 30,
+          registerNumber: "8",
+          status: "closed",
+          terminalId: "terminal-1" as Id<"posTerminal">,
+        }),
+        buildRegisterSession({
+          _creationTime: 20,
+          registerNumber: "8",
+          status: "active",
+          terminalId: "terminal-1" as Id<"posTerminal">,
+        }),
+      ],
+    });
+
+    await expect(
+      hasActiveRegisterSessionForTerminal(ctx as never, {
+        registerNumber: "8",
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+      }),
+    ).resolves.toBe(true);
+  });
+
   it("falls back to latest register-number evidence when the terminal latest session is closed", async () => {
     const ctx = buildCtx({
       registerSession: [

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
@@ -319,16 +319,16 @@ export async function hasActiveRegisterSessionForTerminal(
     terminalId: Id<"posTerminal">;
   },
 ) {
-  const latestByTerminal = await ctx.db
+  const recentByTerminal = await ctx.db
     .query("registerSession")
     .withIndex("by_terminalId", (q) => q.eq("terminalId", args.terminalId))
     .order("desc")
-    .first();
+    .take(25);
 
   if (
-    latestByTerminal?.storeId === args.storeId &&
-    latestByTerminal.terminalId === args.terminalId &&
-    isPosUsableRegisterSessionStatus(latestByTerminal.status)
+    recentByTerminal.some((session) =>
+      isUsableRegisterSessionForTerminal(session, args),
+    )
   ) {
     return true;
   }
@@ -338,17 +338,35 @@ export async function hasActiveRegisterSessionForTerminal(
     return false;
   }
 
-  const latestByRegisterNumber = await ctx.db
+  const recentByRegisterNumber = await ctx.db
     .query("registerSession")
     .withIndex("by_storeId_registerNumber", (q) =>
       q.eq("storeId", args.storeId).eq("registerNumber", registerNumber),
     )
     .order("desc")
-    .first();
+    .take(25);
 
+  return recentByRegisterNumber.some((session) =>
+    isUsableRegisterSessionForTerminal(session, args),
+  );
+}
+
+function isUsableRegisterSessionForTerminal(
+  session: Doc<"registerSession">,
+  args: {
+    registerNumber?: string | null;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+) {
+  const registerNumber = args.registerNumber?.trim();
   return (
-    latestByRegisterNumber?.terminalId === args.terminalId &&
-    isPosUsableRegisterSessionStatus(latestByRegisterNumber.status)
+    session.storeId === args.storeId &&
+    session.terminalId === args.terminalId &&
+    (!registerNumber ||
+      !session.registerNumber ||
+      session.registerNumber === registerNumber) &&
+    isPosUsableRegisterSessionStatus(session.status)
   );
 }
 

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -1297,6 +1297,17 @@ describe("POS terminal public mutations", () => {
     assertConformsToExportedReturns(submitTerminalRuntimeStatus as never, {
       kind: "ok",
       data: {
+        activeRegisterSessionDirective: {
+          cloudRegisterSessionId: "register-session-2",
+          expectedCash: 13_000,
+          localRegisterSessionId: "register-session-2",
+          observedAt: 200,
+          openedAt: 100,
+          openingFloat: 13_000,
+          registerNumber: "8",
+          staffProfileId: "staff-1",
+          status: "active",
+        },
         drawerAuthorityDirective: {
           cloudRegisterSessionId: "register-session-1",
           localRegisterSessionId: "local-register-session-1",

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -145,6 +145,19 @@ const runtimeStatusInputValidator = v.object({
 });
 
 const runtimeStatusWriteResultValidator = v.object({
+  activeRegisterSessionDirective: v.optional(
+    v.object({
+      cloudRegisterSessionId: v.string(),
+      expectedCash: v.number(),
+      localRegisterSessionId: v.string(),
+      observedAt: v.number(),
+      openedAt: v.number(),
+      openingFloat: v.number(),
+      registerNumber: v.optional(v.string()),
+      staffProfileId: v.optional(v.id("staffProfile")),
+      status: v.literal("active"),
+    }),
+  ),
   drawerAuthorityDirective: v.optional(
     v.object({
       cloudRegisterSessionId: v.optional(v.string()),

--- a/packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts
+++ b/packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts
@@ -178,11 +178,13 @@ describe("registerSessionLifecyclePolicy", () => {
     ).toBe(false);
   });
 
-  it("reuses cloud register sessions only when scoped, sale usable, and without open closeout review", () => {
+  it("reuses cloud register sessions only for the same scoped sale-usable drawer identity", () => {
     expect(
       canReuseCloudRegisterSessionForLocalOpen({
         hasOpenRegisterCloseoutReview: false,
+        localRegisterSessionId: "local-drawer-1",
         registerSession: {
+          localRegisterSessionId: "local-drawer-1",
           status: "active",
           storeId: "store-1",
           terminalId: "terminal-1",
@@ -194,7 +196,9 @@ describe("registerSessionLifecyclePolicy", () => {
     expect(
       canReuseCloudRegisterSessionForLocalOpen({
         hasOpenRegisterCloseoutReview: true,
+        localRegisterSessionId: "local-drawer-1",
         registerSession: {
+          localRegisterSessionId: "local-drawer-1",
           status: "active",
           storeId: "store-1",
           terminalId: "terminal-1",
@@ -206,7 +210,9 @@ describe("registerSessionLifecyclePolicy", () => {
     expect(
       canReuseCloudRegisterSessionForLocalOpen({
         hasOpenRegisterCloseoutReview: false,
+        localRegisterSessionId: "local-drawer-1",
         registerSession: {
+          localRegisterSessionId: "local-drawer-1",
           status: "active",
           storeId: "store-1",
           terminalId: "terminal-2",
@@ -215,6 +221,34 @@ describe("registerSessionLifecyclePolicy", () => {
         terminalId: "terminal-1",
       }),
     ).toBe(false);
+    expect(
+      canReuseCloudRegisterSessionForLocalOpen({
+        hasOpenRegisterCloseoutReview: false,
+        localRegisterSessionId: "local-drawer-2",
+        registerSession: {
+          localRegisterSessionId: "local-drawer-1",
+          status: "active",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        },
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toBe(false);
+    expect(
+      canReuseCloudRegisterSessionForLocalOpen({
+        hasOpenRegisterCloseoutReview: false,
+        localRegisterSessionId: "cloud-drawer-1",
+        registerSession: {
+          cloudRegisterSessionId: "cloud-drawer-1",
+          status: "active",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        },
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toBe(true);
   });
 
   it("allows superseding reviewed sale-usable or closing sessions only in scope", () => {
@@ -246,6 +280,22 @@ describe("registerSessionLifecyclePolicy", () => {
           terminalId: "terminal-1",
         },
         reviewSequence: 2,
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toBe(true);
+    expect(
+      canSupersedeReviewedRegisterSessionForLocalOpen({
+        hasOpenRegisterCloseoutReview: false,
+        replacementLocalRegisterSessionId: "replacement-local-drawer",
+        replacementSequence: 1,
+        registerSession: {
+          localRegisterSessionId: "submitted-closeout-drawer",
+          status: "closing",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        },
+        reviewSequence: null,
         storeId: "store-1",
         terminalId: "terminal-1",
       }),

--- a/packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts
+++ b/packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts
@@ -154,12 +154,18 @@ export function isDrawerAuthoritySaleBlocking(input: {
 
 export function canReuseCloudRegisterSessionForLocalOpen(input: {
   hasOpenRegisterCloseoutReview: boolean;
+  localRegisterSessionId: string;
   registerSession?: RegisterSessionLifecycleScopedSession | null;
   storeId: string;
   terminalId: string;
 }) {
+  const isSameDrawerIdentity =
+    input.localRegisterSessionId === input.registerSession?.localRegisterSessionId ||
+    input.localRegisterSessionId === input.registerSession?.cloudRegisterSessionId;
+
   return (
     isScopedRegisterSession(input) &&
+    isSameDrawerIdentity &&
     isRegisterSessionSaleUsable(input.registerSession) &&
     !input.hasOpenRegisterCloseoutReview
   );
@@ -194,6 +200,10 @@ export function canSupersedeReviewedRegisterSessionForLocalOpen(input: {
     input.reviewSequence === undefined ||
     input.reviewSequence === null ||
     input.replacementSequence > input.reviewSequence;
+  const hasSubmittedCloseout =
+    input.registerSession?.status === "closing";
+  const hasReplacementHold =
+    input.hasOpenRegisterCloseoutReview || hasSubmittedCloseout;
 
   return (
     isScopedRegisterSession(input) &&
@@ -202,7 +212,7 @@ export function canSupersedeReviewedRegisterSessionForLocalOpen(input: {
     (isRegisterSessionSaleUsable(input.registerSession) ||
       input.registerSession?.status === "closing" ||
       input.registerSession?.status === "closeout_rejected") &&
-    input.hasOpenRegisterCloseoutReview
+    hasReplacementHold
   );
 }
 

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -345,7 +345,6 @@ describe("RegisterSessionViewContent", () => {
           registerSession: baseSnapshot.registerSession,
         }}
         orgUrlSlug="wigclub"
-        storeId="store-1"
         storeUrlSlug="wigclub"
       />,
     );
@@ -1280,6 +1279,7 @@ describe("RegisterSessionViewContent", () => {
             },
           },
         }}
+        storeId="store-1"
         storeUrlSlug="wigclub"
       />,
     );
@@ -1369,6 +1369,13 @@ describe("RegisterSessionViewContent", () => {
         staffProfileId: "manager-1",
       }),
     );
+    const onAuthenticateForApproval = vi.fn().mockResolvedValue(
+      ok({
+        approvalProofId: "approval-proof-1",
+        approvedByStaffProfileId: "manager-1",
+        expiresAt: Date.now() + 60_000,
+      }),
+    );
     const onResolveSyncReview = vi
       .fn()
       .mockResolvedValue(
@@ -1381,6 +1388,7 @@ describe("RegisterSessionViewContent", () => {
         isLoading={false}
         onRecordDeposit={vi.fn()}
         {...closeoutHandlers}
+        onAuthenticateForApproval={onAuthenticateForApproval}
         onAuthenticateStaff={onAuthenticateStaff}
         onResolveSyncReview={onResolveSyncReview}
         orgUrlSlug="wigclub"
@@ -1416,6 +1424,7 @@ describe("RegisterSessionViewContent", () => {
             },
           },
         }}
+        storeId="store-1"
         storeUrlSlug="wigclub"
       />,
     );
@@ -1446,10 +1455,28 @@ describe("RegisterSessionViewContent", () => {
       }),
     );
 
+    await waitFor(() =>
+      expect(onAuthenticateForApproval).toHaveBeenCalledWith({
+        actionKey: "cash_controls.register_session.resolve_sync_review",
+        pinHash: "hashed-pin",
+        requiredRole: "manager",
+        requestedByStaffProfileId: undefined,
+        storeId: "store-1",
+        subject: {
+          id: "session-1",
+          label: "Register 3",
+          type: "register_session",
+        },
+        username: "ato",
+      }),
+    );
+    expect(onAuthenticateStaff).not.toHaveBeenCalled();
     expect(onResolveSyncReview).toHaveBeenNthCalledWith(1, {
       actorStaffProfileId: "manager-1",
+      approvalProofId: "approval-proof-1",
       decision: "approved",
       registerSessionId: "session-1",
+      requestedByStaffProfileId: undefined,
       reviewConflictIds: ["sync_conflict_missing_mapping"],
     });
 
@@ -1464,8 +1491,10 @@ describe("RegisterSessionViewContent", () => {
 
     expect(onResolveSyncReview).toHaveBeenNthCalledWith(2, {
       actorStaffProfileId: "manager-1",
+      approvalProofId: "approval-proof-1",
       decision: "rejected",
       registerSessionId: "session-1",
+      requestedByStaffProfileId: undefined,
       reviewConflictIds: ["sync_conflict_missing_mapping"],
     });
   });
@@ -1643,7 +1672,10 @@ describe("RegisterSessionViewContent", () => {
               status: "needs_review",
               reconciliationItems: [
                 {
+                  actionPolicy: "apply_or_reject",
                   id: "sync_conflict_1",
+                  localEventId: "event_sale_1",
+                  reviewKind: "missing_register_session_mapping",
                   sale: {
                     cashAmount: 2200000,
                     itemCount: 1,
@@ -1663,7 +1695,19 @@ describe("RegisterSessionViewContent", () => {
                     totalPaid: 2200000,
                   },
                   status: "needs_review",
-                  summary: "Register was not open before this sale synced.",
+                  summary:
+                    "Register session mapping is missing for synced POS history.",
+                  type: "permission",
+                },
+                {
+                  actionPolicy: "apply_or_reject",
+                  id: "sync_conflict_closeout_mapping",
+                  localEventId: "event_closeout_1",
+                  reviewKind: "missing_register_session_mapping",
+                  sequence: 2,
+                  status: "needs_review",
+                  summary:
+                    "Register session mapping is missing for synced POS history.",
                   type: "permission",
                 },
               ],

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -261,8 +261,10 @@ type RegisterCloseoutCommandResult =
 
 type ResolveSyncReviewArgs = {
   actorStaffProfileId: string;
+  approvalProofId?: string;
   decision: "approved" | "rejected";
   registerSessionId: string;
+  requestedByStaffProfileId?: string;
   reviewConflictIds?: string[];
 };
 
@@ -283,6 +285,7 @@ type StaffAuthenticationCommandResult =
 
 type CloseoutApprovalAuthenticationResult = StaffAuthenticationResult & {
   approvalProofId?: string;
+  requestedByStaffProfileId?: string;
 };
 
 type CloseoutApprovalAuthenticationCommandResult =
@@ -401,6 +404,9 @@ function isManagerStaff(staff: StaffAuthenticationResult) {
 function buildDepositSubmissionKey(registerSessionId: string) {
   return `register-session-deposit-${registerSessionId}-${Date.now().toString(36)}`;
 }
+
+const REGISTER_SESSION_SYNC_REVIEW_APPROVAL_ACTION_KEY =
+  "cash_controls.register_session.resolve_sync_review";
 
 function formatCurrency(currency: string, amount?: number | null) {
   if (amount === undefined || amount === null) {
@@ -2859,8 +2865,11 @@ export function RegisterSessionViewContent({
       try {
         const commandResult = await onResolveSyncReview({
           actorStaffProfileId: result.staffProfileId,
+          approvalProofId: result.approvalProofId,
           decision: intent.decision,
           registerSessionId: intent.registerSessionId,
+          requestedByStaffProfileId:
+            result.requestedByStaffProfileId ?? actorStaffProfileId,
           reviewConflictIds: intent.reviewConflictIds,
         });
 
@@ -3290,6 +3299,10 @@ export function RegisterSessionViewContent({
       hasSaleReview:
         getSyncReviewSaleSummaries(visibleSyncReviewItems).length > 0,
     });
+    const saleReviewConflictIds = visibleSyncReviewItems
+      .filter((item) => item.sale)
+      .map((item) => item.id)
+      .filter((id): id is string => Boolean(id));
     const visibleReviewConflictIds = visibleSyncReviewItems
       .map((item) => item.id)
       .filter((id): id is string => Boolean(id));
@@ -3305,6 +3318,8 @@ export function RegisterSessionViewContent({
         options.reviewConflictIds ??
         (isRegisterCloseoutSyncReview && pendingCloseoutReviewItem?.id
           ? [pendingCloseoutReviewItem.id]
+          : saleReviewConflictIds.length > 0
+            ? saleReviewConflictIds
           : visibleReviewConflictIds.length > 0
             ? visibleReviewConflictIds
             : undefined),
@@ -3650,6 +3665,43 @@ export function RegisterSessionViewContent({
             : "Staff credentials confirmed";
         }}
         onAuthenticate={(args) => {
+          if (
+            closeoutStaffAuthIntent?.kind === "sync_review" &&
+            onAuthenticateForApproval &&
+            storeId
+          ) {
+            return onAuthenticateForApproval({
+              actionKey: REGISTER_SESSION_SYNC_REVIEW_APPROVAL_ACTION_KEY,
+              pinHash: args.pinHash,
+              requiredRole: "manager",
+              requestedByStaffProfileId: actorStaffProfileId as
+                | Id<"staffProfile">
+                | undefined,
+              storeId: storeId as Id<"store">,
+              subject: {
+                id: closeoutStaffAuthIntent.registerSessionId,
+                label: registerSession?.registerNumber ?? undefined,
+                type: "register_session",
+              },
+              username: args.username,
+            }).then((result) => {
+              if (result.kind !== "ok") {
+                return result;
+              }
+
+              return {
+                kind: "ok" as const,
+                data: {
+                  approvalProofId: result.data.approvalProofId,
+                  requestedByStaffProfileId:
+                    result.data.requestedByStaffProfileId,
+                  staffProfile: {},
+                  staffProfileId: result.data.approvedByStaffProfileId,
+                },
+              };
+            });
+          }
+
           if (
             closeoutStaffAuthIntent?.kind === "review" &&
             onAuthenticateCloseoutReviewApproval
@@ -5093,8 +5145,12 @@ export function RegisterSessionView() {
     const result = await runCommand(() =>
       resolveRegisterSessionSyncReview({
         actorStaffProfileId: args.actorStaffProfileId as Id<"staffProfile">,
+        approvalProofId: args.approvalProofId as Id<"approvalProof"> | undefined,
         decision: args.decision,
         registerSessionId: args.registerSessionId as Id<"registerSession">,
+        requestedByStaffProfileId: args.requestedByStaffProfileId as
+          | Id<"staffProfile">
+          | undefined,
         reviewConflictIds: args.reviewConflictIds,
         storeId: activeStore._id,
       }),

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -823,6 +823,77 @@ describe("POSRegisterView", () => {
         localStaffAuthorityStatus: "ready",
         localEntryStatus: "ready",
         online: true,
+        runtimeState: {
+          heartbeat: {
+            activeRegisterSession: {
+              cloudRegisterSessionId: "cloud-register-1",
+              localRegisterSessionId: "cloud-register-1",
+              observedAt: Date.UTC(2026, 4, 15, 12, 34, 59),
+              registerNumber: "8",
+              status: "active",
+            },
+            drawerAuthority: {
+              cloudRegisterSessionId: "cloud-register-1",
+              localRegisterSessionId: "cloud-register-1",
+              reason: "cloud_active",
+              status: "active",
+            },
+            localStore: {
+              available: true,
+              schemaVersion: 1,
+              terminalSeedReady: true,
+            },
+            reportedAt: Date.UTC(2026, 4, 15, 12, 35, 2),
+            saleAuthority: {
+              staffProfileId: "staff-1",
+              status: "ready",
+            },
+            source: "runtime",
+            staffAuthority: {
+              staffProfileId: "staff-1",
+              status: "ready",
+            },
+            sync: {
+              failedEventCount: 0,
+              pendingEventCount: 1,
+              reviewEventCount: 2,
+              status: "pending_sync",
+              uploadableEventCount: 1,
+            },
+          },
+          localReadModel: {
+            activeRegisterSession: {
+              cloudRegisterSessionId: "cloud-register-1",
+              expectedCash: 13_000,
+              localRegisterSessionId: "cloud-register-1",
+              registerNumber: "8",
+              status: "active",
+            },
+            canSell: true,
+            sourceEventCount: 4,
+            syncStatus: {
+              lastLocalSequence: 4,
+              lastSyncedSequence: 3,
+              nextPendingSequence: 4,
+              state: "pending_sync",
+            },
+          },
+          repair: {
+            directive: {
+              cloudRegisterSessionId: "cloud-register-1",
+              expectedCash: 13_000,
+              localRegisterSessionId: "cloud-register-1",
+              observedAt: Date.UTC(2026, 4, 15, 12, 35, 1),
+              openedAt: Date.UTC(2026, 4, 15, 12, 0, 0),
+              openingFloat: 13_000,
+              registerNumber: "8",
+              staffProfileId: "staff-1",
+              status: "active",
+            },
+            observedAt: Date.UTC(2026, 4, 15, 12, 35, 3),
+            seedResult: "seeded",
+          },
+        },
         staffSignedIn: true,
         storeId: "store-1",
         syncFlow: {
@@ -952,7 +1023,16 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("oldest 2 next 2")).toBeInTheDocument();
     expect(screen.getByText("scheduler")).toBeInTheDocument();
     expect(screen.getByText("last failure")).toBeInTheDocument();
-    expect(screen.getByText("none")).toBeInTheDocument();
+    expect(screen.getAllByText("none")).not.toHaveLength(0);
+    expect(screen.getByText("Runtime state")).toBeInTheDocument();
+    expect(screen.getByText("heartbeat drawer")).toBeInTheDocument();
+    expect(screen.getByText("local read model")).toBeInTheDocument();
+    expect(screen.getByText("can sell Pending Sync events 4")).toBeInTheDocument();
+    expect(screen.getByText("repair seed result")).toBeInTheDocument();
+    expect(screen.getByText("repair Seeded")).toBeInTheDocument();
+    expect(screen.getByText("repair directive drawer")).toBeInTheDocument();
+    expect(screen.getByText("repair directive expected")).toBeInTheDocument();
+    expect(screen.getByText("13000")).toBeInTheDocument();
 
     pressDebugPanelShortcut();
     expect(

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -454,6 +454,16 @@ function formatDebugTimestamp(timestamp?: number) {
     : "n/a";
 }
 
+function formatDebugIdentifier(value?: string | null) {
+  if (!value) return "none";
+  if (value.length <= 12) return value;
+  return `${value.slice(0, 4)}...${value.slice(-6)}`;
+}
+
+function formatDebugStoredAmount(value?: number | null) {
+  return typeof value === "number" ? String(value) : "n/a";
+}
+
 function formatDebugStatus(value?: string | null) {
   if (!value) return "not ready";
 
@@ -553,6 +563,30 @@ function formatDebugCheckInPublishStatus(value?: string | null) {
     default:
       return "Not observed";
   }
+}
+
+function formatDebugRegisterSession(input?: {
+  cloudRegisterSessionId?: string;
+  localRegisterSessionId?: string;
+  registerNumber?: string;
+  status?: string;
+}) {
+  if (!input?.localRegisterSessionId && !input?.cloudRegisterSessionId) {
+    return "none";
+  }
+
+  return [
+    input.status ? formatDebugStatus(input.status) : "Unknown",
+    input.registerNumber ? `register ${input.registerNumber}` : null,
+    input.localRegisterSessionId
+      ? `local ${formatDebugIdentifier(input.localRegisterSessionId)}`
+      : null,
+    input.cloudRegisterSessionId
+      ? `cloud ${formatDebugIdentifier(input.cloudRegisterSessionId)}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
 }
 
 function getDebugSyncHoldUp(debug: NonNullable<RegisterViewModel["debug"]>) {
@@ -773,6 +807,149 @@ function POSLocalDebugStrip({
       ].join(" "),
     ],
   ];
+  const runtimeState = debug.runtimeState;
+  const heartbeat = runtimeState?.heartbeat;
+  const localReadModel = runtimeState?.localReadModel;
+  const repair = runtimeState?.repair;
+  const runtimeRows = runtimeState
+    ? [
+        [
+          "heartbeat source",
+          heartbeat?.source ? formatDebugStatus(heartbeat.source) : "none",
+        ],
+        ["heartbeat reported", formatDebugTimestamp(heartbeat?.reportedAt)],
+        [
+          "heartbeat local store",
+          heartbeat
+            ? [
+                heartbeat.localStore.available ? "available" : "unavailable",
+                heartbeat.localStore.terminalSeedReady
+                  ? "seed ready"
+                  : "seed missing",
+                heartbeat.localStore.schemaVersion
+                  ? `schema ${heartbeat.localStore.schemaVersion}`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join(" ")
+            : "none",
+        ],
+        [
+          "heartbeat staff",
+          heartbeat
+            ? [
+                formatDebugStatus(heartbeat.staffAuthority.status),
+                heartbeat.staffAuthority.staffProfileId
+                  ? `staff ${formatDebugIdentifier(
+                      heartbeat.staffAuthority.staffProfileId,
+                    )}`
+                  : "no staff",
+              ].join(" ")
+            : "none",
+        ],
+        [
+          "heartbeat sale authority",
+          heartbeat?.saleAuthority
+            ? [
+                formatDebugStatus(heartbeat.saleAuthority.status),
+                heartbeat.saleAuthority.staffProfileId
+                  ? `staff ${formatDebugIdentifier(
+                      heartbeat.saleAuthority.staffProfileId,
+                    )}`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join(" ")
+            : "not ready",
+        ],
+        [
+          "heartbeat drawer",
+          formatDebugRegisterSession(heartbeat?.activeRegisterSession),
+        ],
+        [
+          "heartbeat drawer authority",
+          heartbeat?.drawerAuthority
+            ? [
+                formatDebugStatus(heartbeat.drawerAuthority.status),
+                heartbeat.drawerAuthority.reason
+                  ? formatDebugStatus(heartbeat.drawerAuthority.reason)
+                  : null,
+                `local ${formatDebugIdentifier(
+                  heartbeat.drawerAuthority.localRegisterSessionId,
+                )}`,
+                heartbeat.drawerAuthority.cloudRegisterSessionId
+                  ? `cloud ${formatDebugIdentifier(
+                      heartbeat.drawerAuthority.cloudRegisterSessionId,
+                    )}`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join(" ")
+            : "none",
+        ],
+        [
+          "heartbeat sync",
+          heartbeat
+            ? [
+                formatDebugStatus(heartbeat.sync.status),
+                `pending ${heartbeat.sync.pendingEventCount ?? 0}`,
+                `uploadable ${heartbeat.sync.uploadableEventCount ?? 0}`,
+                `review ${heartbeat.sync.reviewEventCount ?? 0}`,
+                `failed ${heartbeat.sync.failedEventCount ?? 0}`,
+              ].join(" ")
+            : "none",
+        ],
+        [
+          "local read model",
+          localReadModel
+            ? [
+                localReadModel.canSell ? "can sell" : "blocked",
+                formatDebugStatus(localReadModel.syncStatus.state),
+                `events ${localReadModel.sourceEventCount}`,
+              ].join(" ")
+            : "none",
+        ],
+        [
+          "local drawer",
+          formatDebugRegisterSession(localReadModel?.activeRegisterSession),
+        ],
+        [
+          "local block reason",
+          localReadModel?.saleBlockReason
+            ? formatDebugStatus(localReadModel.saleBlockReason)
+            : "none",
+        ],
+        [
+          "local read sequence",
+          localReadModel
+            ? [
+                `local ${localReadModel.syncStatus.lastLocalSequence}`,
+                `synced ${localReadModel.syncStatus.lastSyncedSequence ?? "n/a"}`,
+                `next ${localReadModel.syncStatus.nextPendingSequence ?? "n/a"}`,
+              ].join(" ")
+            : "none",
+        ],
+        [
+          "repair seed result",
+          repair ? formatDebugStatus(repair.seedResult) : "not observed",
+        ],
+        ["repair observed", formatDebugTimestamp(repair?.observedAt)],
+        [
+          "repair directive drawer",
+          formatDebugRegisterSession(repair?.directive),
+        ],
+        [
+          "repair directive staff",
+          repair?.directive?.staffProfileId
+            ? formatDebugIdentifier(repair.directive.staffProfileId)
+            : "none",
+        ],
+        [
+          "repair directive expected",
+          formatDebugStoredAmount(repair?.directive?.expectedCash),
+        ],
+      ]
+    : [];
   const flow = [
     {
       label: debug.online ? "Connected" : "Offline",
@@ -890,6 +1067,50 @@ function POSLocalDebugStrip({
             </Link>
           </Button>
         </div>
+      ) : null}
+      {runtimeRows.length > 0 ? (
+        <section className="mt-4 rounded-md border border-border bg-background/70 p-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Runtime state
+            </p>
+            <span
+              className={cn(
+                "inline-flex h-6 items-center rounded-full border px-2 font-medium",
+                localReadModel?.canSell
+                  ? "border-success/25 bg-success/10 text-success"
+                  : "border-warning/30 bg-warning/15 text-warning",
+              )}
+            >
+              {localReadModel?.canSell ? "local sale ready" : "local gate active"}
+            </span>
+            <span
+              className={cn(
+                "inline-flex h-6 items-center rounded-full border px-2 font-medium",
+                repair?.seedResult === "seeded"
+                  ? "border-success/25 bg-success/10 text-success"
+                  : repair?.seedResult === "gateway_rejected" ||
+                      repair?.seedResult === "missing_staff_identity"
+                    ? "border-warning/30 bg-warning/15 text-warning"
+                    : "border-border bg-muted/30 text-muted-foreground",
+              )}
+            >
+              repair {repair ? formatDebugStatus(repair.seedResult) : "not observed"}
+            </span>
+          </div>
+          <dl className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {runtimeRows.map(([label, value]) => (
+              <div key={label} className="min-w-0">
+                <dt className="uppercase tracking-wide text-muted-foreground">
+                  {label}
+                </dt>
+                <dd className="break-words font-mono text-foreground">
+                  {value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </section>
       ) : null}
       <dl className="mt-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
         {rows.map(([label, value]) => (

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
@@ -1468,6 +1468,77 @@ describe("createLocalCommandGateway", () => {
     await expect(store.listEvents()).resolves.toEqual({ ok: true, value: [] });
   });
 
+  it("allows runtime directive register seeding over stale closeout history", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    await appendOpenDrawer(store);
+    await store.appendEvent({
+      type: "register.closeout_started",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "drawer-1",
+      staffProfileId: "staff-1",
+      payload: { countedCash: 100 },
+    });
+    const gateway = createLocalCommandGateway({
+      allowExplicitRegisterSessionWithoutProjection: true,
+      allowRegisterSessionSeedFromRuntimeDirective: true,
+      store,
+    });
+
+    await expect(
+      gateway.seedRegisterSession({
+        terminalId: "terminal-1",
+        storeId: "store-1",
+        registerNumber: "1",
+        localRegisterSessionId: "cloud-drawer-1",
+        staffProfileId: "staff-1",
+        openingFloat: 100,
+        expectedCash: 100,
+        runtimeDirectiveRepair: true,
+        status: "active",
+      }),
+    ).resolves.toBe(true);
+
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: expect.arrayContaining([
+        expect.objectContaining({
+          localRegisterSessionId: "cloud-drawer-1",
+          type: "register.opened",
+        }),
+      ]),
+    });
+  });
+
+  it("rejects runtime directive register seeding when a different local drawer is already operable", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    await appendOpenDrawer(store);
+    const gateway = createLocalCommandGateway({
+      allowExplicitRegisterSessionWithoutProjection: true,
+      allowRegisterSessionSeedFromRuntimeDirective: true,
+      store,
+    });
+
+    await expect(
+      gateway.seedRegisterSession({
+        terminalId: "terminal-1",
+        storeId: "store-1",
+        registerNumber: "1",
+        localRegisterSessionId: "cloud-drawer-1",
+        staffProfileId: "staff-1",
+        openingFloat: 100,
+        expectedCash: 100,
+        runtimeDirectiveRepair: true,
+        status: "active",
+      }),
+    ).resolves.toBe(false);
+  });
+
   it("blocks explicit sale start when drawer authority is blocked before projection", async () => {
     const store = createPosLocalStore({
       adapter: createMemoryPosLocalStorageAdapter(),

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
@@ -45,6 +45,8 @@ type PosLocalCommandStore = {
 
 type CreateLocalCommandGatewayOptions = {
   allowExplicitRegisterSessionWithoutProjection?: boolean;
+  allowRegisterSessionSeedAfterSettledHistory?: boolean;
+  allowRegisterSessionSeedFromRuntimeDirective?: boolean;
   store: PosLocalCommandStore;
   clock?: () => number;
   createLocalId?: (kind: string) => string;
@@ -264,11 +266,33 @@ export function createLocalCommandGateway(
       terminalId: input.terminalId,
     });
     if (!model.ok) return false;
-    if (model.value.canSell) return true;
-    if (model.value.saleBlockReason) return false;
+    if (model.value.canSell) {
+      return (
+        model.value.activeRegisterSession?.localRegisterSessionId ===
+        input.localRegisterSessionId
+      );
+    }
+    const hasSettledCloseoutSession =
+      model.value.activeRegisterSession?.status === "closing" &&
+      hasSettledRegisterCloseout({
+        events: model.value.sourceEvents,
+        session: model.value.activeRegisterSession,
+      });
+    const canSeedAfterSettledHistory =
+      options.allowRegisterSessionSeedAfterSettledHistory &&
+      (!model.value.activeRegisterSession || hasSettledCloseoutSession);
+    const canSeedFromRuntimeDirective =
+      options.allowRegisterSessionSeedFromRuntimeDirective &&
+      input.runtimeDirectiveRepair === true &&
+      model.value.saleBlockReason !== "terminal_integrity";
+    const canSeedAfterExistingHistory =
+      canSeedAfterSettledHistory || canSeedFromRuntimeDirective;
+    if (model.value.saleBlockReason && !canSeedAfterExistingHistory) {
+      return false;
+    }
     if (
       !options.allowExplicitRegisterSessionWithoutProjection ||
-      model.eventCount > 0
+      (model.eventCount > 0 && !canSeedAfterExistingHistory)
     ) {
       return false;
     }
@@ -827,6 +851,7 @@ type SeedLocalRegisterSessionInput = LocalCommandContext & {
   expectedCash: number;
   notes?: string | null;
   openingFloat: number;
+  runtimeDirectiveRepair?: boolean;
   status: string;
 };
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
@@ -1209,6 +1209,57 @@ describe("projectLocalRegisterReadModel", () => {
     expect(model.saleBlockReason).toBeUndefined();
     expect(model.syncStatus.state).toBe("needs_review");
   });
+
+  it("keeps the current drawer active when a later duplicate drawer open was synced to the same cloud drawer", () => {
+    const model = projectLocalRegisterReadModel({
+      mappings: [
+        {
+          entity: "registerSession",
+          localId: "local-register-1",
+          cloudId: "cloud-register-1",
+          mappedAt: 1_001,
+        },
+        {
+          entity: "registerSession",
+          localId: "local-register-2",
+          cloudId: "cloud-register-1",
+          mappedAt: 1_002,
+        },
+      ],
+      events: [
+        event({
+          sequence: 1,
+          type: "register.opened",
+          payload: { openingFloat: 130, expectedCash: 130 },
+          sync: { status: "synced", uploaded: true },
+        }),
+        event({
+          sequence: 2,
+          uploadSequence: 2,
+          type: "register.opened",
+          localEventId: "duplicate-open",
+          localRegisterSessionId: "local-register-2",
+          payload: {
+            localRegisterSessionId: "local-register-2",
+            openingFloat: 90,
+            expectedCash: 90,
+          },
+          sync: { status: "synced", uploaded: true },
+        }),
+      ],
+      isOnline: true,
+    });
+
+    expect(model.activeRegisterSession).toMatchObject({
+      localRegisterSessionId: "local-register-1",
+      cloudRegisterSessionId: "cloud-register-1",
+      openingFloat: 130,
+      expectedCash: 130,
+    });
+    expect(model.canSell).toBe(true);
+    expect(model.saleBlockReason).toBeUndefined();
+    expect(model.syncStatus.state).toBe("synced");
+  });
 });
 
 function errorCodes(errors: PosLocalRegisterReadModelError[]) {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
@@ -193,7 +193,7 @@ export function projectLocalRegisterReadModel(input: {
       if (
         activeRegisterSession &&
         isOpenLocalRegisterSessionStatus(activeRegisterSession.status) &&
-        isUploadedRegisterOpenReview(event) &&
+        isUploadedRegisterOpenLifecycleEvent(event) &&
         !registerLifecycleEventMatchesActiveSession(event, activeRegisterSession)
       ) {
         continue;
@@ -1014,8 +1014,11 @@ function isOpenLocalRegisterSessionStatus(
   return status === "open" || status === "active";
 }
 
-function isUploadedRegisterOpenReview(event: PosLocalEventRecord) {
-  return event.sync.status === "needs_review" && event.sync.uploaded === true;
+function isUploadedRegisterOpenLifecycleEvent(event: PosLocalEventRecord) {
+  return (
+    event.sync.uploaded === true &&
+    (event.sync.status === "needs_review" || event.sync.status === "synced")
+  );
 }
 
 function serviceModeField(

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -3440,6 +3440,128 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     expect(onLocalEventsChanged).toHaveBeenCalled();
   });
 
+  it("seeds a local active drawer from active register directives over stale local closeout history", async () => {
+    mocks.reportTerminalRuntimeStatus.mockResolvedValue({
+      kind: "ok",
+      data: {
+        activeRegisterSessionDirective: {
+          cloudRegisterSessionId: "cloud-register-1",
+          expectedCash: 13_000,
+          localRegisterSessionId: "cloud-register-1",
+          observedAt: 200,
+          openedAt: 100,
+          openingFloat: 13_000,
+          registerNumber: "8",
+          staffProfileId: "staff-1",
+          status: "active",
+        },
+      },
+    });
+    const events = [
+      buildLocalEvent({
+        localEventId: "event-open",
+        localRegisterSessionId: "old-register-1",
+        payload: {
+          expectedCash: 9_000,
+          localRegisterSessionId: "old-register-1",
+          openingFloat: 9_000,
+          status: "active",
+        },
+        sequence: 1,
+        sync: { status: "synced", uploaded: true },
+        type: "register.opened",
+      }),
+      {
+        createdAt: 2,
+        localEventId: "event-close",
+        localRegisterSessionId: "old-register-1",
+        payload: { countedCash: 9_000, notes: null },
+        schemaVersion: 1,
+        sequence: 2,
+        staffProfileId: "staff-1",
+        staffProofToken: "proof-token-1",
+        storeId: "store-1",
+        sync: { status: "pending" },
+        terminalId: "local-terminal-1",
+        type: "register.closeout_started",
+        uploadSequence: 2,
+      } satisfies PosLocalEventRecord,
+    ];
+    const onLocalEventsChanged = vi.fn();
+    const store = {
+      appendEvent: vi.fn(async (event) => {
+        const localEvent = buildLocalEvent({
+          ...event,
+          localEventId: "event-seeded-open",
+          sequence: events.length + 1,
+          sync: { status: "pending" },
+        });
+        events.push(localEvent);
+        return { ok: true, value: localEvent };
+      }),
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [...events],
+      })),
+      readDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          registerNumber: "8",
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+    };
+
+    const { result } = renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        mode: "status-only",
+        onLocalEventsChanged,
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(store.appendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          localRegisterSessionId: "cloud-register-1",
+          registerNumber: "8",
+          staffProfileId: "staff-1",
+          storeId: "store-1",
+          terminalId: "terminal-cloud-1",
+          type: "register.opened",
+          payload: expect.objectContaining({
+            expectedCash: 13_000,
+            localRegisterSessionId: "cloud-register-1",
+            openingFloat: 13_000,
+            status: "active",
+          }),
+        }),
+      ),
+    );
+    expect(onLocalEventsChanged).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(result.current?.debug?.activeRegisterSessionRepair).toMatchObject({
+        directive: expect.objectContaining({
+          localRegisterSessionId: "cloud-register-1",
+          status: "active",
+        }),
+        seedResult: "seeded",
+      }),
+    );
+  });
+
   it("passively reconciles a pending local closeout when the mapped cloud drawer is closed", async () => {
     mocks.reportTerminalRuntimeStatus.mockResolvedValue({
       kind: "ok",

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -22,6 +22,7 @@ import {
   type PosTerminalIntegrityState,
   type PosProvisionedTerminalSeed,
 } from "./posLocalStore";
+import { createLocalCommandGateway } from "./localCommandGateway";
 import {
   clearRecoverableDrawerAuthorityForSyncedEvents,
   clearSupersededRecoverableDrawerAuthorityBlocks,
@@ -101,6 +102,16 @@ export type PosLocalRuntimeSyncStatusSource = {
 };
 
 export type PosLocalRuntimeSyncDebug = {
+  activeRegisterSessionRepair?: {
+    directive?: RuntimeActiveRegisterSessionDirective;
+    observedAt: number;
+    seedResult:
+      | "gateway_rejected"
+      | "missing_directive"
+      | "missing_staff_identity"
+      | "not_attempted"
+      | "seeded";
+  };
   checkInPublishAttemptedAt?: number;
   checkInPublishCompletedAt?: number;
   checkInPublishMessage?: string;
@@ -162,6 +173,17 @@ type RuntimeDrawerAuthorityDirective = Omit<
   PosDrawerAuthorityState,
   "storeId" | "terminalId"
 >;
+export type RuntimeActiveRegisterSessionDirective = {
+  cloudRegisterSessionId: string;
+  expectedCash: number;
+  localRegisterSessionId: string;
+  observedAt: number;
+  openedAt: number;
+  openingFloat: number;
+  registerNumber?: string;
+  staffProfileId?: string;
+  status: "active";
+};
 type IngestLocalEventsArgs = FunctionArgs<
   typeof api.pos.public.sync.ingestLocalEvents
 >;
@@ -185,6 +207,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
   appUpdateCoordinator?: PosAppUpdateCoordinatorAdapter | null;
   staffProfileId?: string | null;
   staffAuthorityStatus?: PosLocalStaffAuthorityReadiness | "unknown";
+  staffProofToken?: string | null;
   storeFactory?: (() => PosLocalRuntimeStore) | null;
 }): PosLocalRuntimeSyncStatusSource | null {
   const ingestLocalEvents = useMutation(api.pos.public.sync.ingestLocalEvents);
@@ -231,6 +254,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
   const onRetrySync = input.onRetrySync;
   const source = input.source ?? "sync-runtime";
   const staffProfileId = input.staffProfileId;
+  const staffProofToken = input.staffProofToken;
   const uploadSupport = useMemo(
     () => getAppSessionUploadSupport(input.appSessionRecovery),
     [input.appSessionRecovery],
@@ -988,6 +1012,18 @@ export function usePosLocalSyncRuntimeStatus(input: {
                   terminalSeed: runtimeReadiness.terminalSeed,
                 });
               if (!isCurrentPublishScope()) return;
+              const activeRegisterSessionDirective =
+                readRuntimeActiveRegisterSessionDirective(result.data);
+              const activeRegisterSessionSeed =
+                await seedRuntimeActiveRegisterSessionDirective({
+                  directive: activeRegisterSessionDirective,
+                  staffProfileId,
+                  staffProofToken,
+                  store: authorityStore,
+                  storeId: checkInStoreId,
+                  terminalId: checkInTerminalId,
+                });
+              if (!isCurrentPublishScope()) return;
 
               const cleared = await clearAcceptedTerminalIntegrityState({
                 checkInTerminalId,
@@ -1009,6 +1045,29 @@ export function usePosLocalSyncRuntimeStatus(input: {
                 setRuntimeStatusObservationToken((current) => current + 1);
                 onLocalEventsChanged?.();
               }
+              if (activeRegisterSessionSeed.seeded) {
+                const readiness = await refreshTerminalRuntimeReadiness({
+                  store: authorityStore,
+                  storeId: checkInStoreId,
+                  terminalId: checkInTerminalId,
+                  terminalSeed: runtimeReadiness.terminalSeed,
+                });
+                if (!isCurrentPublishScope()) return;
+                setRuntimeReadiness(readiness);
+                setRefreshToken((current) => current + 1);
+                setRuntimeStatusObservationToken((current) => current + 1);
+                onLocalEventsChanged?.();
+              }
+              setDebug((current) => ({
+                ...current,
+                activeRegisterSessionRepair: {
+                  ...(activeRegisterSessionDirective
+                    ? { directive: activeRegisterSessionDirective }
+                    : {}),
+                  observedAt: Date.now(),
+                  seedResult: activeRegisterSessionSeed.seedResult,
+                },
+              }));
             }
           }
 
@@ -1127,6 +1186,8 @@ export function usePosLocalSyncRuntimeStatus(input: {
     onLocalEventsChanged,
     storeFactory,
     storeId,
+    staffProfileId,
+    staffProofToken,
   ]);
 
   useEffect(() => {
@@ -1510,6 +1571,101 @@ function readRuntimeDrawerAuthorityDirective(
       ? { registerNumber: candidate.registerNumber }
       : {}),
     status: "blocked",
+  };
+}
+
+function readRuntimeActiveRegisterSessionDirective(
+  data: unknown,
+): RuntimeActiveRegisterSessionDirective | null {
+  if (!data || typeof data !== "object") return null;
+  const directive = (
+    data as { activeRegisterSessionDirective?: unknown }
+  ).activeRegisterSessionDirective;
+  if (!directive || typeof directive !== "object") return null;
+  const candidate =
+    directive as Partial<RuntimeActiveRegisterSessionDirective>;
+  if (
+    typeof candidate.cloudRegisterSessionId !== "string" ||
+    candidate.cloudRegisterSessionId.length === 0 ||
+    typeof candidate.localRegisterSessionId !== "string" ||
+    candidate.localRegisterSessionId.length === 0 ||
+    typeof candidate.expectedCash !== "number" ||
+    typeof candidate.openedAt !== "number" ||
+    typeof candidate.openingFloat !== "number" ||
+    candidate.status !== "active"
+  ) {
+    return null;
+  }
+
+  return {
+    cloudRegisterSessionId: candidate.cloudRegisterSessionId,
+    expectedCash: candidate.expectedCash,
+    localRegisterSessionId: candidate.localRegisterSessionId,
+    observedAt:
+      typeof candidate.observedAt === "number" ? candidate.observedAt : Date.now(),
+    openedAt: candidate.openedAt,
+    openingFloat: candidate.openingFloat,
+    ...(typeof candidate.registerNumber === "string"
+      ? { registerNumber: candidate.registerNumber }
+      : {}),
+    ...(typeof candidate.staffProfileId === "string"
+      ? { staffProfileId: candidate.staffProfileId }
+      : {}),
+    status: "active",
+  };
+}
+
+async function seedRuntimeActiveRegisterSessionDirective(input: {
+  directive: RuntimeActiveRegisterSessionDirective | null;
+  staffProfileId?: string | null;
+  staffProofToken?: string | null;
+  store: PosLocalRuntimeStore;
+  storeId: string;
+  terminalId: string;
+}): Promise<{
+  seeded: boolean;
+  seedResult: NonNullable<
+    PosLocalRuntimeSyncDebug["activeRegisterSessionRepair"]
+  >["seedResult"];
+}> {
+  if (!input.directive) {
+    return { seeded: false, seedResult: "missing_directive" };
+  }
+  const staffProfileId =
+    input.staffProfileId ?? input.directive.staffProfileId ?? null;
+  if (!staffProfileId) {
+    return { seeded: false, seedResult: "missing_staff_identity" };
+  }
+
+  const gateway = createLocalCommandGateway({
+    allowExplicitRegisterSessionWithoutProjection: true,
+    allowRegisterSessionSeedAfterSettledHistory: true,
+    allowRegisterSessionSeedFromRuntimeDirective: true,
+    staffProofToken:
+      staffProfileId === input.staffProfileId
+        ? (input.staffProofToken ?? undefined)
+        : undefined,
+    store: input.store,
+  });
+
+  const seeded = await gateway.seedRegisterSession({
+    expectedCash: input.directive.expectedCash,
+    localRegisterSessionId: input.directive.localRegisterSessionId,
+    openingFloat: input.directive.openingFloat,
+    registerNumber: input.directive.registerNumber,
+    staffProfileId,
+    storeId: input.storeId,
+    terminalId: input.terminalId,
+    validationMetadata: {
+      flags: ["cloud-validation-uncertain"],
+      observedAt: input.directive.observedAt,
+    },
+    runtimeDirectiveRepair: true,
+    status: input.directive.status,
+  });
+  return {
+    seeded,
+    seedResult: seeded ? "seeded" : "gateway_rejected",
   };
 }
 

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -423,6 +423,89 @@ export interface RegisterViewModel {
     online: boolean;
     staffSignedIn: boolean;
     storeId?: string;
+    runtimeState?: {
+      heartbeat?: {
+        activeRegisterSession?: {
+          cloudRegisterSessionId?: string;
+          localRegisterSessionId: string;
+          observedAt?: number;
+          openedAt?: number;
+          registerNumber?: string;
+          status: string;
+        };
+        drawerAuthority?: {
+          cloudRegisterSessionId?: string;
+          localRegisterSessionId: string;
+          reason?: string;
+          status: string;
+        };
+        localStore: {
+          available: boolean;
+          failureMessage?: string;
+          schemaVersion?: number;
+          terminalSeedReady: boolean;
+        };
+        reportedAt?: number;
+        saleAuthority?: {
+          staffProfileId?: string;
+          status: string;
+        };
+        source?: string;
+        staffAuthority: {
+          expiresAt?: number;
+          staffProfileId?: string;
+          status: string;
+        };
+        sync: {
+          failedEventCount?: number;
+          lastSyncedSequence?: number;
+          nextPendingUploadSequence?: number;
+          pendingEventCount?: number;
+          reviewEventCount?: number;
+          status: string;
+          uploadableEventCount?: number;
+        };
+        terminalIntegrity?: {
+          reason?: string;
+          status: string;
+        };
+      };
+      localReadModel?: {
+        activeRegisterSession?: {
+          cloudRegisterSessionId?: string;
+          expectedCash?: number;
+          localRegisterSessionId: string;
+          openedAt?: number;
+          openingFloat?: number;
+          registerNumber?: string;
+          status: string;
+        };
+        canSell: boolean;
+        saleBlockReason?: string | null;
+        sourceEventCount: number;
+        syncStatus: {
+          lastLocalSequence: number;
+          lastSyncedSequence?: number;
+          nextPendingSequence?: number | null;
+          state: string;
+        };
+      };
+      repair?: {
+        directive?: {
+          cloudRegisterSessionId: string;
+          expectedCash: number;
+          localRegisterSessionId: string;
+          observedAt: number;
+          openedAt: number;
+          openingFloat: number;
+          registerNumber?: string;
+          staffProfileId?: string;
+          status: string;
+        };
+        observedAt: number;
+        seedResult: string;
+      };
+    };
     syncFlow: {
       checkInPublishAttemptedAt?: number;
       checkInPublishCompletedAt?: number;

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterLocalRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterLocalRuntime.ts
@@ -259,6 +259,7 @@ export function useRegisterLocalRuntime(input: {
     onLocalEventsChanged: noteLocalRegisterEventChanged,
     storeId: activeStoreId,
     staffProfileId,
+    staffProofToken,
     terminalId: terminal?._id,
     onRetrySync: onRetryBootstrap,
     storeFactory: localRuntimeStoreFactory,

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -1631,6 +1631,102 @@ describe("useRegisterViewModel", () => {
     );
   });
 
+  it("passes runtime heartbeat, local read model, and repair state through debug runtime state", async () => {
+    mockUsePosLocalSyncRuntimeStatus.mockReturnValue({
+      debug: {
+        activeRegisterSessionRepair: {
+          directive: {
+            cloudRegisterSessionId: "cloud-register-1",
+            expectedCash: 13_000,
+            localRegisterSessionId: "cloud-register-1",
+            observedAt: 200,
+            openedAt: 100,
+            openingFloat: 13_000,
+            registerNumber: "8",
+            staffProfileId: "staff-1",
+            status: "active",
+          },
+          observedAt: 300,
+          seedResult: "seeded",
+        },
+      },
+      runtimeStatus: {
+        activeRegisterSession: {
+          cloudRegisterSessionId: "cloud-register-1",
+          localRegisterSessionId: "cloud-register-1",
+          observedAt: 200,
+          openedAt: 100,
+          registerNumber: "8",
+          status: "active",
+        },
+        localStore: {
+          available: true,
+          schemaVersion: 1,
+          terminalSeedReady: true,
+        },
+        reportedAt: 400,
+        source: "runtime",
+        staffAuthority: {
+          staffProfileId: "staff-1",
+          status: "ready",
+        },
+        sync: {
+          pendingEventCount: 1,
+          status: "pending_sync",
+          uploadableEventCount: 1,
+        },
+      },
+      status: "pending",
+    });
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        buildLocalEvent({
+          localRegisterSessionId: "cloud-register-1",
+          payload: {
+            expectedCash: 13_000,
+            localRegisterSessionId: "cloud-register-1",
+            openingFloat: 13_000,
+            status: "active",
+          },
+          sequence: 1,
+          staffProofToken: "staff-proof-token",
+          sync: { status: "pending" },
+          type: "register.opened",
+        }),
+      ],
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await waitFor(() =>
+      expect(result.current.debug?.runtimeState).toEqual(
+        expect.objectContaining({
+          heartbeat: expect.objectContaining({
+            activeRegisterSession: expect.objectContaining({
+              localRegisterSessionId: "cloud-register-1",
+            }),
+            sync: expect.objectContaining({
+              status: "pending_sync",
+            }),
+          }),
+          localReadModel: expect.objectContaining({
+            activeRegisterSession: expect.objectContaining({
+              localRegisterSessionId: "cloud-register-1",
+              status: "active",
+            }),
+            canSell: true,
+            sourceEventCount: 1,
+          }),
+          repair: expect.objectContaining({
+            seedResult: "seeded",
+          }),
+        }),
+      ),
+    );
+  });
+
   it("does not show pending sync for local session-start records that cannot upload alone", async () => {
     mockUsePosLocalSyncRuntimeStatus.mockReturnValue({
       debug: {
@@ -9936,6 +10032,109 @@ describe("useRegisterViewModel", () => {
         payload: expect.objectContaining({ countedCash: 5_000 }),
       }),
     );
+  });
+
+  it("uses the projected local drawer cash total for closeout after local cash sales", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "staff-1", firstName: "Ama", lastName: "Kusi" },
+      activeRegisterSession: null,
+      activeSession: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+
+    const localEvents: ReturnType<typeof buildLocalEvent>[] = [];
+    mockAppendLocalEvent.mockImplementation(async (event) => {
+      const sequence = localEvents.length + 1;
+      const localEvent = buildLocalEvent({
+        ...event,
+        localEventId: `local-event-${sequence}`,
+        sequence,
+        createdAt: 1_000 + sequence,
+        sync: { status: "pending" },
+      });
+      localEvents.push(localEvent);
+      return { ok: true, value: localEvent };
+    });
+    mockListLocalEvents.mockImplementation(async () => ({
+      ok: true,
+      value: [...localEvents],
+    }));
+    let notifyLocalEventsChanged: (() => void) | undefined;
+    mockUsePosLocalSyncRuntimeStatus.mockImplementation(
+      (input: { onLocalEventsChanged?: () => void }) => {
+        notifyLocalEventsChanged = input.onLocalEventsChanged;
+        return null;
+      },
+    );
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated({
+        activeRoles: ["manager"],
+        staffProfileId: "staff-1" as Id<"staffProfile">,
+        staffProfile: {
+          firstName: "Ama",
+          lastName: "Kusi",
+        },
+        posLocalStaffProof: {
+          expiresAt: Date.now() + 60_000,
+          token: "staff-proof-token",
+        },
+      });
+    });
+
+    act(() => {
+      result.current.drawerGate?.onOpeningFloatChange?.("90.00");
+    });
+    await act(async () => {
+      await result.current.drawerGate?.onSubmit?.();
+    });
+    await waitFor(() =>
+      expect(result.current.closeoutControl?.canCloseout).toBe(true),
+    );
+
+    const localRegisterSessionId = localEvents.find(
+      (event) => event.type === "register.opened",
+    )?.localRegisterSessionId;
+    expect(localRegisterSessionId).toEqual(expect.stringMatching(/^local-/));
+    localEvents.push(
+      buildLocalEvent({
+        sequence: localEvents.length + 1,
+        type: "transaction.completed",
+        localRegisterSessionId,
+        localPosSessionId: "local-sale-1",
+        localTransactionId: "local-txn-1",
+        payload: {
+          localPosSessionId: "local-sale-1",
+          localTransactionId: "local-txn-1",
+          receiptNumber: "R-1",
+          subtotal: 4_000,
+          tax: 0,
+          total: 4_000,
+          payments: [{ method: "cash", amount: 4_000, timestamp: 1_004 }],
+        },
+      }),
+    );
+    act(() => {
+      notifyLocalEventsChanged?.();
+    });
+    await waitFor(() =>
+      expect(result.current.closeoutControl?.canCloseout).toBe(true),
+    );
+
+    act(() => {
+      result.current.closeoutControl?.onRequestCloseout();
+    });
+
+    await waitFor(() =>
+      expect(result.current.drawerGate?.expectedCash).toBe(13_000),
+    );
+    expect(result.current.drawerGate?.mode).toBe("closeoutBlocked");
   });
 
   it("keeps a local sale active instead of claiming an unsupported local hold", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -862,11 +862,15 @@ export function useRegisterViewModel(): RegisterViewModel {
         }
       : null;
   const locallyOperableRegisterSession =
-    localOperableRegisterSession &&
-    activeStoreId === localOperableRegisterSession.storeId &&
-    terminal?._id === localOperableRegisterSession.terminalId
-      ? localOperableRegisterSession
-      : projectedLocalRegisterSession;
+    projectedLocalRegisterSession &&
+    localOperableRegisterSession?.localRegisterSessionId ===
+      projectedLocalRegisterSession.localRegisterSessionId
+      ? projectedLocalRegisterSession
+      : localOperableRegisterSession &&
+          activeStoreId === localOperableRegisterSession.storeId &&
+          terminal?._id === localOperableRegisterSession.terminalId
+        ? localOperableRegisterSession
+        : projectedLocalRegisterSession;
   const closeoutBlockedRegisterSession =
     locallyOperableRegisterSession === null
       ? selectPassiveCloseoutBlockedRegisterSession(
@@ -3022,6 +3026,13 @@ export function useRegisterViewModel(): RegisterViewModel {
       return;
     }
 
+    if (!(await ensureLocalRegisterSessionReady(registerSessionId))) {
+      setDrawerErrorMessage(
+        "Closeout unavailable. Refresh the register and try again.",
+      );
+      return;
+    }
+
     const expectedCloseoutCash = activeCloseoutRegisterSession?.expectedCash;
     const trimmedCloseoutNotes = trimOptional(closeoutNotes);
     const hasCloseoutVariance =
@@ -3093,6 +3104,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     activeCloseoutRegisterSession,
     closeoutCountedCash,
     closeoutNotes,
+    ensureLocalRegisterSessionReady,
     localCommandGateway,
     localSaleValidationMetadata,
     localStore,
@@ -5500,6 +5512,99 @@ export function useRegisterViewModel(): RegisterViewModel {
       online: globalThis.navigator?.onLine ?? true,
       staffSignedIn: Boolean(staffProfileId),
       ...(activeStoreId ? { storeId: activeStoreId } : {}),
+      runtimeState: {
+        ...(localRuntimeSyncSource?.runtimeStatus
+          ? {
+              heartbeat: {
+                ...(localRuntimeSyncSource.runtimeStatus.activeRegisterSession
+                  ? {
+                      activeRegisterSession:
+                        localRuntimeSyncSource.runtimeStatus
+                          .activeRegisterSession,
+                    }
+                  : {}),
+                ...(localRuntimeSyncSource.runtimeStatus.drawerAuthority
+                  ? {
+                      drawerAuthority:
+                        localRuntimeSyncSource.runtimeStatus.drawerAuthority,
+                    }
+                  : {}),
+                localStore: localRuntimeSyncSource.runtimeStatus.localStore,
+                reportedAt: localRuntimeSyncSource.runtimeStatus.reportedAt,
+                ...(localRuntimeSyncSource.runtimeStatus.saleAuthority
+                  ? {
+                      saleAuthority:
+                        localRuntimeSyncSource.runtimeStatus.saleAuthority,
+                    }
+                  : {}),
+                source: localRuntimeSyncSource.runtimeStatus.source,
+                staffAuthority:
+                  localRuntimeSyncSource.runtimeStatus.staffAuthority,
+                sync: localRuntimeSyncSource.runtimeStatus.sync,
+                ...(localRuntimeSyncSource.runtimeStatus.terminalIntegrity
+                  ? {
+                      terminalIntegrity:
+                        localRuntimeSyncSource.runtimeStatus.terminalIntegrity,
+                    }
+                  : {}),
+              },
+            }
+          : {}),
+        ...(localRegisterReadModel
+          ? {
+              localReadModel: {
+                ...(localRegisterReadModel.activeRegisterSession
+                  ? {
+                      activeRegisterSession: {
+                        ...(localRegisterReadModel.activeRegisterSession
+                          .cloudRegisterSessionId
+                          ? {
+                              cloudRegisterSessionId:
+                                localRegisterReadModel.activeRegisterSession
+                                  .cloudRegisterSessionId,
+                            }
+                          : {}),
+                        expectedCash:
+                          localRegisterReadModel.activeRegisterSession
+                            .expectedCash,
+                        localRegisterSessionId:
+                          localRegisterReadModel.activeRegisterSession
+                            .localRegisterSessionId,
+                        openedAt:
+                          localRegisterReadModel.activeRegisterSession.openedAt,
+                        openingFloat:
+                          localRegisterReadModel.activeRegisterSession
+                            .openingFloat,
+                        registerNumber:
+                          localRegisterReadModel.activeRegisterSession
+                            .registerNumber,
+                        status:
+                          localRegisterReadModel.activeRegisterSession.status,
+                      },
+                    }
+                  : {}),
+                canSell: localRegisterReadModel.canSell,
+                saleBlockReason: localRegisterReadModel.saleBlockReason ?? null,
+                sourceEventCount: localRegisterReadModel.sourceEvents.length,
+                syncStatus: {
+                  lastLocalSequence:
+                    localRegisterReadModel.syncStatus.lastLocalSequence,
+                  lastSyncedSequence:
+                    localRegisterReadModel.syncStatus.lastSyncedSequence,
+                  nextPendingSequence:
+                    localRegisterReadModel.syncStatus.nextPendingSequence,
+                  state: localRegisterReadModel.syncStatus.state,
+                },
+              },
+            }
+          : {}),
+        ...(localRuntimeSyncSource?.debug?.activeRegisterSessionRepair
+          ? {
+              repair:
+                localRuntimeSyncSource.debug.activeRegisterSessionRepair,
+            }
+          : {}),
+      },
       syncFlow: {
         checkInPublishAttemptedAt:
           localRuntimeSyncSource?.debug?.checkInPublishAttemptedAt,


### PR DESCRIPTION
## Summary
- add manager repair paths for synced register sale mapping reviews so completed sales can be retained and applied instead of reject-only
- generalize closeout hold handling for register review workflows and update Cash Controls review UI/actions
- reconcile cloud-active register sessions through the POS heartbeat into local register state, with runtime debug visibility and stale-directive guards
- document the reusable register sync repair/runtime reconciliation pattern in `docs/solutions`

## Review
- Correctness reviewer: APPROVE
- TypeScript/runtime reviewer: APPROVE
- Data integrity reviewer: APPROVE
- Testing reviewer: APPROVE

## Validation
- `bun run pr:athena` pass, proof recorded
- `bunx vitest run src/lib/pos/infrastructure/local/localCommandGateway.test.ts src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts src/lib/pos/presentation/register/useRegisterViewModel.test.ts src/components/pos/register/POSRegisterView.test.tsx --reporter=dot --maxWorkers=4`
- `bunx vitest run convex/cashControls/deposits.test.ts convex/pos/application/terminals.test.ts convex/pos/application/queries/terminals.test.ts convex/pos/application/sync/projectLocalEvents.test.ts convex/pos/infrastructure/repositories/terminalRepository.test.ts shared/registerSessionLifecyclePolicy.test.ts --reporter=dot --maxWorkers=4`
- `bunx vitest run convex/pos/public/terminals.test.ts convex/pos/application/terminals.test.ts --reporter=dot --maxWorkers=4`
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bun run --filter '@athena/webapp' lint:frontend:changed`
- `bun run typecheck` in `packages/athena-webapp`
