### PR TITLE
V26-876 V26-877 V26-878 V26-879 V26-880 Extract terminal operational state

### DIFF
--- a/docs/plans/2026-06-27-001-refactor-terminal-operational-state-plan.html
+++ b/docs/plans/2026-06-27-001-refactor-terminal-operational-state-plan.html
@@ -1,0 +1,407 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Plan: Extract Terminal Operational State</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f7f5;
+      --panel: #ffffff;
+      --ink: #1d2528;
+      --muted: #5d6a70;
+      --line: #d9dedb;
+      --accent: #285c6d;
+      --accent-soft: #e6f0f2;
+      --warn: #7a4b12;
+      --warn-soft: #fff4df;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.52;
+    }
+
+    main {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 32px 20px 56px;
+    }
+
+    header {
+      border-bottom: 1px solid var(--line);
+      margin-bottom: 24px;
+      padding-bottom: 20px;
+    }
+
+    h1 {
+      font-size: 32px;
+      line-height: 1.15;
+      margin: 0 0 12px;
+      letter-spacing: 0;
+    }
+
+    h2 {
+      font-size: 20px;
+      margin: 30px 0 12px;
+      letter-spacing: 0;
+    }
+
+    h3 {
+      font-size: 16px;
+      margin: 22px 0 8px;
+      letter-spacing: 0;
+    }
+
+    p {
+      margin: 0 0 12px;
+    }
+
+    a {
+      color: var(--accent);
+      text-decoration-thickness: 1px;
+      text-underline-offset: 2px;
+    }
+
+    code {
+      background: #eef1ef;
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1px 5px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.92em;
+    }
+
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .pill {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 4px 10px;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 14px;
+    }
+
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px;
+    }
+
+    .callout {
+      background: var(--accent-soft);
+      border: 1px solid #bdd2d7;
+      border-radius: 8px;
+      padding: 14px 16px;
+    }
+
+    .warning {
+      background: var(--warn-soft);
+      border: 1px solid #efd2a6;
+      color: var(--warn);
+    }
+
+    ul, ol {
+      padding-left: 22px;
+      margin: 8px 0 12px;
+    }
+
+    li {
+      margin: 6px 0;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+      display: table;
+      margin: 12px 0 18px;
+    }
+
+    th, td {
+      border-bottom: 1px solid var(--line);
+      padding: 10px 12px;
+      text-align: left;
+      vertical-align: top;
+      font-size: 14px;
+    }
+
+    th {
+      background: #eef2f0;
+      font-weight: 650;
+    }
+
+    tr:last-child td {
+      border-bottom: 0;
+    }
+
+    nav {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 12px 16px;
+      margin: 18px 0 24px;
+    }
+
+    nav a {
+      display: inline-block;
+      margin: 4px 14px 4px 0;
+      font-size: 14px;
+    }
+
+    section {
+      scroll-margin-top: 20px;
+    }
+
+    .unit {
+      border-left: 4px solid var(--accent);
+    }
+
+    .small {
+      color: var(--muted);
+      font-size: 14px;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>refactor: Extract Terminal Operational State</h1>
+      <div class="meta">
+        <span class="pill">Type: refactor</span>
+        <span class="pill">Status: active</span>
+        <span class="pill">Date: 2026-06-27</span>
+        <span class="pill">Source: <a href="./2026-06-27-001-refactor-terminal-operational-state-plan.md">Markdown plan</a></span>
+      </div>
+    </header>
+
+    <nav aria-label="Plan sections">
+      <a href="#summary">Summary</a>
+      <a href="#decisions">Key Decisions</a>
+      <a href="#design">Design Shape</a>
+      <a href="#units">Implementation Units</a>
+      <a href="#risks">Risks</a>
+      <a href="#validation">Validation</a>
+    </nav>
+
+    <section id="summary" class="callout">
+      <h2>Summary</h2>
+      <p>Extract POS terminal health and recovery read semantics into one computed server aggregate, <code>TerminalOperationalState</code>. The normalized ledgers remain separate, while Terminal Health, terminal detail, <code>previewTerminalRecovery</code>, and future diagnostics classify terminal state from one policy output.</p>
+    </section>
+
+    <section>
+      <h2>Problem Frame</h2>
+      <p>Terminal truth is currently assembled inline inside the terminal query path from runtime status, sync ledgers, active register-session evidence, command status, cloud repair classification, attention reasons, and public return shaping. That join is becoming the hidden source of truth.</p>
+      <p>The plan addresses that split before any self-heal behavior is implemented.</p>
+    </section>
+
+    <section id="decisions">
+      <h2>Key Decisions</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>Compute, Do Not Persist</h3>
+          <p>The aggregate is computed per query for now. Materialization is deferred until invalidation and race behavior are explicitly designed.</p>
+        </article>
+        <article class="card">
+          <h3>Preserve Ledgers</h3>
+          <p>Sync events, cursors, mappings, conflicts, runtime status, register sessions, and recovery commands remain distinct durable ledgers.</p>
+        </article>
+        <article class="card">
+          <h3>Separate Readiness Concepts</h3>
+          <p>Sales readiness, support recovery, and diagnostic evidence are explicit outputs. <code>healthy_idle</code> and <code>able_to_transact_now</code> stay distinct.</p>
+        </article>
+        <article class="card">
+          <h3>No Self-Heal Yet</h3>
+          <p>Diagnostic classifications are non-actuating. This plan does not issue commands or trigger repairs automatically.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="design">
+      <h2>Design Shape</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Slice</th>
+            <th>Source Facts</th>
+            <th>Posture</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Runtime evidence</td>
+            <td><code>posTerminalRuntimeStatus</code></td>
+            <td>Evidence, not authority by itself</td>
+          </tr>
+          <tr>
+            <td>Sync evidence</td>
+            <td>Events, cursors, conflicts, mappings</td>
+            <td>Review and retry classification</td>
+          </tr>
+          <tr>
+            <td>Register evidence</td>
+            <td><code>registerSession</code> and lifecycle policy</td>
+            <td>Sale usability guardrail</td>
+          </tr>
+          <tr>
+            <td>Recovery evidence</td>
+            <td>Recovery command repository</td>
+            <td>Current action and duplicate-disable state</td>
+          </tr>
+          <tr>
+            <td>Cloud repair candidates</td>
+            <td>Conflict and source event facts</td>
+            <td>Support action candidate, not automatic mutation</td>
+          </tr>
+          <tr>
+            <td>Diagnostic evidence</td>
+            <td>Derived from all slices</td>
+            <td>Non-actuating classification</td>
+          </tr>
+        </tbody>
+      </table>
+      <h3>Sales Readiness</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>State</th>
+            <th>Meaning</th>
+            <th>Key proof</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>healthy_idle</code></td>
+            <td>No current support blocker, not proven to be transacting</td>
+            <td>Active terminal, fresh enough runtime, no support/manual blockers</td>
+          </tr>
+          <tr>
+            <td><code>drawer_open</code></td>
+            <td>Register/drawer evidence exists, but sale authority is not proven</td>
+            <td>Cloud lifecycle allows drawer, sale authority not ready</td>
+          </tr>
+          <tr>
+            <td><code>able_to_transact_now</code></td>
+            <td>Fresh evidence says the terminal can transact now</td>
+            <td>Fresh runtime, ready sale and staff authority, usable active/open register</td>
+          </tr>
+        </tbody>
+      </table>
+      <h3>Support Recovery / Review Action</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>State</th>
+            <th>Meaning</th>
+            <th>Key proof</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>needs_cloud_repair</code></td>
+            <td>Server-side safe repair candidate exists</td>
+            <td>Safe cloud repair policy and fresh precondition facts</td>
+          </tr>
+          <tr>
+            <td><code>needs_terminal_action</code></td>
+            <td>Matching terminal must perform local recovery</td>
+            <td>Current terminal action candidate or active command requirement</td>
+          </tr>
+          <tr>
+            <td><code>needs_manual_review</code></td>
+            <td>Business/review facts need human workflow</td>
+            <td>Payment, inventory, closeout, variance, customer, sale, or manager-review facts</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="units">
+      <h2>Implementation Units</h2>
+      <article class="card unit">
+        <h3>U1. Characterize Current Terminal Read Semantics</h3>
+        <p>Add parity and return-shape characterization before extraction.</p>
+      </article>
+      <article class="card unit">
+        <h3>U2. Create Query-Safe Terminal Operational Facts Boundary</h3>
+        <p>Gather normalized facts in one query-safe, fact-oriented boundary without policy or writes.</p>
+      </article>
+      <article class="card unit">
+        <h3>U3. Build TerminalOperationalState Aggregate and Policy</h3>
+        <p>Classify sales readiness, support recovery, diagnostic evidence, provenance, and freshness.</p>
+      </article>
+      <article class="card unit">
+        <h3>U4. Project Terminal Health and Recovery Preview From Aggregate</h3>
+        <p>Make existing query outputs projections of the aggregate.</p>
+      </article>
+      <article class="card unit">
+        <h3>U5. Preserve Public Contracts and Validator Parity</h3>
+        <p>Keep public args, aliases, validators, browser types, POS-authorized viewing, full-admin repair issuance, and terminal sync-secret check-in/list/claim/ack APIs aligned.</p>
+      </article>
+      <article class="card unit">
+        <h3>U6. Route Frontend Presentation Through Aggregate-Derived Semantics</h3>
+        <p>Keep roster/detail support presentation preview-first and parity-aligned.</p>
+      </article>
+      <article class="card unit">
+        <h3>U7. Document the Boundary and Run Plan-Specific Validation</h3>
+        <p>Capture the aggregate as the future diagnostics comparison boundary.</p>
+      </article>
+    </section>
+
+    <section id="risks">
+      <h2>Risks</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Risk</th>
+            <th>Mitigation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Readiness behavior drifts during extraction</td>
+            <td>Characterization-first tests and roster/detail/preview parity fixtures.</td>
+          </tr>
+          <tr>
+            <td>Aggregate becomes write-capable</td>
+            <td>Keep it query-safe and fact-oriented; writes stay in existing mutations.</td>
+          </tr>
+          <tr>
+            <td>Public validators drift</td>
+            <td>Dedicated validator parity unit before frontend reliance; U4/U5 land together if public return fields change.</td>
+          </tr>
+          <tr>
+            <td>Runtime evidence becomes sale authority</td>
+            <td>Cloud lifecycle policy remains the drawer usability guardrail.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="validation" class="warning">
+      <h2>Validation Posture</h2>
+      <p>The implementation should run focused Terminal Health/query/recovery tests, public validator tests, presentation parity tests, <code>audit:convex</code>, changed-file lint/type checks, graphify rebuild after code changes, and eventually <code>bun run pr:athena</code>.</p>
+      <p class="small">This planning pass did not implement code or run product tests.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-06-27-001-refactor-terminal-operational-state-plan.md
+++ b/docs/plans/2026-06-27-001-refactor-terminal-operational-state-plan.md
@@ -1,0 +1,555 @@
+---
+title: "refactor: Extract Terminal Operational State"
+type: refactor
+status: active
+date: 2026-06-27
+---
+
+# refactor: Extract Terminal Operational State
+
+## Summary
+
+Extract POS terminal health and recovery read semantics into a single server-side `TerminalOperationalState` aggregate. The aggregate will remain a pure computed read boundary for this phase, preserving the normalized sync/runtime/register ledgers while making Terminal Health, terminal detail, `previewTerminalRecovery`, and future diagnostics classify terminal state from one policy output.
+
+---
+
+## Problem Frame
+
+Athena currently assembles terminal truth inline inside Terminal Health queries. `packages/athena-webapp/convex/pos/application/queries/terminals.ts` joins latest runtime status, local sync events/cursors/conflicts, active register-session evidence, recovery command status, cloud repair classification, attention reasons, and public return shaping in one large path.
+
+That shape is workable but fragile: every new diagnostic or recovery behavior is tempted to read the raw ledgers again, and the read-time join becomes an unnamed hidden source of truth. The user explicitly wants the split addressed before planning self-heal behavior.
+
+---
+
+## Requirements
+
+- R1. Define a single server-owned `TerminalOperationalState` aggregate builder used by `listTerminalHealthSummaries`, `getTerminalHealthSummary`, and `previewTerminalRecovery`.
+- R2. Keep underlying ledgers normalized. Do not merge or rewrite `posLocalSyncEvent`, `posLocalSyncCursor`, `posLocalSyncMapping`, `posLocalSyncConflict`, `posTerminalRuntimeStatus`, `registerSession`, or recovery command storage.
+- R3. Keep the aggregate query-safe. Building operational state must not patch command expiry, resolve conflicts, write runtime status, or mutate recovery state.
+- R4. Separate sales readiness, support recovery, and diagnostic evidence. Do not collapse `healthy_idle`, `drawer_open`, and `able_to_transact_now` into one health flag.
+- R5. Preserve public Convex args, aliases, and return-shape compatibility for existing Terminal Health and recovery preview APIs unless an intentional validator-backed shape addition is required.
+- R6. Preserve authority boundaries: POS-authorized users can view terminal state, full admins can issue repairs, terminal sync-secret proof can check in/list/claim/ack scoped commands, and original registrant ownership is not required.
+- R7. Preserve current recovery semantics: command acknowledgement is not verification; fresh runtime evidence verifies recovery.
+- R8. Encode active register precedence explicitly: fresh runtime can prove sale authority, but cloud register lifecycle policy remains the guardrail for drawer usability when evidence conflicts.
+- R9. Classify local sync review safely: retryable lifecycle/reconciliation evidence can inform terminal action, but sale/payment/inventory/closeout/customer/variance facts remain manual review.
+- R10. Preserve operator presentation parity: roster, detail, and `previewTerminalRecovery` must agree on readiness, action category, duplicate-disable state, verification state, active register evidence, and sync/manual-review classification.
+- R11. Add validator and characterization coverage before broad UI or diagnostics consumers rely on the aggregate.
+- R12. Leave self-heal implementation out of scope. This phase may expose non-actuating diagnostic classifications for future use, but it must not issue commands or trigger repairs automatically.
+
+---
+
+## Scope Boundaries
+
+- This plan does not implement terminal self-heal, automatic repair, fleet remediation, or command issuance from diagnostics.
+- This plan does not create a persisted operational-state table. The aggregate is computed per query in this phase; materialization is deferred until invalidation and race behavior are explicitly designed.
+- This plan does not redesign terminal recovery commands, cloud repair execution, Remote Assist, Cash Controls review, or POS cashier workflows.
+- This plan does not change sale authority, drawer authority, staff authority, or local command gateway behavior.
+- This plan does not expose sync secrets, staff proof/PIN material, raw IndexedDB payloads, raw customer/payment data, or raw backend exception text in support-facing state.
+- This plan does not make Terminal Health a hidden Cash Controls or Operations repair surface. Business-fact review remains with the owning workflow.
+
+### Deferred to Follow-Up Work
+
+- Terminal diagnostics/self-heal comparison contract that accepts a redacted local terminal snapshot and classifies repair options.
+- Persisted or cached terminal operational-state snapshots, if roster scale later proves per-query computation too expensive.
+- Fleet-level remediation scheduling and support runbooks after the aggregate stabilizes.
+- New UI affordances beyond preserving existing roster/detail/recovery presentation parity.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/convex/pos/application/queries/terminals.ts` currently defines `TerminalHealthSummary`, `TerminalRecoveryPreview`, and the inline assembly path for runtime evidence, sync evidence, active register evidence, attention reasons, cloud repair preview, command status, and health classification.
+- `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts` provides query helpers for latest runtime status, terminal sync evidence, active register-session evidence, and local-to-cloud mapping lookups.
+- `packages/athena-webapp/convex/pos/public/terminals.ts` is the public Convex boundary with auth checks, return validators, and aliases such as `listTerminalHealth` and `getTerminalHealthDetail`.
+- `packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts` is the existing pure policy for safe cloud repair classification and precondition hashing.
+- `packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts` and `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts` split recovery command lifecycle logic from persistence.
+- `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts` is the frontend projection layer that must remain preview-first while tolerating legacy/partial response shapes.
+- `packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts` is the key precedent for extracting durable cross-layer policy: repositories provide facts, pure policy interprets them, and application code adapts rows into policy inputs.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-pos-terminal-recovery-readiness-boundary-2026-06-14.md` establishes the core boundary: sales readiness, support recovery, and diagnostic evidence are distinct.
+- `docs/solutions/architecture/athena-pos-runtime-decoupling-boundaries-2026-06-15.md` warns against continuing to mix readiness, sync drain, telemetry, recovery, and diagnostics in one effect graph.
+- `docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md` provides the extraction pattern for shared POS policy.
+- `docs/solutions/architecture/athena-pos-remote-terminal-health-recovery-2026-06-11.md` keeps recovery as orchestration verified by runtime evidence, not server-side force-clear.
+- `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md` keeps POS local-first ledgers distinct from cloud projection state.
+- `docs/solutions/architecture/athena-pos-cashier-continuity-review-deferral-2026-06-20.md` says recoverable cloud invariant issues should become review evidence, not cashier blockers, when local recording is still safe.
+- `docs/solutions/harness/convex-query-write-boundary-proof-2026-06-18.md` and `docs/solutions/harness/convex-return-validator-contract-proof-2026-06-18.md` came from this failure class: read paths must stay read-only and public return validators must track shipped shapes.
+- `docs/solutions/logic-errors/athena-pos-register-sync-repair-and-runtime-reconciliation-2026-06-26.md` reinforces the need to keep register sync repair, runtime evidence, and recovery presentation aligned.
+
+### External References
+
+External research was skipped. The work is specific to Athena's Convex POS runtime, local-first sync, terminal recovery, and existing repo patterns.
+
+---
+
+## Key Technical Decisions
+
+- **Compute operational state per query for this phase:** The aggregate is a pure read model builder, not a persisted table. This avoids introducing invalidation, caching, and stale snapshot races before the semantics are stable.
+- **Name the aggregate boundary, not the storage:** `TerminalOperationalState` becomes the server truth for health/recovery read semantics, while the underlying normalized tables remain the durable ledgers.
+- **Keep repositories fact-oriented:** Query-safe repositories return runtime, sync, register, conflict, command, and cloud-repair source facts. Policy modules classify those facts. Repositories should not become the semantic owner of readiness.
+- **Project existing public outputs from the aggregate:** `TerminalHealthSummary` and `TerminalRecoveryPreview` should be projections of `TerminalOperationalState`, not parallel derivations.
+- **Make diagnostics non-actuating:** Future-facing diagnostic classifications may be represented as `diagnosticOnly` or equivalent non-command-bound signals, but this plan does not bind them to command issuance or mutation.
+- **Let cloud lifecycle policy guard drawer usability:** Fresh runtime evidence can prove sale authority only when cloud register lifecycle facts do not make the drawer unusable.
+- **Let business-fact review outrank retry-sync:** Payment, inventory, closeout, variance, sale, customer, and manager-review evidence route to manual review even when retrying sync is also possible.
+- **Treat historical commands as history, not current blockers:** Only active/current relevant command status should affect readiness and duplicate-disable state. Old failed, precondition-failed, or verified commands can remain detail evidence without foregrounding support work after blockers clear.
+- **Preserve validator parity before UI reliance:** Any public return-shape addition must be represented in validators and conformance tests before frontend consumers depend on it.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should `TerminalOperationalState` be materialized now?** No. It should be computed per query in this phase.
+- **Should this plan implement self-heal?** No. It creates the read boundary that future self-heal can compare against.
+- **When runtime says drawer active but cloud lifecycle says closed/reviewed, which wins?** Cloud lifecycle policy remains the guardrail for sale usability; runtime remains diagnostic/sale-authority evidence.
+- **Can local review evidence create a retry-sync action while manual-review conflicts exist?** Only lifecycle/reconciliation review can be retryable. Business-fact review stays manual.
+- **Should `TerminalRecoveryPreview` be the root truth?** No. It remains a support-recovery projection of the broader operational state.
+
+### Deferred to Implementation
+
+- Exact internal module names and type names may adapt to repo conventions, but the plan expects a named `terminalOperationalState` boundary under the Convex POS application layer.
+- The exact lightweight roster projection shape can be refined during implementation, but it must preserve list/detail parity for readiness, action category, command duplicate-disable state, and sync/manual-review classification.
+- Whether existing query helper functions stay in `terminalRepository.ts` or move behind a new read repository can be decided by whichever produces the cleanest query-safe fact boundary. If a new boundary is created, prefer fact-oriented naming such as `collectTerminalOperationalFacts.ts` so it does not become a semantic repository.
+- Exact diagnostic classification labels are deferred, provided they are explicitly non-actuating in this phase.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  Runtime["runtime status facts"]
+  Sync["sync events, cursors, conflicts"]
+  Register["register-session facts"]
+  Commands["recovery command facts"]
+  CloudRepair["cloud repair source facts"]
+  Facts["query-safe operational facts collector"]
+  Aggregate["TerminalOperationalState"]
+  Health["TerminalHealthSummary projection"]
+  Preview["TerminalRecoveryPreview projection"]
+  Presentation["Terminal Health presentation"]
+  Future["future diagnostic assessment"]
+
+  Runtime --> Facts
+  Sync --> Facts
+  Register --> Facts
+  Commands --> Facts
+  CloudRepair --> Facts
+  Facts --> Aggregate
+  Aggregate --> Health
+  Aggregate --> Preview
+  Aggregate --> Presentation
+  Aggregate --> Future
+```
+
+The central architectural change is that `TerminalOperationalState` becomes the named read-side boundary. It receives normalized facts, applies policy once, and exposes projections for existing surfaces. Existing mutations continue to own writes: runtime status reporting, command acknowledgement, cloud repair, sync ingestion, and manual review resolution remain outside the aggregate.
+
+### Operational State Slices
+
+| Slice | Purpose | Source facts | Output posture |
+| --- | --- | --- | --- |
+| Terminal identity | Store/terminal scope, status, register number | `posTerminal` | Required for every projection |
+| Runtime evidence | Freshness, local store, app shell/update, staff/sale authority | `posTerminalRuntimeStatus` | Evidence, not authority by itself |
+| Sync evidence | Latest event, cursor, unresolved conflicts, review facts | `posLocalSyncEvent`, cursor, conflict, mapping | Review and retry classification |
+| Register evidence | Active/open cloud register, lifecycle usability | `registerSession`, lifecycle policy | Sale usability guardrail |
+| Recovery evidence | Command lifecycle and expected verification | recovery command repository | Current action/duplicate-disable state |
+| Cloud repair candidates | Safe duplicate lifecycle repair eligibility | conflict and source event facts | Support action candidate, not automatic mutation |
+| Diagnostic evidence | Missing/stale/degraded evidence | Derived from all slices | Non-actuating classification |
+
+### Sales Readiness Matrix
+
+| Sales readiness | Meaning | Key proof |
+| --- | --- | --- |
+| `healthy_idle` | Terminal has no current support blocker but is not proven to be transacting | Active terminal, fresh enough runtime, no support/manual blockers |
+| `drawer_open` | Register/drawer evidence exists, but current sale authority is not proven | Cloud lifecycle allows drawer, sale authority not ready |
+| `able_to_transact_now` | Fresh evidence says the terminal can transact now | Fresh runtime, sale authority ready, staff authority ready, active/open usable register |
+
+### Support Recovery / Review Action Matrix
+
+| Support recovery state | Meaning | Key proof |
+| --- | --- | --- |
+| `needs_cloud_repair` | A server-side safe repair candidate exists | Safe cloud repair policy and fresh precondition facts |
+| `needs_terminal_action` | Matching terminal must perform local recovery | Current terminal action candidate or active command requirement |
+| `needs_manual_review` | Business/review facts need human workflow | Payment, inventory, closeout, variance, customer, sale, or manager-review facts |
+| No current support action | Terminal has no support repair or manual-review work | No current cloud repair, terminal action, or manual-review evidence |
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 Characterization and contract tests"]
+  U2["U2 Query-safe facts boundary"]
+  U3["U3 TerminalOperationalState aggregate"]
+  U4["U4 Existing projections from aggregate"]
+  U5["U5 Public validators and contracts"]
+  U6["U6 Presentation parity cleanup"]
+  U7["U7 Documentation and validation"]
+
+  U1 --> U2
+  U2 --> U3
+  U3 --> U4
+  U4 --> U5
+  U5 --> U6
+  U6 --> U7
+```
+
+- U1. **Characterize Current Terminal Read Semantics**
+
+**Goal:** Add focused characterization coverage that snapshots current roster/detail/preview classifications before moving logic.
+
+**Requirements:** R4, R5, R7, R8, R9, R10, R11.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/queries/terminals.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.test.ts`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts`
+
+**Approach:**
+- Add representative fixtures before extraction, including healthy idle, drawer open, able to transact, stale runtime, current terminal action, historical command noise, safe cloud repair, and manual business review.
+- Assert roster/detail/preview parity for readiness, action category, command duplicate-disable state, verification state, active register evidence, sync classification, and manual-review classification.
+- Use existing return-validator conformance helpers for any public result fixture involved in characterization.
+- Keep future precedence changes out of U1 expectations. If current inline behavior is intentionally corrected later, U1 should characterize the current output and the target behavior should be asserted under U3/U4.
+
+**Execution note:** Characterization-first. This unit should fail if extraction changes behavior unintentionally.
+
+**Patterns to follow:**
+- Existing Terminal Health query tests in `packages/athena-webapp/convex/pos/application/queries/terminals.test.ts`.
+- Public return conformance tests in `packages/athena-webapp/convex/pos/public/terminals.test.ts`.
+- Presentation classification tests in `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts`.
+
+**Test scenarios:**
+- Happy path: active terminal with fresh runtime, ready staff/sale authority, and usable active register returns `able_to_transact_now`.
+- Happy path: active terminal with fresh healthy runtime and no active sale context returns `healthy_idle`.
+- Edge case: stale runtime never returns `able_to_transact_now`, even when cloud rows look healthy.
+- Current-behavior characterization: runtime-reported active local drawer remains represented as active register evidence under the current inline logic; target cloud-lifecycle precedence is asserted in U3/U4.
+- Edge case: old failed/precondition-failed/verified recovery commands remain detail history but do not create current support work after blockers clear.
+- Error path: revoked/lost terminal returns no repair action and stable support presentation.
+- Integration: roster, detail, and `previewTerminalRecovery` agree on readiness/action/verification for the same fixture.
+
+**Verification:**
+- Current behavior is pinned strongly enough that later units can extract logic without silent drift.
+
+---
+
+- U2. **Create Query-Safe Terminal Operational Facts Boundary**
+
+**Goal:** Introduce a query-safe fact-collector boundary that gathers all facts needed to build terminal operational state without owning policy decisions or writes.
+
+**Requirements:** R1, R2, R3, R5, R6, R11.
+
+**Dependencies:** U1.
+
+**Files:**
+- Create: `packages/athena-webapp/convex/pos/application/terminalOperationalState/facts.ts`
+- Create or modify: `packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.ts`
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts`
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts`
+- Test: `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts`
+- Test: `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.test.ts`
+
+**Approach:**
+- Keep fact collection query-safe and compatible with `QueryCtx`.
+- Use fact-oriented naming and tests so this layer stays non-semantic. It should collect and normalize inputs, not decide readiness or recovery state.
+- Gather terminal identity, latest runtime status, sync evidence, active register-session evidence, command status/history needed for current support work, cloud repair conflict/source event facts, and app update evidence.
+- Preserve existing helper behavior for `getLatestRuntimeStatusForTerminal`, `getTerminalSyncEvidence`, and `hasActiveRegisterSessionForTerminal`, but route aggregate consumers through one fact bundle.
+- Move duplicated query-time cloud-repair eligibility support out of the large terminal query file where appropriate, without changing safe/skipped conflict ordering or precondition hash inputs.
+- Do not persist derived facts in this unit.
+
+**Patterns to follow:**
+- Query-safe repository helpers in `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts`.
+- Read/write separation in `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts`.
+- Pure policy input shaping from `packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts` consumers.
+
+**Test scenarios:**
+- Happy path: fact collector returns latest runtime, sync evidence, active register link, command status, and cloud repair facts for one active terminal.
+- Edge case: terminal with no runtime status still returns sync/register facts and marks runtime evidence absent.
+- Edge case: terminal with no sync events but existing cursor/conflicts returns cursor and unresolved conflict facts.
+- Error path: query-safe fact collection does not call write-only repository methods or patch expired commands.
+- Integration: fact collector preserves current safe cloud repair candidate ordering and precondition inputs.
+
+**Verification:**
+- All raw fact reads needed by Terminal Health are reachable through one query-safe boundary, and policy remains outside the repository layer.
+
+---
+
+- U3. **Build TerminalOperationalState Aggregate and Policy**
+
+**Goal:** Add the server aggregate and pure classification policy that converts terminal facts into sales readiness, support recovery, diagnostic evidence, and provenance/freshness.
+
+**Requirements:** R1, R3, R4, R7, R8, R9, R12.
+
+**Dependencies:** U2.
+
+**Files:**
+- Create: `packages/athena-webapp/convex/pos/application/terminalOperationalState/types.ts`
+- Create: `packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.ts`
+- Create: `packages/athena-webapp/convex/pos/application/terminalOperationalState/buildTerminalOperationalState.ts`
+- Test: `packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/terminalOperationalState/buildTerminalOperationalState.test.ts`
+
+**Approach:**
+- Model top-level slices explicitly: terminal identity, runtime evidence, sync evidence, register evidence, recovery evidence, cloud repair candidates, app update evidence, and diagnostic evidence.
+- Make `salesReadiness`, `supportRecovery`, and `diagnosticEvidence` separate outputs rather than one generic health value.
+- Represent diagnostic classifications as non-actuating. They may explain missing/stale/degraded evidence but must not issue or enqueue repair actions.
+- Encode evidence provenance and freshness enough for consumers to explain whether state came from runtime, cloud sync, register lifecycle, command history, or policy fallback.
+- Apply the resolved precedence rules: cloud lifecycle policy guards drawer usability; business-fact review outranks retry-sync; command acknowledgement is not verification.
+
+**Technical design:** Directional shape only:
+
+```text
+TerminalOperationalState
+  terminalIdentity
+  runtimeEvidence
+  syncEvidence
+  registerEvidence
+  recoveryEvidence
+  cloudRepairEvidence
+  appUpdateEvidence
+  salesReadiness
+  supportRecovery
+  diagnosticEvidence
+```
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts`
+- `packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts`
+- `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts`
+
+**Test scenarios:**
+- Happy path: state classifies an idle active terminal as `healthy_idle` without implying sale authority.
+- Happy path: state classifies fresh runtime plus ready sale/staff authority plus usable active register as `able_to_transact_now`.
+- Edge case: stale runtime downgrades sale readiness while keeping support diagnostics visible.
+- Edge case: runtime active drawer plus cloud closed/reviewed lifecycle produces diagnostic evidence, not sale-ready authority.
+- Edge case: safe duplicate register-open conflict becomes `needs_cloud_repair` only when source event, store/terminal scope, stale age, projection eligibility, and business-fact absence all hold.
+- Edge case: payment/inventory/closeout/variance/customer/sale facts produce `needs_manual_review`, not retry-sync or cloud repair.
+- Edge case: pending/claimed/current relevant command affects duplicate-disable state, while historical resolved command does not create current support work.
+- Error path: revoked/lost terminal does not expose repair actions.
+- Security path: aggregate excludes secret/proof/PIN/raw payload/customer/payment details from support-facing slices.
+
+**Verification:**
+- A pure aggregate policy exists and can classify the full terminal operational state without reaching into public query or UI code.
+
+---
+
+- U4. **Project Terminal Health and Recovery Preview From Aggregate**
+
+**Goal:** Refactor existing terminal query outputs so `TerminalHealthSummary` and `TerminalRecoveryPreview` are projections from `TerminalOperationalState`.
+
+**Requirements:** R1, R4, R5, R7, R8, R9, R10, R11.
+
+**Dependencies:** U3.
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/queries/terminals.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts` only if projection inputs need small policy-facing normalization
+- Test: `packages/athena-webapp/convex/pos/application/queries/terminals.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.test.ts`
+
+**Approach:**
+- Keep public query names and aliases unchanged.
+- Replace inline readiness/recovery assembly in `queries/terminals.ts` with calls to the aggregate builder plus projection helpers.
+- Preserve return fields unless the aggregate requires additive fields; additive fields must be planned through U5 validators.
+- Ensure `previewTerminalRecovery` returns the same recovery projection as detail/roster for the same terminal state.
+- Keep mutation-side cloud repair revalidation behavior compatible with query-side repair candidate classification.
+
+**Patterns to follow:**
+- Existing projection structure in `buildTerminalHealthSummary`.
+- Existing recovery preview tests in `packages/athena-webapp/convex/pos/application/queries/terminals.test.ts`.
+- Mutation recheck pattern in `packages/athena-webapp/convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.ts`.
+
+**Test scenarios:**
+- Happy path: existing terminal health summary fixture has the same visible fields before and after projection refactor.
+- Integration: `listTerminalHealthSummaries`, `getTerminalHealthSummary`, and `previewTerminalRecovery` agree on the same aggregate-derived readiness and actions.
+- Edge case: `includeSyncEvidence` false path, if retained, does not produce misleading manual-review or cloud-repair states.
+- Edge case: app update evidence remains diagnostic/support action evidence and does not affect sales readiness.
+- Target precedence: cloud register lifecycle that is closed or reviewed prevents sale-ready projection even when runtime reports an active local drawer.
+- Error path: changed cloud repair evidence causes mutation precondition failure rather than conflict/event patching.
+- Regression: safe/skipped conflict IDs and precondition hash remain stable for existing fixtures.
+
+**Verification:**
+- Terminal Health and recovery preview read from one server aggregate boundary while public query behavior remains compatible.
+
+---
+
+- U5. **Preserve Public Contracts and Validator Parity**
+
+**Goal:** Keep Convex public return shapes, validators, aliases, and auth behavior aligned with the aggregate projections.
+
+**Requirements:** R5, R6, R10, R11.
+
+**Dependencies:** U4.
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts`
+- Test: `packages/athena-webapp/convex/pos/public/terminals.test.ts`
+
+**Approach:**
+- Keep existing public query names and args stable.
+- Update public return validators only for deliberate additive aggregate-derived fields.
+- Cover representative roster, detail, and preview payloads with exported-return conformance.
+- Preserve the R6 auth categories explicitly: POS-authorized users can view terminal state, full admins can issue repair/cloud-repair actions, and terminal sync-secret proof can check in/list/claim/ack scoped commands.
+- Ensure list/detail alias exports keep the same behavior.
+
+**Patterns to follow:**
+- Existing `assertConformsToExportedReturns` usage in public terminal tests.
+- Validator definitions in `packages/athena-webapp/convex/pos/public/terminals.ts`.
+- Public return validator drift lessons from `docs/solutions/harness/convex-return-validator-contract-proof-2026-06-18.md`.
+
+**Test scenarios:**
+- Happy path: representative `listTerminalHealthSummaries` result conforms to returns validator.
+- Happy path: representative `getTerminalHealthSummary` detail result conforms to returns validator.
+- Happy path: representative `previewTerminalRecovery` result conforms to returns validator.
+- Edge case: nested `recoveryPreview.appUpdate`, `commandStatus.appUpdateCommandExecutionId`, `cloudRepair`, `terminalActions`, `manualReview`, `syncEvidence`, and `runtimeStatus` remain validator-compatible.
+- Error path: terminal proof with wrong sync secret cannot check in, list recovery commands, claim recovery commands, or acknowledge recovery commands; POS-authorized terminal-state viewing and full-admin repair issuance remain unchanged.
+- Compatibility: browser `terminalHealthTypes.ts` remains compatible with old `recovery` fallback and current `recoveryPreview`.
+
+**Verification:**
+- Public API consumers and generated Convex validators do not drift behind aggregate-derived payloads.
+
+---
+
+- U6. **Route Frontend Presentation Through Aggregate-Derived Semantics**
+
+**Goal:** Keep Terminal Health roster/detail and support recovery presentation preview-first and parity-aligned after the server extraction.
+
+**Requirements:** R4, R5, R10, R12.
+
+**Dependencies:** U5.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx`
+- Test: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx`
+
+**Approach:**
+- Continue using shared presentation helpers rather than re-deriving readiness from raw sync/runtime facts in components.
+- Keep raw fallback only for missing/legacy preview responses; fallback must not outrank aggregate-derived recovery preview when present.
+- Preserve loading metrics behavior such as `-` instead of false zeroes.
+- Keep detail-only payloads detail-only, while roster rows retain readiness, current action category, duplicate-disable command state, verification state, and sync/manual-review classification.
+- Do not add new action buttons for diagnostics/self-heal in this phase.
+
+**Patterns to follow:**
+- Existing presentation helper tests in `terminalHealthPresentation.test.ts`.
+- Terminal recovery readiness boundary solution doc.
+- Product copy tone in `docs/product-copy-tone.md`.
+
+**Test scenarios:**
+- Happy path: roster and detail render matching labels for `healthy_idle`, `drawer_open`, and `able_to_transact_now`.
+- Happy path: cloud repair, terminal action, and manual review categories render the same action category in roster/detail.
+- Edge case: missing `recoveryPreview` uses safe fallback copy without contradicting aggregate preview when it exists.
+- Edge case: historical command failure does not foreground support work when aggregate says no current blocker.
+- Edge case: loading metrics render as unknown placeholders, not zero.
+- Error path: revoked/lost terminal renders no repair action.
+- Redaction: UI copy excludes raw conflict IDs, secret/proof material, raw local payload, customer data, and payment details.
+
+**Verification:**
+- Frontend presentation consumes aggregate-derived semantics and no longer creates a second readiness source.
+
+---
+
+- U7. **Document the Boundary and Run Plan-Specific Validation**
+
+**Goal:** Capture the new server truth boundary and validation posture so future diagnostics/self-heal work builds on the aggregate instead of recreating raw joins.
+
+**Requirements:** R1, R2, R3, R4, R11, R12.
+
+**Dependencies:** U6.
+
+**Files:**
+- Create: `docs/solutions/architecture/athena-terminal-operational-state-aggregate-2026-06-27.md`
+- Modify: `packages/athena-webapp/docs/agent/validation-guide.md` only if a new validation-map entry is required
+- Generated if code changes: `graphify-out/**`
+
+**Approach:**
+- Document `TerminalOperationalState` as the server truth boundary for terminal health/recovery read semantics.
+- Record that normalized ledgers remain source ledgers and the aggregate is computed, query-safe, and non-actuating.
+- Note the required follow-on path for diagnostics/self-heal: compare a redacted terminal-local snapshot against the aggregate, then route action through existing audited mutations.
+- Run focused test groups before broad gates, and rebuild graphify after code changes.
+
+**Patterns to follow:**
+- `docs/solutions/architecture/athena-pos-terminal-recovery-readiness-boundary-2026-06-14.md`
+- `docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md`
+- `packages/athena-webapp/docs/agent/validation-guide.md`
+
+**Test scenarios:**
+- Test expectation: none for the solution doc itself; validation is through the focused tests and repo gates attached to U1-U6.
+
+**Verification:**
+- Future implementers have a documented boundary and validation map for the aggregate.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Terminal Health roster, terminal detail, `previewTerminalRecovery`, cloud repair preview, recovery command lifecycle, runtime status check-in verification, and frontend presentation all become consumers of the same aggregate-derived semantics.
+- **Error propagation:** Query-time fact collection should degrade into absent/stale diagnostic evidence where appropriate, not into write attempts or operator-visible raw backend errors.
+- **State lifecycle risks:** Computed state avoids cache invalidation for now. The plan explicitly defers materialization to avoid stale snapshots and race conditions.
+- **API surface parity:** Existing public Convex queries, aliases, POS-authorized terminal-state viewing, full-admin repair issuance, and terminal sync-secret check-in/list/claim/ack APIs must keep compatible args/returns. Validator parity is a required unit.
+- **Integration coverage:** Unit tests on the aggregate are insufficient alone; roster/detail/preview parity and public return conformance are required.
+- **Unchanged invariants:** Runtime status remains evidence, command acknowledgement remains non-verifying, cloud repair mutations still revalidate safety, business review stays manual, and POS local-first ledgers remain durable source ledgers.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Extraction changes operator-visible readiness behavior | Start with characterization tests and require roster/detail/preview parity fixtures. |
+| Aggregate becomes another hidden write service | Keep it query-safe, fact-oriented, and covered by query/write boundary tests and review. |
+| Public return validators drift | Make validator parity its own implementation unit before frontend reliance. If U4 adds public-return fields, U4 and U5 should land as one green validation slice so validators never trail implementation. |
+| Runtime evidence accidentally becomes sale authority | Encode cloud lifecycle precedence and distinct sales/support/diagnostic slices in policy tests. |
+| Manual business review appears as auto-repair | Business-fact review outranks retry-sync and cloud repair in aggregate policy tests. |
+| Roster read cost increases | Keep materialization deferred but watch query fan-out during implementation; optimize fact collection without changing semantics. |
+| Future self-heal starts from raw ledgers anyway | Document the aggregate as the required comparison boundary for diagnostics/self-heal follow-up work. |
+
+---
+
+## Documentation / Operational Notes
+
+- The implementation should add a `docs/solutions/architecture/` note after code lands.
+- If code files change, run `bun run graphify:rebuild` before handoff, per repo instructions.
+- Validation should include focused Terminal Health/query/recovery tests, public validator tests, relevant presentation tests, `audit:convex`, changed-file lint/type checks, and eventually `bun run pr:athena`.
+- No production rollout or deploy is part of this planning request.
+
+---
+
+## Sources & References
+
+- Related code: `packages/athena-webapp/convex/pos/application/queries/terminals.ts`
+- Related code: `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts`
+- Related code: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts`
+- Related code: `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts`
+- Related code: `packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts`
+- Related code: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`
+- Product copy: `docs/product-copy-tone.md`
+- Related plan: `docs/plans/2026-06-15-001-refactor-pos-runtime-decoupling-plan.md`
+- Related plan: `docs/plans/2026-06-11-001-feat-pos-remote-terminal-health-plan.md`
+- Related plan: `docs/plans/2026-06-23-001-refactor-pos-register-lifecycle-policy-plan.md`
+- Related plan: `docs/plans/2026-06-26-001-register-sync-mapping-repair-plan.md`
+- Related learning: `docs/solutions/architecture/athena-pos-terminal-recovery-readiness-boundary-2026-06-14.md`
+- Related learning: `docs/solutions/architecture/athena-pos-runtime-decoupling-boundaries-2026-06-15.md`
+- Related learning: `docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md`
+- Related learning: `docs/solutions/architecture/athena-pos-remote-terminal-health-recovery-2026-06-11.md`
+- Related learning: `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md`
+- Related learning: `docs/solutions/architecture/athena-pos-cashier-continuity-review-deferral-2026-06-20.md`
+- Related learning: `docs/solutions/logic-errors/athena-pos-register-sync-repair-and-runtime-reconciliation-2026-06-26.md`
+- Related learning: `docs/solutions/harness/convex-query-write-boundary-proof-2026-06-18.md`
+- Related learning: `docs/solutions/harness/convex-return-validator-contract-proof-2026-06-18.md`

--- a/docs/solutions/architecture/athena-terminal-operational-state-aggregate-2026-06-27.md
+++ b/docs/solutions/architecture/athena-terminal-operational-state-aggregate-2026-06-27.md
@@ -1,0 +1,53 @@
+---
+title: Athena Terminal Operational State Aggregate
+date: 2026-06-27
+category: architecture
+module: pos-terminal-health
+problem_type: architecture_pattern
+component: service_object
+resolution_type: workflow_improvement
+severity: medium
+tags:
+  - pos
+  - terminal-health
+  - recovery
+  - query-boundary
+related:
+  - docs/solutions/architecture/athena-pos-terminal-recovery-readiness-boundary-2026-06-14.md
+  - docs/solutions/architecture/athena-pos-runtime-decoupling-boundaries-2026-06-15.md
+  - docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md
+---
+
+# Athena Terminal Operational State Aggregate
+
+## Problem
+
+Terminal Health read semantics were split across local sync evidence, runtime status, active register sessions, recovery commands, cloud repair previews, and frontend fallback presentation. That made `TerminalRecoveryPreview` useful but still too narrow as the server truth boundary: new diagnostics could recreate raw joins from ledgers instead of reusing one policy output.
+
+## Solution
+
+Use `TerminalOperationalState` as the server-side read boundary for terminal health and recovery semantics. The aggregate is computed, query-safe, and non-actuating. It preserves the normalized source ledgers:
+
+- `posTerminalRuntimeStatus`
+- `posLocalSyncEvent`
+- `posLocalSyncCursor`
+- `posLocalSyncMapping`
+- `posLocalSyncConflict`
+- `registerSession`
+- `posTerminalRecoveryCommand`
+
+Repositories collect facts. Policy classifies facts. Existing mutations still own writes for runtime status reporting, recovery command lifecycle, cloud repair, sync ingestion, and manual review resolution.
+
+Keep the output concepts separate:
+
+- `salesReadiness`: `healthy_idle`, `drawer_open`, or `able_to_transact_now`
+- `supportRecovery`: cloud repair, terminal action, or manual review when support work exists
+- `diagnosticEvidence`: non-actuating stale or conflicting evidence for support/debugging
+
+Fresh runtime evidence can prove active local drawer evidence and sale authority, but cloud register lifecycle evidence remains the guardrail for sale-ready projection when it conflicts. Command acknowledgement is not verification; fresh runtime evidence is still required to verify recovery.
+
+## Prevention
+
+Future diagnostics or self-heal work should compare a redacted local terminal snapshot against this aggregate. It should not recreate raw joins from the ledgers, and it should route any action through the existing audited mutation paths.
+
+When Terminal Health return shapes change, keep public Convex validators and frontend types in the same slice. When readiness semantics change, add policy tests and query projection tests so roster, detail, and `previewTerminalRecovery` cannot drift.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2128 files · ~0 words
+- 2135 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8055 nodes · 9481 edges · 2056 communities detected
+- 8083 nodes · 9510 edges · 2063 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2066,6 +2066,13 @@
 - [[_COMMUNITY_Community 2053|Community 2053]]
 - [[_COMMUNITY_Community 2054|Community 2054]]
 - [[_COMMUNITY_Community 2055|Community 2055]]
+- [[_COMMUNITY_Community 2056|Community 2056]]
+- [[_COMMUNITY_Community 2057|Community 2057]]
+- [[_COMMUNITY_Community 2058|Community 2058]]
+- [[_COMMUNITY_Community 2059|Community 2059]]
+- [[_COMMUNITY_Community 2060|Community 2060]]
+- [[_COMMUNITY_Community 2061|Community 2061]]
+- [[_COMMUNITY_Community 2062|Community 2062]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2142,44 +2149,44 @@ Cohesion: 0.09
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.09
-Nodes (35): annotateTerminalSyncEvidenceReviewTargets(), buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalRecoveryActions(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryManualReview(), buildTerminalRecoveryPreview() (+27 more)
-
-### Community 13 - "Community 13"
 Cohesion: 0.06
 Nodes (22): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+14 more)
 
-### Community 14 - "Community 14"
+### Community 13 - "Community 13"
 Cohesion: 0.07
 Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
-### Community 15 - "Community 15"
+### Community 14 - "Community 14"
 Cohesion: 0.07
 Nodes (10): arrayDetail(), buildCashControlsDashboardSnapshot(), buildReviewedSaleProjectionEvent(), getCompletedTransactionForRegisterMappingRepair(), normalizeReviewedNonCashOverpaymentPayload(), numberDetail(), recordDetail(), roundCurrencyAmount() (+2 more)
 
-### Community 16 - "Community 16"
+### Community 15 - "Community 15"
 Cohesion: 0.08
 Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
 
-### Community 17 - "Community 17"
+### Community 16 - "Community 16"
 Cohesion: 0.11
 Nodes (33): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+25 more)
 
-### Community 18 - "Community 18"
+### Community 17 - "Community 17"
 Cohesion: 0.12
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
-### Community 19 - "Community 19"
+### Community 18 - "Community 18"
 Cohesion: 0.14
 Nodes (34): asRecord(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale() (+26 more)
 
-### Community 20 - "Community 20"
+### Community 19 - "Community 19"
 Cohesion: 0.16
 Nodes (31): completed(), executeCallbackCommand(), executeClearStaleDrawerAuthority(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand(), executeUpdateApp(), failed() (+23 more)
 
-### Community 21 - "Community 21"
+### Community 20 - "Community 20"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
+
+### Community 21 - "Community 21"
+Cohesion: 0.12
+Nodes (25): annotateTerminalSyncEvidenceReviewTargets(), buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalOperationalStateForSummary(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryPreview(), createTerminalCloudRepairQueryRepository() (+17 more)
 
 ### Community 22 - "Community 22"
 Cohesion: 0.11
@@ -2238,84 +2245,84 @@ Cohesion: 0.19
 Nodes (23): assertRegisterNumberIsAvailable(), buildRuntimeActiveRegisterSessionDirective(), buildRuntimeDrawerAuthorityDirective(), cleanActiveRegisterSession(), cleanAppSessionRecovery(), cleanAppShell(), cleanAppUpdate(), cleanBrowserInfo() (+15 more)
 
 ### Community 36 - "Community 36"
+Cohesion: 0.1
+Nodes (12): getLatestRuntimeStatusForTerminal(), getTerminalByFingerprint(), getTerminalSyncEvidence(), isActionableRejectedSyncEvent(), isActionableTerminalReviewSyncEvent(), mapTerminalRecord(), mergeRuntimeStatusPatch(), omitUndefined() (+4 more)
+
+### Community 37 - "Community 37"
 Cohesion: 0.09
 Nodes (6): getConversionRequestId(), handleClick(), handleFinalize(), isSkuReserved(), normalizeCommandMessage(), shouldDisable()
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.1
 Nodes (15): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+7 more)
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.12
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
-### Community 39 - "Community 39"
+### Community 40 - "Community 40"
 Cohesion: 0.15
 Nodes (21): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+13 more)
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.16
 Nodes (19): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), pendingCheckoutItemMatchesLine(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding() (+11 more)
 
-### Community 41 - "Community 41"
+### Community 42 - "Community 42"
 Cohesion: 0.09
 Nodes (5): listCompletedTransactionsForDay(), listCompletedTransactionsForRange(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 42 - "Community 42"
+### Community 43 - "Community 43"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.19
 Nodes (23): assertCompoundSolutionCheck(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSourceLineChanges(), countFileLines(), extractFrontmatter() (+15 more)
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.21
 Nodes (23): buildCartChange(), buildLegacyContextPayload(), buildLegacyProductId(), compactPayload(), compileLegacyStorefrontAnalyticsRow(), compileLegacyStorefrontAnalyticsRows(), compileLegacyStorefrontAnalyticsRowsWithReport(), containsSensitiveText() (+15 more)
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
 Cohesion: 0.19
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
 Cohesion: 0.18
 Nodes (23): buildEventMessage(), buildNextEvidence(), buildNextSaleEvidence(), buildReviewPriority(), buildWorkItemPriority(), createOrReusePendingCheckoutItem(), createProvisionalCatalogAnchors(), findMatchingPendingCheckoutItem() (+15 more)
 
-### Community 48 - "Community 48"
-Cohesion: 0.09
-Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
-
 ### Community 49 - "Community 49"
+Cohesion: 0.09
+Nodes (3): buildPersistedRuntimeStatus(), buildRegisterSession(), buildRuntimeStatus()
+
+### Community 50 - "Community 50"
 Cohesion: 0.12
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
 
-### Community 50 - "Community 50"
+### Community 51 - "Community 51"
 Cohesion: 0.17
 Nodes (21): buildHomepageSnapshotV1(), hydrateCategory(), hydrateFeaturedItem(), hydrateProduct(), hydrateSubcategory(), hydrateTargetProducts(), isCustomerVisibleProduct(), isCustomerVisibleSku() (+13 more)
 
-### Community 51 - "Community 51"
+### Community 52 - "Community 52"
 Cohesion: 0.17
 Nodes (19): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady(), mapSyncStatus() (+11 more)
 
-### Community 52 - "Community 52"
+### Community 53 - "Community 53"
 Cohesion: 0.16
 Nodes (17): asRecord(), buildSnapshotHash(), buildStoreInsightsPromptFromContextBundle(), buildStoreInsightsPromptFromContextEvents(), buildUserInsightsPromptFromContextBundle(), buildUserInsightsPromptFromContextEvents(), compactContextEventsForPrompt(), compactEnvironmentForPrompt() (+9 more)
 
-### Community 53 - "Community 53"
+### Community 54 - "Community 54"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.15
 Nodes (16): findLatestOpenOperatingDay(), getTodaySummary(), getTransactionById(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile() (+8 more)
-
-### Community 55 - "Community 55"
-Cohesion: 0.12
-Nodes (12): getLatestRuntimeStatusForTerminal(), getTerminalByFingerprint(), getTerminalSyncEvidence(), isActionableRejectedSyncEvent(), isActionableTerminalReviewSyncEvent(), mapTerminalRecord(), mergeRuntimeStatusPatch(), omitUndefined() (+4 more)
 
 ### Community 56 - "Community 56"
 Cohesion: 0.21
@@ -2490,844 +2497,844 @@ Cohesion: 0.32
 Nodes (14): buildPosOperatorSnapshot(), buildRecentDayBuckets(), buildSummaryTrendBucket(), buildTransactionDateBuckets(), calculateDeltaPercent(), formatHourLabel(), formatPaymentMethodLabel(), formatShortDate() (+6 more)
 
 ### Community 99 - "Community 99"
+Cohesion: 0.28
+Nodes (14): buildDiagnosticEvidence(), buildTerminalOperationalState(), buildTerminalRecoveryActions(), buildTerminalRecoveryManualReview(), classifySalesReadiness(), classifySupportRecovery(), classifyTerminalHealth(), dedupeTerminalActions() (+6 more)
+
+### Community 100 - "Community 100"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.28
 Nodes (14): buildActorRefs(), buildReturnExchangeTraceEvent(), buildReturnExchangeTraceRecord(), buildTraceEvent(), buildTraceRecord(), compactDetails(), recordOnlineOrderReturnExchangeTraceBestEffort(), recordOnlineOrderTraceBestEffort() (+6 more)
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.17
 Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.18
 Nodes (7): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.22
 Nodes (10): extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), normalizeIdentifier(), parseCatalogSearchInput(), searchByText(), searchRegisterCatalog() (+2 more)
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.21
 Nodes (8): canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), getSaleBlockingDrawerAuthority(), isDrawerAuthoritySaleBlocking(), isRegisterSessionConflictBlocking(), isRegisterSessionReplacementBlocking(), isRegisterSessionSaleUsable(), isScopedRegisterSession()
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.14
 Nodes (0):
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.16
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.26
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.22
 Nodes (6): buildParticipantIdentity(), getDataPublishRouting(), getParticipantRole(), isAllowedSender(), LiveKitRemoteAssistClient, parseParticipantRole()
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.26
 Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.22
 Nodes (6): buildTrustedInventoryFinalizationPayload(), buildTrustedInventoryMoneyPayload(), getTrustedInventoryReviewValidationMessage(), isNonNegativeInteger(), parseVariantDisplayMoney(), resolveTrustedInventoryReviewState()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.17
 Nodes (2): getNextTransactionPageSearch(), getNextTransactionTimeFilterSearch()
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.29
 Nodes (10): applyTheme(), emitThemeChange(), getStorage(), getStoredThemeMode(), getSystemTheme(), getThemeSnapshot(), initializeAthenaTheme(), isThemeMode() (+2 more)
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.2
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.26
 Nodes (9): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), canProjectRegisterOpenForTerminalCloudRepair(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), getRepairOpenRegisterCloseoutReviewState(), isDuplicateRegisterOpenConflict(), normalizeRepairString() (+1 more)
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.2
 Nodes (4): formatProductLineMeta(), formatServiceLabel(), formatServiceLineMeta(), formatStoredAmount()
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.21
 Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.24
 Nodes (6): blocked(), evaluateLocalPosReadiness(), hasSettledLocalCloseout(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.18
 Nodes (2): expenseItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.29
 Nodes (8): isFiniteNumber(), isPointInsideViewport(), isPositiveFiniteNumber(), isRecord(), isValidViewport(), validateKeyEvent(), validatePointerEvent(), validateRemoteAssistControlEvent()
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.2
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.25
 Nodes (7): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus()
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.33
 Nodes (7): createAthenaProviderError(), createProviderFailureResult(), getProviderFailureDiagnostic(), invokeStructuredTextProvider(), isJsonObject(), isJsonValue(), sanitizeDiagnostic()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.27
 Nodes (5): clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), runProcess(), writePrAthenaProviderEvidence()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.39
 Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.25
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 171 - "Community 171"
-Cohesion: 0.39
-Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
-
 ### Community 172 - "Community 172"
-Cohesion: 0.5
-Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
-
-### Community 173 - "Community 173"
-Cohesion: 0.33
-Nodes (6): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), saveProduct(), updateVariantSku()
-
-### Community 174 - "Community 174"
-Cohesion: 0.39
-Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
-
-### Community 175 - "Community 175"
-Cohesion: 0.28
-Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
-
-### Community 176 - "Community 176"
-Cohesion: 0.25
-Nodes (2): buildUsername(), normalizeNameSegment()
-
-### Community 177 - "Community 177"
-Cohesion: 0.39
-Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
-
-### Community 178 - "Community 178"
-Cohesion: 0.28
-Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
-
-### Community 179 - "Community 179"
-Cohesion: 0.25
-Nodes (2): isValidMessageBlocker(), isValidPriority()
-
-### Community 180 - "Community 180"
-Cohesion: 0.44
-Nodes (1): Logger
-
-### Community 181 - "Community 181"
-Cohesion: 0.36
-Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
-
-### Community 182 - "Community 182"
-Cohesion: 0.25
-Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
-
-### Community 183 - "Community 183"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 184 - "Community 184"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
-### Community 185 - "Community 185"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
-### Community 186 - "Community 186"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 187 - "Community 187"
+### Community 173 - "Community 173"
 Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
+
+### Community 174 - "Community 174"
+Cohesion: 0.5
+Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
+
+### Community 175 - "Community 175"
+Cohesion: 0.33
+Nodes (6): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), saveProduct(), updateVariantSku()
+
+### Community 176 - "Community 176"
+Cohesion: 0.39
+Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
+
+### Community 177 - "Community 177"
+Cohesion: 0.28
+Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
+
+### Community 178 - "Community 178"
+Cohesion: 0.25
+Nodes (2): buildUsername(), normalizeNameSegment()
+
+### Community 179 - "Community 179"
+Cohesion: 0.39
+Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
+
+### Community 180 - "Community 180"
+Cohesion: 0.28
+Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
+
+### Community 181 - "Community 181"
+Cohesion: 0.25
+Nodes (2): isValidMessageBlocker(), isValidPriority()
+
+### Community 182 - "Community 182"
+Cohesion: 0.44
+Nodes (1): Logger
+
+### Community 183 - "Community 183"
+Cohesion: 0.36
+Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
+
+### Community 184 - "Community 184"
+Cohesion: 0.25
+Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
+
+### Community 185 - "Community 185"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
+
+### Community 186 - "Community 186"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
+### Community 187 - "Community 187"
+Cohesion: 0.22
+Nodes (0):
 
 ### Community 188 - "Community 188"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 189 - "Community 189"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 190 - "Community 190"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+
+### Community 191 - "Community 191"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 190 - "Community 190"
+### Community 192 - "Community 192"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 191 - "Community 191"
+### Community 193 - "Community 193"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 192 - "Community 192"
+### Community 194 - "Community 194"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 193 - "Community 193"
+### Community 195 - "Community 195"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 194 - "Community 194"
+### Community 196 - "Community 196"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 195 - "Community 195"
+### Community 197 - "Community 197"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 196 - "Community 196"
+### Community 198 - "Community 198"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 197 - "Community 197"
+### Community 199 - "Community 199"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 198 - "Community 198"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 199 - "Community 199"
-Cohesion: 0.5
-Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
 ### Community 200 - "Community 200"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 201 - "Community 201"
-Cohesion: 0.36
-Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
+Cohesion: 0.5
+Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
 ### Community 202 - "Community 202"
-Cohesion: 0.36
-Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
-
-### Community 203 - "Community 203"
-Cohesion: 0.39
-Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
-
-### Community 204 - "Community 204"
-Cohesion: 0.29
-Nodes (2): appendTransition(), applyOnlineOrderUpdate()
-
-### Community 205 - "Community 205"
-Cohesion: 0.25
-Nodes (1): DataTableRowActions()
-
-### Community 206 - "Community 206"
-Cohesion: 0.32
-Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
-
-### Community 207 - "Community 207"
-Cohesion: 0.25
-Nodes (1): ResizeObserverStub
-
-### Community 208 - "Community 208"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 209 - "Community 209"
+### Community 203 - "Community 203"
+Cohesion: 0.36
+Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
+
+### Community 204 - "Community 204"
+Cohesion: 0.36
+Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+
+### Community 205 - "Community 205"
+Cohesion: 0.39
+Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
+
+### Community 206 - "Community 206"
 Cohesion: 0.29
-Nodes (2): handleKeyDown(), isDebugShortcut()
+Nodes (2): appendTransition(), applyOnlineOrderUpdate()
+
+### Community 207 - "Community 207"
+Cohesion: 0.25
+Nodes (1): DataTableRowActions()
+
+### Community 208 - "Community 208"
+Cohesion: 0.32
+Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
+
+### Community 209 - "Community 209"
+Cohesion: 0.25
+Nodes (1): ResizeObserverStub
 
 ### Community 210 - "Community 210"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 211 - "Community 211"
+Cohesion: 0.29
+Nodes (2): handleKeyDown(), isDebugShortcut()
+
+### Community 212 - "Community 212"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 213 - "Community 213"
 Cohesion: 0.39
 Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
-### Community 212 - "Community 212"
+### Community 214 - "Community 214"
 Cohesion: 0.39
 Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
 
-### Community 213 - "Community 213"
+### Community 215 - "Community 215"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 214 - "Community 214"
+### Community 216 - "Community 216"
 Cohesion: 0.29
 Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
 
-### Community 215 - "Community 215"
+### Community 217 - "Community 217"
 Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
-### Community 216 - "Community 216"
+### Community 218 - "Community 218"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 217 - "Community 217"
+### Community 219 - "Community 219"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 218 - "Community 218"
+### Community 220 - "Community 220"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 219 - "Community 219"
+### Community 221 - "Community 221"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 220 - "Community 220"
+### Community 222 - "Community 222"
 Cohesion: 0.38
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 221 - "Community 221"
+### Community 223 - "Community 223"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 222 - "Community 222"
+### Community 224 - "Community 224"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 223 - "Community 223"
+### Community 225 - "Community 225"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 224 - "Community 224"
+### Community 226 - "Community 226"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 225 - "Community 225"
+### Community 227 - "Community 227"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 226 - "Community 226"
+### Community 228 - "Community 228"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 227 - "Community 227"
+### Community 229 - "Community 229"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 228 - "Community 228"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 229 - "Community 229"
-Cohesion: 0.29
-Nodes (0):
-
 ### Community 230 - "Community 230"
-Cohesion: 0.48
-Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 231 - "Community 231"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 232 - "Community 232"
-Cohesion: 0.33
-Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
+Cohesion: 0.48
+Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
 ### Community 233 - "Community 233"
-Cohesion: 0.52
-Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 234 - "Community 234"
 Cohesion: 0.33
-Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
+Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
 ### Community 235 - "Community 235"
+Cohesion: 0.52
+Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
+
+### Community 236 - "Community 236"
+Cohesion: 0.33
+Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
+
+### Community 237 - "Community 237"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 236 - "Community 236"
+### Community 238 - "Community 238"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 237 - "Community 237"
+### Community 239 - "Community 239"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 238 - "Community 238"
+### Community 240 - "Community 240"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 239 - "Community 239"
+### Community 241 - "Community 241"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 240 - "Community 240"
+### Community 242 - "Community 242"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 241 - "Community 241"
+### Community 243 - "Community 243"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 242 - "Community 242"
+### Community 244 - "Community 244"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 243 - "Community 243"
+### Community 245 - "Community 245"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 244 - "Community 244"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 245 - "Community 245"
-Cohesion: 0.29
-Nodes (0):
-
 ### Community 246 - "Community 246"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 247 - "Community 247"
-Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 248 - "Community 248"
 Cohesion: 0.33
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 249 - "Community 249"
-Cohesion: 0.29
-Nodes (1): ResizeObserverStub
+Cohesion: 0.33
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 250 - "Community 250"
+Cohesion: 0.33
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+
+### Community 251 - "Community 251"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 253 - "Community 253"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 252 - "Community 252"
+### Community 254 - "Community 254"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 253 - "Community 253"
+### Community 255 - "Community 255"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 254 - "Community 254"
+### Community 256 - "Community 256"
 Cohesion: 0.52
 Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
-### Community 255 - "Community 255"
+### Community 257 - "Community 257"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 256 - "Community 256"
+### Community 258 - "Community 258"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 257 - "Community 257"
+### Community 259 - "Community 259"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 258 - "Community 258"
+### Community 260 - "Community 260"
 Cohesion: 0.38
 Nodes (3): getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusSignature()
 
-### Community 259 - "Community 259"
+### Community 261 - "Community 261"
 Cohesion: 0.33
 Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 260 - "Community 260"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 261 - "Community 261"
-Cohesion: 0.29
-Nodes (0):
-
 ### Community 262 - "Community 262"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 263 - "Community 263"
-Cohesion: 0.43
-Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 264 - "Community 264"
 Cohesion: 0.52
-Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
 ### Community 265 - "Community 265"
+Cohesion: 0.43
+Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
+
+### Community 266 - "Community 266"
+Cohesion: 0.52
+Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
+
+### Community 267 - "Community 267"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 266 - "Community 266"
+### Community 268 - "Community 268"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 267 - "Community 267"
+### Community 269 - "Community 269"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 268 - "Community 268"
+### Community 270 - "Community 270"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 269 - "Community 269"
+### Community 271 - "Community 271"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 270 - "Community 270"
+### Community 272 - "Community 272"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 271 - "Community 271"
+### Community 273 - "Community 273"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
 
-### Community 272 - "Community 272"
+### Community 274 - "Community 274"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 273 - "Community 273"
+### Community 275 - "Community 275"
 Cohesion: 0.47
 Nodes (3): canListRegisterSessionSyncConflicts(), listPendingCompletedSaleVoidApprovals(), listRegisterSessionCloseoutHolds()
 
-### Community 274 - "Community 274"
+### Community 276 - "Community 276"
 Cohesion: 0.4
 Nodes (2): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository()
-
-### Community 275 - "Community 275"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 276 - "Community 276"
-Cohesion: 0.73
-Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 277 - "Community 277"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 278 - "Community 278"
-Cohesion: 0.6
-Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
+Cohesion: 0.73
+Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 279 - "Community 279"
-Cohesion: 0.53
-Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 280 - "Community 280"
 Cohesion: 0.6
-Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
 ### Community 281 - "Community 281"
+Cohesion: 0.53
+Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
+
+### Community 282 - "Community 282"
+Cohesion: 0.6
+Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+
+### Community 283 - "Community 283"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 282 - "Community 282"
+### Community 284 - "Community 284"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 283 - "Community 283"
+### Community 285 - "Community 285"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 284 - "Community 284"
+### Community 286 - "Community 286"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 285 - "Community 285"
+### Community 287 - "Community 287"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 286 - "Community 286"
+### Community 288 - "Community 288"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 287 - "Community 287"
+### Community 289 - "Community 289"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 288 - "Community 288"
+### Community 290 - "Community 290"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 289 - "Community 289"
+### Community 291 - "Community 291"
 Cohesion: 0.4
 Nodes (2): moveBestSeller(), saveOrder()
 
-### Community 290 - "Community 290"
+### Community 292 - "Community 292"
 Cohesion: 0.4
 Nodes (2): moveFeaturedItem(), saveOrder()
 
-### Community 291 - "Community 291"
+### Community 293 - "Community 293"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 292 - "Community 292"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 293 - "Community 293"
-Cohesion: 0.4
-Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
-
 ### Community 294 - "Community 294"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 295 - "Community 295"
 Cohesion: 0.4
-Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
+Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
 ### Community 296 - "Community 296"
+Cohesion: 0.33
+Nodes (1): ResizeObserverStub
+
+### Community 297 - "Community 297"
+Cohesion: 0.4
+Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
+
+### Community 298 - "Community 298"
 Cohesion: 0.4
 Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
-### Community 297 - "Community 297"
+### Community 299 - "Community 299"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 298 - "Community 298"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 299 - "Community 299"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 300 - "Community 300"
-Cohesion: 0.47
-Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 301 - "Community 301"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 302 - "Community 302"
+Cohesion: 0.47
+Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
+
+### Community 303 - "Community 303"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 304 - "Community 304"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 303 - "Community 303"
+### Community 305 - "Community 305"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 304 - "Community 304"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 305 - "Community 305"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 306 - "Community 306"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 307 - "Community 307"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 308 - "Community 308"
-Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 309 - "Community 309"
 Cohesion: 0.33
@@ -3338,204 +3345,204 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 311 - "Community 311"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 312 - "Community 312"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 313 - "Community 313"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 314 - "Community 314"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 313 - "Community 313"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 314 - "Community 314"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
 ### Community 315 - "Community 315"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
 ### Community 316 - "Community 316"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (1): MemoryCache
 
 ### Community 317 - "Community 317"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 318 - "Community 318"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 319 - "Community 319"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 320 - "Community 320"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 321 - "Community 321"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 322 - "Community 322"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 323 - "Community 323"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 324 - "Community 324"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 325 - "Community 325"
-Cohesion: 0.53
-Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 326 - "Community 326"
-Cohesion: 0.47
-Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 327 - "Community 327"
 Cohesion: 0.53
-Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
 ### Community 328 - "Community 328"
+Cohesion: 0.47
+Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+
+### Community 329 - "Community 329"
+Cohesion: 0.53
+Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+
+### Community 330 - "Community 330"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 329 - "Community 329"
+### Community 331 - "Community 331"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 330 - "Community 330"
+### Community 332 - "Community 332"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 331 - "Community 331"
+### Community 333 - "Community 333"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 332 - "Community 332"
-Cohesion: 0.6
-Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 333 - "Community 333"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 334 - "Community 334"
 Cohesion: 0.6
-Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
+Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 335 - "Community 335"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 336 - "Community 336"
+Cohesion: 0.6
+Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
+
+### Community 337 - "Community 337"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 338 - "Community 338"
 Cohesion: 0.5
 Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
-### Community 337 - "Community 337"
+### Community 339 - "Community 339"
 Cohesion: 0.5
 Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
-### Community 338 - "Community 338"
+### Community 340 - "Community 340"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 339 - "Community 339"
+### Community 341 - "Community 341"
 Cohesion: 0.5
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 340 - "Community 340"
+### Community 342 - "Community 342"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 341 - "Community 341"
+### Community 343 - "Community 343"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 342 - "Community 342"
+### Community 344 - "Community 344"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 343 - "Community 343"
+### Community 345 - "Community 345"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 344 - "Community 344"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 345 - "Community 345"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 346 - "Community 346"
-Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 347 - "Community 347"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 348 - "Community 348"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 349 - "Community 349"
 Cohesion: 0.5
-Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
+Nodes (2): baseInput(), buildRuntimeStatus()
 
 ### Community 350 - "Community 350"
-Cohesion: 0.6
-Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 351 - "Community 351"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 352 - "Community 352"
-Cohesion: 0.7
-Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
+Cohesion: 0.5
+Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
 ### Community 353 - "Community 353"
 Cohesion: 0.6
-Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
+Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
 ### Community 354 - "Community 354"
-Cohesion: 0.5
-Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 355 - "Community 355"
 Cohesion: 0.7
-Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
+Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
 ### Community 356 - "Community 356"
+Cohesion: 0.6
+Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
+
+### Community 357 - "Community 357"
+Cohesion: 0.5
+Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+
+### Community 358 - "Community 358"
+Cohesion: 0.7
+Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
+
+### Community 359 - "Community 359"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
 
-### Community 357 - "Community 357"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 358 - "Community 358"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 359 - "Community 359"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 360 - "Community 360"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 361 - "Community 361"
 Cohesion: 0.4
@@ -3546,36 +3553,36 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 363 - "Community 363"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 364 - "Community 364"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 365 - "Community 365"
-Cohesion: 0.5
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 366 - "Community 366"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 367 - "Community 367"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
-
-### Community 368 - "Community 368"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 368 - "Community 368"
+Cohesion: 0.5
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 369 - "Community 369"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 370 - "Community 370"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 371 - "Community 371"
 Cohesion: 0.4
@@ -3586,196 +3593,196 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 373 - "Community 373"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 374 - "Community 374"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 375 - "Community 375"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 376 - "Community 376"
+Cohesion: 0.7
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+
+### Community 377 - "Community 377"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 378 - "Community 378"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 376 - "Community 376"
+### Community 379 - "Community 379"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 377 - "Community 377"
+### Community 380 - "Community 380"
 Cohesion: 0.5
 Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
-### Community 378 - "Community 378"
+### Community 381 - "Community 381"
 Cohesion: 0.5
 Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
-### Community 379 - "Community 379"
+### Community 382 - "Community 382"
 Cohesion: 0.5
 Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
 
-### Community 380 - "Community 380"
+### Community 383 - "Community 383"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 381 - "Community 381"
+### Community 384 - "Community 384"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 382 - "Community 382"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 383 - "Community 383"
-Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
-
-### Community 384 - "Community 384"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 385 - "Community 385"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 386 - "Community 386"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 387 - "Community 387"
-Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
-
-### Community 388 - "Community 388"
-Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
-
-### Community 389 - "Community 389"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 388 - "Community 388"
+Cohesion: 0.6
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+
+### Community 389 - "Community 389"
+Cohesion: 0.6
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+
 ### Community 390 - "Community 390"
-Cohesion: 0.7
-Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
+Cohesion: 0.6
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
 ### Community 391 - "Community 391"
-Cohesion: 0.5
-Nodes (2): buildAdminSkuSearchOption(), compactJoin()
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
 ### Community 392 - "Community 392"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 393 - "Community 393"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 394 - "Community 394"
+Cohesion: 0.5
+Nodes (2): buildAdminSkuSearchOption(), compactJoin()
+
+### Community 395 - "Community 395"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 395 - "Community 395"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
-
 ### Community 396 - "Community 396"
-Cohesion: 0.5
-Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 397 - "Community 397"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 398 - "Community 398"
+Cohesion: 0.5
+Nodes (2): completePendingAuthSync(), sleep()
+
+### Community 399 - "Community 399"
+Cohesion: 0.5
+Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+
+### Community 400 - "Community 400"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 401 - "Community 401"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 399 - "Community 399"
+### Community 402 - "Community 402"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 400 - "Community 400"
+### Community 403 - "Community 403"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
-### Community 401 - "Community 401"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 402 - "Community 402"
-Cohesion: 0.6
-Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
-
-### Community 403 - "Community 403"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 404 - "Community 404"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 405 - "Community 405"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
 ### Community 406 - "Community 406"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 407 - "Community 407"
-Cohesion: 0.6
-Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 408 - "Community 408"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 409 - "Community 409"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 410 - "Community 410"
+Cohesion: 0.6
+Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
+
+### Community 411 - "Community 411"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 412 - "Community 412"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 410 - "Community 410"
+### Community 413 - "Community 413"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 411 - "Community 411"
+### Community 414 - "Community 414"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 412 - "Community 412"
+### Community 415 - "Community 415"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 413 - "Community 413"
+### Community 416 - "Community 416"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 414 - "Community 414"
+### Community 417 - "Community 417"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 415 - "Community 415"
+### Community 418 - "Community 418"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 416 - "Community 416"
+### Community 419 - "Community 419"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 417 - "Community 417"
+### Community 420 - "Community 420"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 418 - "Community 418"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 419 - "Community 419"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 420 - "Community 420"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 421 - "Community 421"
 Cohesion: 0.5
@@ -3787,27 +3794,27 @@ Nodes (0):
 
 ### Community 423 - "Community 423"
 Cohesion: 0.67
-Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 424 - "Community 424"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 425 - "Community 425"
-Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
-
-### Community 426 - "Community 426"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 426 - "Community 426"
+Cohesion: 0.67
+Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
 ### Community 427 - "Community 427"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 428 - "Community 428"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 429 - "Community 429"
 Cohesion: 0.5
@@ -3818,40 +3825,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 431 - "Community 431"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 432 - "Community 432"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 433 - "Community 433"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 434 - "Community 434"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 432 - "Community 432"
+### Community 435 - "Community 435"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 433 - "Community 433"
+### Community 436 - "Community 436"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
-
-### Community 434 - "Community 434"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 435 - "Community 435"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 436 - "Community 436"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 437 - "Community 437"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 438 - "Community 438"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 439 - "Community 439"
-Cohesion: 0.67
-Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 440 - "Community 440"
 Cohesion: 0.5
@@ -3859,139 +3866,139 @@ Nodes (0):
 
 ### Community 441 - "Community 441"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 442 - "Community 442"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
 ### Community 443 - "Community 443"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 444 - "Community 444"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 445 - "Community 445"
-Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 446 - "Community 446"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 447 - "Community 447"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 448 - "Community 448"
-Cohesion: 0.67
-Nodes (2): buildCtx(), buildQueryCtx()
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 449 - "Community 449"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 450 - "Community 450"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 451 - "Community 451"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildCtx(), buildQueryCtx()
 
 ### Community 452 - "Community 452"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 453 - "Community 453"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 454 - "Community 454"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 455 - "Community 455"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 456 - "Community 456"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 457 - "Community 457"
-Cohesion: 0.83
-Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 458 - "Community 458"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 459 - "Community 459"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 460 - "Community 460"
 Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
 ### Community 461 - "Community 461"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 462 - "Community 462"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 463 - "Community 463"
+Cohesion: 0.83
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+
+### Community 464 - "Community 464"
 Cohesion: 0.83
 Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
-### Community 462 - "Community 462"
+### Community 465 - "Community 465"
 Cohesion: 0.83
 Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
-### Community 463 - "Community 463"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 464 - "Community 464"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 465 - "Community 465"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 466 - "Community 466"
-Cohesion: 0.83
-Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 467 - "Community 467"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 468 - "Community 468"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 469 - "Community 469"
-Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Cohesion: 0.83
+Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
 ### Community 470 - "Community 470"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 471 - "Community 471"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 472 - "Community 472"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 473 - "Community 473"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 474 - "Community 474"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 475 - "Community 475"
 Cohesion: 0.5
@@ -4014,8 +4021,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 480 - "Community 480"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 481 - "Community 481"
 Cohesion: 0.5
@@ -4026,12 +4033,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 483 - "Community 483"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 484 - "Community 484"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 485 - "Community 485"
 Cohesion: 0.5
@@ -4042,12 +4049,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 487 - "Community 487"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 488 - "Community 488"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 489 - "Community 489"
 Cohesion: 0.5
@@ -4059,119 +4066,119 @@ Nodes (0):
 
 ### Community 491 - "Community 491"
 Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 492 - "Community 492"
-Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
-
-### Community 493 - "Community 493"
-Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
-
-### Community 494 - "Community 494"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 493 - "Community 493"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 494 - "Community 494"
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 495 - "Community 495"
 Cohesion: 0.67
-Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 496 - "Community 496"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
 ### Community 497 - "Community 497"
-Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
-
-### Community 498 - "Community 498"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 499 - "Community 499"
+### Community 498 - "Community 498"
 Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
+Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
+
+### Community 499 - "Community 499"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 500 - "Community 500"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 501 - "Community 501"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 502 - "Community 502"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 503 - "Community 503"
 Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 504 - "Community 504"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 505 - "Community 505"
-Cohesion: 0.83
-Nodes (3): completedEvent(), event(), item()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 506 - "Community 506"
 Cohesion: 0.67
-Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
 ### Community 507 - "Community 507"
-Cohesion: 0.83
-Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 508 - "Community 508"
 Cohesion: 0.83
-Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
+Nodes (3): completedEvent(), event(), item()
 
 ### Community 509 - "Community 509"
-Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+Cohesion: 0.67
+Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
 ### Community 510 - "Community 510"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
 ### Community 511 - "Community 511"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
 ### Community 512 - "Community 512"
 Cohesion: 0.83
-Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
 ### Community 513 - "Community 513"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 514 - "Community 514"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 515 - "Community 515"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
 ### Community 516 - "Community 516"
-Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 517 - "Community 517"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 518 - "Community 518"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 519 - "Community 519"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 520 - "Community 520"
 Cohesion: 0.5
@@ -4194,72 +4201,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 525 - "Community 525"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 526 - "Community 526"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 527 - "Community 527"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 528 - "Community 528"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 526 - "Community 526"
+### Community 529 - "Community 529"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 527 - "Community 527"
+### Community 530 - "Community 530"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 528 - "Community 528"
+### Community 531 - "Community 531"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 529 - "Community 529"
+### Community 532 - "Community 532"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 530 - "Community 530"
+### Community 533 - "Community 533"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 531 - "Community 531"
+### Community 534 - "Community 534"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 532 - "Community 532"
+### Community 535 - "Community 535"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 533 - "Community 533"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
-
-### Community 534 - "Community 534"
-Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
-
-### Community 535 - "Community 535"
-Cohesion: 0.83
-Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
 ### Community 536 - "Community 536"
 Cohesion: 0.67
-Nodes (2): collectHarnessTestTargets(), runHarnessTest()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 537 - "Community 537"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
 ### Community 538 - "Community 538"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
 ### Community 539 - "Community 539"
 Cohesion: 0.67
-Nodes (0):
+Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
 ### Community 540 - "Community 540"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 541 - "Community 541"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 542 - "Community 542"
 Cohesion: 0.67
@@ -4270,8 +4277,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 544 - "Community 544"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 545 - "Community 545"
 Cohesion: 0.67
@@ -4322,36 +4329,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 557 - "Community 557"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 558 - "Community 558"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 559 - "Community 559"
-Cohesion: 1.0
-Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 560 - "Community 560"
 Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 561 - "Community 561"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
 ### Community 562 - "Community 562"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 563 - "Community 563"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 564 - "Community 564"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 565 - "Community 565"
 Cohesion: 0.67
@@ -4359,11 +4366,11 @@ Nodes (0):
 
 ### Community 566 - "Community 566"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 567 - "Community 567"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 568 - "Community 568"
 Cohesion: 0.67
@@ -4378,8 +4385,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 571 - "Community 571"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 572 - "Community 572"
 Cohesion: 0.67
@@ -4390,8 +4397,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 574 - "Community 574"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 575 - "Community 575"
 Cohesion: 0.67
@@ -4406,16 +4413,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 578 - "Community 578"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 579 - "Community 579"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 579 - "Community 579"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
-
 ### Community 580 - "Community 580"
-Cohesion: 1.0
-Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 581 - "Community 581"
 Cohesion: 0.67
@@ -4426,20 +4433,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 583 - "Community 583"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 584 - "Community 584"
 Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
 
 ### Community 585 - "Community 585"
-Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 586 - "Community 586"
-Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 587 - "Community 587"
 Cohesion: 0.67
@@ -4447,23 +4454,23 @@ Nodes (0):
 
 ### Community 588 - "Community 588"
 Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 589 - "Community 589"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 590 - "Community 590"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 591 - "Community 591"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 592 - "Community 592"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 593 - "Community 593"
 Cohesion: 0.67
@@ -4475,11 +4482,11 @@ Nodes (0):
 
 ### Community 595 - "Community 595"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 596 - "Community 596"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 597 - "Community 597"
 Cohesion: 0.67
@@ -4494,20 +4501,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 600 - "Community 600"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 601 - "Community 601"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 602 - "Community 602"
-Cohesion: 1.0
-Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 603 - "Community 603"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 604 - "Community 604"
 Cohesion: 0.67
@@ -4519,11 +4526,11 @@ Nodes (0):
 
 ### Community 606 - "Community 606"
 Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
+Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
 ### Community 607 - "Community 607"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 608 - "Community 608"
 Cohesion: 0.67
@@ -4531,11 +4538,11 @@ Nodes (0):
 
 ### Community 609 - "Community 609"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 610 - "Community 610"
 Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 611 - "Community 611"
 Cohesion: 0.67
@@ -4547,15 +4554,15 @@ Nodes (0):
 
 ### Community 613 - "Community 613"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 614 - "Community 614"
 Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 615 - "Community 615"
-Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 616 - "Community 616"
 Cohesion: 0.67
@@ -4566,12 +4573,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 618 - "Community 618"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 619 - "Community 619"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 620 - "Community 620"
 Cohesion: 0.67
@@ -4594,8 +4601,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 625 - "Community 625"
-Cohesion: 1.0
-Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 626 - "Community 626"
 Cohesion: 0.67
@@ -4610,8 +4617,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 629 - "Community 629"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
 
 ### Community 630 - "Community 630"
 Cohesion: 0.67
@@ -4619,91 +4626,91 @@ Nodes (0):
 
 ### Community 631 - "Community 631"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 632 - "Community 632"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 633 - "Community 633"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (0):
 
 ### Community 634 - "Community 634"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (0):
 
 ### Community 635 - "Community 635"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 636 - "Community 636"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 637 - "Community 637"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): AppSkeleton()
 
 ### Community 638 - "Community 638"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): DashboardSkeleton()
 
 ### Community 639 - "Community 639"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): TableSkeleton()
 
 ### Community 640 - "Community 640"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 641 - "Community 641"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): NotFound()
 
 ### Community 642 - "Community 642"
-Cohesion: 0.67
-Nodes (1): LoadingButton()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 643 - "Community 643"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): AppContextMenu()
 
 ### Community 644 - "Community 644"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): Badge()
 
 ### Community 645 - "Community 645"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (0):
 
 ### Community 646 - "Community 646"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): LoadingButton()
 
 ### Community 647 - "Community 647"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): onChange()
 
 ### Community 648 - "Community 648"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): AlertModal()
 
 ### Community 649 - "Community 649"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): OverlayModal()
 
 ### Community 650 - "Community 650"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Skeleton()
 
 ### Community 651 - "Community 651"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 652 - "Community 652"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 653 - "Community 653"
 Cohesion: 0.67
@@ -4723,7 +4730,7 @@ Nodes (0):
 
 ### Community 657 - "Community 657"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 658 - "Community 658"
 Cohesion: 0.67
@@ -4739,7 +4746,7 @@ Nodes (0):
 
 ### Community 661 - "Community 661"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 662 - "Community 662"
 Cohesion: 0.67
@@ -4754,44 +4761,44 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 665 - "Community 665"
-Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 666 - "Community 666"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 667 - "Community 667"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 668 - "Community 668"
-Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
-
-### Community 669 - "Community 669"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 670 - "Community 670"
+### Community 669 - "Community 669"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): getApprovalGuidance(), presentCommandToast()
+
+### Community 670 - "Community 670"
+Cohesion: 0.67
+Nodes (1): isInMaintenanceMode()
 
 ### Community 671 - "Community 671"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 672 - "Community 672"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 673 - "Community 673"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 674 - "Community 674"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 674 - "Community 674"
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 675 - "Community 675"
 Cohesion: 0.67
@@ -4802,8 +4809,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 677 - "Community 677"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 678 - "Community 678"
 Cohesion: 0.67
@@ -4818,12 +4825,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 681 - "Community 681"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 682 - "Community 682"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 683 - "Community 683"
 Cohesion: 0.67
@@ -4835,75 +4842,75 @@ Nodes (0):
 
 ### Community 685 - "Community 685"
 Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 686 - "Community 686"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 687 - "Community 687"
 Cohesion: 0.67
-Nodes (1): hashPassword()
+Nodes (0):
 
 ### Community 688 - "Community 688"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 689 - "Community 689"
-Cohesion: 0.67
-Nodes (1): manualChunks()
+Cohesion: 1.0
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 690 - "Community 690"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 691 - "Community 691"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 692 - "Community 692"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 693 - "Community 693"
-Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Cohesion: 0.67
+Nodes (1): manualChunks()
 
 ### Community 694 - "Community 694"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 695 - "Community 695"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 696 - "Community 696"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 697 - "Community 697"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 698 - "Community 698"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 699 - "Community 699"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 700 - "Community 700"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 701 - "Community 701"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 702 - "Community 702"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 703 - "Community 703"
 Cohesion: 0.67
@@ -4919,7 +4926,7 @@ Nodes (0):
 
 ### Community 706 - "Community 706"
 Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 707 - "Community 707"
 Cohesion: 0.67
@@ -4934,8 +4941,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 710 - "Community 710"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 711 - "Community 711"
 Cohesion: 0.67
@@ -4990,56 +4997,56 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 724 - "Community 724"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 725 - "Community 725"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 726 - "Community 726"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 727 - "Community 727"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 728 - "Community 728"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
 ### Community 729 - "Community 729"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 730 - "Community 730"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
-### Community 730 - "Community 730"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 731 - "Community 731"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 732 - "Community 732"
 Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 733 - "Community 733"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 734 - "Community 734"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 735 - "Community 735"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 736 - "Community 736"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 737 - "Community 737"
 Cohesion: 1.0
@@ -6151,7 +6158,7 @@ Nodes (0):
 
 ### Community 1014 - "Community 1014"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1015 - "Community 1015"
 Cohesion: 1.0
@@ -6167,7 +6174,7 @@ Nodes (0):
 
 ### Community 1018 - "Community 1018"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1019 - "Community 1019"
 Cohesion: 1.0
@@ -10317,372 +10324,400 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2056 - "Community 2056"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2057 - "Community 2057"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2058 - "Community 2058"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2059 - "Community 2059"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2060 - "Community 2060"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2061 - "Community 2061"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2062 - "Community 2062"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 733`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 737`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 738`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 739`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 740`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 741`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 742`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 743`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 744`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 745`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 746`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 747`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 748`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 749`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 750`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 751`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 752`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 753`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 754`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 755`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 756`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 757`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 758`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 759`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 760`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 761`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 762`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 763`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 764`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 765`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 766`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 767`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 768`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 769`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 770`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 771`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 772`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 773`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 774`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 775`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 776`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 777`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 778`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 779`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 780`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 781`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 782`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 783`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 784`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 785`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 786`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 787`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 788`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 789`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 790`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 791`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 792`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 793`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 794`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 795`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 796`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 797`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 798`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 799`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 800`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 801`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 802`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 803`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 804`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 805`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 806`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 807`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 808`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 809`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 810`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 811`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 812`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 813`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 814`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 815`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 816`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 817`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 818`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 819`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 820`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 821`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 822`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 823`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 824`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 825`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 826`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 827`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 828`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 829`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 830`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 831`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 832`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 833`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 834`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 835`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 836`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 837`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 838`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 839`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 840`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 841`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 842`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 843`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 844`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 845`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 846`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 847`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 848`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 849`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 850`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 851`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 852`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 853`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 854`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 855`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 856`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 857`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 858`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 859`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 860`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 861`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 862`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 863`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 864`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 865`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 866`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 867`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 868`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 869`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 870`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 871`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 872`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 873`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 874`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 875`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 876`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 877`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 878`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 879`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 880`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 881`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 882`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 883`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 884`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 885`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 886`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 887`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 888`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 889`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 890`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 891`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 892`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 893`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 894`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 895`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 896`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 897`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 898`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 899`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 900`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 901`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
+- **Thin community `Community 902`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 903`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 904`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 905`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 906`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 907`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 908`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 909`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 910`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 911`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 912`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 913`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 914`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 915`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 916`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
+- **Thin community `Community 917`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 918`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -10718,1361 +10753,1353 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 919`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 920`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 921`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 922`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 923`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 924`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 925`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 926`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 927`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 928`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
+- **Thin community `Community 929`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 930`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 931`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 932`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 933`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 934`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 935`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 936`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 937`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 938`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 939`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 940`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 941`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 942`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 943`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 944`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 945`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 946`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 947`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 948`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 949`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 950`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 951`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 952`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 953`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 954`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 955`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 956`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 957`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 958`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 959`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 960`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 961`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 962`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 963`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 964`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 965`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 966`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 967`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 968`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 969`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 970`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 971`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 972`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 973`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 974`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 975`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 976`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 977`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 978`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 979`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 980`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 981`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 982`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 983`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 984`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 985`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 986`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 987`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 988`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 989`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 990`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 991`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 992`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 993`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 994`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 995`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 996`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 997`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 998`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 999`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1000`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1001`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1002`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1003`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1004`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1005`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1006`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1007`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1008`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1009`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1010`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1011`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1012`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1013`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1014`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1015`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1016`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1017`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1018`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1019`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1020`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1021`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1022`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1023`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1024`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1025`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 1026`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1027`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1028`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1029`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1030`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1031`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1032`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1033`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1034`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1035`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1036`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1037`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
+- **Thin community `Community 1038`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1039`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1040`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1041`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1042`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
+- **Thin community `Community 1043`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1044`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1045`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1046`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1047`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1048`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1049`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1050`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1051`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1052`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1053`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1054`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1055`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `Index()`, `-index-route-view.tsx`
+- **Thin community `Community 1056`** (2 nodes): `Index()`, `-index-route-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1057`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1058`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1059`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1060`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1061`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1062`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1063`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1064`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1065`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
+- **Thin community `Community 1066`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1067`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1068`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1069`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1070`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1071`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1072`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1073`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1074`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1075`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1076`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1077`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1078`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1079`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1080`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1081`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1082`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1083`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1084`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1085`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1086`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1087`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1088`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1089`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1090`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1091`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1092`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1093`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1094`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1095`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1096`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1097`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1098`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1099`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1100`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1101`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1102`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1103`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1104`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1105`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1106`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1107`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1108`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1109`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1110`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1111`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1112`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1113`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1114`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1115`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1116`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1117`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1118`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1119`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1120`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1121`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1122`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1123`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1124`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1125`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1126`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1127`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1128`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1129`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1130`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1131`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1132`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1133`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1134`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1135`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1136`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1137`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1138`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1139`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1140`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1141`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1142`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1143`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1144`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1145`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1146`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1147`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1148`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1149`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1150`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1151`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1152`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1153`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1154`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1155`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1156`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1157`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1158`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1159`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1160`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1161`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1162`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1163`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1164`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1165`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1166`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1167`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1168`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1169`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1170`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1171`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1172`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1173`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1174`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1175`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1176`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1177`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1178`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1179`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1180`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1181`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1182`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1183`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1184`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1185`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1186`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1187`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1188`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1189`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1190`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1191`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1192`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1193`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1194`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1195`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1196`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1197`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1198`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1199`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1200`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1201`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1202`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1203`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1204`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1205`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1206`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1207`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1208`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1209`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `runGit()`, `pr-athena-delivery-run.test.ts`
+- **Thin community `Community 1210`** (2 nodes): `runGit()`, `pr-athena-delivery-run.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1211`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1212`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `api.js`
+- **Thin community `Community 1213`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1214`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1215`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `server.js`
+- **Thin community `Community 1216`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `app.ts`
+- **Thin community `Community 1217`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1218`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1219`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1220`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1221`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `auth.ts`
+- **Thin community `Community 1222`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1223`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1224`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1225`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `countries.ts`
+- **Thin community `Community 1226`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `email.ts`
+- **Thin community `Community 1227`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1228`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `payment.ts`
+- **Thin community `Community 1229`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `contextEvents.test.ts`
+- **Thin community `Community 1230`** (1 nodes): `contextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1231`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `types.ts`
+- **Thin community `Community 1232`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1233`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `crons.ts`
+- **Thin community `Community 1234`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1235`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `internal.ts`
+- **Thin community `Community 1236`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1237`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1238`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1239`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1240`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1241`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1242`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1243`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1244`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1245`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1246`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1247`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `env.ts`
+- **Thin community `Community 1248`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1249`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `auth.ts`
+- **Thin community `Community 1250`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1251`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `colors.ts`
+- **Thin community `Community 1252`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `index.ts`
+- **Thin community `Community 1253`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1254`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `products.ts`
+- **Thin community `Community 1255`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1256`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `stores.ts`
+- **Thin community `Community 1257`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1258`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `bag.ts`
+- **Thin community `Community 1259`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `guest.ts`
+- **Thin community `Community 1260`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1261`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `index.ts`
+- **Thin community `Community 1262`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `me.ts`
+- **Thin community `Community 1263`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `offers.ts`
+- **Thin community `Community 1264`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1265`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1266`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1267`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1268`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1269`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1270`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1271`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1272`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1273`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `user.ts`
+- **Thin community `Community 1274`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1275`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `index.ts`
+- **Thin community `Community 1276`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1277`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `http.ts`
+- **Thin community `Community 1278`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `access.ts`
+- **Thin community `Community 1279`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1280`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1281`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1282`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `index.ts`
+- **Thin community `Community 1283`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1284`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `types.ts`
+- **Thin community `Community 1285`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1286`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `categories.ts`
+- **Thin community `Community 1287`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `colors.ts`
+- **Thin community `Community 1288`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1289`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1290`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1291`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1292`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `pos.ts`
+- **Thin community `Community 1293`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1294`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1295`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1296`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1297`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1298`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1299`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1300`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1301`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1302`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1303`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1304`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1305`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1306`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1307`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1308`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1309`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1310`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `types.ts`
+- **Thin community `Community 1311`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1312`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1313`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1314`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1315`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1316`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1317`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `dto.ts`
+- **Thin community `Community 1318`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1319`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1320`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1321`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `types.ts`
+- **Thin community `Community 1322`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `types.ts`
+- **Thin community `Community 1323`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `types.ts`
+- **Thin community `Community 1324`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1325`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1326`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `customers.ts`
+- **Thin community `Community 1327`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `register.test.ts`
+- **Thin community `Community 1328`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `register.ts`
+- **Thin community `Community 1329`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `sync.ts`
+- **Thin community `Community 1330`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1331`** (1 nodes): `register.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1332`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1333`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `schema.ts`
+- **Thin community `Community 1334`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `automation.ts`
+- **Thin community `Community 1335`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1336`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1337`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `index.ts`
+- **Thin community `Community 1338`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1339`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1340`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1341`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1342`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1343`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1344`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1345`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `category.ts`
+- **Thin community `Community 1346`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `color.ts`
+- **Thin community `Community 1347`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1348`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1349`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `index.ts`
+- **Thin community `Community 1350`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1351`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1352`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1353`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1354`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `organization.ts`
+- **Thin community `Community 1355`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1356`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `product.ts`
+- **Thin community `Community 1357`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1358`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1359`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1360`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `store.ts`
+- **Thin community `Community 1361`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1362`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `index.ts`
+- **Thin community `Community 1363`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1364`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1365`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1366`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1367`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1368`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1369`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1370`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `index.ts`
+- **Thin community `Community 1371`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1372`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1373`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1374`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1375`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1376`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1377`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1378`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1379`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1380`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1381`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1382`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `customer.ts`
+- **Thin community `Community 1383`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1384`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1385`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1386`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1387`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `index.ts`
+- **Thin community `Community 1388`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1389`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1390`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1391`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1392`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1393`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1394`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1395`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1396`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1397`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1398`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1399`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1400`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1401`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1402`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1403`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1404`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1405`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1406`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1407`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `index.ts`
+- **Thin community `Community 1408`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1409`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1410`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `index.ts`
+- **Thin community `Community 1411`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1412`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `serviceCase.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `serviceCaseLineItem.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `serviceCatalog.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `serviceInventoryUsage.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1413`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1414`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1415`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1416`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1417`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1418`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1419`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1420`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `bag.ts`
+- **Thin community `Community 1421`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1422`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1423`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1424`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `guest.ts`
+- **Thin community `Community 1425`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `index.ts`
+- **Thin community `Community 1426`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `offer.ts`
+- **Thin community `Community 1427`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1428`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1429`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `review.ts`
+- **Thin community `Community 1430`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1431`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1432`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1433`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1434`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1435`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1436`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1437`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1438`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1439`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `bag.ts`
+- **Thin community `Community 1440`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1441`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `customer.ts`
+- **Thin community `Community 1442`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `guest.ts`
+- **Thin community `Community 1443`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1444`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1445`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1446`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1447`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1448`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1449`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1450`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `users.ts`
+- **Thin community `Community 1451`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `payment.ts`
+- **Thin community `Community 1452`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1453`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1454`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1455`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1456`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1457`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1458`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1459`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `index.ts`
+- **Thin community `Community 1460`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1461`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1462`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1463`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1464`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `auth.ts`
+- **Thin community `Community 1465`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1466`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1467`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1468`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1469`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1470`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1471`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1472`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `index.ts`
+- **Thin community `Community 1473`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1474`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1475`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1476`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1477`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1478`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1479`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1480`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1481`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1482`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1483`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1484`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1485`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1486`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1487`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1488`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1489`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1490`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1491`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1492`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1493`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1494`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `constants.ts`
+- **Thin community `Community 1495`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1496`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1497`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1498`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `types.ts`
+- **Thin community `Community 1499`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1500`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1501`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1502`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1503`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1504`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1505`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1506`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1507`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1508`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1509`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1510`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1511`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1512`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1513`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1514`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1515`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1516`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1517`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1518`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1519`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `constants.ts`
+- **Thin community `Community 1520`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1521`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1522`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1523`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `data.ts`
+- **Thin community `Community 1524`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1525`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1526`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1527`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1528`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1529`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1530`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1531`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1532`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1533`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `constants.ts`
+- **Thin community `Community 1534`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1535`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1536`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1537`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `data.ts`
+- **Thin community `Community 1538`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1539`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1540`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1541`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1542`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1543`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1544`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1545`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1546`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1547`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1548`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1549`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1550`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `constants.ts`
+- **Thin community `Community 1551`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1552`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1553`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1554`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1555`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1556`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1557`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1558`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1559`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1560`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1561`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1562`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1563`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1564`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1565`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1566`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1567`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1568`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1569`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1570`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1571`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1572`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1573`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1574`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1575`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1576`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1577`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1578`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1579`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1580`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1581`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1582`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1583`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1584`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1585`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `constants.ts`
+- **Thin community `Community 1586`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1587`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1588`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1589`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `data.ts`
+- **Thin community `Community 1590`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1591`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1592`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1593`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -12080,13 +12107,13 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1595`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1596`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1597`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `data.ts`
+- **Thin community `Community 1598`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1599`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1600`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -12100,905 +12127,919 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1605`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1606`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1607`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1608`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1609`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1610`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1611`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1612`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1613`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1614`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1615`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1616`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1617`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1618`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1619`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1620`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1621`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1622`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1623`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1624`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1625`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1626`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1627`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1628`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1629`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1630`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1631`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1632`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1633`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `types.ts`
+- **Thin community `Community 1634`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1635`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1636`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1637`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1638`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1639`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1640`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1641`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1642`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 1643`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1644`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1645`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1646`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1647`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1648`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1649`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1650`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1651`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1652`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `data.ts`
+- **Thin community `Community 1653`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1654`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1655`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1656`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1657`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1658`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1659`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1660`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1661`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1662`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1663`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1664`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1665`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `constants.ts`
+- **Thin community `Community 1666`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1667`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1668`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1669`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `data.ts`
+- **Thin community `Community 1670`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `types.ts`
+- **Thin community `Community 1671`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1672`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1673`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1674`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1675`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1676`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `index.ts`
+- **Thin community `Community 1677`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1678`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1679`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1680`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1681`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `index.tsx`
+- **Thin community `Community 1682`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1683`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1684`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1685`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1686`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1687`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1688`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1689`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1690`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `index.tsx`
+- **Thin community `Community 1691`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1692`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1693`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1694`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `button.tsx`
+- **Thin community `Community 1695`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1696`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `card.tsx`
+- **Thin community `Community 1697`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1698`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1699`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `command.tsx`
+- **Thin community `Community 1700`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1701`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1702`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1703`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `form.tsx`
+- **Thin community `Community 1704`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1705`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1706`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `input.tsx`
+- **Thin community `Community 1707`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1708`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1709`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1710`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1711`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1712`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1713`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `select.tsx`
+- **Thin community `Community 1714`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1715`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1716`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1717`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1718`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `table.tsx`
+- **Thin community `Community 1719`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1720`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1721`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1722`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1723`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1724`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1725`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1726`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1727`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `constants.ts`
+- **Thin community `Community 1728`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1729`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1730`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1731`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `data.ts`
+- **Thin community `Community 1732`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1733`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1734`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1735`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1736`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1737`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1738`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1739`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1740`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1741`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1742`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `index.ts`
+- **Thin community `Community 1743`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1744`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1745`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1746`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 1747`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1748`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1749`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1750`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1751`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1752`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1753`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1754`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1755`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 1756`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 1757`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `index.ts`
+- **Thin community `Community 1758`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 1759`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `index.ts`
+- **Thin community `Community 1760`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 1761`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 1762`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `aws.ts`
+- **Thin community `Community 1763`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `constants.ts`
+- **Thin community `Community 1764`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `countries.ts`
+- **Thin community `Community 1765`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1766`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1767`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1768`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1769`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1770`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1771`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1772`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 1773`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `dto.ts`
+- **Thin community `Community 1774`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `ports.ts`
+- **Thin community `Community 1775`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `constants.ts`
+- **Thin community `Community 1776`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1777`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1778`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `index.ts`
+- **Thin community `Community 1779`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1780`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `types.ts`
+- **Thin community `Community 1781`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1782`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1783`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1784`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1785`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1786`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1787`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1788`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1789`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1790`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 1791`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 1792`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 1793`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 1794`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 1795`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1796`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1797`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1798`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1799`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `index.ts`
+- **Thin community `Community 1800`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1801`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `category.ts`
+- **Thin community `Community 1802`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `product.ts`
+- **Thin community `Community 1803`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `store.ts`
+- **Thin community `Community 1804`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1805`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `user.ts`
+- **Thin community `Community 1806`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1807`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1808`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1809`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1810`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1811`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `main.tsx`
+- **Thin community `Community 1812`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 1813`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1814`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1815`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1816`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1817`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1818`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `index.tsx`
+- **Thin community `Community 1819`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `index.tsx`
+- **Thin community `Community 1820`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `index.tsx`
+- **Thin community `Community 1821`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1822`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1823`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1824`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1825`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1826`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1827`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1828`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1829`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1830`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `home.tsx`
+- **Thin community `Community 1831`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1832`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1833`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1834`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `index.tsx`
+- **Thin community `Community 1835`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `review.tsx`
+- **Thin community `Community 1836`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1837`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1838`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `index.tsx`
+- **Thin community `Community 1839`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1840`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1841`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1842`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `index.tsx`
+- **Thin community `Community 1843`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1844`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1845`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1846`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1847`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1848`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1849`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 1850`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `index.tsx`
+- **Thin community `Community 1851`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1852`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1853`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1854`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1855`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1856`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1857`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1858`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1859`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1860`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `index.tsx`
+- **Thin community `Community 1861`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1862`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `index.tsx`
+- **Thin community `Community 1863`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `new.tsx`
+- **Thin community `Community 1864`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `index.tsx`
+- **Thin community `Community 1865`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `new.tsx`
+- **Thin community `Community 1866`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1867`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1868`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `index.tsx`
+- **Thin community `Community 1869`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `new.tsx`
+- **Thin community `Community 1870`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `index.tsx`
+- **Thin community `Community 1871`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1872`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1873`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1874`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1875`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1876`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1877`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1878`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1879`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `index.tsx`
+- **Thin community `Community 1880`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1881`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `_authed.tsx`
+- **Thin community `Community 1882`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1883`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `index.tsx`
+- **Thin community `Community 1884`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1885`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1886`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1887`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 1888`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1889`** (1 nodes): `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 1890`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1891`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 1892`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1893`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1894`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1895`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1896`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1897`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1898`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1899`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1900`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1901`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1902`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1903`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1904`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1905`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1906`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1907`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1908`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `setup.ts`
+- **Thin community `Community 1909`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1910`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `types.ts`
+- **Thin community `Community 1911`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1912`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1913`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1914`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1915`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1916`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1917`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1918`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `types.ts`
+- **Thin community `Community 1919`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1920`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1921`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1922`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1923`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1924`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1925`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1926`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1927`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `schema.ts`
+- **Thin community `Community 1928`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1929`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1930`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1931`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1932`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1933`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1934`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1935`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1936`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1937`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `types.ts`
+- **Thin community `Community 1938`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1939`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1940`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1941`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1942`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1943`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1944`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1945`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `constants.ts`
+- **Thin community `Community 1946`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1947`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `About.tsx`
+- **Thin community `Community 1948`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1949`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1950`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1951`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1952`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1953`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1954`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1955`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1956`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1957`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1958`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `types.ts`
+- **Thin community `Community 1959`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1960`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1961`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1962`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1963`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1964`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1965`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1966`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1967`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1968`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1969`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1970`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `button.tsx`
+- **Thin community `Community 1971`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `card.tsx`
+- **Thin community `Community 1972`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1973`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `command.tsx`
+- **Thin community `Community 1974`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1975`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1976`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1977`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `form.tsx`
+- **Thin community `Community 1978`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1979`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1980`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1981`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1982`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `input.tsx`
+- **Thin community `Community 1983`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `label.tsx`
+- **Thin community `Community 1984`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1985`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1986`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1987`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `index.ts`
+- **Thin community `Community 1988`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `types.ts`
+- **Thin community `Community 1989`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1990`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1991`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1992`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1993`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `select.tsx`
+- **Thin community `Community 1994`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1995`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1996`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `table.tsx`
+- **Thin community `Community 1997`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1998`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1999`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2000`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2001`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2002`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `config.ts`
+- **Thin community `Community 2003`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2004`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2005`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2006`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2007`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2008`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `constants.ts`
+- **Thin community `Community 2009`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `countries.ts`
+- **Thin community `Community 2010`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2011`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2012`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2013`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2014`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `index.ts`
+- **Thin community `Community 2015`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2016`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `store.ts`
+- **Thin community `Community 2017`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `bag.ts`
+- **Thin community `Community 2018`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2019`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `category.ts`
+- **Thin community `Community 2020`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `organization.ts`
+- **Thin community `Community 2021`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `product.ts`
+- **Thin community `Community 2022`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `store.ts`
+- **Thin community `Community 2023`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2024`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `user.ts`
+- **Thin community `Community 2025`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `states.ts`
+- **Thin community `Community 2026`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2027`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2028`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2029`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2030`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2031`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2032`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2033`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2034`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `index.tsx`
+- **Thin community `Community 2035`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2036`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `index.tsx`
+- **Thin community `Community 2037`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2038`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2039`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2040`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2041`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2042`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `index.tsx`
+- **Thin community `Community 2043`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2044`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2045`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2046`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2047`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2048`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `index.js`
+- **Thin community `Community 2049`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2050`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2051`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2052`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2053`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2054`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2055`** (1 nodes): `vitest.setup.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2056`** (1 nodes): `index.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2057`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2058`** (1 nodes): `athena-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2059`** (1 nodes): `storefront-runtime-api.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2060`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2061`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2062`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2128
-- Graph nodes: 8055
-- Graph edges: 9481
-- Communities: 2056
+- Code files discovered: 2135
+- Graph nodes: 8083
+- Graph edges: 9510
+- Communities: 2063
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (89 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (15 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 189) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 191) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/_generated/api.d.ts
+++ b/packages/athena-webapp/convex/_generated/api.d.ts
@@ -209,6 +209,10 @@ import type * as pos_application_sync_staffProof from "../pos/application/sync/s
 import type * as pos_application_sync_staffProofValidation from "../pos/application/sync/staffProofValidation.js";
 import type * as pos_application_sync_terminalSyncSecret from "../pos/application/sync/terminalSyncSecret.js";
 import type * as pos_application_sync_types from "../pos/application/sync/types.js";
+import type * as pos_application_terminalOperationalState_collectTerminalOperationalFacts from "../pos/application/terminalOperationalState/collectTerminalOperationalFacts.js";
+import type * as pos_application_terminalOperationalState_facts from "../pos/application/terminalOperationalState/facts.js";
+import type * as pos_application_terminalOperationalState_policy from "../pos/application/terminalOperationalState/policy.js";
+import type * as pos_application_terminalOperationalState_types from "../pos/application/terminalOperationalState/types.js";
 import type * as pos_application_terminalRecovery_cloudRepairPolicy from "../pos/application/terminalRecovery/cloudRepairPolicy.js";
 import type * as pos_application_terminalRecovery_resolveTerminalCloudRepair from "../pos/application/terminalRecovery/resolveTerminalCloudRepair.js";
 import type * as pos_application_terminalRecovery_terminalCommandService from "../pos/application/terminalRecovery/terminalCommandService.js";
@@ -216,6 +220,7 @@ import type * as pos_application_terminalRecovery_types from "../pos/application
 import type * as pos_application_terminalRuntime_postRuntimeStatusSideEffects from "../pos/application/terminalRuntime/postRuntimeStatusSideEffects.js";
 import type * as pos_domain_errors from "../pos/domain/errors.js";
 import type * as pos_domain_sessionRules from "../pos/domain/sessionRules.js";
+import type * as pos_domain_terminalSyncEvidence from "../pos/domain/terminalSyncEvidence.js";
 import type * as pos_domain_types from "../pos/domain/types.js";
 import type * as pos_infrastructure_integrations_inventoryHoldGateway from "../pos/infrastructure/integrations/inventoryHoldGateway.js";
 import type * as pos_infrastructure_integrations_paymentAllocationService from "../pos/infrastructure/integrations/paymentAllocationService.js";
@@ -623,6 +628,10 @@ declare const fullApi: ApiFromModules<{
   "pos/application/sync/staffProofValidation": typeof pos_application_sync_staffProofValidation;
   "pos/application/sync/terminalSyncSecret": typeof pos_application_sync_terminalSyncSecret;
   "pos/application/sync/types": typeof pos_application_sync_types;
+  "pos/application/terminalOperationalState/collectTerminalOperationalFacts": typeof pos_application_terminalOperationalState_collectTerminalOperationalFacts;
+  "pos/application/terminalOperationalState/facts": typeof pos_application_terminalOperationalState_facts;
+  "pos/application/terminalOperationalState/policy": typeof pos_application_terminalOperationalState_policy;
+  "pos/application/terminalOperationalState/types": typeof pos_application_terminalOperationalState_types;
   "pos/application/terminalRecovery/cloudRepairPolicy": typeof pos_application_terminalRecovery_cloudRepairPolicy;
   "pos/application/terminalRecovery/resolveTerminalCloudRepair": typeof pos_application_terminalRecovery_resolveTerminalCloudRepair;
   "pos/application/terminalRecovery/terminalCommandService": typeof pos_application_terminalRecovery_terminalCommandService;
@@ -630,6 +639,7 @@ declare const fullApi: ApiFromModules<{
   "pos/application/terminalRuntime/postRuntimeStatusSideEffects": typeof pos_application_terminalRuntime_postRuntimeStatusSideEffects;
   "pos/domain/errors": typeof pos_domain_errors;
   "pos/domain/sessionRules": typeof pos_domain_sessionRules;
+  "pos/domain/terminalSyncEvidence": typeof pos_domain_terminalSyncEvidence;
   "pos/domain/types": typeof pos_domain_types;
   "pos/infrastructure/integrations/inventoryHoldGateway": typeof pos_infrastructure_integrations_inventoryHoldGateway;
   "pos/infrastructure/integrations/paymentAllocationService": typeof pos_infrastructure_integrations_paymentAllocationService;

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
@@ -846,6 +846,50 @@ describe("terminal health queries", () => {
     expect(summary?.recoveryPreview?.readiness).toBe("drawer_open");
   });
 
+  it("does not report sale-ready when runtime drawer evidence conflicts with closed cloud lifecycle", async () => {
+    const ctx = buildQueryCtx({
+      posTerminal: [buildTerminal()],
+      posTerminalRuntimeStatus: [
+        buildRuntimeStatus({
+          activeRegisterSession: {
+            localRegisterSessionId: "local-register-1",
+            observedAt: now - 1_000,
+            openedAt: now - 20_000,
+            registerNumber: "8",
+            status: "open",
+          },
+          saleAuthority: {
+            observedAt: now - 1_000,
+            status: "ready",
+            transactionMode: "products_and_services",
+          },
+        }),
+      ],
+      registerSession: [
+        buildRegisterSession({
+          _id: "register-closed" as Id<"registerSession">,
+          closedAt: now - 1_000,
+          openedAt: now - 20_000,
+          registerNumber: "8",
+          status: "closed",
+        }),
+      ],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.recoveryPreview?.evidence).toEqual(
+      expect.objectContaining({
+        activeRegisterSession: true,
+      }),
+    );
+    expect(summary?.recoveryPreview?.readiness).toBe("drawer_open");
+  });
+
   it("links terminal cards to the active register session for the terminal", async () => {
     const ctx = buildQueryCtx({
       posTerminal: [

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.ts
@@ -1,22 +1,14 @@
 import type { Doc, Id } from "../../../_generated/dataModel";
 import type { QueryCtx } from "../../../_generated/server";
 import {
-  isPosUsableRegisterSessionStatus,
   isRegisterSessionConflictBlockingStatus,
 } from "../../../../shared/registerSessionStatus";
-import {
-  isRegisterSessionReplacementBlocking,
-} from "../../../../shared/registerSessionLifecyclePolicy";
 
 import {
-  getLatestRuntimeStatusForTerminal,
   getTerminalByFingerprint as getTerminalByFingerprintRecord,
   getTerminalById,
-  getTerminalSyncEvidence,
-  hasActiveRegisterSessionForTerminal,
   listTerminalsForStore,
   resolveTerminalRegisterSessionActionTarget,
-  type TerminalSyncEvidence,
 } from "../../infrastructure/repositories/terminalRepository";
 import {
   createTerminalRecoveryCommandReadRepository,
@@ -36,12 +28,27 @@ import type {
   LocalSyncIngestionRepository,
   LocalSyncMappingRecord,
 } from "../sync/types";
+import type { TerminalRecoveryCommandType } from "../terminalRecovery/types";
+import { collectTerminalOperationalFacts } from "../terminalOperationalState/collectTerminalOperationalFacts";
+import { buildTerminalOperationalState } from "../terminalOperationalState/policy";
+import type { TerminalSyncEvidence } from "../../domain/terminalSyncEvidence";
 import type {
-  TerminalRecoveryCommandPayload,
-  TerminalRecoveryCommandType,
-  TerminalRecoveryExpectedEvidence,
-  TerminalRecoveryReadiness,
-} from "../terminalRecovery/types";
+  TerminalAppUpdatePreview,
+  TerminalAppUpdateStatus,
+  TerminalHealth,
+  TerminalHealthAttentionActionTarget,
+  TerminalHealthAttentionReason,
+  TerminalOperationalState,
+  TerminalRecoveryPreview,
+} from "../terminalOperationalState/types";
+
+export type {
+  TerminalAppUpdatePreview,
+  TerminalAppUpdateStatus,
+  TerminalHealthAttentionActionTarget,
+  TerminalHealthAttentionReason,
+  TerminalRecoveryPreview,
+} from "../terminalOperationalState/types";
 
 const EMPTY_TERMINAL_SYNC_EVIDENCE: TerminalSyncEvidence = {
   latestEvent: null,
@@ -58,46 +65,6 @@ const EMPTY_TERMINAL_SYNC_EVIDENCE: TerminalSyncEvidence = {
   heldCount: 0,
   rejectedCount: 0,
 };
-
-export type TerminalHealth =
-  | "online"
-  | "stale"
-  | "offline"
-  | "needs_attention"
-  | "unknown";
-
-export type TerminalHealthAttentionReason = {
-  actionTarget?: TerminalHealthAttentionActionTarget;
-  count?: number;
-  latestEventSequence?: number;
-  latestEventStatus?: string;
-  nextPendingUploadSequence?: number;
-  oldestPendingEventAt?: number;
-  source: "cloud_sync" | "local_runtime" | "terminal_runtime";
-  summary: string;
-  type:
-    | "cloud_conflict"
-    | "cloud_held"
-    | "cloud_rejected"
-    | "synced_sale_inventory_review"
-    | "local_review"
-    | "local_store_unavailable"
-    | "sync_failed"
-    | "sync_unavailable"
-    | "terminal_authorization_failed"
-    | "drawer_authority_blocked"
-    | "terminal_seed_missing";
-};
-
-export type TerminalHealthAttentionActionTarget =
-  | {
-      automaticRepairEligible?: boolean;
-      type: "cash_control_register_session";
-      registerSessionId: Id<"registerSession">;
-    }
-  | { label?: string; type: "open_work" }
-  | { type: "pos_register" }
-  | { type: "pos_settings" };
 
 export type TerminalHealthSummary = {
   terminal: {
@@ -128,68 +95,6 @@ type ActiveRegisterSessionLinkStatus = Extract<
   Doc<"registerSession">["status"],
   "active" | "open"
 >;
-
-export type TerminalRecoveryPreview = {
-  appUpdate: TerminalAppUpdatePreview;
-  readiness: TerminalRecoveryReadiness;
-  runtimeFresh: boolean;
-  evidence: {
-    freshRuntimeRequiredForAbleToTransactNow: true;
-    activeRegisterSession: boolean;
-  };
-  cloudRepair: {
-    preconditionHash: string;
-    safeConflictIds: Array<Id<"posLocalSyncConflict">>;
-    skippedConflictIds: Array<Id<"posLocalSyncConflict">>;
-  };
-  commandStatus: {
-    appUpdateCommandExecutionId?: string;
-    commandId?: Id<"posTerminalRecoveryCommand">;
-    commandType: TerminalRecoveryCommandType;
-    label: string;
-    latestAcknowledgement?: string;
-    status: Doc<"posTerminalRecoveryCommand">["status"];
-    verificationStatus: Doc<"posTerminalRecoveryCommand">["verificationStatus"];
-  } | null;
-  terminalActions: Array<{
-    commandType: TerminalRecoveryCommandType;
-    expectedEvidence: TerminalRecoveryExpectedEvidence;
-    commandContext: TerminalRecoveryCommandPayload;
-    reason: string;
-  }>;
-  manualReview: Array<{
-    reason: string;
-    source:
-      | TerminalHealthAttentionReason["source"]
-      | "cloud_repair";
-    type: TerminalHealthAttentionReason["type"] | "unsafe_cloud_conflict";
-  }>;
-};
-
-export type TerminalAppUpdateStatus =
-  | "applying"
-  | "blocked"
-  | "current"
-  | "detector_failed"
-  | "stale"
-  | "unknown"
-  | "update_ready"
-  | "update_ready_unstaged";
-
-export type TerminalAppUpdatePreview = {
-  commandCorrelated?: boolean;
-  currentBuildId?: string;
-  evidenceFresh: boolean;
-  observedAt?: number;
-  pendingBuildId?: string;
-  stagingAssetCount?: number;
-  stagingFailedAssetCount?: number;
-  stagingReason?: string;
-  stagingRejectedAssetCount?: number;
-  stagingStatus?: string;
-  status: TerminalAppUpdateStatus;
-  summary?: string;
-};
 
 export async function listTerminals(
   ctx: QueryCtx,
@@ -252,83 +157,6 @@ export async function getTerminalHealthSummary(
 export const listTerminalHealth = listTerminalHealthSummaries;
 export const getTerminalHealthDetail = getTerminalHealthSummary;
 
-async function normalizeRuntimeStatusForSupport(
-  ctx: QueryCtx,
-  args: {
-    runtimeStatus: Doc<"posTerminalRuntimeStatus"> | null;
-    terminal: Doc<"posTerminal">;
-  },
-): Promise<Doc<"posTerminalRuntimeStatus"> | null> {
-  if (!args.runtimeStatus) {
-    return null;
-  }
-
-  if (
-    !(await isCleanlyClosedDrawerAuthority(ctx, {
-      runtimeStatus: args.runtimeStatus,
-      terminal: args.terminal,
-    }))
-  ) {
-    return args.runtimeStatus;
-  }
-
-  return {
-    ...args.runtimeStatus,
-    drawerAuthority: undefined,
-  };
-}
-
-async function isCleanlyClosedDrawerAuthority(
-  ctx: QueryCtx,
-  args: {
-    runtimeStatus: Doc<"posTerminalRuntimeStatus">;
-    terminal: Doc<"posTerminal">;
-  },
-) {
-  const drawerAuthority = args.runtimeStatus.drawerAuthority;
-  if (
-    drawerAuthority?.status !== "blocked" ||
-    drawerAuthority.reason !== "cloud_closed" ||
-    !drawerAuthority.cloudRegisterSessionId
-  ) {
-    return false;
-  }
-
-  const db = ctx.db as {
-    get?: (
-      tableName: "registerSession",
-      id: Id<"registerSession">,
-    ) => Promise<Doc<"registerSession"> | null>;
-    normalizeId?: (
-      tableName: "registerSession",
-      id: string,
-    ) => Id<"registerSession"> | null;
-  } | null;
-  if (!db || typeof db.get !== "function") {
-    return false;
-  }
-
-  const registerSessionId =
-    typeof db.normalizeId === "function"
-      ? db.normalizeId("registerSession", drawerAuthority.cloudRegisterSessionId)
-      : (drawerAuthority.cloudRegisterSessionId as Id<"registerSession">);
-  if (!registerSessionId) {
-    return false;
-  }
-
-  const registerSession = await db.get("registerSession", registerSessionId);
-  if (
-    registerSession?.storeId !== args.terminal.storeId ||
-    registerSession.terminalId !== args.terminal._id
-  ) {
-    return false;
-  }
-  return !isRegisterSessionReplacementBlocking({
-    hasSubmittedCloseout: registerSession.status === "closing",
-    session: registerSession,
-  });
-}
-
 async function buildTerminalHealthSummary(
   ctx: QueryCtx,
   args: {
@@ -337,53 +165,27 @@ async function buildTerminalHealthSummary(
     now: number;
   },
 ): Promise<TerminalHealthSummary> {
-  const [runtimeStatus, rawSyncEvidence, registerSessionLink] = await Promise.all([
-    getLatestRuntimeStatusForTerminal(ctx, {
-      storeId: args.terminal.storeId,
-      terminalId: args.terminal._id,
-    }),
-    args.includeSyncEvidence
-      ? getTerminalSyncEvidence(ctx, {
-          storeId: args.terminal.storeId,
-          terminalId: args.terminal._id,
-        })
-      : EMPTY_TERMINAL_SYNC_EVIDENCE,
-    getActiveRegisterSessionLink(ctx, {
-      storeId: args.terminal.storeId,
-      terminalId: args.terminal._id,
-    }),
-  ]);
+  const facts = await collectTerminalOperationalFacts(ctx, {
+    emptySyncEvidence: EMPTY_TERMINAL_SYNC_EVIDENCE,
+    includeSyncEvidence: args.includeSyncEvidence,
+    terminal: args.terminal,
+  });
+  const { runtimeStatus, registerSessionLink } = facts;
   const syncEvidence = await annotateTerminalSyncEvidenceReviewTargets(ctx, {
     storeId: args.terminal.storeId,
-    syncEvidence: rawSyncEvidence,
-  });
-  const supportRuntimeStatus = await normalizeRuntimeStatusForSupport(ctx, {
-    runtimeStatus,
-    terminal: args.terminal,
+    syncEvidence: facts.rawSyncEvidence,
   });
   const runtimeAgeMs = runtimeStatus
     ? Math.max(0, args.now - runtimeStatus.receivedAt)
     : null;
-  const attentionReasons = deriveTerminalHealthAttentionReasons({
-    runtimeStatus: supportRuntimeStatus,
-    syncEvidence,
-    terminalStatus: args.terminal.status,
-  });
-  const resolvedAttentionReasons = await resolveAttentionReasonActionTargets(
-    ctx,
-    {
-      attentionReasons,
-      storeId: args.terminal.storeId,
-      syncEvidence,
-      terminalId: args.terminal._id,
-    },
-  );
-  const recoveryPreview = args.includeSyncEvidence
-    ? await buildTerminalRecoveryPreview(ctx, {
-        attentionReasons: resolvedAttentionReasons,
+  const operationalState = args.includeSyncEvidence
+    ? await buildTerminalOperationalStateForSummary(ctx, {
+        activeRegisterSession: facts.activeRegisterSession,
+        drawerAuthorityRegisterSession: facts.drawerAuthorityRegisterSession,
+        latestRegisterSession: facts.latestRegisterSession,
         now: args.now,
         runtimeAgeMs,
-        runtimeStatus: supportRuntimeStatus,
+        runtimeStatus,
         registerNumber: args.terminal.registerNumber,
         storeId: args.terminal.storeId,
         syncEvidence,
@@ -391,6 +193,16 @@ async function buildTerminalHealthSummary(
         terminalStatus: args.terminal.status,
       })
     : null;
+  const resolvedAttentionReasons = await resolveAttentionReasonActionTargets(
+    ctx,
+    {
+      attentionReasons: operationalState?.attentionReasons ?? [],
+      storeId: args.terminal.storeId,
+      syncEvidence,
+      terminalId: args.terminal._id,
+    },
+  );
+  const recoveryPreview = operationalState?.recoveryPreview ?? null;
 
   return {
     terminal: {
@@ -402,63 +214,16 @@ async function buildTerminalHealthSummary(
       status: args.terminal.status,
       browserInfo: args.terminal.browserInfo,
     },
-    health: deriveTerminalHealth({
-      attentionReasons: resolvedAttentionReasons,
-      runtimeAgeMs,
-      runtimeStatus: supportRuntimeStatus,
-      syncEvidence,
-      terminalStatus: args.terminal.status,
-    }),
+    health: operationalState?.terminalHealth ?? "unknown",
     runtimeAgeMs,
-    runtimeStatus: supportRuntimeStatus
-      ? stripRuntimeStatusIdentity(supportRuntimeStatus)
+    runtimeStatus: operationalState?.runtimeEvidence.effectiveStatus
+      ? stripRuntimeStatusIdentity(operationalState.runtimeEvidence.effectiveStatus)
       : null,
     attentionReasons: resolvedAttentionReasons,
     recoveryPreview,
     registerSessionLink,
     syncEvidence,
   };
-}
-
-async function getActiveRegisterSessionLink(
-  ctx: QueryCtx,
-  args: {
-    storeId: Id<"store">;
-    terminalId: Id<"posTerminal">;
-  },
-): Promise<TerminalHealthSummary["registerSessionLink"]> {
-  if (!ctx.db || typeof ctx.db.query !== "function") {
-    return null;
-  }
-
-  const byTerminal = await ctx.db
-    .query("registerSession")
-    .withIndex("by_terminalId", (q) => q.eq("terminalId", args.terminalId))
-    .order("desc")
-    .take(20);
-  const activeSession = byTerminal
-    .filter(
-      (session) =>
-        session.storeId === args.storeId &&
-        session.terminalId === args.terminalId,
-    )
-    .filter(isActiveRegisterSessionLinkTarget)
-    .sort((left, right) => right.openedAt - left.openedAt)[0];
-
-  return activeSession
-    ? {
-        registerSessionId: activeSession._id,
-        status: activeSession.status,
-      }
-    : null;
-}
-
-function isActiveRegisterSessionLinkTarget(
-  session: Doc<"registerSession">,
-): session is Doc<"registerSession"> & {
-  status: ActiveRegisterSessionLinkStatus;
-} {
-  return isPosUsableRegisterSessionStatus(session.status);
 }
 
 export async function previewTerminalRecovery(
@@ -476,7 +241,9 @@ export async function previewTerminalRecovery(
 async function buildTerminalRecoveryPreview(
   ctx: QueryCtx,
   args: {
-    attentionReasons: TerminalHealthAttentionReason[];
+    activeRegisterSession: Doc<"registerSession"> | null;
+    drawerAuthorityRegisterSession: Doc<"registerSession"> | null;
+    latestRegisterSession: Doc<"registerSession"> | null;
     now: number;
     runtimeAgeMs: number | null;
     runtimeStatus: Doc<"posTerminalRuntimeStatus"> | null;
@@ -487,40 +254,39 @@ async function buildTerminalRecoveryPreview(
     terminalStatus: Doc<"posTerminal">["status"];
   },
 ): Promise<TerminalRecoveryPreview> {
+  const operationalState = await buildTerminalOperationalStateForSummary(ctx, args);
+
+  return operationalState.recoveryPreview;
+}
+
+async function buildTerminalOperationalStateForSummary(
+  ctx: QueryCtx,
+  args: {
+    activeRegisterSession: Doc<"registerSession"> | null;
+    drawerAuthorityRegisterSession: Doc<"registerSession"> | null;
+    latestRegisterSession: Doc<"registerSession"> | null;
+    now: number;
+    runtimeAgeMs: number | null;
+    runtimeStatus: Doc<"posTerminalRuntimeStatus"> | null;
+    registerNumber?: string | null;
+    storeId: Id<"store">;
+    syncEvidence: TerminalSyncEvidence;
+    terminalId: Id<"posTerminal">;
+    terminalStatus: Doc<"posTerminal">["status"];
+  },
+): Promise<TerminalOperationalState> {
   const runtimeFresh =
     !!args.runtimeStatus &&
     args.runtimeAgeMs !== null &&
     args.runtimeAgeMs <= 2 * 60 * 1000 &&
     args.runtimeStatus.browserInfo?.online !== false;
   const cloudRepair = await buildTerminalRecoveryCloudRepairPreview(ctx, args);
-  const terminalActions = buildTerminalRecoveryActions(args);
-  const activeRegisterSession =
-    runtimeHasActiveRegisterSession(args.runtimeStatus) ||
-    (await hasActiveRegisterSessionForTerminal(ctx, {
-      registerNumber: args.registerNumber,
-      storeId: args.storeId,
-      terminalId: args.terminalId,
-    }));
   const commandStatus = await buildTerminalRecoveryCommandStatus(ctx, {
     now: args.now,
     storeId: args.storeId,
     terminalId: args.terminalId,
   });
-  const manualReview = buildTerminalRecoveryManualReview({
-    attentionReasons: args.attentionReasons,
-    skippedConflictIds: cloudRepair.skippedConflictIds,
-  });
-  const healthyIdle =
-    args.terminalStatus === "active" &&
-    runtimeFresh &&
-    terminalActions.length === 0 &&
-    manualReview.length === 0 &&
-    cloudRepair.safeConflictIds.length === 0 &&
-    runtimeHasHealthyIdleEvidence(args.runtimeStatus, args.syncEvidence);
-  const ableToTransactNow =
-    activeRegisterSession && healthyIdle && runtimeHasSaleAuthority(args.runtimeStatus);
-
-  return {
+  const operationalState = buildTerminalOperationalState({
     appUpdate: buildTerminalAppUpdatePreview({
       commandStatus,
       now: args.now,
@@ -528,27 +294,22 @@ async function buildTerminalRecoveryPreview(
       runtimeFresh,
       runtimeStatus: args.runtimeStatus,
     }),
-    readiness: ableToTransactNow
-      ? "able_to_transact_now"
-      : manualReview.length > 0
-        ? "needs_manual_review"
-        : terminalActions.length > 0
-          ? "needs_terminal_action"
-          : cloudRepair.safeConflictIds.length > 0
-            ? "needs_cloud_repair"
-            : activeRegisterSession
-              ? "drawer_open"
-            : "healthy_idle",
-    runtimeFresh,
-    evidence: {
-      activeRegisterSession,
-      freshRuntimeRequiredForAbleToTransactNow: true,
-    },
     cloudRepair,
     commandStatus,
-    terminalActions,
-    manualReview,
-  };
+    activeRegisterSession: args.activeRegisterSession,
+    drawerAuthorityRegisterSession: args.drawerAuthorityRegisterSession,
+    latestCloudRegisterSessionStatus: args.latestRegisterSession?.status,
+    latestRegisterSession: args.latestRegisterSession,
+    runtimeAgeMs: args.runtimeAgeMs,
+    runtimeFresh,
+    runtimeStatus: args.runtimeStatus,
+    storeId: args.storeId,
+    syncEvidence: args.syncEvidence,
+    terminalId: args.terminalId,
+    terminalStatus: args.terminalStatus,
+  });
+
+  return operationalState;
 }
 
 function buildTerminalAppUpdatePreview(args: {
@@ -1090,168 +851,6 @@ function createTerminalCloudRepairQueryRepository(
   };
 }
 
-function buildTerminalRecoveryActions(args: {
-  runtimeStatus: Doc<"posTerminalRuntimeStatus"> | null;
-}): TerminalRecoveryPreview["terminalActions"] {
-  const status = args.runtimeStatus;
-  if (!status) {
-    return [];
-  }
-
-  const actions: TerminalRecoveryPreview["terminalActions"] = [];
-  if (status.localStore.available === false || status.localStore.terminalSeedReady === false) {
-    actions.push({
-      commandType: "repair_terminal_seed",
-      expectedEvidence: {
-        localStoreAvailable: true,
-        terminalSeedReady: true,
-        terminalIntegrityStatus: "healthy",
-      },
-      commandContext: {
-        expectedBlockerType: "terminal_seed",
-        reason: "Terminal setup data needs repair.",
-      },
-      reason: "Terminal setup data needs repair before this checkout station can sell.",
-    });
-  }
-  if (status.terminalIntegrity && status.terminalIntegrity.status !== "healthy") {
-    actions.push({
-      commandType: "repair_terminal_seed",
-      expectedEvidence: {
-        terminalIntegrityStatus: "healthy",
-      },
-      commandContext: {
-        expectedBlockerType: status.terminalIntegrity.reason ?? "terminal_integrity",
-        reason: "Terminal integrity requires repair.",
-      },
-      reason: "Terminal integrity requires local repair.",
-    });
-  }
-  if (status.drawerAuthority?.status === "blocked") {
-    actions.push({
-      commandType: "clear_stale_drawer_authority",
-      expectedEvidence: {
-        drawerAuthorityStatus: "healthy",
-        localRegisterSessionId: status.drawerAuthority.localRegisterSessionId,
-      },
-      commandContext: {
-        cloudRegisterSessionId: status.drawerAuthority.cloudRegisterSessionId,
-        expectedBlockerType: status.drawerAuthority.reason ?? "drawer_authority",
-        localRegisterSessionId: status.drawerAuthority.localRegisterSessionId,
-        reason: "Drawer authority requires terminal-local repair.",
-      },
-      reason: "Drawer authority requires terminal-local repair.",
-    });
-  }
-  if (status.sync.status === "failed" || status.sync.status === "unavailable") {
-    actions.push({
-      commandType: "retry_sync",
-      expectedEvidence: {
-        syncStatus: "idle",
-      },
-      commandContext: {
-        expectedBlockerType: "sync_runtime",
-        reason: "Local sync needs a terminal retry.",
-      },
-      reason: "Local sync needs a terminal retry.",
-    });
-  }
-  if (status.sync.status === "needs_review" || status.sync.reviewEventCount > 0) {
-    actions.push({
-      commandType: "retry_sync",
-      expectedEvidence: {
-        syncStatus: "idle",
-      },
-      commandContext: {
-        expectedBlockerType: "local_review",
-        reason: "Local review items need a terminal sync retry.",
-      },
-      reason: "Local review items need a terminal sync retry.",
-    });
-  }
-  return dedupeTerminalActions(actions);
-}
-
-function buildTerminalRecoveryManualReview(args: {
-  attentionReasons: TerminalHealthAttentionReason[];
-  skippedConflictIds: Array<Id<"posLocalSyncConflict">>;
-}): TerminalRecoveryPreview["manualReview"] {
-  const manual: TerminalRecoveryPreview["manualReview"] = args.attentionReasons
-    .filter((reason) =>
-      reason.type === "cloud_held" ||
-      reason.type === "cloud_rejected" ||
-      reason.type === "local_review",
-    )
-    .map((reason) => ({
-      reason: reason.summary,
-      source: reason.source,
-      type: reason.type,
-    }));
-  for (const conflictId of args.skippedConflictIds) {
-    manual.push({
-      reason:
-        "A cloud sync conflict needs manual review before support can repair this terminal.",
-      source: "cloud_repair" as const,
-      type: "unsafe_cloud_conflict" as const,
-    });
-  }
-  return manual;
-}
-
-function runtimeHasHealthyIdleEvidence(
-  status: Doc<"posTerminalRuntimeStatus"> | null,
-  syncEvidence: TerminalSyncEvidence,
-) {
-  return (
-    !!status &&
-    status.localStore.available &&
-    status.localStore.terminalSeedReady &&
-    status.staffAuthority.status === "ready" &&
-    status.sync.status !== "failed" &&
-    status.sync.status !== "needs_review" &&
-    status.sync.status !== "unavailable" &&
-    status.sync.failedEventCount === 0 &&
-    status.sync.reviewEventCount === 0 &&
-    (!status.terminalIntegrity || status.terminalIntegrity.status === "healthy") &&
-    (!status.drawerAuthority || status.drawerAuthority.status === "healthy") &&
-    (syncEvidence.unresolvedConflictCount ?? 0) === 0 &&
-    syncEvidence.conflictedCount === 0 &&
-    syncEvidence.heldCount === 0 &&
-    syncEvidence.rejectedCount === 0
-  );
-}
-
-function runtimeHasSaleAuthority(status: Doc<"posTerminalRuntimeStatus"> | null) {
-  return (
-    !!status &&
-    status.staffAuthority.status === "ready" &&
-    status.saleAuthority?.status === "ready"
-  );
-}
-
-function runtimeHasActiveRegisterSession(
-  status: Doc<"posTerminalRuntimeStatus"> | null,
-) {
-  return (
-    status?.activeRegisterSession?.status === "open" ||
-    status?.activeRegisterSession?.status === "active"
-  );
-}
-
-function dedupeTerminalActions(
-  actions: TerminalRecoveryPreview["terminalActions"],
-) {
-  const seen = new Set<string>();
-  return actions.filter((action) => {
-    const key = `${action.commandType}:${action.commandContext.expectedBlockerType ?? ""}:${action.commandContext.localRegisterSessionId ?? ""}`;
-    if (seen.has(key)) {
-      return false;
-    }
-    seen.add(key);
-    return true;
-  });
-}
-
 async function resolveAttentionReasonActionTargets(
   ctx: QueryCtx,
   args: {
@@ -1450,177 +1049,6 @@ async function annotateTerminalSyncEvidenceReviewTargets(
       };
     }),
   };
-}
-
-function deriveTerminalHealth(input: {
-  attentionReasons: TerminalHealthAttentionReason[];
-  runtimeAgeMs: number | null;
-  runtimeStatus: Doc<"posTerminalRuntimeStatus"> | null;
-  syncEvidence: TerminalSyncEvidence;
-  terminalStatus: Doc<"posTerminal">["status"];
-}): TerminalHealth {
-  if (input.terminalStatus !== "active") {
-    return "offline";
-  }
-
-  if (input.attentionReasons.length > 0) {
-    return "needs_attention";
-  }
-
-  if (!input.runtimeStatus || input.runtimeAgeMs === null) {
-    return "unknown";
-  }
-
-  if (
-    input.runtimeAgeMs <= 2 * 60 * 1000 &&
-    input.runtimeStatus.browserInfo?.online !== false
-  ) {
-    return "online";
-  }
-
-  return input.runtimeAgeMs <= 15 * 60 * 1000 ? "stale" : "offline";
-}
-
-function deriveTerminalHealthAttentionReasons(input: {
-  runtimeStatus: Doc<"posTerminalRuntimeStatus"> | null;
-  syncEvidence: TerminalSyncEvidence;
-  terminalStatus: Doc<"posTerminal">["status"];
-}): TerminalHealthAttentionReason[] {
-  if (input.terminalStatus !== "active") {
-    return [];
-  }
-
-  const reasons: TerminalHealthAttentionReason[] = [];
-  const sync = input.runtimeStatus?.sync;
-  const latestEvent = input.syncEvidence.latestEvent;
-
-  if (
-    input.runtimeStatus?.terminalIntegrity &&
-    input.runtimeStatus.terminalIntegrity.status !== "healthy"
-  ) {
-    reasons.push({
-      source: "terminal_runtime",
-      summary:
-        "Terminal setup needs repair before this checkout station can record new sales.",
-      type: "terminal_authorization_failed",
-    });
-  }
-
-  if (input.runtimeStatus?.drawerAuthority?.status === "blocked") {
-    reasons.push({
-      source: "terminal_runtime",
-      summary:
-        "Drawer setup needs repair before this checkout station can record new sales.",
-      type: "drawer_authority_blocked",
-    });
-  }
-
-  if (sync && (sync.status === "needs_review" || sync.reviewEventCount > 0)) {
-    const count = Math.max(1, sync.reviewEventCount);
-    reasons.push({
-      count,
-      nextPendingUploadSequence: sync.nextPendingUploadSequence,
-      oldestPendingEventAt: sync.oldestPendingEventAt,
-      source: "local_runtime",
-      summary: `${count} local review item${count === 1 ? " is" : "s are"} still on this terminal.`,
-      type: "local_review",
-    });
-  }
-
-  if (sync && (sync.status === "failed" || sync.failedEventCount > 0)) {
-    const count = Math.max(1, sync.failedEventCount);
-    reasons.push({
-      count,
-      nextPendingUploadSequence: sync.nextPendingUploadSequence,
-      oldestPendingEventAt: sync.oldestPendingEventAt,
-      source: "local_runtime",
-      summary: `${count} local sync item${count === 1 ? " has" : "s have"} failed on this terminal.`,
-      type: "sync_failed",
-    });
-  }
-
-  if (sync?.status === "unavailable") {
-    reasons.push({
-      source: "local_runtime",
-      summary: "Local sync runtime is unavailable on this terminal.",
-      type: "sync_unavailable",
-    });
-  }
-
-  if (input.runtimeStatus?.localStore.available === false) {
-    reasons.push({
-      source: "terminal_runtime",
-      summary: "Local terminal storage is not available.",
-      type: "local_store_unavailable",
-    });
-  }
-
-  if (input.runtimeStatus?.localStore.terminalSeedReady === false) {
-    reasons.push({
-      source: "terminal_runtime",
-      summary: "Terminal setup data is not ready on this checkout station.",
-      type: "terminal_seed_missing",
-    });
-  }
-
-  const inventoryReviewCount =
-    input.syncEvidence.unresolvedConflicts?.filter(
-      (conflict) =>
-        conflict.conflictType === "inventory" &&
-        conflict.reviewTarget?.workItemType ===
-          "synced_sale_inventory_review",
-    ).length ?? 0;
-
-  if (inventoryReviewCount > 0) {
-    reasons.push({
-      count: inventoryReviewCount,
-      latestEventSequence: latestEvent?.sequence,
-      latestEventStatus: latestEvent?.status,
-      source: "cloud_sync",
-      summary: `${inventoryReviewCount} inventory review item${inventoryReviewCount === 1 ? " needs" : "s need"} attention.`,
-      type: "synced_sale_inventory_review",
-    });
-  }
-
-  const conflictedCount = Math.max(
-    0,
-    input.syncEvidence.conflictedCount - inventoryReviewCount,
-  );
-
-  if (conflictedCount > 0) {
-    reasons.push({
-      count: conflictedCount,
-      latestEventSequence: latestEvent?.sequence,
-      latestEventStatus: latestEvent?.status,
-      source: "cloud_sync",
-      summary: `${conflictedCount} cloud sync conflict${conflictedCount === 1 ? " needs" : "s need"} review.`,
-      type: "cloud_conflict",
-    });
-  }
-
-  if (input.syncEvidence.heldCount > 0) {
-    reasons.push({
-      count: input.syncEvidence.heldCount,
-      latestEventSequence: latestEvent?.sequence,
-      latestEventStatus: latestEvent?.status,
-      source: "cloud_sync",
-      summary: `${input.syncEvidence.heldCount} synced item${input.syncEvidence.heldCount === 1 ? " is" : "s are"} held before projection.`,
-      type: "cloud_held",
-    });
-  }
-
-  if (input.syncEvidence.rejectedCount > 0) {
-    reasons.push({
-      count: input.syncEvidence.rejectedCount,
-      latestEventSequence: latestEvent?.sequence,
-      latestEventStatus: latestEvent?.status,
-      source: "cloud_sync",
-      summary: `${input.syncEvidence.rejectedCount} synced item${input.syncEvidence.rejectedCount === 1 ? " was" : "s were"} rejected by the server.`,
-      type: "cloud_rejected",
-    });
-  }
-
-  return reasons;
 }
 
 function stripRuntimeStatusIdentity(status: Doc<"posTerminalRuntimeStatus">) {

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from "vitest";
+
+import type { Doc, Id } from "../../../_generated/dataModel";
+import type { QueryCtx } from "../../../_generated/server";
+import { collectTerminalOperationalFacts } from "./collectTerminalOperationalFacts";
+
+const now = 2_000_000;
+const storeId = "store-1" as Id<"store">;
+const terminalId = "terminal-1" as Id<"posTerminal">;
+
+describe("collectTerminalOperationalFacts", () => {
+  it("keeps latest lifecycle evidence separate from active card-link evidence", async () => {
+    const ctx = buildQueryCtx({
+      posTerminalRuntimeStatus: [buildRuntimeStatus()],
+      registerSession: [
+        buildRegisterSession({
+          _id: "register-open" as Id<"registerSession">,
+          openedAt: now - 100_000,
+          status: "open",
+        }),
+        buildRegisterSession({
+          _id: "register-closed" as Id<"registerSession">,
+          closedAt: now - 1_000,
+          openedAt: now - 20_000,
+          status: "closed",
+        }),
+      ],
+    });
+
+    const facts = await collectTerminalOperationalFacts(ctx, {
+      emptySyncEvidence: emptySyncEvidence(),
+      includeSyncEvidence: false,
+      terminal: buildTerminal(),
+    });
+
+    expect(facts.latestRegisterSession?._id).toBe("register-closed");
+    expect(facts.registerSessionLink).toEqual({
+      registerSessionId: "register-open",
+      status: "open",
+    });
+    expect(facts.drawerAuthorityRegisterSession).toBeNull();
+    expect(facts.runtimeStatus?._id).toBe("runtime-1");
+  });
+
+  it("collects drawer authority cloud register session as a fact", async () => {
+    const ctx = buildQueryCtx({
+      posTerminalRuntimeStatus: [
+        buildRuntimeStatus({
+          drawerAuthority: {
+            cloudRegisterSessionId: "register-closed",
+            localRegisterSessionId: "local-register-1",
+            observedAt: now - 1_000,
+            reason: "cloud_closed",
+            status: "blocked",
+          },
+        }),
+      ],
+      registerSession: [
+        buildRegisterSession({
+          _id: "register-closed" as Id<"registerSession">,
+          closedAt: now - 500,
+          openedAt: now - 20_000,
+          status: "closed",
+        }),
+      ],
+    });
+
+    const facts = await collectTerminalOperationalFacts(ctx, {
+      emptySyncEvidence: emptySyncEvidence(),
+      includeSyncEvidence: false,
+      terminal: buildTerminal(),
+    });
+
+    expect(facts.drawerAuthorityRegisterSession?._id).toBe("register-closed");
+  });
+
+  it("collects local sync events, cursors, and conflicts when sync evidence is included", async () => {
+    const ctx = buildQueryCtx({
+      posLocalSyncConflict: [
+        buildSyncConflict({
+          _id: "conflict-1" as Id<"posLocalSyncConflict">,
+          sequence: 11,
+        }),
+      ],
+      posLocalSyncCursor: [
+        {
+          _id: "cursor-1" as Id<"posLocalSyncCursor">,
+          _creationTime: now - 4_000,
+          acceptedThroughSequence: 9,
+          cursorKey: "terminal",
+          storeId,
+          terminalId,
+          updatedAt: now - 2_000,
+        },
+      ],
+      posLocalSyncEvent: [
+        buildSyncEvent({
+          _id: "event-rejected" as Id<"posLocalSyncEvent">,
+          localEventId: "local-rejected",
+          sequence: 12,
+          status: "rejected",
+        }),
+        buildSyncEvent({
+          _id: "event-accepted" as Id<"posLocalSyncEvent">,
+          localEventId: "local-accepted",
+          sequence: 10,
+          status: "accepted",
+        }),
+      ],
+      posTerminalRuntimeStatus: [buildRuntimeStatus()],
+      registerSession: [buildRegisterSession()],
+    });
+
+    const facts = await collectTerminalOperationalFacts(ctx, {
+      emptySyncEvidence: emptySyncEvidence(),
+      includeSyncEvidence: true,
+      terminal: buildTerminal(),
+    });
+
+    expect(facts.rawSyncEvidence.latestEvent?.localEventId).toBe(
+      "local-rejected",
+    );
+    expect(facts.rawSyncEvidence.rejectedCount).toBe(1);
+    expect(facts.rawSyncEvidence.acceptedCount).toBe(1);
+    expect(facts.rawSyncEvidence.acceptedThroughSequence).toBe(9);
+    expect(facts.rawSyncEvidence.unresolvedConflictCount).toBe(1);
+    expect(facts.rawSyncEvidence.unresolvedConflicts?.[0]?._id).toBe(
+      "conflict-1",
+    );
+  });
+});
+
+type TestTable =
+  | "posLocalSyncConflict"
+  | "posLocalSyncCursor"
+  | "posLocalSyncEvent"
+  | "posTerminalRuntimeStatus"
+  | "registerSession";
+
+function buildQueryCtx(
+  records: Partial<Record<TestTable, Array<Record<string, unknown>>>>,
+) {
+  return {
+    db: {
+      get(table: TestTable, id: string) {
+        return Promise.resolve(
+          records[table]?.find((record) => record._id === id) ?? null,
+        );
+      },
+      query(table: TestTable) {
+        return buildQuery(records[table] ?? []);
+      },
+    },
+  } as unknown as QueryCtx;
+}
+
+function buildTerminal(
+  overrides: Partial<Doc<"posTerminal">> = {},
+): Doc<"posTerminal"> {
+  return {
+    _id: terminalId,
+    _creationTime: now - 50_000,
+    browserInfo: {
+      userAgent: "Mozilla/5.0",
+    },
+    displayName: "Front register",
+    fingerprintHash: "fingerprint",
+    registeredAt: now - 50_000,
+    registeredByUserId: "user-1" as Id<"athenaUser">,
+    registerNumber: "8",
+    status: "active",
+    storeId,
+    ...overrides,
+  };
+}
+
+function buildRuntimeStatus(
+  overrides: Partial<Doc<"posTerminalRuntimeStatus">> = {},
+): Doc<"posTerminalRuntimeStatus"> {
+  return {
+    _id: "runtime-1" as Id<"posTerminalRuntimeStatus">,
+    _creationTime: now - 2_000,
+    appSessionRecovery: {
+      status: "ready",
+    },
+    browserInfo: {
+      online: true,
+      userAgent: "Mozilla/5.0",
+    },
+    localStore: {
+      available: true,
+      terminalSeedReady: true,
+    },
+    receivedAt: now - 1_000,
+    reportedAt: now - 1_000,
+    snapshots: {},
+    source: "sync-runtime",
+    staffAuthority: {
+      status: "ready",
+    },
+    storeId,
+    sync: {
+      failedEventCount: 0,
+      localOnlyEventCount: 0,
+      pendingEventCount: 0,
+      reviewEventCount: 0,
+      status: "idle",
+      uploadableEventCount: 0,
+    },
+    terminalId,
+    terminalIntegrity: {
+      observedAt: now - 1_000,
+      status: "healthy",
+    },
+    ...overrides,
+  };
+}
+
+function buildRegisterSession(
+  overrides: Partial<Doc<"registerSession">> = {},
+): Doc<"registerSession"> {
+  return {
+    _id: "register-1" as Id<"registerSession">,
+    _creationTime: now - 10_000,
+    closeoutRecords: [],
+    closedAt: undefined,
+    expectedCash: 0,
+    openedAt: now - 100_000,
+    openingFloat: 0,
+    registerNumber: "8",
+    status: "open",
+    storeId,
+    terminalId,
+    ...overrides,
+  };
+}
+
+function buildSyncEvent(
+  overrides: Partial<Doc<"posLocalSyncEvent">> = {},
+): Doc<"posLocalSyncEvent"> {
+  return {
+    _id: "event-1" as Id<"posLocalSyncEvent">,
+    _creationTime: now - 5_000,
+    acceptedAt: undefined,
+    eventType: "sale",
+    localEventId: "local-event-1",
+    localRegisterSessionId: "local-register-1",
+    occurredAt: now - 5_000,
+    payload: "{}",
+    projectedAt: undefined,
+    rejectionCode: undefined,
+    sequence: 1,
+    status: "accepted",
+    storeId,
+    submittedAt: now - 4_000,
+    terminalId,
+    ...overrides,
+  } as Doc<"posLocalSyncEvent">;
+}
+
+function buildSyncConflict(
+  overrides: Partial<Doc<"posLocalSyncConflict">> = {},
+): Doc<"posLocalSyncConflict"> {
+  return {
+    _id: "conflict-1" as Id<"posLocalSyncConflict">,
+    _creationTime: now - 3_000,
+    conflictType: "inventory",
+    createdAt: now - 3_000,
+    localEventId: "local-event-1",
+    localRegisterSessionId: "local-register-1",
+    resolution: undefined,
+    sequence: 1,
+    status: "needs_review",
+    storeId,
+    summary: "Inventory review required.",
+    terminalId,
+    updatedAt: now - 3_000,
+    ...overrides,
+  } as Doc<"posLocalSyncConflict">;
+}
+
+function emptySyncEvidence() {
+  return {
+    latestEvent: null,
+    latestReviewEvent: null,
+    latestReviewEventsByStatus: {
+      conflicted: null,
+      held: null,
+      rejected: null,
+    },
+    sampledEventCount: 0,
+    acceptedCount: 0,
+    projectedCount: 0,
+    conflictedCount: 0,
+    heldCount: 0,
+    rejectedCount: 0,
+    unresolvedConflictCount: 0,
+    unresolvedConflicts: [],
+  };
+}
+
+function buildQuery(records: Array<Record<string, unknown>>) {
+  const chain = {
+    collect: () => Promise.resolve(records),
+    first: () => Promise.resolve(records[0] ?? null),
+    order: () => chain,
+    take: (count: number) => Promise.resolve(records.slice(0, count)),
+    unique: () => Promise.resolve(records[0] ?? null),
+    withIndex: () => chain,
+  };
+
+  return chain;
+}

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.ts
@@ -1,0 +1,72 @@
+import type { Doc, Id } from "../../../_generated/dataModel";
+import type { QueryCtx } from "../../../_generated/server";
+import { isPosUsableRegisterSessionStatus } from "../../../../shared/registerSessionStatus";
+import {
+  getActiveRegisterSessionForTerminal,
+  getDrawerAuthorityRegisterSession,
+  getLatestRegisterSessionForTerminal,
+  getLatestRuntimeStatusForTerminal,
+  getTerminalSyncEvidence,
+} from "../../infrastructure/repositories/terminalRepository";
+import type { TerminalOperationalFacts } from "./facts";
+
+export async function collectTerminalOperationalFacts(
+  ctx: QueryCtx,
+  args: {
+    emptySyncEvidence: TerminalOperationalFacts["rawSyncEvidence"];
+    includeSyncEvidence: boolean;
+    terminal: Doc<"posTerminal">;
+  },
+): Promise<TerminalOperationalFacts> {
+  const runtimeStatusPromise = getLatestRuntimeStatusForTerminal(ctx, {
+    storeId: args.terminal.storeId,
+    terminalId: args.terminal._id,
+  });
+  const [runtimeStatus, rawSyncEvidence, latestRegisterSession, activeRegisterSession] =
+    await Promise.all([
+      runtimeStatusPromise,
+      args.includeSyncEvidence
+        ? getTerminalSyncEvidence(ctx, {
+            storeId: args.terminal.storeId,
+            terminalId: args.terminal._id,
+          })
+        : args.emptySyncEvidence,
+      getLatestRegisterSessionForTerminal(ctx, {
+        registerNumber: args.terminal.registerNumber,
+        storeId: args.terminal.storeId,
+        terminalId: args.terminal._id,
+      }),
+      getActiveRegisterSessionForTerminal(ctx, {
+        registerNumber: args.terminal.registerNumber,
+        storeId: args.terminal.storeId,
+        terminalId: args.terminal._id,
+      }),
+    ]);
+  const drawerAuthorityRegisterSession = await getDrawerAuthorityRegisterSession(ctx, {
+    runtimeStatus,
+    storeId: args.terminal.storeId,
+    terminalId: args.terminal._id,
+  });
+
+  return {
+    activeRegisterSession,
+    drawerAuthorityRegisterSession,
+    latestRegisterSession,
+    rawSyncEvidence,
+    registerSessionLink: toRegisterSessionLink(activeRegisterSession),
+    runtimeStatus,
+  };
+}
+
+function toRegisterSessionLink(
+  session: Doc<"registerSession"> | null,
+): TerminalOperationalFacts["registerSessionLink"] {
+  if (!session || !isPosUsableRegisterSessionStatus(session.status)) {
+    return null;
+  }
+
+  return {
+    registerSessionId: session._id,
+    status: session.status as Extract<Doc<"registerSession">["status"], "active" | "open">,
+  };
+}

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/facts.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/facts.ts
@@ -1,0 +1,16 @@
+import type { Doc, Id } from "../../../_generated/dataModel";
+import type { TerminalSyncEvidence } from "../../domain/terminalSyncEvidence";
+
+export type TerminalRegisterSessionLink = {
+  registerSessionId: Id<"registerSession">;
+  status: Extract<Doc<"registerSession">["status"], "active" | "open">;
+} | null;
+
+export type TerminalOperationalFacts = {
+  activeRegisterSession: Doc<"registerSession"> | null;
+  drawerAuthorityRegisterSession: Doc<"registerSession"> | null;
+  latestRegisterSession: Doc<"registerSession"> | null;
+  rawSyncEvidence: TerminalSyncEvidence;
+  registerSessionLink: TerminalRegisterSessionLink;
+  runtimeStatus: Doc<"posTerminalRuntimeStatus"> | null;
+};

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts
@@ -1,0 +1,382 @@
+import { describe, expect, it } from "vitest";
+
+import type { Doc, Id } from "../../../_generated/dataModel";
+import {
+  buildTerminalOperationalState,
+  classifyTerminalHealth,
+  classifySalesReadiness,
+  classifySupportRecovery,
+} from "./policy";
+import type { TerminalOperationalPolicyInput } from "./types";
+
+const storeId = "store-1" as Id<"store">;
+const terminalId = "terminal-1" as Id<"posTerminal">;
+
+describe("terminal operational state policy", () => {
+  it("keeps sales readiness distinct from support recovery", () => {
+    expect(
+      classifySalesReadiness({
+        activeRegisterSession: false,
+        healthyIdle: true,
+        saleAuthorityReady: false,
+      }),
+    ).toBe("healthy_idle");
+    expect(
+      classifySalesReadiness({
+        activeRegisterSession: true,
+        healthyIdle: true,
+        saleAuthorityReady: false,
+      }),
+    ).toBe("drawer_open");
+    expect(
+      classifySalesReadiness({
+        activeRegisterSession: true,
+        healthyIdle: true,
+        saleAuthorityReady: true,
+      }),
+    ).toBe("able_to_transact_now");
+  });
+
+  it("lets cloud register lifecycle block sale-ready projection without erasing drawer evidence", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        latestRegisterSession: buildRegisterSession({
+          status: "closed",
+        }),
+        latestCloudRegisterSessionStatus: "closed",
+        runtimeStatus: buildRuntimeStatus({
+          activeRegisterSession: {
+            localRegisterSessionId: "local-register-1",
+            observedAt: 1_999_000,
+            openedAt: 1_980_000,
+            status: "open",
+          },
+          saleAuthority: {
+            observedAt: 1_999_000,
+            status: "ready",
+            transactionMode: "products_and_services",
+          },
+        }),
+      }),
+    );
+
+    expect(state.salesReadiness).toBe("drawer_open");
+    expect(state.recoveryPreview.readiness).toBe("drawer_open");
+    expect(state.recoveryPreview.evidence.activeRegisterSession).toBe(true);
+    expect(state.diagnosticEvidence).toContainEqual(
+      expect.objectContaining({
+        source: "cloud_register_lifecycle",
+      }),
+    );
+  });
+
+  it("orders manual review before terminal actions and cloud repair", () => {
+    const input = baseInput({
+      cloudRepair: {
+        preconditionHash: "hash",
+        safeConflictIds: ["conflict-1" as Id<"posLocalSyncConflict">],
+        skippedConflictIds: [],
+      },
+      syncEvidence: {
+        ...emptySyncEvidence(),
+        heldCount: 1,
+        latestEvent: {
+          eventType: "sale_completed",
+          localEventId: "local-held",
+          localRegisterSessionId: "local-register-1",
+          occurredAt: 1_999_000,
+          sequence: 12,
+          status: "held",
+          submittedAt: 1_999_000,
+        },
+      },
+      runtimeStatus: buildRuntimeStatus({
+        sync: {
+          failedEventCount: 1,
+          localOnlyEventCount: 0,
+          pendingEventCount: 1,
+          reviewEventCount: 0,
+          status: "failed",
+          uploadableEventCount: 1,
+        },
+      }),
+    });
+
+    expect(buildTerminalOperationalState(input).recoveryPreview.readiness).toBe(
+      "needs_manual_review",
+    );
+  });
+
+  it("classifies safe cloud repair when no manual review or terminal action exists", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        cloudRepair: {
+          preconditionHash: "hash",
+          safeConflictIds: ["conflict-1" as Id<"posLocalSyncConflict">],
+          skippedConflictIds: [],
+        },
+      }),
+    );
+
+    expect(
+      classifySupportRecovery({
+        cloudRepair: state.recoveryEvidence.cloudRepair,
+        manualReview: state.recoveryEvidence.manualReview,
+        terminalActions: state.recoveryEvidence.terminalActions,
+      }),
+    ).toEqual({
+      reasonCount: 1,
+      status: "needs_cloud_repair",
+    });
+    expect(state.recoveryPreview.readiness).toBe("needs_cloud_repair");
+  });
+
+  it("does not treat command acknowledgement as verification", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        commandStatus: {
+          commandId: "command-1" as Id<"posTerminalRecoveryCommand">,
+          commandType: "retry_sync",
+          label: "Sync retry",
+          latestAcknowledgement: "Retry completed locally.",
+          status: "completed",
+          verificationStatus: "runtime_verification_ready",
+        },
+      }),
+    );
+
+    expect(state.diagnosticEvidence).toContainEqual(
+      expect.objectContaining({
+        source: "recovery_command",
+      }),
+    );
+  });
+
+  it("classifies terminal health from aggregate inputs", () => {
+    expect(
+      classifyTerminalHealth({
+        attentionReasons: [],
+        runtimeAgeMs: 1_000,
+        runtimeStatus: buildRuntimeStatus(),
+        terminalStatus: "active",
+      }),
+    ).toBe("online");
+    expect(
+      classifyTerminalHealth({
+        attentionReasons: [
+          {
+            source: "local_runtime",
+            summary: "Local sync runtime is unavailable on this terminal.",
+            type: "sync_unavailable",
+          },
+        ],
+        runtimeAgeMs: 1_000,
+        runtimeStatus: buildRuntimeStatus(),
+        terminalStatus: "active",
+      }),
+    ).toBe("needs_attention");
+    expect(
+      classifyTerminalHealth({
+        attentionReasons: [],
+        runtimeAgeMs: null,
+        runtimeStatus: null,
+        terminalStatus: "active",
+      }),
+    ).toBe("unknown");
+    expect(
+      classifyTerminalHealth({
+        attentionReasons: [],
+        runtimeAgeMs: 10 * 60 * 1_000,
+        runtimeStatus: buildRuntimeStatus(),
+        terminalStatus: "active",
+      }),
+    ).toBe("stale");
+    expect(
+      classifyTerminalHealth({
+        attentionReasons: [],
+        runtimeAgeMs: 16 * 60 * 1_000,
+        runtimeStatus: buildRuntimeStatus(),
+        terminalStatus: "active",
+      }),
+    ).toBe("offline");
+  });
+
+  it("derives attention reasons inside the aggregate policy", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        syncEvidence: {
+          ...emptySyncEvidence(),
+          conflictedCount: 1,
+          latestEvent: {
+            eventType: "sale_completed",
+            localEventId: "local-conflicted",
+            localRegisterSessionId: "local-register-1",
+            occurredAt: 1_999_000,
+            sequence: 7,
+            status: "conflicted",
+            submittedAt: 1_999_000,
+          },
+        },
+      }),
+    );
+
+    expect(state.attentionReasons).toContainEqual(
+      expect.objectContaining({
+        count: 1,
+        latestEventSequence: 7,
+        source: "cloud_sync",
+        type: "cloud_conflict",
+      }),
+    );
+    expect(state.terminalHealth).toBe("needs_attention");
+  });
+
+  it("clears cleanly closed drawer authority inside the aggregate policy", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        drawerAuthorityRegisterSession: buildRegisterSession({
+          _id: "register-closed" as Id<"registerSession">,
+          closedAt: 1_999_000,
+          status: "closed",
+        }),
+        runtimeStatus: buildRuntimeStatus({
+          drawerAuthority: {
+            cloudRegisterSessionId: "register-closed",
+            localRegisterSessionId: "local-register-1",
+            observedAt: 1_999_000,
+            reason: "cloud_closed",
+            status: "blocked",
+          },
+        }),
+      }),
+    );
+
+    expect(state.runtimeEvidence.effectiveStatus?.drawerAuthority).toBeUndefined();
+    expect(state.attentionReasons.map((reason) => reason.type)).not.toContain(
+      "drawer_authority_blocked",
+    );
+    expect(state.recoveryPreview.terminalActions).toEqual([]);
+  });
+});
+
+function baseInput(
+  overrides: Partial<TerminalOperationalPolicyInput> = {},
+): TerminalOperationalPolicyInput {
+  return {
+    appUpdate: {
+      evidenceFresh: false,
+      status: "unknown",
+    },
+    cloudRepair: {
+      preconditionHash: "empty",
+      safeConflictIds: [],
+      skippedConflictIds: [],
+    },
+    commandStatus: null,
+    latestRegisterSession: null,
+    runtimeStatus: buildRuntimeStatus(),
+    runtimeAgeMs: 1_000,
+    runtimeFresh: true,
+    storeId,
+    syncEvidence: {
+      latestEvent: null,
+      latestReviewEvent: null,
+      latestReviewEventsByStatus: {
+        conflicted: null,
+        held: null,
+        rejected: null,
+      },
+      sampledEventCount: 0,
+      acceptedCount: 0,
+      projectedCount: 0,
+      conflictedCount: 0,
+      heldCount: 0,
+      rejectedCount: 0,
+      unresolvedConflictCount: 0,
+      unresolvedConflicts: [],
+    },
+    terminalId,
+    terminalStatus: "active",
+    ...overrides,
+  } satisfies TerminalOperationalPolicyInput;
+}
+
+function emptySyncEvidence(): TerminalOperationalPolicyInput["syncEvidence"] {
+  return {
+    latestEvent: null,
+    latestReviewEvent: null,
+    latestReviewEventsByStatus: {
+      conflicted: null,
+      held: null,
+      rejected: null,
+    },
+    sampledEventCount: 0,
+    acceptedCount: 0,
+    projectedCount: 0,
+    conflictedCount: 0,
+    heldCount: 0,
+    rejectedCount: 0,
+    unresolvedConflictCount: 0,
+    unresolvedConflicts: [],
+  };
+}
+
+function buildRuntimeStatus(
+  overrides: Partial<Doc<"posTerminalRuntimeStatus">> = {},
+): Doc<"posTerminalRuntimeStatus"> {
+  return {
+    _id: "runtime-1" as Id<"posTerminalRuntimeStatus">,
+    _creationTime: 1_998_000,
+    appSessionRecovery: {
+      status: "ready",
+    },
+    browserInfo: {
+      online: true,
+      userAgent: "Mozilla/5.0",
+    },
+    localStore: {
+      available: true,
+      terminalSeedReady: true,
+    },
+    receivedAt: 1_999_000,
+    reportedAt: 1_999_000,
+    snapshots: {},
+    source: "sync-runtime",
+    staffAuthority: {
+      status: "ready",
+    },
+    storeId,
+    sync: {
+      failedEventCount: 0,
+      localOnlyEventCount: 0,
+      pendingEventCount: 0,
+      reviewEventCount: 0,
+      status: "idle",
+      uploadableEventCount: 0,
+    },
+    terminalId,
+    terminalIntegrity: {
+      observedAt: 1_999_000,
+      status: "healthy",
+    },
+    ...overrides,
+  };
+}
+
+function buildRegisterSession(
+  overrides: Partial<Doc<"registerSession">> = {},
+): Doc<"registerSession"> {
+  return {
+    _id: "register-1" as Id<"registerSession">,
+    _creationTime: 1_990_000,
+    closeoutRecords: [],
+    closedAt: undefined,
+    expectedCash: 0,
+    openedAt: 1_980_000,
+    openingFloat: 0,
+    status: "open",
+    storeId,
+    terminalId,
+    ...overrides,
+  };
+}

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.ts
@@ -1,0 +1,605 @@
+import {
+  isRegisterSessionReplacementBlocking,
+  isRegisterSessionSaleUsable,
+} from "../../../../shared/registerSessionLifecyclePolicy";
+import type {
+  TerminalHealthAttentionReason,
+  TerminalOperationalPolicyInput,
+  TerminalOperationalState,
+  TerminalSalesReadiness,
+  TerminalSupportRecovery,
+} from "./types";
+
+type TerminalSupportRecoveryInput = Pick<
+  TerminalOperationalState["recoveryEvidence"],
+  "cloudRepair" | "manualReview" | "terminalActions"
+>;
+
+type TerminalSalesReadinessInput = {
+  activeRegisterSession: boolean;
+  cloudRegisterSessionSaleUsable?: boolean;
+  healthyIdle: boolean;
+  saleAuthorityReady: boolean;
+};
+
+export function buildTerminalOperationalState(
+  input: TerminalOperationalPolicyInput,
+): TerminalOperationalState {
+  const effectiveRuntimeStatus = normalizeRuntimeStatusForPolicy(input);
+  const activeRegisterSession =
+    runtimeHasActiveRegisterSession(effectiveRuntimeStatus) ||
+    isRegisterSessionSaleUsable(input.activeRegisterSession) ||
+    isRegisterSessionSaleUsable(input.latestRegisterSession);
+  const cloudRegisterSessionSaleUsable = input.latestRegisterSession
+    ? isRegisterSessionSaleUsable(input.latestRegisterSession)
+    : undefined;
+  const attentionReasons = deriveTerminalHealthAttentionReasons({
+    ...input,
+    runtimeStatus: effectiveRuntimeStatus,
+  });
+  const terminalActions = buildTerminalRecoveryActions({
+    runtimeStatus: effectiveRuntimeStatus,
+  });
+  const manualReview = buildTerminalRecoveryManualReview({
+    attentionReasons,
+    skippedConflictIds: input.cloudRepair.skippedConflictIds,
+  });
+  const healthyIdle = hasHealthyIdleEvidence({
+    runtimeStatus: effectiveRuntimeStatus,
+    syncEvidence: input.syncEvidence,
+    terminalActions,
+    manualReview,
+    cloudRepair: input.cloudRepair,
+    terminalStatus: input.terminalStatus,
+    runtimeFresh: input.runtimeFresh,
+  });
+  const supportRecovery = classifySupportRecovery({
+    cloudRepair: input.cloudRepair,
+    manualReview,
+    terminalActions,
+  });
+  const salesReadiness = classifySalesReadiness({
+    activeRegisterSession,
+    cloudRegisterSessionSaleUsable,
+    healthyIdle,
+    saleAuthorityReady: runtimeHasSaleAuthority(effectiveRuntimeStatus),
+  });
+  const readiness = supportRecovery?.status ?? salesReadiness;
+  const diagnosticEvidence = buildDiagnosticEvidence({
+    ...input,
+    runtimeStatus: effectiveRuntimeStatus,
+  });
+  const terminalHealth = classifyTerminalHealth({
+    attentionReasons,
+    runtimeAgeMs: input.runtimeAgeMs,
+    runtimeStatus: effectiveRuntimeStatus,
+    terminalStatus: input.terminalStatus,
+  });
+
+  return {
+    appUpdateEvidence: input.appUpdate,
+    attentionReasons,
+    diagnosticEvidence,
+    recoveryEvidence: {
+      cloudRepair: input.cloudRepair,
+      commandStatus: input.commandStatus,
+      manualReview,
+      terminalActions,
+    },
+    recoveryPreview: {
+      appUpdate: input.appUpdate,
+      readiness,
+      runtimeFresh: input.runtimeFresh,
+      evidence: {
+        activeRegisterSession,
+        freshRuntimeRequiredForAbleToTransactNow: true,
+      },
+      cloudRepair: input.cloudRepair,
+      commandStatus: input.commandStatus,
+      terminalActions,
+      manualReview,
+    },
+    registerEvidence: {
+      activeRegisterSession,
+      cloudRegisterSessionSaleUsable,
+      latestCloudRegisterSessionStatus: input.latestCloudRegisterSessionStatus,
+    },
+    terminalHealth,
+    runtimeEvidence: {
+      effectiveStatus: effectiveRuntimeStatus,
+      fresh: input.runtimeFresh,
+      runtimeAgeMs: input.runtimeAgeMs,
+    },
+    salesReadiness,
+    supportRecovery,
+    syncEvidence: input.syncEvidence,
+    terminalIdentity: {
+      storeId: input.storeId,
+      terminalId: input.terminalId,
+      terminalStatus: input.terminalStatus,
+    },
+  };
+}
+
+function normalizeRuntimeStatusForPolicy(
+  input: Pick<
+    TerminalOperationalPolicyInput,
+    "drawerAuthorityRegisterSession" | "runtimeStatus"
+  >,
+): TerminalOperationalPolicyInput["runtimeStatus"] {
+  const status = input.runtimeStatus;
+  if (!status || !isCleanlyClosedDrawerAuthority(input)) {
+    return status;
+  }
+
+  return {
+    ...status,
+    drawerAuthority: undefined,
+  };
+}
+
+function isCleanlyClosedDrawerAuthority(
+  input: Pick<
+    TerminalOperationalPolicyInput,
+    "drawerAuthorityRegisterSession" | "runtimeStatus"
+  >,
+) {
+  const drawerAuthority = input.runtimeStatus?.drawerAuthority;
+  const registerSession = input.drawerAuthorityRegisterSession;
+  if (
+    drawerAuthority?.status !== "blocked" ||
+    drawerAuthority.reason !== "cloud_closed" ||
+    !registerSession
+  ) {
+    return false;
+  }
+
+  return !isRegisterSessionReplacementBlocking({
+    hasSubmittedCloseout: registerSession.status === "closing",
+    session: registerSession,
+  });
+}
+
+export function deriveTerminalHealthAttentionReasons(
+  input: Pick<
+    TerminalOperationalPolicyInput,
+    "runtimeStatus" | "syncEvidence" | "terminalStatus"
+  >,
+): TerminalHealthAttentionReason[] {
+  if (input.terminalStatus !== "active") {
+    return [];
+  }
+
+  const reasons: TerminalHealthAttentionReason[] = [];
+  const sync = input.runtimeStatus?.sync;
+  const latestEvent = input.syncEvidence.latestEvent;
+
+  if (
+    input.runtimeStatus?.terminalIntegrity &&
+    input.runtimeStatus.terminalIntegrity.status !== "healthy"
+  ) {
+    reasons.push({
+      source: "terminal_runtime",
+      summary:
+        "Terminal setup needs repair before this checkout station can record new sales.",
+      type: "terminal_authorization_failed",
+    });
+  }
+
+  if (input.runtimeStatus?.drawerAuthority?.status === "blocked") {
+    reasons.push({
+      source: "terminal_runtime",
+      summary:
+        "Drawer setup needs repair before this checkout station can record new sales.",
+      type: "drawer_authority_blocked",
+    });
+  }
+
+  if (sync && (sync.status === "needs_review" || sync.reviewEventCount > 0)) {
+    const count = Math.max(1, sync.reviewEventCount);
+    reasons.push({
+      count,
+      nextPendingUploadSequence: sync.nextPendingUploadSequence,
+      oldestPendingEventAt: sync.oldestPendingEventAt,
+      source: "local_runtime",
+      summary: `${count} local review item${count === 1 ? " is" : "s are"} still on this terminal.`,
+      type: "local_review",
+    });
+  }
+
+  if (sync && (sync.status === "failed" || sync.failedEventCount > 0)) {
+    const count = Math.max(1, sync.failedEventCount);
+    reasons.push({
+      count,
+      nextPendingUploadSequence: sync.nextPendingUploadSequence,
+      oldestPendingEventAt: sync.oldestPendingEventAt,
+      source: "local_runtime",
+      summary: `${count} local sync item${count === 1 ? " has" : "s have"} failed on this terminal.`,
+      type: "sync_failed",
+    });
+  }
+
+  if (sync?.status === "unavailable") {
+    reasons.push({
+      source: "local_runtime",
+      summary: "Local sync runtime is unavailable on this terminal.",
+      type: "sync_unavailable",
+    });
+  }
+
+  if (input.runtimeStatus?.localStore.available === false) {
+    reasons.push({
+      source: "terminal_runtime",
+      summary: "Local terminal storage is not available.",
+      type: "local_store_unavailable",
+    });
+  }
+
+  if (input.runtimeStatus?.localStore.terminalSeedReady === false) {
+    reasons.push({
+      source: "terminal_runtime",
+      summary: "Terminal setup data is not ready on this checkout station.",
+      type: "terminal_seed_missing",
+    });
+  }
+
+  const inventoryReviewCount =
+    input.syncEvidence.unresolvedConflicts?.filter(
+      (conflict) =>
+        conflict.conflictType === "inventory" &&
+        conflict.reviewTarget?.workItemType ===
+          "synced_sale_inventory_review",
+    ).length ?? 0;
+
+  if (inventoryReviewCount > 0) {
+    reasons.push({
+      count: inventoryReviewCount,
+      latestEventSequence: latestEvent?.sequence,
+      latestEventStatus: latestEvent?.status,
+      source: "cloud_sync",
+      summary: `${inventoryReviewCount} inventory review item${inventoryReviewCount === 1 ? " needs" : "s need"} attention.`,
+      type: "synced_sale_inventory_review",
+    });
+  }
+
+  const conflictedCount = Math.max(
+    0,
+    input.syncEvidence.conflictedCount - inventoryReviewCount,
+  );
+
+  if (conflictedCount > 0) {
+    reasons.push({
+      count: conflictedCount,
+      latestEventSequence: latestEvent?.sequence,
+      latestEventStatus: latestEvent?.status,
+      source: "cloud_sync",
+      summary: `${conflictedCount} cloud sync conflict${conflictedCount === 1 ? " needs" : "s need"} review.`,
+      type: "cloud_conflict",
+    });
+  }
+
+  if (input.syncEvidence.heldCount > 0) {
+    reasons.push({
+      count: input.syncEvidence.heldCount,
+      latestEventSequence: latestEvent?.sequence,
+      latestEventStatus: latestEvent?.status,
+      source: "cloud_sync",
+      summary: `${input.syncEvidence.heldCount} synced item${input.syncEvidence.heldCount === 1 ? " is" : "s are"} held before projection.`,
+      type: "cloud_held",
+    });
+  }
+
+  if (input.syncEvidence.rejectedCount > 0) {
+    reasons.push({
+      count: input.syncEvidence.rejectedCount,
+      latestEventSequence: latestEvent?.sequence,
+      latestEventStatus: latestEvent?.status,
+      source: "cloud_sync",
+      summary: `${input.syncEvidence.rejectedCount} synced item${input.syncEvidence.rejectedCount === 1 ? " was" : "s were"} rejected by the server.`,
+      type: "cloud_rejected",
+    });
+  }
+
+  return reasons;
+}
+
+export function classifySupportRecovery(
+  input: TerminalSupportRecoveryInput,
+): TerminalSupportRecovery {
+  if (input.manualReview.length > 0) {
+    return {
+      reasonCount: input.manualReview.length,
+      status: "needs_manual_review",
+    };
+  }
+
+  if (input.terminalActions.length > 0) {
+    return {
+      reasonCount: input.terminalActions.length,
+      status: "needs_terminal_action",
+    };
+  }
+
+  if (input.cloudRepair.safeConflictIds.length > 0) {
+    return {
+      reasonCount: input.cloudRepair.safeConflictIds.length,
+      status: "needs_cloud_repair",
+    };
+  }
+
+  return null;
+}
+
+export function classifyTerminalHealth(input: {
+  attentionReasons: TerminalHealthAttentionReason[];
+  runtimeAgeMs: number | null;
+  runtimeStatus: TerminalOperationalPolicyInput["runtimeStatus"];
+  terminalStatus: TerminalOperationalPolicyInput["terminalStatus"];
+}): TerminalOperationalState["terminalHealth"] {
+  if (input.terminalStatus !== "active") {
+    return "offline";
+  }
+
+  if (input.attentionReasons.length > 0) {
+    return "needs_attention";
+  }
+
+  if (!input.runtimeStatus || input.runtimeAgeMs === null) {
+    return "unknown";
+  }
+
+  if (
+    input.runtimeAgeMs <= 2 * 60 * 1000 &&
+    input.runtimeStatus.browserInfo?.online !== false
+  ) {
+    return "online";
+  }
+
+  return input.runtimeAgeMs <= 15 * 60 * 1000 ? "stale" : "offline";
+}
+
+export function classifySalesReadiness(
+  input: TerminalSalesReadinessInput,
+): TerminalSalesReadiness {
+  if (
+    input.healthyIdle &&
+    input.activeRegisterSession &&
+    input.saleAuthorityReady &&
+    input.cloudRegisterSessionSaleUsable !== false
+  ) {
+    return "able_to_transact_now";
+  }
+
+  if (input.activeRegisterSession) {
+    return "drawer_open";
+  }
+
+  return "healthy_idle";
+}
+
+function buildDiagnosticEvidence(input: TerminalOperationalPolicyInput) {
+  const diagnostics = [];
+  const activeRegisterSession =
+    runtimeHasActiveRegisterSession(input.runtimeStatus) ||
+    isRegisterSessionSaleUsable(input.activeRegisterSession) ||
+    isRegisterSessionSaleUsable(input.latestRegisterSession);
+  const saleAuthorityReady = runtimeHasSaleAuthority(input.runtimeStatus);
+  const cloudRegisterSessionSaleUsable = input.latestRegisterSession
+    ? isRegisterSessionSaleUsable(input.latestRegisterSession)
+    : undefined;
+
+  if (!input.runtimeFresh) {
+    diagnostics.push({
+      severity: "warning" as const,
+      source: "local_runtime" as const,
+      summary: "Terminal runtime evidence is stale or unavailable.",
+    });
+  }
+
+  if (
+    activeRegisterSession &&
+    saleAuthorityReady &&
+    cloudRegisterSessionSaleUsable === false
+  ) {
+    diagnostics.push({
+      severity: "warning" as const,
+      source: "cloud_register_lifecycle" as const,
+      summary:
+        "Runtime reports an active drawer, but cloud register lifecycle evidence is not sale-usable.",
+    });
+  }
+
+  if (input.commandStatus && input.commandStatus.verificationStatus !== "verified") {
+    diagnostics.push({
+      severity: "info" as const,
+      source: "recovery_command" as const,
+      summary: "Recovery command acknowledgement is awaiting runtime verification.",
+    });
+  }
+
+  if ((input.syncEvidence.unresolvedConflictCount ?? 0) > 0) {
+    diagnostics.push({
+      severity: "warning" as const,
+      source: "sync_evidence" as const,
+      summary: "Terminal sync evidence includes unresolved review items.",
+    });
+  }
+
+  return diagnostics;
+}
+
+function buildTerminalRecoveryActions(
+  input: Pick<TerminalOperationalPolicyInput, "runtimeStatus">,
+): TerminalOperationalState["recoveryEvidence"]["terminalActions"] {
+  const status = input.runtimeStatus;
+  if (!status) {
+    return [];
+  }
+
+  const actions: TerminalOperationalState["recoveryEvidence"]["terminalActions"] = [];
+  if (status.localStore.available === false || status.localStore.terminalSeedReady === false) {
+    actions.push({
+      commandType: "repair_terminal_seed",
+      expectedEvidence: {
+        localStoreAvailable: true,
+        terminalSeedReady: true,
+        terminalIntegrityStatus: "healthy",
+      },
+      commandContext: {
+        expectedBlockerType: "terminal_seed",
+        reason: "Terminal setup data needs repair.",
+      },
+      reason: "Terminal setup data needs repair before this checkout station can sell.",
+    });
+  }
+  if (status.terminalIntegrity && status.terminalIntegrity.status !== "healthy") {
+    actions.push({
+      commandType: "repair_terminal_seed",
+      expectedEvidence: {
+        terminalIntegrityStatus: "healthy",
+      },
+      commandContext: {
+        expectedBlockerType: status.terminalIntegrity.reason ?? "terminal_integrity",
+        reason: "Terminal integrity requires repair.",
+      },
+      reason: "Terminal integrity requires local repair.",
+    });
+  }
+  if (status.drawerAuthority?.status === "blocked") {
+    actions.push({
+      commandType: "clear_stale_drawer_authority",
+      expectedEvidence: {
+        drawerAuthorityStatus: "healthy",
+        localRegisterSessionId: status.drawerAuthority.localRegisterSessionId,
+      },
+      commandContext: {
+        cloudRegisterSessionId: status.drawerAuthority.cloudRegisterSessionId,
+        expectedBlockerType: status.drawerAuthority.reason ?? "drawer_authority",
+        localRegisterSessionId: status.drawerAuthority.localRegisterSessionId,
+        reason: "Drawer authority requires terminal-local repair.",
+      },
+      reason: "Drawer authority requires terminal-local repair.",
+    });
+  }
+  if (status.sync.status === "failed" || status.sync.status === "unavailable") {
+    actions.push({
+      commandType: "retry_sync",
+      expectedEvidence: {
+        syncStatus: "idle",
+      },
+      commandContext: {
+        expectedBlockerType: "sync_runtime",
+        reason: "Local sync needs a terminal retry.",
+      },
+      reason: "Local sync needs a terminal retry.",
+    });
+  }
+  if (status.sync.status === "needs_review" || status.sync.reviewEventCount > 0) {
+    actions.push({
+      commandType: "retry_sync",
+      expectedEvidence: {
+        syncStatus: "idle",
+      },
+      commandContext: {
+        expectedBlockerType: "local_review",
+        reason: "Local review items need a terminal sync retry.",
+      },
+      reason: "Local review items need a terminal sync retry.",
+    });
+  }
+  return dedupeTerminalActions(actions);
+}
+
+function buildTerminalRecoveryManualReview(args: {
+  attentionReasons: TerminalHealthAttentionReason[];
+  skippedConflictIds: TerminalOperationalPolicyInput["cloudRepair"]["skippedConflictIds"];
+}): TerminalOperationalState["recoveryEvidence"]["manualReview"] {
+  const manual: TerminalOperationalState["recoveryEvidence"]["manualReview"] =
+    args.attentionReasons
+      .filter((reason) =>
+        reason.type === "cloud_held" ||
+        reason.type === "cloud_rejected" ||
+        reason.type === "local_review",
+      )
+      .map((reason) => ({
+        reason: reason.summary,
+        source: reason.source,
+        type: reason.type,
+      }));
+  for (const conflictId of args.skippedConflictIds) {
+    manual.push({
+      reason:
+        "A cloud sync conflict needs manual review before support can repair this terminal.",
+      source: "cloud_repair",
+      type: "unsafe_cloud_conflict",
+    });
+  }
+  return manual;
+}
+
+function hasHealthyIdleEvidence(args: {
+  cloudRepair: TerminalOperationalPolicyInput["cloudRepair"];
+  manualReview: TerminalOperationalState["recoveryEvidence"]["manualReview"];
+  runtimeFresh: boolean;
+  runtimeStatus: TerminalOperationalPolicyInput["runtimeStatus"];
+  syncEvidence: TerminalOperationalPolicyInput["syncEvidence"];
+  terminalActions: TerminalOperationalState["recoveryEvidence"]["terminalActions"];
+  terminalStatus: TerminalOperationalPolicyInput["terminalStatus"];
+}) {
+  const status = args.runtimeStatus;
+  return (
+    args.terminalStatus === "active" &&
+    args.runtimeFresh &&
+    !!status &&
+    status.localStore.available &&
+    status.localStore.terminalSeedReady &&
+    status.staffAuthority.status === "ready" &&
+    status.sync.status !== "failed" &&
+    status.sync.status !== "needs_review" &&
+    status.sync.status !== "unavailable" &&
+    status.sync.failedEventCount === 0 &&
+    status.sync.reviewEventCount === 0 &&
+    (!status.terminalIntegrity || status.terminalIntegrity.status === "healthy") &&
+    (!status.drawerAuthority || status.drawerAuthority.status === "healthy") &&
+    (args.syncEvidence.unresolvedConflictCount ?? 0) === 0 &&
+    args.syncEvidence.conflictedCount === 0 &&
+    args.syncEvidence.heldCount === 0 &&
+    args.syncEvidence.rejectedCount === 0 &&
+    args.terminalActions.length === 0 &&
+    args.manualReview.length === 0 &&
+    args.cloudRepair.safeConflictIds.length === 0
+  );
+}
+
+function runtimeHasSaleAuthority(
+  status: TerminalOperationalPolicyInput["runtimeStatus"],
+) {
+  return (
+    !!status &&
+    status.staffAuthority.status === "ready" &&
+    status.saleAuthority?.status === "ready"
+  );
+}
+
+function runtimeHasActiveRegisterSession(
+  status: TerminalOperationalPolicyInput["runtimeStatus"],
+) {
+  return (
+    status?.activeRegisterSession?.status === "open" ||
+    status?.activeRegisterSession?.status === "active"
+  );
+}
+
+function dedupeTerminalActions(
+  actions: TerminalOperationalState["recoveryEvidence"]["terminalActions"],
+) {
+  const seen = new Set<string>();
+  return actions.filter((action) => {
+    const key = `${action.commandType}:${action.commandContext.expectedBlockerType ?? ""}:${action.commandContext.localRegisterSessionId ?? ""}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/types.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/types.ts
@@ -1,0 +1,181 @@
+import type { Doc, Id } from "../../../_generated/dataModel";
+import type { TerminalSyncEvidence } from "../../domain/terminalSyncEvidence";
+import type {
+  TerminalRecoveryCommandPayload,
+  TerminalRecoveryCommandType,
+  TerminalRecoveryExpectedEvidence,
+  TerminalRecoveryReadiness,
+} from "../terminalRecovery/types";
+
+export type TerminalSalesReadiness =
+  | "healthy_idle"
+  | "drawer_open"
+  | "able_to_transact_now";
+
+export type TerminalSupportRecovery =
+  | {
+      reasonCount: number;
+      status: "needs_cloud_repair" | "needs_manual_review" | "needs_terminal_action";
+    }
+  | null;
+
+export type TerminalDiagnosticEvidence = Array<{
+  severity: "info" | "warning";
+  source:
+    | "cloud_register_lifecycle"
+    | "local_runtime"
+    | "recovery_command"
+    | "sync_evidence";
+  summary: string;
+}>;
+
+export type TerminalHealthAttentionReason = {
+  actionTarget?: TerminalHealthAttentionActionTarget;
+  count?: number;
+  latestEventSequence?: number;
+  latestEventStatus?: string;
+  nextPendingUploadSequence?: number;
+  oldestPendingEventAt?: number;
+  source: "cloud_sync" | "local_runtime" | "terminal_runtime";
+  summary: string;
+  type:
+    | "cloud_conflict"
+    | "cloud_held"
+    | "cloud_rejected"
+    | "synced_sale_inventory_review"
+    | "local_review"
+    | "local_store_unavailable"
+    | "sync_failed"
+    | "sync_unavailable"
+    | "terminal_authorization_failed"
+    | "drawer_authority_blocked"
+    | "terminal_seed_missing";
+};
+
+export type TerminalHealthAttentionActionTarget =
+  | {
+      automaticRepairEligible?: boolean;
+      type: "cash_control_register_session";
+      registerSessionId: Id<"registerSession">;
+    }
+  | { label?: string; type: "open_work" }
+  | { type: "pos_register" }
+  | { type: "pos_settings" };
+
+export type TerminalHealth =
+  | "online"
+  | "stale"
+  | "offline"
+  | "needs_attention"
+  | "unknown";
+
+export type TerminalRecoveryPreview = {
+  appUpdate: TerminalAppUpdatePreview;
+  readiness: TerminalRecoveryReadiness;
+  runtimeFresh: boolean;
+  evidence: {
+    freshRuntimeRequiredForAbleToTransactNow: true;
+    activeRegisterSession: boolean;
+  };
+  cloudRepair: {
+    preconditionHash: string;
+    safeConflictIds: Array<Id<"posLocalSyncConflict">>;
+    skippedConflictIds: Array<Id<"posLocalSyncConflict">>;
+  };
+  commandStatus: {
+    appUpdateCommandExecutionId?: string;
+    commandId?: Id<"posTerminalRecoveryCommand">;
+    commandType: TerminalRecoveryCommandType;
+    label: string;
+    latestAcknowledgement?: string;
+    status: Doc<"posTerminalRecoveryCommand">["status"];
+    verificationStatus: Doc<"posTerminalRecoveryCommand">["verificationStatus"];
+  } | null;
+  terminalActions: Array<{
+    commandType: TerminalRecoveryCommandType;
+    expectedEvidence: TerminalRecoveryExpectedEvidence;
+    commandContext: TerminalRecoveryCommandPayload;
+    reason: string;
+  }>;
+  manualReview: Array<{
+    reason: string;
+    source:
+      | TerminalHealthAttentionReason["source"]
+      | "cloud_repair";
+    type: TerminalHealthAttentionReason["type"] | "unsafe_cloud_conflict";
+  }>;
+};
+
+export type TerminalAppUpdateStatus =
+  | "applying"
+  | "blocked"
+  | "current"
+  | "detector_failed"
+  | "stale"
+  | "unknown"
+  | "update_ready"
+  | "update_ready_unstaged";
+
+export type TerminalAppUpdatePreview = {
+  commandCorrelated?: boolean;
+  currentBuildId?: string;
+  evidenceFresh: boolean;
+  observedAt?: number;
+  pendingBuildId?: string;
+  stagingAssetCount?: number;
+  stagingFailedAssetCount?: number;
+  stagingReason?: string;
+  stagingRejectedAssetCount?: number;
+  stagingStatus?: string;
+  status: TerminalAppUpdateStatus;
+  summary?: string;
+};
+
+export type TerminalOperationalState = {
+  appUpdateEvidence: TerminalRecoveryPreview["appUpdate"];
+  attentionReasons: TerminalHealthAttentionReason[];
+  diagnosticEvidence: TerminalDiagnosticEvidence;
+  recoveryEvidence: {
+    cloudRepair: TerminalRecoveryPreview["cloudRepair"];
+    commandStatus: TerminalRecoveryPreview["commandStatus"];
+    manualReview: TerminalRecoveryPreview["manualReview"];
+    terminalActions: TerminalRecoveryPreview["terminalActions"];
+  };
+  recoveryPreview: TerminalRecoveryPreview;
+  registerEvidence: {
+    activeRegisterSession: boolean;
+    cloudRegisterSessionSaleUsable?: boolean;
+    latestCloudRegisterSessionStatus?: Doc<"registerSession">["status"];
+  };
+  terminalHealth: TerminalHealth;
+  runtimeEvidence: {
+    effectiveStatus: Doc<"posTerminalRuntimeStatus"> | null;
+    fresh: boolean;
+    runtimeAgeMs: number | null;
+  };
+  salesReadiness: TerminalSalesReadiness;
+  supportRecovery: TerminalSupportRecovery;
+  syncEvidence: TerminalSyncEvidence;
+  terminalIdentity: {
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+    terminalStatus: Doc<"posTerminal">["status"];
+  };
+};
+
+export type TerminalOperationalPolicyInput = {
+  appUpdate: TerminalRecoveryPreview["appUpdate"];
+  activeRegisterSession?: Doc<"registerSession"> | null;
+  cloudRepair: TerminalRecoveryPreview["cloudRepair"];
+  commandStatus: TerminalRecoveryPreview["commandStatus"];
+  drawerAuthorityRegisterSession?: Doc<"registerSession"> | null;
+  latestCloudRegisterSessionStatus?: Doc<"registerSession">["status"];
+  latestRegisterSession?: Doc<"registerSession"> | null;
+  runtimeStatus: Doc<"posTerminalRuntimeStatus"> | null;
+  runtimeAgeMs: number | null;
+  runtimeFresh: boolean;
+  storeId: Id<"store">;
+  syncEvidence: TerminalSyncEvidence;
+  terminalId: Id<"posTerminal">;
+  terminalStatus: Doc<"posTerminal">["status"];
+};

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -16,6 +16,9 @@ import {
   type TerminalRecoveryCommandRepository,
 } from "./terminalRecovery/terminalCommandService";
 import {
+  getActiveRegisterSessionForTerminal,
+  getDrawerAuthorityRegisterSession,
+  getLatestRegisterSessionForTerminal,
   getLatestRuntimeStatusForTerminal,
   getTerminalByFingerprint,
   getTerminalById,
@@ -71,6 +74,9 @@ vi.mock("../infrastructure/repositories/terminalRepository", () => ({
   getTerminalByFingerprint: vi.fn(),
   getTerminalById: vi.fn(),
   getTerminalByStoreIdAndRegisterNumber: vi.fn(),
+  getActiveRegisterSessionForTerminal: vi.fn(),
+  getDrawerAuthorityRegisterSession: vi.fn(),
+  getLatestRegisterSessionForTerminal: vi.fn(),
   getLatestRuntimeStatusForTerminal: vi.fn(),
   getTerminalSyncEvidence: vi.fn(),
   hasActiveRegisterSessionForTerminal: vi.fn(),
@@ -876,6 +882,9 @@ describe("terminal health summaries", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(resolveTerminalRegisterSessionActionTarget).mockResolvedValue(null);
+    vi.mocked(getActiveRegisterSessionForTerminal).mockResolvedValue(null);
+    vi.mocked(getDrawerAuthorityRegisterSession).mockResolvedValue(null);
+    vi.mocked(getLatestRegisterSessionForTerminal).mockResolvedValue(null);
     vi.mocked(hasActiveRegisterSessionForTerminal).mockResolvedValue(false);
     vi.mocked(listTerminalRecoveryConflictsForRepair).mockResolvedValue([]);
     vi.mocked(getTerminalRecoverySourceEvent).mockResolvedValue(null);
@@ -1848,7 +1857,12 @@ describe("terminal health summaries", () => {
     );
     expect(healthyIdle?.recoveryPreview?.readiness).toBe("healthy_idle");
 
-    vi.mocked(hasActiveRegisterSessionForTerminal).mockResolvedValue(true);
+    vi.mocked(getActiveRegisterSessionForTerminal).mockResolvedValue(
+      buildRegisterSession({
+        _id: "register-1" as Id<"registerSession">,
+        status: "active",
+      }),
+    );
     vi.mocked(getLatestRuntimeStatusForTerminal).mockResolvedValue(
       buildPersistedRuntimeStatus({
         receivedAt: 230,
@@ -2148,6 +2162,25 @@ function buildSyncEvent(
     submittedAt: 110,
     ...overrides,
   } as Doc<"posLocalSyncEvent">;
+}
+
+function buildRegisterSession(
+  overrides: Partial<Doc<"registerSession">> = {},
+): Doc<"registerSession"> {
+  return {
+    _id: "register-1" as Id<"registerSession">,
+    _creationTime: 100,
+    closeoutRecords: [],
+    closedAt: undefined,
+    expectedCash: 0,
+    openedAt: 100,
+    openingFloat: 0,
+    registerNumber: "A1",
+    status: "open",
+    storeId: "store-1" as Id<"store">,
+    terminalId: "terminal-1" as Id<"posTerminal">,
+    ...overrides,
+  };
 }
 
 function buildTerminalHealthDb(

--- a/packages/athena-webapp/convex/pos/domain/terminalSyncEvidence.ts
+++ b/packages/athena-webapp/convex/pos/domain/terminalSyncEvidence.ts
@@ -1,0 +1,52 @@
+import type { Doc, Id } from "../../_generated/dataModel";
+
+export type TerminalSyncReviewEvent = {
+  localEventId: string;
+  localRegisterSessionId: string;
+  sequence: number;
+  eventType: Doc<"posLocalSyncEvent">["eventType"];
+  status: Doc<"posLocalSyncEvent">["status"];
+};
+
+export type TerminalSyncEvidence = {
+  latestEvent: {
+    localEventId: string;
+    localRegisterSessionId: string;
+    sequence: number;
+    eventType: Doc<"posLocalSyncEvent">["eventType"];
+    status: Doc<"posLocalSyncEvent">["status"];
+    occurredAt: number;
+    submittedAt: number;
+    acceptedAt?: number;
+    projectedAt?: number;
+  } | null;
+  latestReviewEvent?: TerminalSyncReviewEvent | null;
+  latestReviewEventsByStatus?: {
+    conflicted?: TerminalSyncReviewEvent | null;
+    held?: TerminalSyncReviewEvent | null;
+    rejected?: TerminalSyncReviewEvent | null;
+  };
+  sampledEventCount: number;
+  acceptedCount: number;
+  projectedCount: number;
+  conflictedCount: number;
+  heldCount: number;
+  rejectedCount: number;
+  unresolvedConflictCount?: number;
+  unresolvedConflicts?: Array<{
+    _id: Id<"posLocalSyncConflict">;
+    conflictType: Doc<"posLocalSyncConflict">["conflictType"];
+    createdAt: number;
+    localEventId: string;
+    localRegisterSessionId: string;
+    reviewTarget?: {
+      type: "open_work";
+      workItemId: Id<"operationalWorkItem">;
+      workItemType: "synced_sale_inventory_review";
+    };
+    sequence: number;
+    summary: string;
+  }>;
+  acceptedThroughSequence?: number;
+  cursorUpdatedAt?: number;
+};

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
@@ -3,19 +3,15 @@ import type { MutationCtx, QueryCtx } from "../../../_generated/server";
 
 import type { PosLocalSyncEventStatus } from "../../../../shared/posLocalSyncContract";
 import { isPosUsableRegisterSessionStatus } from "../../../../shared/registerSessionStatus";
+import type {
+  TerminalSyncEvidence,
+  TerminalSyncReviewEvent,
+} from "../../domain/terminalSyncEvidence";
 import type { PosTerminalSummary } from "../../domain/types";
 
 const MANAGER_REJECTED_SYNC_REVIEW_CODE = "manager_rejected";
 
 type PosTerminalReadCtx = QueryCtx | MutationCtx;
-
-type TerminalSyncReviewEvent = {
-  localEventId: string;
-  localRegisterSessionId: string;
-  sequence: number;
-  eventType: Doc<"posLocalSyncEvent">["eventType"];
-  status: PosLocalSyncEventStatus;
-};
 
 export function mapTerminalRecord(
   terminal: Doc<"posTerminal">,
@@ -140,49 +136,6 @@ function omitUndefined<T extends Record<string, unknown>>(input: T) {
     Object.entries(input).filter((entry) => entry[1] !== undefined),
   ) as T;
 }
-
-export type TerminalSyncEvidence = {
-  latestEvent: {
-    localEventId: string;
-    localRegisterSessionId: string;
-    sequence: number;
-    eventType: Doc<"posLocalSyncEvent">["eventType"];
-    status: PosLocalSyncEventStatus;
-    occurredAt: number;
-    submittedAt: number;
-    acceptedAt?: number;
-    projectedAt?: number;
-  } | null;
-  latestReviewEvent?: TerminalSyncReviewEvent | null;
-  latestReviewEventsByStatus?: {
-    conflicted?: TerminalSyncReviewEvent | null;
-    held?: TerminalSyncReviewEvent | null;
-    rejected?: TerminalSyncReviewEvent | null;
-  };
-  sampledEventCount: number;
-  acceptedCount: number;
-  projectedCount: number;
-  conflictedCount: number;
-  heldCount: number;
-  rejectedCount: number;
-  unresolvedConflictCount?: number;
-  unresolvedConflicts?: Array<{
-    _id: Id<"posLocalSyncConflict">;
-    conflictType: Doc<"posLocalSyncConflict">["conflictType"];
-    createdAt: number;
-    localEventId: string;
-    localRegisterSessionId: string;
-    reviewTarget?: {
-      type: "open_work";
-      workItemId: Id<"operationalWorkItem">;
-      workItemType: "synced_sale_inventory_review";
-    };
-    sequence: number;
-    summary: string;
-  }>;
-  acceptedThroughSequence?: number;
-  cursorUpdatedAt?: number;
-};
 
 const EMPTY_TERMINAL_SYNC_EVIDENCE: TerminalSyncEvidence = {
   latestEvent: null,
@@ -351,6 +304,126 @@ export async function hasActiveRegisterSessionForTerminal(
   );
 }
 
+export async function getLatestRegisterSessionForTerminal(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    registerNumber?: string | null;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+): Promise<Doc<"registerSession"> | null> {
+  const recentByTerminal = await ctx.db
+    .query("registerSession")
+    .withIndex("by_terminalId", (q) => q.eq("terminalId", args.terminalId))
+    .order("desc")
+    .take(25);
+  const terminalSession = recentByTerminal
+    .filter((session) => isScopedRegisterSessionForTerminal(session, args))
+    .sort((left, right) => right.openedAt - left.openedAt)[0];
+  if (terminalSession) {
+    return terminalSession;
+  }
+
+  const registerNumber = args.registerNumber?.trim();
+  if (!registerNumber) {
+    return null;
+  }
+
+  const recentByRegisterNumber = await ctx.db
+    .query("registerSession")
+    .withIndex("by_storeId_registerNumber", (q) =>
+      q.eq("storeId", args.storeId).eq("registerNumber", registerNumber),
+    )
+    .order("desc")
+    .take(25);
+
+  return (
+    recentByRegisterNumber
+      .filter((session) => isScopedRegisterSessionForTerminal(session, args))
+      .sort((left, right) => right.openedAt - left.openedAt)[0] ?? null
+  );
+}
+
+export async function getActiveRegisterSessionForTerminal(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    registerNumber?: string | null;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+): Promise<Doc<"registerSession"> | null> {
+  const recentByTerminal = await ctx.db
+    .query("registerSession")
+    .withIndex("by_terminalId", (q) => q.eq("terminalId", args.terminalId))
+    .order("desc")
+    .take(25);
+  const terminalSession = recentByTerminal
+    .filter((session) => isUsableRegisterSessionForTerminal(session, args))
+    .sort((left, right) => right.openedAt - left.openedAt)[0];
+  if (terminalSession) {
+    return terminalSession;
+  }
+
+  const registerNumber = args.registerNumber?.trim();
+  if (!registerNumber) {
+    return null;
+  }
+
+  const recentByRegisterNumber = await ctx.db
+    .query("registerSession")
+    .withIndex("by_storeId_registerNumber", (q) =>
+      q.eq("storeId", args.storeId).eq("registerNumber", registerNumber),
+    )
+    .order("desc")
+    .take(25);
+
+  return (
+    recentByRegisterNumber
+      .filter((session) => isUsableRegisterSessionForTerminal(session, args))
+      .sort((left, right) => right.openedAt - left.openedAt)[0] ?? null
+  );
+}
+
+export async function getDrawerAuthorityRegisterSession(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    runtimeStatus: Doc<"posTerminalRuntimeStatus"> | null;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+): Promise<Doc<"registerSession"> | null> {
+  const cloudRegisterSessionId =
+    args.runtimeStatus?.drawerAuthority?.cloudRegisterSessionId;
+  if (!cloudRegisterSessionId) {
+    return null;
+  }
+
+  const normalizeId = (
+    ctx.db as unknown as {
+      normalizeId?: (
+        tableName: "registerSession",
+        id: string,
+      ) => Id<"registerSession"> | null;
+    }
+  ).normalizeId;
+  const registerSessionId =
+    normalizeId?.call(ctx.db, "registerSession", cloudRegisterSessionId) ??
+    (cloudRegisterSessionId as Id<"registerSession">);
+  if (!registerSessionId) {
+    return null;
+  }
+
+  const registerSession = await ctx.db.get("registerSession", registerSessionId);
+  if (
+    registerSession?.storeId === args.storeId &&
+    registerSession.terminalId === args.terminalId
+  ) {
+    return registerSession;
+  }
+
+  return null;
+}
+
 function isUsableRegisterSessionForTerminal(
   session: Doc<"registerSession">,
   args: {
@@ -367,6 +440,24 @@ function isUsableRegisterSessionForTerminal(
       !session.registerNumber ||
       session.registerNumber === registerNumber) &&
     isPosUsableRegisterSessionStatus(session.status)
+  );
+}
+
+function isScopedRegisterSessionForTerminal(
+  session: Doc<"registerSession">,
+  args: {
+    registerNumber?: string | null;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+) {
+  const registerNumber = args.registerNumber?.trim();
+  return (
+    session.storeId === args.storeId &&
+    session.terminalId === args.terminalId &&
+    (!registerNumber ||
+      !session.registerNumber ||
+      session.registerNumber === registerNumber)
   );
 }
 

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -187,7 +187,7 @@ function buildTerminalHealthSummaryResult() {
     },
     registerSessionLink: {
       registerSessionId: "register-session-1",
-      status: "closeout_rejected",
+      status: "open",
     },
     syncEvidence: {
       latestEvent: {

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -433,9 +433,6 @@ const terminalHealthSummaryReturnValidator = v.object({
       status: v.union(
         v.literal("open"),
         v.literal("active"),
-        v.literal("closing"),
-        v.literal("closeout_rejected"),
-        v.literal("closed"),
       ),
     }),
     v.null(),

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 16 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, cycleCountDrafts.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 8 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCaseTracing.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 19 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 598 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 605 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 9 file(s); key children: README.md, SUMMARY.md, pos, prod.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -126,6 +126,8 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/pos/application/sessionCommands.test.ts`](../../convex/pos/application/sessionCommands.test.ts)
 - [`convex/pos/application/sync/ingestLocalEvents.test.ts`](../../convex/pos/application/sync/ingestLocalEvents.test.ts)
 - [`convex/pos/application/sync/projectLocalEvents.test.ts`](../../convex/pos/application/sync/projectLocalEvents.test.ts)
+- [`convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts`](../../convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts)
+- [`convex/pos/application/terminalOperationalState/policy.test.ts`](../../convex/pos/application/terminalOperationalState/policy.test.ts)
 - [`convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts`](../../convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts)
 - [`convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.test.ts`](../../convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.test.ts)
 - [`convex/pos/application/terminalRecovery/terminalCommandService.test.ts`](../../convex/pos/application/terminalRecovery/terminalCommandService.test.ts)

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
@@ -439,7 +439,7 @@ export type TerminalHealthSummary = {
   health?: "needs_attention" | "offline" | "online" | "stale" | "unknown" | string;
   registerSessionLink?: {
     registerSessionId: Id<"registerSession"> | string;
-    status: "active" | "open" | string;
+    status: "active" | "open";
   } | null;
   recovery?: TerminalRecoveryPreview | null;
   recoveryPreview?: TerminalRecoveryPreview | null;


### PR DESCRIPTION
## Summary
- Introduces `TerminalOperationalState` as the server-owned read boundary for terminal health, recovery readiness, attention reasons, diagnostics, register evidence, and effective runtime evidence.
- Moves sync evidence DTO ownership to the POS domain layer and keeps repositories fact-oriented while policy owns classification.
- Routes Terminal Health and recovery preview projections through the aggregate, including active/latest register-session semantics and drawer-authority normalization.
- Adds focused policy, fact collector, query/public contract, and legacy terminal health tests; includes the approved plan and solution note.

## Validation
- `bun run pr:athena` passed and recorded proof.
- Final reviewer loop approved unanimously: correctness, architecture, security, testing, and project standards.
