### PR TITLE
fix: stabilize POS drawer sync contract

### DIFF
--- a/docs/plans/2026-06-27-002-fix-pos-sync-contract-plan.html
+++ b/docs/plans/2026-06-27-002-fix-pos-sync-contract-plan.html
@@ -1,0 +1,246 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>fix: Stabilize POS local/cloud sync contract</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fa;
+      --panel: #ffffff;
+      --ink: #18202a;
+      --muted: #617080;
+      --line: #d8dee7;
+      --accent: #235ea9;
+      --risk: #7c3f00;
+    }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 32px 24px 56px;
+    }
+    header, section {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 22px 24px;
+      margin-bottom: 18px;
+    }
+    h1, h2, h3 {
+      line-height: 1.2;
+      margin: 0 0 12px;
+    }
+    h1 { font-size: 28px; }
+    h2 { font-size: 20px; }
+    h3 { font-size: 16px; color: var(--muted); }
+    p { margin: 0 0 12px; }
+    a { color: var(--accent); }
+    .meta {
+      color: var(--muted);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px 18px;
+      margin-top: 12px;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      gap: 12px;
+    }
+    .callout {
+      border-left: 4px solid var(--accent);
+      background: #eef5ff;
+      padding: 12px 14px;
+      border-radius: 6px;
+    }
+    .risk {
+      border-left-color: var(--risk);
+      background: #fff5e8;
+    }
+    ul, ol { margin: 8px 0 0 20px; padding: 0; }
+    li { margin: 5px 0; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 10px;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 8px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: #f1f4f8; }
+    code {
+      background: #eef1f5;
+      border-radius: 4px;
+      padding: 1px 4px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.92em;
+    }
+    .unit {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px 16px;
+      margin-top: 12px;
+    }
+    .unit strong { color: var(--accent); }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>fix: Stabilize POS local/cloud sync contract</h1>
+      <p>Stabilize Athena POS drawer lifecycle and sync settlement in two stacked delivery PRs. PR1 tightens drawer authority, replacement freshness, and local/cloud register identity; PR2 builds on that contract to repair broader sync settlement, cursor, reopen, closeout, and Cash Controls presentation behavior.</p>
+      <div class="meta">
+        <span>Type: fix</span>
+        <span>Status: active</span>
+        <span>Date: 2026-06-27</span>
+        <span>Source: <a href="2026-06-27-002-fix-pos-sync-contract-plan.md">Markdown plan</a></span>
+      </div>
+    </header>
+
+    <section>
+      <h2>Delivery Shape</h2>
+      <div class="grid">
+        <div class="callout">
+          <h3>PR1</h3>
+          <p>Drawer lifecycle authority, replacement freshness, local/cloud drawer identity, duplicate register opens, and closeout readiness.</p>
+        </div>
+        <div class="callout">
+          <h3>PR2</h3>
+          <p>Sync cursor identity, rejected/held/conflicted settlement, reopen policy, closeout failure truthfulness, and Cash Controls presentation.</p>
+        </div>
+        <div class="callout risk">
+          <h3>Execution Constraint</h3>
+          <p>All work happens in delivery worktrees. Root is reserved for final fast-forward alignment after merge.</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Requirements Digest</h2>
+      <ul>
+        <li>Replacement drawers cannot become sale-usable from uploaded <code>needs_review</code> opens.</li>
+        <li>Drawer authority and closeout settlement must compare local and cloud register-session identity consistently.</li>
+        <li>Duplicate <code>register_opened</code> reuse must conflict unless it is a true idempotent retry.</li>
+        <li>POS and expense sync cursors must batch independently and in upload-sequence order.</li>
+        <li><code>projected</code>, <code>conflicted</code>, <code>held</code>, and <code>rejected</code> must remain distinct local settlement states.</li>
+        <li><code>register_reopened</code> is deferred from uploadable local sync until a manager-review replay contract exists; existing uploaded review rows stay visible/rejectable and are not retried into projection.</li>
+        <li>Closeout and Cash Controls copy must present pending/review state truthfully.</li>
+        <li>Manager/runtime repair must be freshness-checked, idempotent, and unable to override current drawer authority.</li>
+        <li>Repair/review authorization must never persist raw PINs or proof tokens; server mutations authorize fresh active same-store manager proof at action time.</li>
+        <li>Old open browsers and queued offline events must remain safe through Convex-first rollout.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Settlement Contract</h2>
+      <table>
+        <thead>
+          <tr><th>Server outcome</th><th>Local row state</th><th>Precursor handling</th><th>Operator label</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>projected</code></td>
+            <td>Synced/uploaded</td>
+            <td>Eligible local-only precursors may settle when the projected parent proves them.</td>
+            <td>Synced</td>
+          </tr>
+          <tr>
+            <td><code>conflicted</code></td>
+            <td>Needs review/uploaded</td>
+            <td>Precursors remain unsettled unless the conflict proves a specific local-only precursor is obsolete.</td>
+            <td>Needs manager review</td>
+          </tr>
+          <tr>
+            <td><code>held</code></td>
+            <td>Pending or held, not synced</td>
+            <td>No precursor settlement.</td>
+            <td>Waiting for earlier POS history</td>
+          </tr>
+          <tr>
+            <td><code>rejected</code></td>
+            <td>Failed or needs review with server reason, not synced</td>
+            <td>No precursor settlement unless explicitly local-settled by a named policy.</td>
+            <td>Sync rejected; review required</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Implementation Units</h2>
+      <div class="unit">
+        <strong>U1. PR1 Shared Drawer Lifecycle Contract</strong>
+        <p>Make shared policy authoritative for sale usability, replacement eligibility, review evidence, and freshness.</p>
+      </div>
+      <div class="unit">
+        <strong>U2. PR1 Browser-Local Authority and Readiness</strong>
+        <p>Normalize local/cloud drawer identity for read model, drawer authority lookup, and local POS readiness.</p>
+      </div>
+      <div class="unit">
+        <strong>U3. PR1 Cloud Projection Freshness and Duplicate Opens</strong>
+        <p>Enforce same lifecycle contract in Convex projection and terminal repair preview.</p>
+      </div>
+      <div class="unit">
+        <strong>U4. PR2 Sync Cursor and Settlement Vocabulary</strong>
+        <p>Separate POS/expense cursors and keep rejected, held, conflicted, and projected outcomes visible. Public sync result changes must be additive and old-client safe for open browsers and queued offline events.</p>
+      </div>
+      <div class="unit">
+        <strong>U5. PR2 Reopen, Closeout, and Cash Controls Truthfulness</strong>
+        <p>Defer <code>register_reopened</code> cloud upload, keep existing uploaded reopen review rows manager-visible/rejectable, enforce fresh same-store manager proof without persisting raw PINs or proof tokens, and make closeout failure presentation and Cash Controls target context truthful.</p>
+        <p>Runtime directives require issued-at, directive id/nonce, max age, terminal/store/register scope, and drawer-authority freshness. Expired, replayed, or stale directives fail before local event append at server issue/claim/ack, public terminal mutation, local terminal recovery execution, sync runtime, and command-gateway boundaries.</p>
+      </div>
+      <div class="unit">
+        <strong>U6. Integration, Tracking, Review, Merge, and Deploy</strong>
+        <p>Track Linear tickets, execute two stacked PRs, run reviewer loops, merge, align root, and deploy Convex then Athena. Include the Markdown and HTML plan artifacts in final delivery.</p>
+        <p>Each worker subagent must leave a handoff artifact in the related Linear issue or PR comment with scope, changed files, tests/sensors run, blockers or assumptions, integrator disposition, and any follow-up owner before the worker is closed.</p>
+      </div>
+    </section>
+
+    <section>
+      <h2>Validation Strategy</h2>
+      <table>
+        <thead>
+          <tr><th>Phase</th><th>Primary sensors</th><th>Deployment surface</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>PR1</td>
+            <td>Shared policy, local register/readiness, drawer authority, projection tests; Graphify rebuild; <code>bun run pr:athena</code></td>
+            <td>Convex and Athena webapp</td>
+          </tr>
+          <tr>
+            <td>PR2</td>
+            <td>Scheduler, runtime, ingest, Cash Controls, register view-model, legacy compatibility tests; Graphify rebuild; <code>bun run pr:athena</code></td>
+            <td>Convex and Athena webapp</td>
+          </tr>
+          <tr>
+            <td>Final</td>
+            <td>Reviewer unanimity, merged PRs, clean root fast-forward, deploy status</td>
+            <td>From clean root: <code>convex-prod</code> then <code>athena-local</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Risks</h2>
+      <ul>
+        <li>PR2 could accidentally redefine drawer authority; mitigate by landing PR1 first and reviewing PR2 against shared policy only.</li>
+        <li>Freshness checks can compare unrelated sequence streams; mitigate with closeout/review boundary evidence and scoped identity tests.</li>
+        <li>Rejected outcomes can disappear as synced; mitigate by replacing current test expectations with visible failed/review semantics.</li>
+        <li>Deploy order can strand clients; mitigate with old-client-safe Convex responses, then deploy Convex before Athena webapp from clean root.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-06-27-002-fix-pos-sync-contract-plan.md
+++ b/docs/plans/2026-06-27-002-fix-pos-sync-contract-plan.md
@@ -1,0 +1,502 @@
+---
+title: "fix: Stabilize POS local/cloud sync contract"
+type: fix
+status: active
+date: 2026-06-27
+---
+
+# fix: Stabilize POS local/cloud sync contract
+
+## Summary
+
+Stabilize Athena POS drawer lifecycle and sync settlement in two stacked delivery PRs. PR1 tightens drawer authority, replacement freshness, and local/cloud register identity; PR2 builds on that contract to repair broader sync settlement, cursor, reopen, closeout, and Cash Controls presentation behavior.
+
+---
+
+## Problem Frame
+
+The current POS register can drift between browser-local event truth and cloud projection truth. The audit found that some lifecycle review rows can be locally treated as usable too early, some authority blocks are keyed under an id the reader does not ask for, and broader sync outcomes can hide rejected or cursor-invalid work as settled. These are money/drawer lifecycle issues, so the implementation must keep cashier continuity without weakening drawer authority or manager review evidence.
+
+---
+
+## Requirements
+
+- R1. Work must happen in delivery worktrees, not on the local root checkout.
+- R2. PR1 must land first and define the drawer lifecycle/authority baseline consumed by PR2.
+- R3. A replacement drawer cannot become sale-usable from a `needs_review` register open; replacement usability requires accepted/projected cloud evidence or an explicitly safe policy path.
+- R4. Drawer authority and closeout settlement must compare local and cloud register-session identities consistently.
+- R5. Duplicate `register_opened` uploads reusing the same local drawer id with a different source event must not silently project as success.
+- R6. Closing/reviewed drawer replacement freshness must use a real closeout/review boundary, not cross-drawer sequence comparison alone.
+- R7. PR2 must keep POS and expense sync cursor identities separate and submit cursor-ordered batches.
+- R8. Server `rejected`, `conflicted`, `held`, and `projected` outcomes must have distinct local settlement semantics.
+- R9. Offline `register_reopened` must have an explicit proof/review policy instead of being uploadable but unprojectable.
+- R10. Zero-variance closeout failures and replacement-drawer Cash Controls links must present truthful pending/review state.
+- R11. Manager review and runtime repair paths must be freshness-checked, idempotent, and unable to override current drawer authority.
+- R12. Final delivery must include focused tests, `bun run pr:athena`, graph rebuild after code changes, merge, local root alignment, and production deploy of relevant Convex and Athena web surfaces.
+- R13. PR2 rollout must remain backward-compatible for already-open browsers and queued offline events until the matching Athena webapp is deployed.
+- R14. Repair/review authorization must never persist raw PINs or proof tokens; server mutations must authorize active same-store manager proof at the point of action.
+
+---
+
+## Scope Boundaries
+
+- This plan does not redesign POS drawer opening, closeout submission, or Cash Controls information architecture beyond the audited contract gaps.
+- This plan does not add Terminal Health auto-repair for business facts such as sales, payments, inventory, or closeouts.
+- This plan does not patch browser IndexedDB directly; all local repair remains event-log or command-gateway based.
+- This plan does not do implementation from the local root checkout.
+- This plan does not require one PR per Linear ticket; the execution strategy is two stacked delivery PRs to control shared generated-artifact and contract churn.
+- Expense-session work is limited to preserving cursor partitioning in the shared POS sync drain; this plan does not broaden expense behavior, approval policy, or expense UI.
+
+### Deferred to Follow-Up Work
+
+- A broader Operations repair UI for missing mapping or inventory review outcomes.
+- A full support dashboard for all POS sync review kinds.
+- New repo sensors if execution discovers a validation parity gap separate from these contract fixes.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts` is the shared lifecycle policy boundary.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts` derives browser-local drawer state and sellability from event log plus drawer authority.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts` gates durable local POS appends.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts` writes and clears local drawer authority state from sync outcomes.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts` drains local events, applies returned mappings/conflicts, and marks local sync state.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts` orders and groups upload batches.
+- `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts` owns server-side batch cursor validation and accepted/held/conflicted/rejected outcomes.
+- `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts` owns cloud projection, register-session creation/reuse, and conflict creation.
+- `packages/athena-webapp/convex/cashControls/closeouts.ts` and `packages/athena-webapp/convex/cashControls/deposits.ts` own manager review, closeout, and deposit surfaces.
+- `packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.ts` keeps sales readiness, support recovery, and diagnostics distinct.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md`: drawer lifecycle decisions belong in a pure shared policy, not duplicated across browser and Convex.
+- `docs/solutions/logic-errors/athena-pos-closeout-review-only-lifecycle-2026-06-25.md`: closeout review state must remain manager-visible without becoming sale-usable drawer state.
+- `docs/solutions/logic-errors/athena-register-closeout-generic-holds-2026-06-26.md`: final closeout/deposit blockers should use generic hold providers rather than one-off branches.
+- `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md`: POS sync is an event-log settlement system; local ids and business facts must be preserved through review.
+- `docs/solutions/architecture/athena-pos-hub-owned-local-sync-drain-2026-05-18.md`: sync drain belongs to the POS hub/runtime, not individual register UI flows.
+- `docs/solutions/logic-errors/athena-pos-register-sync-repair-and-runtime-reconciliation-2026-06-26.md`: runtime repair must append through command-gateway paths and remain evidence-driven.
+- `docs/solutions/architecture/athena-terminal-operational-state-aggregate-2026-06-27.md`: terminal readiness diagnostics should reuse `TerminalOperationalState` concepts.
+- `docs/solutions/harness/pr-athena-prepare-validate-proof-2026-06-13.md`: `bun run pr:athena` is the merge-level proof ladder.
+
+### External References
+
+- None. Existing Athena POS, Convex, Cash Controls, and terminal runtime patterns are the source of truth.
+
+---
+
+## Key Technical Decisions
+
+- **Use two stacked delivery PRs:** PR1 lands drawer lifecycle/authority/freshness first; PR2 is based on PR1 and rebased after PR1 reaches `main`.
+- **Use delivery worktrees throughout:** Planning, PR1, PR2, validation, and deploy staging run from worktrees. Root is used only for final alignment after merge.
+- **Keep PR1 policy-centered:** PR1 may touch local read model, readiness, drawer authority reconciliation, and Convex projection, but only to close lifecycle authority gaps. It must not redefine broader sync settlement.
+- **Make freshness evidence explicit:** PR1 must lock stale/unknown replacement behavior using accepted projection, closeout/review boundary facts, and scoped store/terminal/register identity rather than comparing unrelated drawer sequence streams.
+- **Separate local-safe settlement from cloud projection:** PR2 must name the status vocabulary for `projected`, `conflicted`, `held`, `rejected`, and locally settled precursor rows instead of treating them all as synced.
+- **Keep manager and runtime repairs freshness-checked:** Repair-capable paths use exact source ids and precondition evidence; stale directives or stale manager decisions fail without side effects.
+- **Deploy from clean root after merge:** Feature implementation and validation use delivery worktrees, but production deploy runs only after root `main` is clean and fast-forwarded to merged `origin/main`.
+- **Use a compatibility-safe deploy order:** Because both PRs affect Convex behavior and browser runtime/UI, final deploy should run `convex-prod` before `athena-local` only after PR2 proves old-client-safe Convex responses. If implementation cannot prove that compatibility, PR2 must ship a tolerant browser-handling slice before enabling new server settlement semantics.
+- **Defer `register_reopened` cloud upload:** PR2 should remove/defer `register_reopened` from uploadable local sync until a dedicated manager-review replay contract exists. Existing uploaded review rows remain manager-visible/rejectable but are not retried into projection in this work.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Do the PRs depend on each other?** Yes. PR2 should be stacked on PR1 and rebased after PR1 lands.
+- **Should implementation happen on local root?** No. Delivery worktrees are required.
+- **Should PR2 redefine drawer authority if settlement changes require it?** No. PR2 consumes PR1's shared lifecycle policy.
+- **Should external research be used?** No. The relevant contracts are repo-local POS/Convex/Cash Controls contracts.
+
+### Deferred to Implementation
+
+- The exact field list for manager-review freshness hashes should be finalized while touching the Cash Controls mutation/read model, but it must cover conflict ids/statuses, source event statuses, target register status, mapping state, closeout hold state, Daily Close status, target validation facts, actor proof metadata, and policy version.
+- Whether `clearSettledRecoverableDrawerAuthorityBlock` remains under readiness observation or moves to reconciliation-only code depends on the cleanest testable boundary.
+- Exact operator copy should follow `docs/product-copy-tone.md`.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  U1["U1 PR1: lifecycle policy tests"] --> U2["U2 PR1: local authority/readiness"]
+  U1 --> U3["U3 PR1: cloud projection freshness"]
+  U2 --> U4["U4 PR2: settlement vocabulary/cursors"]
+  U3 --> U4
+  U4 --> U5["U5 PR2: reopen/closeout/Cash Controls"]
+  U5 --> U6["U6 integration: validation, merge, deploy"]
+```
+
+The contract should keep these layers distinct:
+
+| Layer | Owns | Must not own |
+| --- | --- | --- |
+| Shared lifecycle policy | Drawer status, authority, replacement eligibility, freshness decisions over plain facts | Repository reads, React state, Convex table access |
+| Browser local POS | Event-log projection, command-gateway acceptance, drawer authority reads | Cloud projection truth, manager review finality |
+| Convex sync | Upload cursor validation, idempotent projection, conflict creation | Browser readiness UI, local IndexedDB repair |
+| Cash Controls | Manager review, closeout/deposit holds, repair approvals | Terminal Health auto-repair for business facts |
+| Terminal operational state | Diagnostics, support readiness, runtime evidence | Sale authority by itself |
+
+Server sync outcomes must map to local state deliberately:
+
+| Server outcome | Local row state | Precursor handling | Operator-facing label |
+| --- | --- | --- | --- |
+| `projected` | Synced/uploaded | Eligible local-only precursors may settle when the projected parent proves them | Synced |
+| `conflicted` | Needs review/uploaded | Precursors remain unsettled unless the conflict proves a specific local-only precursor is obsolete | Needs manager review |
+| `held` | Pending or held, not synced | No precursor settlement | Waiting for earlier POS history |
+| `rejected` | Failed or needs review with server reason, not synced | No precursor settlement unless explicitly local-settled by a named policy | Sync rejected; review required |
+
+---
+
+## Implementation Units
+
+- U1. **PR1 Shared Drawer Lifecycle Contract**
+
+**Goal:** Make shared drawer lifecycle policy the authoritative contract for sale usability, replacement eligibility, non-blocking lifecycle review, and freshness.
+
+**Requirements:** R2, R3, R4, R6, R11
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts`
+- Modify: `packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts`
+- Modify: `packages/athena-webapp/shared/registerSessionStatus.ts` only if current status helpers need reuse
+
+**Approach:**
+- Add or tighten helpers that separate sale attachment from opening a replacement drawer.
+- Require scoped store/terminal/register identity and real freshness facts for replacement decisions.
+- Treat `needs_review` lifecycle rows as review evidence, not accepted replacement proof.
+- Preserve the existing shared-module rule: pure inputs only, no Convex or browser adapter imports.
+
+**Execution note:** Test-first. Add failing policy cases before changing callers.
+
+**Patterns to follow:**
+- `packages/athena-webapp/shared/registerSessionStatus.ts`
+- `docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md`
+
+**Test scenarios:**
+- Happy path: synced/projected replacement open in same store/terminal can supersede an old reviewed/closed drawer when freshness evidence is newer.
+- Edge case: uploaded `needs_review` replacement open does not make the replacement drawer sale-usable.
+- Edge case: `closing` remains lifecycle-visible and not sale-usable.
+- Edge case: foreign store, foreign terminal, wrong register, or unknown freshness fails closed.
+- Error path: stale replacement evidence older than the closeout/review boundary does not clear authority.
+
+**Verification:**
+- Shared policy tests prove the authority matrix before PR1 integration code depends on it.
+
+---
+
+- U2. **PR1 Browser-Local Authority and Readiness**
+
+**Goal:** Make local register projection, drawer authority lookup, and store-day readiness use consistent local/cloud drawer identity.
+
+**Requirements:** R3, R4, R11
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/localRegisterReader.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts` for authority-clear behavior if needed
+
+**Approach:**
+- Read drawer authority by canonical local id and mapped cloud id, or normalize persisted authority to canonical local id while preserving cloud evidence.
+- Ensure cloud-id closeout events settle local readiness when the register mapping proves the same drawer.
+- Keep readiness as store-day entry readiness; drawer authority remains in the register read model and reconciliation boundaries.
+- Make `runtimeReadiness`/authority-clear side effects explicit with tests if touched.
+
+**Execution note:** Characterization-first where existing behavior is ambiguous, then intended-behavior tests.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts`
+- `docs/solutions/logic-errors/athena-pos-synced-closeout-readiness-2026-06-17.md`
+
+**Test scenarios:**
+- Happy path: synced closeout recorded under mapped cloud register id releases local closeout readiness.
+- Edge case: authority block persisted under cloud id is still observed when local reader asks for the active local drawer.
+- Edge case: stale `cloud_closed` authority for an old drawer does not block a distinct projected replacement drawer.
+- Error path: current drawer remains blocked when authority belongs to the active mapped drawer.
+- Integration: `readProjectedLocalRegisterModel` returns the same sale-blocking answer when authority is stored under local id or cloud id.
+
+**Verification:**
+- Local register/readiness tests prove local and cloud drawer identity do not diverge at sale-blocking boundaries.
+
+---
+
+- U3. **PR1 Cloud Projection Freshness and Duplicate Opens**
+
+**Goal:** Make Convex projection enforce the same lifecycle contract for duplicate register opens, direct cloud ids, and closing/reviewed replacement drawers.
+
+**Requirements:** R5, R6, R11
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/queries/terminals.ts` only if repair preview must expose new freshness reasons
+
+**Approach:**
+- Existing register-session mappings for `register_opened` are idempotent only when the source event is the same retry or otherwise explicitly allowed; different source event reuse conflicts.
+- Closing/reviewed replacement projection must prove the replacement happened after the closeout/review boundary.
+- Direct cloud register ids take the same sale-usability and closeout-review checks as mapped local ids.
+- Terminal cloud repair remains narrow: duplicate stale register-open repair only, never business facts.
+
+**Execution note:** Test-first at projection boundary because this is the authoritative guard against stale clients.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- `packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts`
+
+**Test scenarios:**
+- Happy path: legitimate later replacement drawer opens against a closing/reviewed previous drawer and creates a new cloud register session.
+- Edge case: older/orphaned replacement open before closeout/review conflicts.
+- Edge case: duplicate `register_opened` same local drawer id but different local event id conflicts instead of silently projecting.
+- Edge case: direct cloud id closeout/review bypass cannot attach sales to a reviewed drawer.
+- Integration: terminal repair run twice settles one safe duplicate-open conflict and does not resurrect older conflicts.
+
+**Verification:**
+- Projection tests prove PR1 authority invariants hold on the cloud boundary.
+
+---
+
+- U4. **PR2 Sync Cursor and Settlement Vocabulary**
+
+**Goal:** Make local upload batching and server outcomes preserve cursor identity and operator-visible settlement semantics.
+
+**Requirements:** R7, R8, R11, R13
+
+**Dependencies:** U1, U2, U3 implemented in the PR1 base. PR2 work may start on a stacked worktree while PR1 is in review, but PR2 cannot merge until PR1 has landed on `main` and PR2 has been rebased onto that merged base.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.test.ts`
+- Modify: `packages/athena-webapp/convex/schemas/pos/posLocalSyncCursor.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/types.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/sync.ts` only if public result typing changes
+
+**Approach:**
+- Carry an explicit upload cursor identity for POS register sessions and expense sessions rather than grouping expenses under an empty register id.
+- Include cursor schema/index shape, repository interface changes, public validator/result shape, local pending-event identity shape, and migration/backward compatibility for existing cursor rows.
+- Preserve old-client-safe public result fields while adding any new cursor-scope fields additively.
+- Sort and select batches by cursor and upload sequence so later upload sequences cannot starve earlier ones.
+- Split local handling of `projected`, `conflicted`, `held`, and `rejected`; rejected rows must remain visible as failed/reviewable rather than silently synced.
+- Preserve local-only precursor settlement only when the parent outcome actually projected or is intentionally local-settled.
+
+**Execution note:** Test-first for scheduler and runtime settlement helpers.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts`
+- `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`
+
+**Test scenarios:**
+- Happy path: two expense events with different local expense session ids produce separate ingest calls.
+- Edge case: inverted `createdAt` with upload sequences 2 then 1 uploads sequence 1 first.
+- Edge case: server `rejected` outcome marks the local row failed/reviewable and does not mark embedded local-only precursors synced.
+- Edge case: held out-of-order rows do not loop forever ahead of a missing earlier sequence.
+- Integration: status presentation distinguishes projected, conflicted, held, and rejected rows according to the outcome mapping table.
+- Integration: legacy browser fixtures continue to receive old-client-safe sync result fields during Convex-first deploy.
+
+**Verification:**
+- Runtime and ingest tests prove cursor and settlement vocabulary is explicit across local and cloud boundaries.
+
+---
+
+- U5. **PR2 Reopen, Closeout, and Cash Controls Truthfulness**
+
+**Goal:** Make review/reopen/closeout presentation and repair-capable flows truthful after PR2 settlement semantics are explicit.
+
+**Requirements:** R8, R9, R10, R11, R13, R14
+
+**Dependencies:** U4
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.test.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.test.ts`
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx` only if Cash Controls UI needs surfaced target/action changes
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+
+**Approach:**
+- Remove/defer `register_reopened` from uploadable local sync until a dedicated manager-review replay contract exists. Local reopen behavior remains local-first review evidence, and existing uploaded review rows stay manager-visible/rejectable rather than retrying projection.
+- Require fresh active same-store manager proof for repair/review mutations. Never persist raw PINs or proof tokens; persist only server-issued proof metadata such as actor, store, role, auth method, issued time, policy version, precondition hash, and one-time use status.
+- Runtime directives must include issued-at, directive id/nonce, max age, terminal/store/register scope, and drawer-authority epoch or equivalent freshness evidence. Expired, replayed, or stale directives fail without local event append.
+- Enforce directive replay protection at every mutation boundary: server issue/claim/ack in `terminalCommandService`, public terminal command mutations, local terminal recovery command execution, sync runtime claim/ack handling, and local command-gateway append acceptance.
+- Treat zero-variance closeout cloud failure as “saved locally / pending sync or review,” not completed final closure.
+- Include `closeout_rejected` in any legacy closeout snapshot still consumed, or remove/deprecate the legacy path if no active consumer remains.
+- Carry closeout-specific Cash Controls target context through replacement-drawer mode.
+- Require freshness/precondition evidence for repair-capable manager actions and stale runtime directives; stale actions fail without side effects.
+
+**Execution note:** Characterization-first for current UI/read-model behavior, then intended-behavior tests.
+
+**Patterns to follow:**
+- `docs/product-copy-tone.md`
+- `packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts`
+- `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+
+**Test scenarios:**
+- Happy path: zero-variance direct cloud closeout success marks local event uploaded/synced and shows completed state.
+- Error path: zero-variance cloud closeout non-ok keeps pending local state visible and does not show completed closeout copy.
+- Edge case: rejected closeout appears in legacy and dashboard closeout snapshots as pending manager work.
+- Edge case: replacement drawer initial setup still carries the prior closeout Cash Controls target when prior drawer needs review.
+- Error path: `register_reopened` is not selected for upload and existing uploaded reopen review rows cannot silently retry projection.
+- Error path: stale manager-review freshness hash, expired runtime directive, replayed directive nonce, or missing same-store manager authorization fails without side effects.
+- Integration: mixed review rows do not show unsafe global repair; stale freshness/precondition failures show refresh-oriented copy.
+
+**Verification:**
+- Cash Controls and register view-model tests prove operator-visible state matches cloud/local settlement truth.
+
+---
+
+- U6. **Integration, Tracking, Review, Merge, and Deploy**
+
+**Goal:** Deliver the two stacked PRs through Linear, reviewer loops, merge, local root alignment, and production deploy.
+
+**Requirements:** R1, R2, R12
+
+**Dependencies:** U1, U2, U3, U4, U5
+
+**Files:**
+- Modify: `graphify-out/GRAPH_REPORT.md`
+- Modify: `graphify-out/graph.json`
+- Modify: `graphify-out/wiki/index.md`
+- Create or update: `docs/solutions/logic-errors/<new-learning>.md` only if execution reveals a durable new pattern
+
+**Approach:**
+- Track U1-U5 into atomic Linear tickets under project `athena` / team `yaegars`.
+- Include these plan artifacts in final delivery: `docs/plans/2026-06-27-002-fix-pos-sync-contract-plan.md` and `docs/plans/2026-06-27-002-fix-pos-sync-contract-plan.html`.
+- Execute PR1 from `.worktrees/codex/pos-sync-contract-pr1`.
+- Execute PR2 from a delivery worktree branched from PR1 after PR1 is review-ready; rebase PR2 onto `origin/main` after PR1 lands. PR2 may be developed stacked, but it may not merge before PR1.
+- Use worker subagents with explicit ownership: PR1 policy/projection worker, PR1 local authority worker, PR2 cursor/settlement worker, and PR2 Cash Controls/reopen/closeout worker. The main integrator owns branch integration, reviewer loops, validation, and final merge/deploy.
+- Record a worker handoff artifact for each worker before closing it. The artifact can live in the associated Linear issue comment or PR comment and must include worker scope, changed files, tests/sensors run, blockers or assumptions, integrator disposition, and follow-up owner if any issue remains.
+- Close each worker subagent after reviewing its changed files, integrating or rejecting its diff, and recording any blocker in Linear.
+- Keep generated Graphify changes in the relevant PR after code changes, not root.
+- Run relevant reviewer subagents until unanimous approval before merge.
+- Use `bun run github:pr-merge -- <pr> --method squash --delete-branch` or auto-merge helper per repo policy.
+- Final delivery is complete only after both PRs actually merge, local root `main` is fast-forwarded to `origin/main`, root is clean, and production deploy completes. Armed auto-merge is an interim state, not final delivery.
+- Deploy from clean fast-forwarded root `main`, not a feature worktree. Use `convex-prod` then `athena-local` unless the final merged diff proves a narrower deploy surface.
+
+**Execution note:** Sensor-heavy. No behavior changes here beyond generated/docs/deploy artifacts.
+
+**Patterns to follow:**
+- `.agents/skills/track/SKILL.md`
+- `.agents/skills/execute/SKILL.md`
+- `docs/solutions/harness/pr-athena-prepare-validate-proof-2026-06-13.md`
+
+**Test scenarios:**
+- Test expectation: none for ticket/deploy orchestration itself; behavior is proven by U1-U5 tests and PR/deploy sensors.
+
+**Verification:**
+- Linear tickets exist with dependencies, PR links, validation evidence, and final comments.
+- Both PRs are merged or auto-merge is armed only after local gates and reviewer unanimity.
+- Interim readiness can report auto-merge armed, but final acceptance requires both PRs actually merged.
+- Root checkout is clean, on `main`, and reflects merged `origin/main`.
+- Production deploy reports completed `convex-prod` and `athena-local` versions from clean root.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Local POS event projection, sync runtime, Convex ingest/projection, Cash Controls, terminal operational state, and deploy scripts are all affected.
+- **Error propagation:** Sync errors must stay visible as pending/review/held/rejected states instead of being collapsed into `synced`.
+- **State lifecycle risks:** Stale replacement opens, duplicate register opens, stale manager review hashes, and stale runtime directives can otherwise mutate money/drawer state out of order.
+- **API surface parity:** Any public Convex validator/result changes must be kept in sync with browser callers and generated API references when needed.
+- **Integration coverage:** Unit tests alone are not enough; PR gates must include focused cross-layer tests plus `bun run pr:athena`.
+- **Unchanged invariants:** Cashier actions remain local-first; Terminal Health does not auto-repair business facts; Cash Controls remains the manager review surface.
+
+---
+
+## Risk Analysis & Mitigation
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| PR2 accidentally weakens drawer authority | Medium | High | Land PR1 first, make PR2 consume shared policy, and review PR2 specifically for authority redefinition. |
+| Freshness checks use incomparable sequence streams | High | High | Require real closeout/review boundary evidence and scoped identity; test stale and legitimate replacement pairs. |
+| Rejected sync outcomes disappear from operator view | High | High | Split settlement vocabulary and update tests that currently assert rejected rows settle as synced. |
+| Delivery work leaks into root checkout | Medium | Medium | Use worktrees for plan, PR1, PR2, generated artifacts, validation, and deploy staging; reserve root for final fast-forward. |
+| Convex/browser deploy order creates compatibility gap | Medium | High | Deploy Convex first, then Athena webapp; include compatibility notes in PR2 rollout. |
+| Reviewer loop misses cross-boundary regression | Medium | High | Use correctness, testing, architecture, data-integrity, and project-standards reviewers until unanimous approval. |
+
+---
+
+## Phased Delivery
+
+### Phase 1: PR1 Drawer Lifecycle Contract
+
+- Land U1-U3 in a dedicated delivery worktree.
+- Validate focused shared policy, local register/readiness, drawer authority, projection, and terminal repair tests.
+- Run `bun run graphify:rebuild` and `bun run pr:athena` before merge.
+
+### Phase 2: PR2 Sync Settlement Runtime Contract
+
+- Branch from PR1 while PR1 is in review if useful for parallelism; do not merge before PR1 lands. Rebase after PR1 lands.
+- Land U4-U5 without redefining PR1 authority semantics.
+- Validate focused scheduler/runtime/ingest/Cash Controls/register UI tests.
+- Validate legacy browser and queued offline-event compatibility before Convex-first deploy.
+- Run `bun run graphify:rebuild` and `bun run pr:athena` before merge.
+
+### Phase 3: Alignment and Deploy
+
+- Fast-forward root `main` after both PRs land.
+- Deploy from clean root `main`: `convex-prod`, then `athena-local`, unless final diff proves a narrower surface.
+- Report deployed versions and final Linear/PR state.
+
+---
+
+## Documentation / Operational Notes
+
+- Track the plan into Linear before implementation. Use one issue per feature-bearing unit unless implementation and validation are inseparable.
+- Mark the tickets as a coordinated two-PR batch because Graphify and POS sync surfaces are shared.
+- If execution yields a new durable invariant, add a focused `docs/solutions/` entry in the relevant PR.
+- Browser validation is user-owned unless the user later asks for browser checks; repo gates and production deploy still remain in scope.
+
+---
+
+## Sources & References
+
+- Related plan: `docs/plans/2026-06-23-001-refactor-pos-register-lifecycle-policy-plan.md`
+- Related plan: `docs/plans/2026-06-26-001-register-sync-mapping-repair-plan.md`
+- Related solution: `docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md`
+- Related solution: `docs/solutions/logic-errors/athena-pos-closeout-replacement-self-heal-2026-06-25.md`
+- Related solution: `docs/solutions/logic-errors/athena-pos-register-sync-repair-and-runtime-reconciliation-2026-06-26.md`
+- Related solution: `docs/solutions/harness/pr-athena-prepare-validate-proof-2026-06-13.md`
+- Repo guidance: `AGENTS.md`

--- a/docs/solutions/logic-errors/athena-pos-drawer-sync-contract-2026-06-27.md
+++ b/docs/solutions/logic-errors/athena-pos-drawer-sync-contract-2026-06-27.md
@@ -1,0 +1,67 @@
+---
+title: Athena POS Drawer Sync Contract
+date: 2026-06-27
+category: logic-errors
+module: athena-webapp
+problem_type: logic_error
+component: pos-register-sync
+symptoms:
+  - "POS could loop the open-drawer gate after the cloud drawer was active"
+  - "Replacement drawers could be blocked by a prior closeout variance review"
+  - "Cash Controls and POS could disagree about local versus cloud register identity"
+root_cause: drawer_lifecycle_rules_were_split_across_local_readiness_cloud_projection_and_repair_paths
+resolution_type: code_fix
+severity: high
+tags:
+  - pos
+  - register-session
+  - local-sync
+  - cash-controls
+  - drawer-authority
+---
+
+# Athena POS Drawer Sync Contract
+
+## Problem
+
+The drawer lifecycle contract was spread across local readiness, local read
+models, cloud projection, repair preview, and Cash Controls. Each boundary used
+slightly different evidence for the same decision: whether a drawer can sell,
+whether a prior drawer can be superseded, and whether a conflicted local open is
+safe to repair.
+
+That split allowed regressions where a replacement drawer opened locally but did
+not become a usable cloud drawer. POS could keep showing the open-drawer gate or
+label the drawer by a local id while Cash Controls had no matching cloud drawer.
+
+## Solution
+
+Keep drawer lifecycle decisions behind a shared policy and pass explicit facts
+into it:
+
+- Sale-blocking drawer authority must match the active drawer identity. Authority
+  for a superseded local or cloud drawer is review evidence, not a sale blocker.
+- Replacement opens must prove same store and terminal scope, a distinct drawer
+  identity, and freshness against the closeout or review boundary. Unknown
+  freshness fails closed unless the caller opts into a legacy compatibility path.
+- Direct local ids that are already valid cloud register-session ids may only be
+  reused when they are the same sale-usable drawer and have no open closeout
+  review.
+- Repair-created mappings need a source-event marker so projection can avoid
+  mistaking repair idempotency for a conflicting client replay.
+- Clearing drawer-authority state should delete the exact local drawer state
+  being settled while read paths may still resolve local and cloud aliases.
+
+## Prevention
+
+- Add shared-policy tests before changing drawer lifecycle behavior.
+- Cover local read model, readiness, cloud projection, repair preview, and repair
+  mutation with the same local/cloud identity cases.
+- Fixture closeout variance conflicts with `closeoutOccurredAt` when testing a
+  replacement open after review; otherwise the repair path falls back to conflict
+  creation time and correctly treats unknown ordering as unsafe.
+- Keep Cash Controls labels honest: show cloud register targets where they exist
+  and local ids only as local-session diagnostics.
+- When source-event provenance is added to sync mappings, preserve compatibility
+  for legacy rows that lack the field so existing repair mappings are not
+  stranded.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8083 nodes · 9510 edges · 2063 communities detected
+- 8093 nodes · 9525 edges · 2063 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2078,7 +2078,7 @@
 1. `createJourneyEvent()` - 40 edges
 2. `buildDailyCloseSnapshotWithCtx()` - 33 edges
 3. `collectConvexQueryWriteBoundaryFindings()` - 28 edges
-4. `projectLocalRegisterReadModel()` - 26 edges
+4. `projectLocalRegisterReadModel()` - 27 edges
 5. `buildDailyOpeningSnapshotWithCtx()` - 18 edges
 6. `buildDailyOperationsSnapshotWithCtx()` - 17 edges
 7. `submitTerminalRuntimeStatus()` - 17 edges
@@ -2113,12 +2113,12 @@ Cohesion: 0.05
 Nodes (70): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildApprovalRequestsById(), buildDailyCloseApprovalSubject() (+62 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.07
-Nodes (60): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildRegisterCloseoutTimelineMessage(), buildWeekMetricForDate(), buildWeekMetrics() (+52 more)
+Cohesion: 0.09
+Nodes (61): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), capNonCashPaymentsToExpectedTotal(), collectExistingSaleMappings() (+53 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.09
-Nodes (60): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), capNonCashPaymentsToExpectedTotal(), collectExistingSaleMappings() (+52 more)
+Cohesion: 0.07
+Nodes (60): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildRegisterCloseoutTimelineMessage(), buildWeekMetricForDate(), buildWeekMetrics() (+52 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.09
@@ -2129,16 +2129,16 @@ Cohesion: 0.08
 Nodes (46): buildRecoveryBlockers(), buildRecoveryBlockersFromPreview(), buildRecoveryReadiness(), buildTerminalAppUpdatePresentation(), buildTerminalRecoveryPresentation(), buildUpdateAppAction(), classifyTerminalHealth(), defaultBlockerSummary() (+38 more)
 
 ### Community 7 - "Community 7"
+Cohesion: 0.06
+Nodes (26): asRecord(), createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), getExpenseLocalSessionId(), getUploadSequenceScopeId(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeLocalEventPayload() (+18 more)
+
+### Community 8 - "Community 8"
 Cohesion: 0.09
 Nodes (48): buildFinalTrustedQuantitiesByRowNumber(), buildProductPageFinalizationMetadata(), buildProductPageFinalizationPayloadHash(), buildProvisionalSkuPatch(), buildSaleEvidenceFingerprint(), buildSkuInsert(), buildSkuPatch(), buildTrustedSkuFingerprint() (+40 more)
 
-### Community 8 - "Community 8"
-Cohesion: 0.06
-Nodes (27): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatCompactTextList(), formatPaymentMethods(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp() (+19 more)
-
 ### Community 9 - "Community 9"
 Cohesion: 0.06
-Nodes (26): asRecord(), createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), getExpenseLocalSessionId(), getUploadSequenceScopeId(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeLocalEventPayload() (+18 more)
+Nodes (27): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatCompactTextList(), formatPaymentMethods(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp() (+19 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.06
@@ -2165,16 +2165,16 @@ Cohesion: 0.08
 Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
 
 ### Community 16 - "Community 16"
+Cohesion: 0.14
+Nodes (35): asRecord(), canUploadedRegisterOpenReplaceBlockedDrawer(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta() (+27 more)
+
+### Community 17 - "Community 17"
 Cohesion: 0.11
 Nodes (33): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+25 more)
 
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
 Cohesion: 0.12
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
-
-### Community 18 - "Community 18"
-Cohesion: 0.14
-Nodes (34): asRecord(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale() (+26 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.16
@@ -2509,120 +2509,120 @@ Cohesion: 0.28
 Nodes (14): buildActorRefs(), buildReturnExchangeTraceEvent(), buildReturnExchangeTraceRecord(), buildTraceEvent(), buildTraceRecord(), compactDetails(), recordOnlineOrderReturnExchangeTraceBestEffort(), recordOnlineOrderTraceBestEffort() (+6 more)
 
 ### Community 102 - "Community 102"
+Cohesion: 0.2
+Nodes (9): canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), drawerAuthorityMatchesActiveRegisterSession(), getSaleBlockingDrawerAuthority(), isDrawerAuthoritySaleBlocking(), isRegisterSessionConflictBlocking(), isRegisterSessionReplacementBlocking(), isRegisterSessionSaleUsable() (+1 more)
+
+### Community 103 - "Community 103"
 Cohesion: 0.17
 Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.18
 Nodes (7): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.22
 Nodes (10): extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), normalizeIdentifier(), parseCatalogSearchInput(), searchByText(), searchRegisterCatalog() (+2 more)
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
+Cohesion: 0.22
+Nodes (10): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), canProjectRegisterOpenForTerminalCloudRepair(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), getRepairOpenRegisterCloseoutReviewState(), getRepairRegisterSessionCloseoutBoundaryAt(), isDuplicateRegisterOpenConflict() (+2 more)
+
+### Community 108 - "Community 108"
 Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
-### Community 107 - "Community 107"
-Cohesion: 0.21
-Nodes (8): canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), getSaleBlockingDrawerAuthority(), isDrawerAuthoritySaleBlocking(), isRegisterSessionConflictBlocking(), isRegisterSessionReplacementBlocking(), isRegisterSessionSaleUsable(), isScopedRegisterSession()
-
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.14
 Nodes (0):
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.16
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.26
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.22
 Nodes (6): buildParticipantIdentity(), getDataPublishRouting(), getParticipantRole(), isAllowedSender(), LiveKitRemoteAssistClient, parseParticipantRole()
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.26
 Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.22
 Nodes (6): buildTrustedInventoryFinalizationPayload(), buildTrustedInventoryMoneyPayload(), getTrustedInventoryReviewValidationMessage(), isNonNegativeInteger(), parseVariantDisplayMoney(), resolveTrustedInventoryReviewState()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.17
 Nodes (2): getNextTransactionPageSearch(), getNextTransactionTimeFilterSearch()
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.29
 Nodes (10): applyTheme(), emitThemeChange(), getStorage(), getStoredThemeMode(), getSystemTheme(), getThemeSnapshot(), initializeAthenaTheme(), isThemeMode() (+2 more)
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.2
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
-
-### Community 130 - "Community 130"
-Cohesion: 0.26
-Nodes (9): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), canProjectRegisterOpenForTerminalCloudRepair(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), getRepairOpenRegisterCloseoutReviewState(), isDuplicateRegisterOpenConflict(), normalizeRepairString() (+1 more)
 
 ### Community 131 - "Community 131"
 Cohesion: 0.2
@@ -2773,24 +2773,24 @@ Cohesion: 0.27
 Nodes (5): clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), runProcess(), writePrAthenaProviderEvidence()
 
 ### Community 168 - "Community 168"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 169 - "Community 169"
 Cohesion: 0.25
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 170 - "Community 170"
+### Community 169 - "Community 169"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 171 - "Community 171"
+### Community 170 - "Community 170"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 172 - "Community 172"
+### Community 171 - "Community 171"
 Cohesion: 0.22
 Nodes (0):
+
+### Community 172 - "Community 172"
+Cohesion: 0.39
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 173 - "Community 173"
 Cohesion: 0.39
@@ -2841,28 +2841,28 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 185 - "Community 185"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
-### Community 186 - "Community 186"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
-### Community 187 - "Community 187"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 188 - "Community 188"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 189 - "Community 189"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 190 - "Community 190"
+### Community 186 - "Community 186"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
+
+### Community 187 - "Community 187"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
+### Community 188 - "Community 188"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 189 - "Community 189"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+
+### Community 190 - "Community 190"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 191 - "Community 191"
 Cohesion: 0.22
@@ -2913,116 +2913,116 @@ Cohesion: 0.25
 Nodes (0):
 
 ### Community 203 - "Community 203"
-Cohesion: 0.36
-Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 204 - "Community 204"
 Cohesion: 0.36
-Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
 
 ### Community 205 - "Community 205"
+Cohesion: 0.36
+Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+
+### Community 206 - "Community 206"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.29
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 209 - "Community 209"
+### Community 210 - "Community 210"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.29
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 213 - "Community 213"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 214 - "Community 214"
 Cohesion: 0.39
-Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 215 - "Community 215"
+Cohesion: 0.39
+Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+
+### Community 216 - "Community 216"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 216 - "Community 216"
+### Community 217 - "Community 217"
 Cohesion: 0.29
 Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.38
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 230 - "Community 230"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 231 - "Community 231"
 Cohesion: 0.29
@@ -3905,24 +3905,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 451 - "Community 451"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 452 - "Community 452"
 Cohesion: 0.67
 Nodes (2): buildCtx(), buildQueryCtx()
 
-### Community 452 - "Community 452"
+### Community 453 - "Community 453"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 453 - "Community 453"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
 
 ### Community 454 - "Community 454"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 455 - "Community 455"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 456 - "Community 456"
 Cohesion: 0.5
@@ -3937,36 +3937,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 459 - "Community 459"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 460 - "Community 460"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 460 - "Community 460"
+### Community 461 - "Community 461"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 461 - "Community 461"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 462 - "Community 462"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 463 - "Community 463"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 464 - "Community 464"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 465 - "Community 465"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 466 - "Community 466"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 467 - "Community 467"
 Cohesion: 0.5
@@ -3977,32 +3977,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 469 - "Community 469"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 470 - "Community 470"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 470 - "Community 470"
+### Community 471 - "Community 471"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 471 - "Community 471"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 472 - "Community 472"
 Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 473 - "Community 473"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 474 - "Community 474"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 475 - "Community 475"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 476 - "Community 476"
 Cohesion: 0.5
@@ -4033,12 +4033,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 483 - "Community 483"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
-
-### Community 484 - "Community 484"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 484 - "Community 484"
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 485 - "Community 485"
 Cohesion: 0.5
@@ -4049,12 +4049,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 487 - "Community 487"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 488 - "Community 488"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 488 - "Community 488"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 489 - "Community 489"
 Cohesion: 0.5
@@ -4065,124 +4065,124 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 491 - "Community 491"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 492 - "Community 492"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 492 - "Community 492"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 493 - "Community 493"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 494 - "Community 494"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 495 - "Community 495"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 496 - "Community 496"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 497 - "Community 497"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 498 - "Community 498"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 498 - "Community 498"
+### Community 499 - "Community 499"
 Cohesion: 0.67
 Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
-### Community 499 - "Community 499"
+### Community 500 - "Community 500"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 500 - "Community 500"
+### Community 501 - "Community 501"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 501 - "Community 501"
+### Community 502 - "Community 502"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 502 - "Community 502"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 503 - "Community 503"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 504 - "Community 504"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 505 - "Community 505"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 506 - "Community 506"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 507 - "Community 507"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 507 - "Community 507"
+### Community 508 - "Community 508"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 508 - "Community 508"
+### Community 509 - "Community 509"
 Cohesion: 0.83
 Nodes (3): completedEvent(), event(), item()
 
-### Community 509 - "Community 509"
+### Community 510 - "Community 510"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 510 - "Community 510"
+### Community 511 - "Community 511"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 511 - "Community 511"
+### Community 512 - "Community 512"
 Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
-### Community 512 - "Community 512"
+### Community 513 - "Community 513"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
-
-### Community 513 - "Community 513"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 514 - "Community 514"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 515 - "Community 515"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 516 - "Community 516"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 516 - "Community 516"
+### Community 517 - "Community 517"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 517 - "Community 517"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 518 - "Community 518"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 519 - "Community 519"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 520 - "Community 520"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 521 - "Community 521"
 Cohesion: 0.5
@@ -4213,63 +4213,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 528 - "Community 528"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 529 - "Community 529"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 530 - "Community 530"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 531 - "Community 531"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 531 - "Community 531"
+### Community 532 - "Community 532"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 532 - "Community 532"
+### Community 533 - "Community 533"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 533 - "Community 533"
+### Community 534 - "Community 534"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 534 - "Community 534"
+### Community 535 - "Community 535"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 535 - "Community 535"
+### Community 536 - "Community 536"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 536 - "Community 536"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 537 - "Community 537"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 538 - "Community 538"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 539 - "Community 539"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 539 - "Community 539"
+### Community 540 - "Community 540"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 540 - "Community 540"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 541 - "Community 541"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 542 - "Community 542"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 543 - "Community 543"
@@ -4277,12 +4277,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 544 - "Community 544"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 545 - "Community 545"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 545 - "Community 545"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 546 - "Community 546"
 Cohesion: 0.67
@@ -4341,16 +4341,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 560 - "Community 560"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 561 - "Community 561"
 Cohesion: 1.0
-Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 562 - "Community 562"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
 ### Community 563 - "Community 563"
 Cohesion: 1.0
@@ -13054,8 +13054,8 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.05 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**
-  _Cohesion score 0.07 - nodes in this community are weakly interconnected._
-- **Should `Community 4` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._
+- **Should `Community 4` be split into smaller, more focused modules?**
+  _Cohesion score 0.07 - nodes in this community are weakly interconnected._
 - **Should `Community 5` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,19 +8,19 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2135
-- Graph nodes: 8083
-- Graph edges: 9510
+- Graph nodes: 8093
+- Graph edges: 9525
 - Communities: 2063
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (89 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `harness-inferential-review.ts` (85 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `dailyClose.ts` (82 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `dailyOperations.ts` (63 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `projectLocalEvents.ts` (63 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `projectLocalEvents.ts` (65 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `dailyOperations.ts` (63 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 - `terminalHealthPresentation.ts` (53 edges, Community 6) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
-- `catalogImport.ts` (49 edges, Community 7) - [`packages/athena-webapp/convex/inventory/catalogImport.ts`](../../packages/athena-webapp/convex/inventory/catalogImport.ts)
+- `posLocalStore.ts` (50 edges, Community 7) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 
 ## Registered Packages
 - [Athena Webapp](packages/athena-webapp.md)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -19,8 +19,8 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 ## Graph Hotspots
 - `DailyCloseView.tsx` (89 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (82 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `dailyOperations.ts` (63 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `projectLocalEvents.ts` (63 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `projectLocalEvents.ts` (65 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `dailyOperations.ts` (63 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 
 ## Navigation

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
@@ -561,6 +561,7 @@ describe("terminal health queries", () => {
       _id: "closeout-conflict" as Id<"posLocalSyncConflict">,
       conflictType: "permission",
       details: {
+        closeoutOccurredAt: now - 21 * 60 * 1000,
         countedCash: 95,
         expectedCash: 100,
         variance: -5,

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -125,6 +125,47 @@ describe("projectLocalSyncEvent", () => {
     expect(repository.mappings).toHaveLength(1);
   });
 
+  it("replays register open idempotently after a repair-created register mapping", async () => {
+    const repository = createProjectionRepository();
+    repository.mappings[0] = {
+      ...repository.mappings[0],
+      localEventId: "event-sale-repaired-1",
+      sourceEventType: "repair",
+    };
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-opened-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 1,
+        eventType: "register_opened",
+        occurredAt: 10,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: {
+          openingFloat: 100,
+          registerNumber: "1",
+        },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("projected");
+    expect(result.mappings).toEqual([
+      expect.objectContaining({
+        cloudId: "register-session-1",
+        localId: "local-register-1",
+        localEventId: "event-sale-repaired-1",
+        sourceEventType: "repair",
+      }),
+    ]);
+    expect(result.conflicts).toEqual([]);
+    expect(repository.createdRegisterSessions).toEqual([]);
+  });
+
   it("rejects register-session repair when the local drawer maps elsewhere", async () => {
     const repository = createProjectionRepository();
 
@@ -3705,6 +3746,45 @@ describe("projectLocalSyncEvent", () => {
     expect(repository.createdRegisterSessions).toEqual([]);
   });
 
+  it("conflicts duplicate register opens that reuse the same local drawer id from another source event", async () => {
+    const repository = createProjectionRepository();
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-opened-reused",
+        localRegisterSessionId: "local-register-1",
+        sequence: 2,
+        eventType: "register_opened",
+        occurredAt: 20,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: {
+          openingFloat: 100,
+          registerNumber: "1",
+        },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("conflicted");
+    expect(result.mappings).toEqual([]);
+    expect(result.conflicts).toEqual([
+      expect.objectContaining({
+        conflictType: "duplicate_local_id",
+        summary:
+          "Local register session id was reused by a different synced register open.",
+        details: expect.objectContaining({
+          existingLocalEventId: "event-register-opened-1",
+          localRegisterSessionId: "local-register-1",
+          reason: "duplicate_register_opened",
+        }),
+      }),
+    ]);
+  });
+
   it("conflicts a stale register open when the active drawer has a newer closeout review", async () => {
     const repository = createProjectionRepository({
       blockingRegisterSession: {
@@ -3716,9 +3796,12 @@ describe("projectLocalSyncEvent", () => {
         storeId: "store-1",
         terminalId: "terminal-1",
       },
-      registerSessionsWithCloseoutReview: new Set([
-        "register-session-reviewed",
-      ]),
+      registerReviewConflictFacts: [
+        buildRegisterCloseoutReviewFact({
+          closeoutOccurredAt: 50,
+          registerSessionId: "register-session-reviewed",
+        }),
+      ],
     });
 
     const result = await projectLocalSyncEvent(repository, {
@@ -3773,7 +3856,7 @@ describe("projectLocalSyncEvent", () => {
       event: {
         localEventId: "event-register-opened-closing-review",
         localRegisterSessionId: "local-register-2",
-        sequence: 4,
+        sequence: 1,
         eventType: "register_opened",
         occurredAt: 10,
         staffProfileId: "staff-1" as never,
@@ -3811,7 +3894,7 @@ describe("projectLocalSyncEvent", () => {
       blockingRegisterSession: {
         _id: "register-session-closing",
         expectedCash: 100,
-        closeoutRecords: [],
+        closeoutRecords: [{ occurredAt: 5 }],
         registerNumber: "1",
         status: "closing",
         storeId: "store-1",
@@ -3900,6 +3983,56 @@ describe("projectLocalSyncEvent", () => {
         localId: "register-session-1",
         cloudTable: "registerSession",
         cloudId: "register-session-1",
+      }),
+    ]);
+  });
+
+  it("conflicts direct cloud register opens while the mapped drawer has closeout review", async () => {
+    const repository = createProjectionRepository({
+      registerSession: {
+        _id: "register-session-1",
+        expectedCash: 100,
+        closeoutRecords: [],
+        registerNumber: "1",
+        status: "active",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      } as never,
+      registerSessionsWithCloseoutReview: new Set(["register-session-1"]),
+      validCloudIds: new Set(["register-session-1"]),
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-opened-cloud",
+        localRegisterSessionId: "register-session-1",
+        sequence: 1,
+        eventType: "register_opened",
+        occurredAt: 10,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: {
+          openingFloat: 100,
+          registerNumber: "1",
+        },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("conflicted");
+    expect(result.mappings).toEqual([]);
+    expect(result.conflicts).toEqual([
+      expect.objectContaining({
+        conflictType: "permission",
+        summary: "Register session mapping is not usable for synced POS history.",
+        details: expect.objectContaining({
+          cloudRegisterSessionId: "register-session-1",
+          localRegisterSessionId: "register-session-1",
+          status: "active",
+        }),
       }),
     ]);
   });
@@ -5827,6 +5960,7 @@ function createProjectionRepository(
       terminalId: "terminal-1" as never,
       localRegisterSessionId: "local-register-1",
       localEventId: "event-register-opened-1",
+      sourceEventType: "register_opened",
       localIdKind: "registerSession",
       localId: "local-register-1",
       cloudTable: "registerSession",
@@ -6213,6 +6347,7 @@ function createProjectionRepository(
             conflictType: "permission" as const,
             createdAt: 1_700_000_000_000 + index,
             details: {
+              closeoutOccurredAt: 5,
               countedCash: 100,
               expectedCash: 90,
               variance: 10,
@@ -6425,5 +6560,41 @@ function createProjectionRepository(
         traceId: `register-trace-${recordedRegisterSessionTraces.length}`,
       };
     },
+  };
+}
+
+function buildRegisterCloseoutReviewFact(args: {
+  closeoutOccurredAt?: number;
+  registerSessionId: string;
+  sequence?: number;
+}): LocalSyncRegisterReviewConflictFact {
+  return {
+    conflict: {
+      _id: `review-conflict-${args.registerSessionId}`,
+      conflictType: "permission",
+      createdAt: 1_700_000_000_000,
+      details: {
+        ...(args.closeoutOccurredAt === undefined
+          ? {}
+          : { closeoutOccurredAt: args.closeoutOccurredAt }),
+        countedCash: 100,
+        expectedCash: 90,
+        variance: 10,
+      },
+      localEventId: `review-event-${args.registerSessionId}`,
+      localRegisterSessionId: args.registerSessionId,
+      sequence: args.sequence ?? 3,
+      status: "needs_review",
+      storeId: "store-1" as never,
+      summary:
+        "Register closeout variance requires manager review before synced closeout can be applied.",
+      terminalId: "terminal-1" as never,
+    },
+    directRegisterSession: {
+      _id: args.registerSessionId as Id<"registerSession">,
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+    },
+    registerSessionMapping: null,
   };
 }

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -76,7 +76,7 @@ type PosSessionRecord = Awaited<
 
 type OpenRegisterCloseoutReviewState = {
   hasOpenRegisterCloseoutReview: boolean;
-  latestReviewSequence?: number;
+  latestReviewBoundaryAt?: number;
 };
 
 type CanonicalSaleItem = {
@@ -306,6 +306,7 @@ export async function createOrReuseRegisterSessionRepairMapping(
     terminalId: args.terminalId,
     localRegisterSessionId: args.localRegisterSessionId,
     localEventId: args.localEventId,
+    sourceEventType: "repair",
     localIdKind: "registerSession",
     localId: args.localRegisterSessionId,
     cloudTable: "registerSession",
@@ -884,12 +885,14 @@ async function canSupersedeReviewedRegisterSessionForLocalOpen(
         });
 
   return canSupersedeReviewedRegisterSessionForLocalOpenPolicy({
+    closeoutReviewBoundaryAt:
+      hasOpenRegisterCloseoutReview.latestReviewBoundaryAt ??
+      getRegisterSessionCloseoutBoundaryAt(registerSession),
     hasOpenRegisterCloseoutReview:
       hasOpenRegisterCloseoutReview.hasOpenRegisterCloseoutReview,
     replacementLocalRegisterSessionId: args.event.localRegisterSessionId,
-    replacementSequence: args.event.sequence,
+    replacementOpenedAt: args.event.occurredAt,
     registerSession,
-    reviewSequence: hasOpenRegisterCloseoutReview.latestReviewSequence ?? null,
     storeId: args.storeId,
     terminalId: args.terminalId,
   });
@@ -913,12 +916,46 @@ async function getOpenRegisterCloseoutReviewState(
 
   return {
     hasOpenRegisterCloseoutReview: closeoutReviewConflicts.length > 0,
-    latestReviewSequence: closeoutReviewConflicts.reduce<number | undefined>(
+    latestReviewBoundaryAt: closeoutReviewConflicts.reduce<number | undefined>(
       (latest, conflict) =>
-        latest === undefined ? conflict.sequence : Math.max(latest, conflict.sequence),
+        latest === undefined
+          ? getConflictCloseoutReviewBoundaryAt(conflict)
+          : Math.max(latest, getConflictCloseoutReviewBoundaryAt(conflict)),
       undefined,
     ),
   };
+}
+
+function getConflictCloseoutReviewBoundaryAt(conflict: LocalSyncConflictRecord) {
+  return typeof conflict.details.closeoutOccurredAt === "number"
+    ? conflict.details.closeoutOccurredAt
+    : conflict.createdAt;
+}
+
+function getRegisterSessionCloseoutBoundaryAt(
+  registerSession:
+    | Awaited<ReturnType<SyncProjectionRepository["getRegisterSession"]>>
+    | null
+    | undefined,
+) {
+  const latestCloseoutRecord = registerSession?.closeoutRecords?.reduce<
+    number | undefined
+  >((latest, record) => {
+    const occurredAt =
+      typeof record === "object" &&
+      record !== null &&
+      "occurredAt" in record &&
+      typeof record.occurredAt === "number"
+        ? record.occurredAt
+        : undefined;
+    if (occurredAt === undefined) return latest;
+    return latest === undefined ? occurredAt : Math.max(latest, occurredAt);
+  }, undefined);
+  if (latestCloseoutRecord !== undefined) return latestCloseoutRecord;
+
+  return typeof registerSession?.closedAt === "number"
+    ? registerSession.closedAt
+    : null;
 }
 
 function factMatchesRegisterSessionCloseoutReview(
@@ -947,6 +984,22 @@ async function projectRegisterOpened(
     localId: args.event.localRegisterSessionId,
   });
   if (existing) {
+    if (
+      existing.localEventId !== args.event.localEventId &&
+      existing.sourceEventType === "register_opened"
+    ) {
+      const conflict = await createConflict(repository, args, {
+        conflictType: "duplicate_local_id",
+        summary: "Local register session id was reused by a different synced register open.",
+        details: {
+          existingLocalEventId: existing.localEventId,
+          localIdKind: "registerSession",
+          localRegisterSessionId: args.event.localRegisterSessionId,
+          reason: "duplicate_register_opened",
+        },
+      });
+      return { status: "conflicted", mappings: [], conflicts: [conflict] };
+    }
     return { status: "projected", mappings: [existing], conflicts: [] };
   }
 
@@ -3602,6 +3655,7 @@ async function projectRegisterClosed(
       conflictType: "permission",
       summary: REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY,
       details: {
+        closeoutOccurredAt: args.event.occurredAt,
         countedCash,
         expectedCash: registerSession.expectedCash,
         notes: payload.notes,
@@ -3897,6 +3951,7 @@ function createMapping(
     terminalId: args.terminalId,
     localRegisterSessionId: args.event.localRegisterSessionId ?? "",
     localEventId: args.event.localEventId,
+    sourceEventType: args.event.eventType,
     createdAt: args.now,
     ...input,
   };

--- a/packages/athena-webapp/convex/pos/application/sync/types.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/types.ts
@@ -227,6 +227,7 @@ type LocalSyncMappingRecordBase = {
   localRegisterSessionId: string;
   localExpenseSessionId?: string;
   localEventId: string;
+  sourceEventType?: PosLocalSyncEventType | "repair";
   localId: string;
   createdAt: number;
 };

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest";
 import type { Doc, Id } from "../../../_generated/dataModel";
 import {
   buildTerminalCloudRepairPreview,
+  canProjectRegisterOpenForTerminalCloudRepair,
   classifyTerminalCloudRepairConflict,
 } from "./cloudRepairPolicy";
+import type { TerminalCloudRepairProjectionEligibilityRepository } from "./cloudRepairPolicy";
 
 const now = 1_000_000;
 const storeId = "store-1" as Id<"store">;
@@ -112,7 +114,127 @@ describe("terminal cloud repair policy", () => {
       }).preconditionHash,
     ).not.toBe(preview.preconditionHash);
   });
+
+  it("rejects direct cloud register repair projection while closeout review is open", async () => {
+    const repository = createRepairProjectionRepository({
+      registerSession: {
+        _id: "register-1",
+        status: "active",
+        storeId,
+        terminalId,
+      },
+      reviewRegisterSessionIds: new Set(["register-1"]),
+      validCloudIds: new Set(["register-1"]),
+    });
+
+    await expect(
+      canProjectRegisterOpenForTerminalCloudRepair(repository, {
+        event: {
+          localEventId: "event-1",
+          localRegisterSessionId: "register-1",
+          sequence: 2,
+          eventType: "register_opened",
+          occurredAt: 20,
+          staffProfileId: "staff-1" as Id<"staffProfile">,
+          staffProofToken: "proof-token-1",
+          payload: {
+            openingFloat: 100,
+            registerNumber: "A1",
+          },
+        },
+        now,
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toBe(false);
+  });
 });
+
+function createRepairProjectionRepository(overrides: {
+  registerSession?: {
+    _id: string;
+    status: string;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  } | null;
+  reviewRegisterSessionIds?: Set<string>;
+  validCloudIds?: Set<string>;
+} = {}): TerminalCloudRepairProjectionEligibilityRepository {
+  return {
+    async findBlockingRegisterSession() {
+      return null;
+    },
+    async getRegisterSession(registerSessionId) {
+      return overrides.registerSession &&
+        overrides.registerSession._id === registerSessionId
+        ? ({
+            closeoutRecords: [],
+            expectedCash: 100,
+            registerNumber: "A1",
+            ...overrides.registerSession,
+          } as never)
+        : null;
+    },
+    async getStaffProfile(staffProfileId) {
+      return staffProfileId === "staff-1"
+        ? ({
+            _id: "staff-1",
+            status: "active",
+            storeId,
+          } as never)
+        : null;
+    },
+    async getTerminal(id) {
+      return id === terminalId
+        ? ({
+            _id: terminalId,
+            registerNumber: "A1",
+            status: "active",
+            storeId,
+          } as never)
+        : null;
+    },
+    async hasActivePosRole() {
+      return true;
+    },
+    async listOpenRegisterReviewConflictFacts(args) {
+      return overrides.reviewRegisterSessionIds?.has(args.registerSessionId) === true
+        ? [
+            {
+              conflict: {
+                _id: "conflict-1",
+                conflictType: "permission",
+                createdAt: now - 1_000,
+                details: {
+                  closeoutOccurredAt: now - 2_000,
+                  countedCash: 100,
+                  expectedCash: 90,
+                  variance: 10,
+                },
+                localEventId: "event-closeout-1",
+                localRegisterSessionId: args.registerSessionId,
+                sequence: 1,
+                status: "needs_review",
+                storeId: args.storeId,
+                summary:
+                  "Register closeout variance requires manager review before synced closeout can be applied.",
+                terminalId: args.terminalId,
+              },
+              directRegisterSession: {
+                _id: args.registerSessionId,
+                storeId: args.storeId,
+                terminalId: args.terminalId,
+              },
+              registerSessionMapping: null,
+            },
+          ]
+        : [];
+    },
+    normalizeCloudId(_tableName, value) {
+      return overrides.validCloudIds?.has(value) ? (value as never) : null;
+    },
+  };
+}
 
 function buildConflict(
   overrides: Partial<Doc<"posLocalSyncConflict">> = {},

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts
@@ -211,8 +211,15 @@ export async function canProjectRegisterOpenForTerminalCloudRepair(
   );
   if (directRegisterSessionId) {
     const registerSession = await repository.getRegisterSession(directRegisterSessionId);
+    const reviewState = registerSession
+      ? await getRepairOpenRegisterCloseoutReviewState(repository, {
+          registerSessionId: registerSession._id,
+          storeId: args.storeId,
+          terminalId: args.terminalId,
+        })
+      : { hasOpenRegisterCloseoutReview: false };
     return canReuseCloudRegisterSessionForLocalOpenPolicy({
-      hasOpenRegisterCloseoutReview: false,
+      hasOpenRegisterCloseoutReview: reviewState.hasOpenRegisterCloseoutReview,
       localRegisterSessionId: args.event.localRegisterSessionId,
       registerSession: registerSession
         ? {
@@ -239,11 +246,13 @@ export async function canProjectRegisterOpenForTerminalCloudRepair(
   });
 
   return canSupersedeReviewedRegisterSessionForLocalOpenPolicy({
+    closeoutReviewBoundaryAt:
+      reviewState.latestReviewBoundaryAt ??
+      getRepairRegisterSessionCloseoutBoundaryAt(blockingRegisterSession),
     hasOpenRegisterCloseoutReview: reviewState.hasOpenRegisterCloseoutReview,
     replacementLocalRegisterSessionId: args.event.localRegisterSessionId,
-    replacementSequence: args.event.sequence,
+    replacementOpenedAt: args.event.occurredAt,
     registerSession: blockingRegisterSession,
-    reviewSequence: reviewState.latestReviewSequence ?? null,
     storeId: args.storeId,
     terminalId: args.terminalId,
   });
@@ -267,12 +276,47 @@ async function getRepairOpenRegisterCloseoutReviewState(
 
   return {
     hasOpenRegisterCloseoutReview: conflicts.length > 0,
-    latestReviewSequence: conflicts.reduce<number | undefined>(
+    latestReviewBoundaryAt: conflicts.reduce<number | undefined>(
       (latest, conflict) =>
-        latest === undefined ? conflict.sequence : Math.max(latest, conflict.sequence),
+        latest === undefined
+          ? getRepairConflictCloseoutReviewBoundaryAt(conflict)
+          : Math.max(latest, getRepairConflictCloseoutReviewBoundaryAt(conflict)),
       undefined,
     ),
   };
+}
+
+function getRepairConflictCloseoutReviewBoundaryAt(
+  conflict: LocalSyncRegisterReviewConflictFact["conflict"],
+) {
+  return typeof conflict.details.closeoutOccurredAt === "number"
+    ? conflict.details.closeoutOccurredAt
+    : conflict.createdAt;
+}
+
+function getRepairRegisterSessionCloseoutBoundaryAt(
+  registerSession: Awaited<
+    ReturnType<TerminalCloudRepairProjectionEligibilityRepository["findBlockingRegisterSession"]>
+  >,
+) {
+  const latestCloseoutRecord = registerSession?.closeoutRecords?.reduce<
+    number | undefined
+  >((latest, record) => {
+    const occurredAt =
+      typeof record === "object" &&
+      record !== null &&
+      "occurredAt" in record &&
+      typeof record.occurredAt === "number"
+        ? record.occurredAt
+        : undefined;
+    if (occurredAt === undefined) return latest;
+    return latest === undefined ? occurredAt : Math.max(latest, occurredAt);
+  }, undefined);
+  if (latestCloseoutRecord !== undefined) return latestCloseoutRecord;
+
+  return typeof registerSession?.closedAt === "number"
+    ? registerSession.closedAt
+    : null;
 }
 
 function repairFactMatchesRegisterSessionCloseoutReview(

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.test.ts
@@ -66,6 +66,7 @@ describe("resolveTerminalCloudRepair", () => {
       _id: "closeout-conflict" as Id<"posLocalSyncConflict">,
       conflictType: "permission",
       details: {
+        closeoutOccurredAt: now - 21 * 60 * 1000,
         countedCash: 95,
         expectedCash: 100,
         variance: -5,

--- a/packages/athena-webapp/convex/schemas/pos/posLocalSyncMapping.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posLocalSyncMapping.ts
@@ -1,5 +1,7 @@
 import { v } from "convex/values";
 
+import { posLocalSyncEventTypeValidator } from "./posLocalSyncEvent";
+
 export const posLocalSyncMappingKindValidator = v.union(
   v.literal("registerSession"),
   v.literal("posSession"),
@@ -23,6 +25,9 @@ export const posLocalSyncMappingSchema = v.object({
   localRegisterSessionId: v.string(),
   localExpenseSessionId: v.optional(v.string()),
   localEventId: v.string(),
+  sourceEventType: v.optional(
+    v.union(posLocalSyncEventTypeValidator, v.literal("repair")),
+  ),
   localIdKind: posLocalSyncMappingKindValidator,
   localId: v.string(),
   cloudTable: v.string(),

--- a/packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts
+++ b/packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts
@@ -22,6 +22,7 @@ describe("registerSessionLifecyclePolicy", () => {
       false,
     );
     expect(isRegisterSessionSaleUsable({ status: "closed" })).toBe(false);
+    expect(isRegisterSessionSaleUsable({ status: "needs_review" })).toBe(false);
   });
 
   it("allows void application for open, active, and closing register sessions", () => {
@@ -149,6 +150,23 @@ describe("registerSessionLifecyclePolicy", () => {
     ).toBe("cloud_closed");
   });
 
+  it("ignores drawer authority that belongs to a superseded drawer identity", () => {
+    expect(
+      getSaleBlockingDrawerAuthority({
+        activeRegisterSession: {
+          cloudRegisterSessionId: "cloud-drawer-2",
+          localRegisterSessionId: "local-drawer-2",
+        },
+        drawerAuthority: {
+          cloudRegisterSessionId: "cloud-drawer-1",
+          localRegisterSessionId: "local-drawer-1",
+          reason: "cloud_closed",
+          status: "blocked",
+        },
+      }),
+    ).toBeNull();
+  });
+
   it("allows local replacement drawers only for cloud-closed, settled closeout, or submitted closeout blocks", () => {
     expect(
       canOpenReplacementDrawerForLocalBlock({
@@ -254,55 +272,71 @@ describe("registerSessionLifecyclePolicy", () => {
   it("allows superseding reviewed sale-usable or closing sessions only in scope", () => {
     expect(
       canSupersedeReviewedRegisterSessionForLocalOpen({
+        closeoutReviewBoundaryAt: 20,
         hasOpenRegisterCloseoutReview: true,
         replacementLocalRegisterSessionId: "replacement-local-drawer",
-        replacementSequence: 2,
+        replacementOpenedAt: 30,
         registerSession: {
           localRegisterSessionId: "reviewed-local-drawer",
           status: "closing",
           storeId: "store-1",
           terminalId: "terminal-1",
         },
-        reviewSequence: 2,
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).toBe(true);
+    expect(
+      canSupersedeReviewedRegisterSessionForLocalOpen({
+        closeoutReviewBoundaryAt: 50,
+        hasOpenRegisterCloseoutReview: true,
+        replacementLocalRegisterSessionId: "replacement-local-drawer",
+        replacementOpenedAt: 10,
+        registerSession: {
+          localRegisterSessionId: "reviewed-local-drawer",
+          status: "closing",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        },
         storeId: "store-1",
         terminalId: "terminal-1",
       }),
     ).toBe(false);
     expect(
       canSupersedeReviewedRegisterSessionForLocalOpen({
+        closeoutReviewBoundaryAt: 20,
         hasOpenRegisterCloseoutReview: true,
         replacementLocalRegisterSessionId: "replacement-local-drawer",
-        replacementSequence: 3,
+        replacementOpenedAt: 30,
         registerSession: {
           localRegisterSessionId: "reviewed-local-drawer",
           status: "closing",
           storeId: "store-1",
           terminalId: "terminal-1",
         },
-        reviewSequence: 2,
         storeId: "store-1",
         terminalId: "terminal-1",
       }),
     ).toBe(true);
     expect(
       canSupersedeReviewedRegisterSessionForLocalOpen({
+        closeoutReviewBoundaryAt: null,
         hasOpenRegisterCloseoutReview: false,
         replacementLocalRegisterSessionId: "replacement-local-drawer",
-        replacementSequence: 1,
+        replacementOpenedAt: 20,
         registerSession: {
           localRegisterSessionId: "submitted-closeout-drawer",
           status: "closing",
           storeId: "store-1",
           terminalId: "terminal-1",
         },
-        reviewSequence: null,
         storeId: "store-1",
         terminalId: "terminal-1",
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       canSupersedeReviewedRegisterSessionForLocalOpen({
-        allowUnknownReviewSequence: true,
+        allowUnknownCloseoutReviewBoundary: true,
         hasOpenRegisterCloseoutReview: true,
         replacementLocalRegisterSessionId: "replacement-local-drawer",
         registerSession: {
@@ -317,7 +351,7 @@ describe("registerSessionLifecyclePolicy", () => {
     ).toBe(true);
     expect(
       canSupersedeReviewedRegisterSessionForLocalOpen({
-        allowUnknownReviewSequence: true,
+        allowUnknownCloseoutReviewBoundary: true,
         hasOpenRegisterCloseoutReview: true,
         replacementLocalRegisterSessionId: "replacement-local-drawer",
         registerSession: {
@@ -332,7 +366,7 @@ describe("registerSessionLifecyclePolicy", () => {
     ).toBe(false);
     expect(
       canSupersedeReviewedRegisterSessionForLocalOpen({
-        allowUnknownReviewSequence: true,
+        allowUnknownCloseoutReviewBoundary: true,
         hasOpenRegisterCloseoutReview: true,
         replacementLocalRegisterSessionId: "reviewed-local-drawer",
         registerSession: {
@@ -347,7 +381,7 @@ describe("registerSessionLifecyclePolicy", () => {
     ).toBe(false);
     expect(
       canSupersedeReviewedRegisterSessionForLocalOpen({
-        allowUnknownReviewSequence: true,
+        allowUnknownCloseoutReviewBoundary: true,
         hasOpenRegisterCloseoutReview: true,
         replacementLocalRegisterSessionId: "replacement-local-drawer",
         registerSession: {
@@ -362,7 +396,7 @@ describe("registerSessionLifecyclePolicy", () => {
     ).toBe(true);
     expect(
       canSupersedeReviewedRegisterSessionForLocalOpen({
-        allowUnknownReviewSequence: true,
+        allowUnknownCloseoutReviewBoundary: true,
         hasOpenRegisterCloseoutReview: true,
         replacementLocalRegisterSessionId: "replacement-local-drawer",
         registerSession: {
@@ -377,7 +411,7 @@ describe("registerSessionLifecyclePolicy", () => {
     ).toBe(false);
     expect(
       canSupersedeReviewedRegisterSessionForLocalOpen({
-        allowUnknownReviewSequence: true,
+        allowUnknownCloseoutReviewBoundary: true,
         hasOpenRegisterCloseoutReview: true,
         replacementLocalRegisterSessionId: "replacement-local-drawer",
         registerSession: {

--- a/packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts
+++ b/packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts
@@ -135,6 +135,14 @@ export function getSaleBlockingDrawerAuthority<
   if (!drawerAuthority) return null;
   if (drawerAuthority.status !== "blocked") return null;
   if (
+    !drawerAuthorityMatchesActiveRegisterSession({
+      activeRegisterSession: input.activeRegisterSession,
+      drawerAuthority,
+    })
+  ) {
+    return null;
+  }
+  if (
     drawerAuthority.reason === "lifecycle_rejected" &&
     drawerAuthority.localRegisterSessionId ===
       input.activeRegisterSession?.localRegisterSessionId
@@ -173,14 +181,14 @@ export function canReuseCloudRegisterSessionForLocalOpen(input: {
 
 type RegisterSessionSupersedeFreshnessInput =
   | {
-      replacementSequence: number;
-      reviewSequence: number | null | undefined;
-      allowUnknownReviewSequence?: never;
+      closeoutReviewBoundaryAt: number | null | undefined;
+      replacementOpenedAt: number;
+      allowUnknownCloseoutReviewBoundary?: never;
     }
   | {
-      allowUnknownReviewSequence: true;
-      replacementSequence?: number | null;
-      reviewSequence?: number | null;
+      allowUnknownCloseoutReviewBoundary: true;
+      closeoutReviewBoundaryAt?: number | null;
+      replacementOpenedAt?: number | null;
     };
 
 export function canSupersedeReviewedRegisterSessionForLocalOpen(input: {
@@ -195,13 +203,12 @@ export function canSupersedeReviewedRegisterSessionForLocalOpen(input: {
       input.registerSession?.localRegisterSessionId &&
     input.replacementLocalRegisterSessionId !==
       input.registerSession?.cloudRegisterSessionId;
-  const hasFreshReplacement =
-    input.allowUnknownReviewSequence === true ||
-    input.reviewSequence === undefined ||
-    input.reviewSequence === null ||
-    input.replacementSequence > input.reviewSequence;
   const hasSubmittedCloseout =
     input.registerSession?.status === "closing";
+  const hasFreshReplacement =
+    input.allowUnknownCloseoutReviewBoundary === true ||
+    (typeof input.closeoutReviewBoundaryAt === "number" &&
+      input.replacementOpenedAt > input.closeoutReviewBoundaryAt);
   const hasReplacementHold =
     input.hasOpenRegisterCloseoutReview || hasSubmittedCloseout;
 
@@ -278,4 +285,22 @@ function isScopedRegisterSession(input: {
     input.registerSession?.storeId === input.storeId &&
     input.registerSession.terminalId === input.terminalId
   );
+}
+
+function drawerAuthorityMatchesActiveRegisterSession(input: {
+  activeRegisterSession?: RegisterSessionLifecycleScopedSession | null;
+  drawerAuthority: RegisterSessionLifecycleDrawerAuthority;
+}) {
+  const activeIds = new Set(
+    [
+      input.activeRegisterSession?.localRegisterSessionId,
+      input.activeRegisterSession?.cloudRegisterSessionId,
+    ].filter((id): id is string => Boolean(id)),
+  );
+  if (activeIds.size === 0) return true;
+
+  return [
+    input.drawerAuthority.localRegisterSessionId,
+    input.drawerAuthority.cloudRegisterSessionId,
+  ].some((id) => id !== undefined && activeIds.has(id));
 }

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.test.ts
@@ -219,6 +219,55 @@ describe("localPosReadiness", () => {
     });
   });
 
+  it("allows POS after a mapped cloud drawer closeout has synced", () => {
+    expect(
+      evaluateLocalPosReadiness({
+        entryContext,
+        operatingDate: "2026-05-14",
+        localReadiness: {
+          storeId: "store-1",
+          operatingDate: "2026-05-14",
+          status: "started",
+          source: "daily_opening",
+          updatedAt: 1_000,
+        },
+        registerReadModel: {
+          activeRegisterSession: {
+            localRegisterSessionId: "local-register-1",
+            cloudRegisterSessionId: "cloud-register-1",
+          },
+          canSell: false,
+          closeoutState: {
+            status: "closed_locally",
+            localRegisterSessionId: "local-register-1",
+            updatedAt: 1_100,
+          },
+          sourceEvents: [
+            {
+              localEventId: "event-1",
+              schemaVersion: 1,
+              sequence: 1,
+              uploadSequence: 1,
+              type: "register.closeout_started",
+              terminalId: "terminal-1",
+              storeId: "store-1",
+              registerNumber: "1",
+              localRegisterSessionId: "cloud-register-1",
+              staffProfileId: "staff-1",
+              payload: { countedCash: 100 },
+              createdAt: 1_100,
+              sync: { status: "synced" },
+            },
+          ],
+        } as PosLocalRegisterReadModel,
+      }),
+    ).toEqual({
+      status: "ready",
+      source: "local_readiness",
+      storeDayStatus: "started",
+    });
+  });
+
   it("shows store-day start readiness before local drawer recovery", () => {
     expect(
       evaluateLocalPosReadiness({

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts
@@ -3,11 +3,13 @@ import { useEffect, useMemo, useState } from "react";
 import type { PosLocalEntryContext } from "./localPosEntryContext";
 import type { RegisterServiceCatalogSnapshotState } from "./registerServiceCatalogSnapshot";
 import { readProjectedLocalRegisterModel } from "./localRegisterReader";
-import type { PosLocalRegisterReadModel } from "./registerReadModel";
+import {
+  hasSettledRegisterCloseout,
+  type PosLocalRegisterReadModel,
+} from "./registerReadModel";
 import {
   createIndexedDbPosLocalStorageAdapter,
   createPosLocalStore,
-  type PosLocalEventRecord,
   type PosLocalStoreDayReadiness,
   type PosLocalStoreResult,
 } from "./posLocalStore";
@@ -241,15 +243,10 @@ function hasSettledLocalCloseout(model: PosLocalRegisterReadModel) {
   const localRegisterSessionId = model.closeoutState?.localRegisterSessionId;
   if (!localRegisterSessionId) return false;
 
-  const latestCloseout = [...(model.sourceEvents ?? [])]
-    .reverse()
-    .find(
-      (event: PosLocalEventRecord) =>
-        event.type === "register.closeout_started" &&
-        event.localRegisterSessionId === localRegisterSessionId,
-    );
-
-  return latestCloseout?.sync.status === "synced";
+  return hasSettledRegisterCloseout({
+    events: model.sourceEvents ?? [],
+    session: model.activeRegisterSession ?? { localRegisterSessionId },
+  });
 }
 
 export function evaluateLocalPosServiceCatalogReadiness(

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localRegisterReader.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localRegisterReader.ts
@@ -20,6 +20,7 @@ export type PosLocalRegisterReaderStore = {
   listEvents(): Promise<PosLocalStoreResult<PosLocalEventRecord[]>>;
   listLocalCloudMappings?(): Promise<PosLocalStoreResult<PosLocalCloudMapping[]>>;
   readDrawerAuthorityState?(input: {
+    cloudRegisterSessionId?: string;
     localRegisterSessionId: string;
     storeId: string;
     terminalId: string;
@@ -118,11 +119,14 @@ export async function readProjectedLocalRegisterModel(input: {
   });
   const activeLocalRegisterSessionId =
     baseModel.activeRegisterSession?.localRegisterSessionId;
+  const activeCloudRegisterSessionId =
+    baseModel.activeRegisterSession?.cloudRegisterSessionId;
   const drawerAuthority =
     input.store.readDrawerAuthorityState &&
     scope.storeId &&
     activeLocalRegisterSessionId
       ? await readLatestDrawerAuthorityState({
+          cloudRegisterSessionId: activeCloudRegisterSessionId,
           localRegisterSessionId: activeLocalRegisterSessionId,
           store: input.store,
           storeId: scope.storeId,
@@ -145,6 +149,7 @@ export async function readProjectedLocalRegisterModel(input: {
 }
 
 async function readLatestDrawerAuthorityState(input: {
+  cloudRegisterSessionId?: string;
   localRegisterSessionId: string;
   store: PosLocalRegisterReaderStore;
   storeId: string;
@@ -157,6 +162,9 @@ async function readLatestDrawerAuthorityState(input: {
   const states: PosDrawerAuthorityState[] = [];
   for (const terminalId of input.terminalIds) {
     const result = await input.store.readDrawerAuthorityState({
+      ...(input.cloudRegisterSessionId
+        ? { cloudRegisterSessionId: input.cloudRegisterSessionId }
+        : {}),
       localRegisterSessionId: input.localRegisterSessionId,
       storeId: input.storeId,
       terminalId,

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
@@ -318,6 +318,123 @@ describe("posLocalStore", () => {
     });
   });
 
+  it("projects drawer authority written under the mapped cloud register id for the active local drawer", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 3_000,
+    });
+
+    await store.writeProvisionedTerminalSeed({
+      terminalId: "local-terminal-1",
+      cloudTerminalId: "terminal-cloud-1",
+      syncSecretHash: "sync-secret-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      displayName: "Front register",
+      provisionedAt: 1_000,
+      schemaVersion: POS_LOCAL_STORE_SCHEMA_VERSION,
+    });
+    await store.writeLocalCloudMapping({
+      entity: "registerSession",
+      localId: "local-register-1",
+      cloudId: "cloud-register-1",
+      mappedAt: 1_500,
+    });
+    await store.appendEvent({
+      type: "register.opened",
+      terminalId: "local-terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "local-register-1",
+      payload: {
+        localRegisterSessionId: "local-register-1",
+        openingFloat: 100,
+        expectedCash: 100,
+        status: "open",
+      },
+      initialSyncStatus: "synced",
+    });
+    await store.writeDrawerAuthorityState({
+      cloudRegisterSessionId: "cloud-register-1",
+      localRegisterSessionId: "cloud-register-1",
+      observedAt: 2_900,
+      reason: "cloud_closed",
+      status: "blocked",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+    });
+
+    await expect(
+      readProjectedLocalRegisterModel({
+        store,
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: {
+        canSell: false,
+        drawerAuthorityReason: "cloud_closed",
+        saleBlockReason: "drawer_authority",
+      },
+    });
+  });
+
+  it("clears drawer authority by exact local drawer id without deleting cloud-id aliases", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+
+    await store.writeDrawerAuthorityState({
+      cloudRegisterSessionId: "cloud-register-1",
+      localRegisterSessionId: "local-register-1",
+      observedAt: 2_000,
+      reason: "cloud_closed",
+      status: "blocked",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+    });
+    await store.writeDrawerAuthorityState({
+      cloudRegisterSessionId: "cloud-register-1",
+      localRegisterSessionId: "local-register-2",
+      observedAt: 2_100,
+      reason: "authority_unknown",
+      status: "blocked",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+    });
+
+    await expect(
+      store.clearDrawerAuthorityState({
+        cloudRegisterSessionId: "cloud-register-1",
+        localRegisterSessionId: "local-register-1",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+    ).resolves.toEqual({ ok: true, value: null });
+
+    await expect(
+      store.readDrawerAuthorityState({
+        localRegisterSessionId: "local-register-1",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+    ).resolves.toEqual({ ok: true, value: null });
+    await expect(
+      store.readDrawerAuthorityState({
+        localRegisterSessionId: "local-register-2",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: {
+        localRegisterSessionId: "local-register-2",
+        reason: "authority_unknown",
+      },
+    });
+  });
+
   it("atomically writes repaired terminal seed and clears stale integrity state", async () => {
     const store = createPosLocalStore({
       adapter: createMemoryPosLocalStorageAdapter(),

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
@@ -689,6 +689,7 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
     },
 
     async readDrawerAuthorityState(input: {
+      cloudRegisterSessionId?: string;
       localRegisterSessionId: string;
       storeId: string;
       terminalId: string;
@@ -704,11 +705,7 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
               states
                 .filter(isDrawerAuthorityState)
                 .filter(
-                  (state) =>
-                    state.storeId === input.storeId &&
-                    state.terminalId === input.terminalId &&
-                    state.localRegisterSessionId ===
-                      input.localRegisterSessionId,
+                  (state) => drawerAuthorityMatchesReadInput(state, input),
                 )
                 .sort((left, right) => right.observedAt - left.observedAt)
                 .at(0) ?? null
@@ -723,6 +720,7 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
     },
 
     async clearDrawerAuthorityState(input: {
+      cloudRegisterSessionId?: string;
       localRegisterSessionId: string;
       storeId: string;
       terminalId: string;
@@ -737,9 +735,7 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
             for (const state of states) {
               if (
                 isDrawerAuthorityState(state) &&
-                state.storeId === input.storeId &&
-                state.terminalId === input.terminalId &&
-                state.localRegisterSessionId === input.localRegisterSessionId
+                drawerAuthorityMatchesExactLocalInput(state, input)
               ) {
                 await transaction.delete("authority", drawerAuthorityKey(state));
               }
@@ -1588,6 +1584,46 @@ function drawerAuthorityKey(input: {
   localRegisterSessionId: string;
 }) {
   return `${DRAWER_AUTHORITY_PREFIX}${input.storeId}:${input.terminalId}:${input.localRegisterSessionId}`;
+}
+
+function drawerAuthorityMatchesReadInput(
+  state: PosDrawerAuthorityState,
+  input: {
+    cloudRegisterSessionId?: string;
+    localRegisterSessionId: string;
+    storeId: string;
+    terminalId: string;
+  },
+) {
+  const registerSessionIds = new Set(
+    [input.localRegisterSessionId, input.cloudRegisterSessionId].filter(
+      (id): id is string => typeof id === "string" && id.length > 0,
+    ),
+  );
+
+  return (
+    state.storeId === input.storeId &&
+    state.terminalId === input.terminalId &&
+    (registerSessionIds.has(state.localRegisterSessionId) ||
+      (state.cloudRegisterSessionId
+        ? registerSessionIds.has(state.cloudRegisterSessionId)
+        : false))
+  );
+}
+
+function drawerAuthorityMatchesExactLocalInput(
+  state: PosDrawerAuthorityState,
+  input: {
+    localRegisterSessionId: string;
+    storeId: string;
+    terminalId: string;
+  },
+) {
+  return (
+    state.storeId === input.storeId &&
+    state.terminalId === input.terminalId &&
+    state.localRegisterSessionId === input.localRegisterSessionId
+  );
 }
 
 function readinessKey(storeId: string, operatingDate: string) {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
@@ -1088,6 +1088,234 @@ describe("projectLocalRegisterReadModel", () => {
     expect(model.drawerAuthorityReason).toBe("cloud_closed");
   });
 
+  it("keeps a synced replacement drawer active after the previous drawer was cloud-closed", () => {
+    const model = projectLocalRegisterReadModel({
+      drawerAuthority: {
+        cloudRegisterSessionId: "cloud-register-1",
+        localRegisterSessionId: "local-register-1",
+        observedAt: 1_050,
+        reason: "cloud_closed",
+        status: "blocked",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      },
+      mappings: [
+        {
+          entity: "registerSession",
+          localId: "local-register-1",
+          cloudId: "cloud-register-1",
+          mappedAt: 1_001,
+        },
+        {
+          entity: "registerSession",
+          localId: "local-register-2",
+          cloudId: "cloud-register-2",
+          mappedAt: 1_002,
+        },
+      ],
+      events: [
+        event({
+          sequence: 1,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-1",
+          payload: {
+            localRegisterSessionId: "local-register-1",
+            openingFloat: 100,
+          },
+          sync: { status: "synced", uploaded: true },
+        }),
+        event({
+          sequence: 2,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-2",
+          payload: {
+            localRegisterSessionId: "local-register-2",
+            openingFloat: 250,
+            expectedCash: 250,
+          },
+          sync: { status: "synced", uploaded: true },
+        }),
+      ],
+    });
+
+    expect(model.activeRegisterSession).toMatchObject({
+      localRegisterSessionId: "local-register-2",
+      cloudRegisterSessionId: "cloud-register-2",
+      openingFloat: 250,
+      expectedCash: 250,
+    });
+    expect(model.canSell).toBe(true);
+    expect(model.saleBlockReason).toBeUndefined();
+    expect(model.drawerAuthorityReason).toBeUndefined();
+  });
+
+  it("does not use an uploaded review replacement open to bypass active drawer authority", () => {
+    const model = projectLocalRegisterReadModel({
+      drawerAuthority: {
+        cloudRegisterSessionId: "cloud-register-1",
+        localRegisterSessionId: "local-register-1",
+        observedAt: 1_050,
+        reason: "cloud_closed",
+        status: "blocked",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      },
+      mappings: [
+        {
+          entity: "registerSession",
+          localId: "local-register-1",
+          cloudId: "cloud-register-1",
+          mappedAt: 1_001,
+        },
+        {
+          entity: "registerSession",
+          localId: "local-register-2",
+          cloudId: "cloud-register-2",
+          mappedAt: 1_002,
+        },
+      ],
+      events: [
+        event({
+          sequence: 1,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-1",
+          payload: {
+            localRegisterSessionId: "local-register-1",
+            openingFloat: 100,
+          },
+          sync: { status: "synced", uploaded: true },
+        }),
+        event({
+          sequence: 2,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-2",
+          payload: {
+            localRegisterSessionId: "local-register-2",
+            openingFloat: 250,
+            expectedCash: 250,
+          },
+          sync: { status: "needs_review", uploaded: true },
+        }),
+      ],
+    });
+
+    expect(model.activeRegisterSession).toMatchObject({
+      localRegisterSessionId: "local-register-1",
+      cloudRegisterSessionId: "cloud-register-1",
+    });
+    expect(model.canSell).toBe(false);
+    expect(model.saleBlockReason).toBe("drawer_authority");
+    expect(model.drawerAuthorityReason).toBe("cloud_closed");
+  });
+
+  it("does not let synced replacement drawers bypass non-recoverable active authority", () => {
+    const model = projectLocalRegisterReadModel({
+      drawerAuthority: {
+        cloudRegisterSessionId: "cloud-register-1",
+        localRegisterSessionId: "local-register-1",
+        observedAt: 1_050,
+        reason: "authority_unknown",
+        status: "blocked",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      },
+      mappings: [
+        {
+          entity: "registerSession",
+          localId: "local-register-1",
+          cloudId: "cloud-register-1",
+          mappedAt: 1_001,
+        },
+        {
+          entity: "registerSession",
+          localId: "local-register-2",
+          cloudId: "cloud-register-2",
+          mappedAt: 1_002,
+        },
+      ],
+      events: [
+        event({
+          sequence: 1,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-1",
+          payload: {
+            localRegisterSessionId: "local-register-1",
+            openingFloat: 100,
+          },
+          sync: { status: "synced", uploaded: true },
+        }),
+        event({
+          sequence: 2,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-2",
+          payload: {
+            localRegisterSessionId: "local-register-2",
+            openingFloat: 250,
+            expectedCash: 250,
+          },
+          sync: { status: "synced", uploaded: true },
+        }),
+      ],
+    });
+
+    expect(model.activeRegisterSession).toMatchObject({
+      localRegisterSessionId: "local-register-1",
+      cloudRegisterSessionId: "cloud-register-1",
+    });
+    expect(model.canSell).toBe(false);
+    expect(model.saleBlockReason).toBe("drawer_authority");
+    expect(model.drawerAuthorityReason).toBe("authority_unknown");
+  });
+
+  it("keeps a synced replacement drawer active after stale authority is cleared", () => {
+    const model = projectLocalRegisterReadModel({
+      mappings: [
+        {
+          entity: "registerSession",
+          localId: "local-register-1",
+          cloudId: "cloud-register-1",
+          mappedAt: 1_001,
+        },
+        {
+          entity: "registerSession",
+          localId: "local-register-2",
+          cloudId: "cloud-register-2",
+          mappedAt: 1_002,
+        },
+      ],
+      events: [
+        event({
+          sequence: 1,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-1",
+          payload: {
+            localRegisterSessionId: "local-register-1",
+            openingFloat: 100,
+          },
+          sync: { status: "synced", uploaded: true },
+        }),
+        event({
+          sequence: 2,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-2",
+          payload: {
+            localRegisterSessionId: "local-register-2",
+            openingFloat: 250,
+            expectedCash: 250,
+          },
+          sync: { status: "synced", uploaded: true },
+        }),
+      ],
+    });
+
+    expect(model.activeRegisterSession).toMatchObject({
+      localRegisterSessionId: "local-register-2",
+      cloudRegisterSessionId: "cloud-register-2",
+    });
+    expect(model.canSell).toBe(true);
+    expect(model.saleBlockReason).toBeUndefined();
+  });
+
   it("keeps selling available when uploaded lifecycle review does not invalidate local authority", () => {
     const model = projectLocalRegisterReadModel({
       events: [

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
@@ -194,7 +194,13 @@ export function projectLocalRegisterReadModel(input: {
         activeRegisterSession &&
         isOpenLocalRegisterSessionStatus(activeRegisterSession.status) &&
         isUploadedRegisterOpenLifecycleEvent(event) &&
-        !registerLifecycleEventMatchesActiveSession(event, activeRegisterSession)
+        !registerLifecycleEventMatchesActiveSession(event, activeRegisterSession) &&
+        !canUploadedRegisterOpenReplaceBlockedDrawer({
+          activeRegisterSession,
+          drawerAuthority: input.drawerAuthority,
+          event,
+          mappings,
+        })
       ) {
         continue;
       }
@@ -1018,6 +1024,35 @@ function isUploadedRegisterOpenLifecycleEvent(event: PosLocalEventRecord) {
   return (
     event.sync.uploaded === true &&
     (event.sync.status === "needs_review" || event.sync.status === "synced")
+  );
+}
+
+function canUploadedRegisterOpenReplaceBlockedDrawer(input: {
+  activeRegisterSession: PosLocalCashDrawerReadModel;
+  drawerAuthority?: PosDrawerAuthorityState | null;
+  event: PosLocalEventRecord;
+  mappings: ReturnType<typeof createMappingIndex>;
+}) {
+  const activeDrawerAuthority = getSaleBlockingDrawerAuthority({
+    activeRegisterSession: input.activeRegisterSession,
+    drawerAuthority: input.drawerAuthority,
+  });
+
+  const replacementLocalRegisterSessionId =
+    input.event.localRegisterSessionId ??
+    stringField(input.event.payload, "localRegisterSessionId");
+  const replacementCloudRegisterSessionId = replacementLocalRegisterSessionId
+    ? input.mappings.registerSession.get(replacementLocalRegisterSessionId)
+    : undefined;
+
+  return Boolean(
+    input.event.sync.status === "synced" &&
+      replacementCloudRegisterSessionId &&
+      input.activeRegisterSession.cloudRegisterSessionId &&
+      replacementCloudRegisterSessionId !==
+        input.activeRegisterSession.cloudRegisterSessionId &&
+      (!activeDrawerAuthority ||
+        activeDrawerAuthority.reason === "cloud_closed"),
   );
 }
 


### PR DESCRIPTION
## Summary
- Adds the approved POS sync contract plan artifacts (`.md` and `.html`) for the two-PR delivery.
- Tightens shared drawer lifecycle policy so replacement drawers require scoped identity and real closeout/review freshness evidence.
- Fixes local POS drawer authority/readiness identity across local/cloud register ids.
- Enforces cloud projection freshness, direct-cloud-id review checks, and duplicate `register_opened` source handling without stranding repair-created mappings.

## Linear
- V26-881
- V26-882
- V26-883

## Validation
- `bun run --filter '@athena/webapp' test -- src/lib/pos/infrastructure/local/registerReadModel.test.ts src/lib/pos/infrastructure/local/localPosReadiness.test.ts src/lib/pos/infrastructure/local/posLocalStore.test.ts src/lib/pos/infrastructure/local/localCommandGateway.test.ts src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts ../../shared/registerSessionLifecyclePolicy.test.ts convex/pos/application/sync/projectLocalEvents.test.ts convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts` (332 passed)
- `bun run --filter '@athena/webapp' test -- convex/pos/application/sync/projectLocalEvents.test.ts src/lib/pos/infrastructure/local/posLocalStore.test.ts` (156 passed after review fixes)
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bun run --filter '@athena/webapp' lint:frontend:changed`
- `bun run --filter '@athena/webapp' audit:convex`
- `bun run graphify:rebuild`
- Pre-push partial ladder passed: graphify check, architecture check, harness review, 487 harness-selected tests, Convex audit, changed-file linters

## Known unrelated blocker
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json` is blocked by existing `src/components/ui/calendar.tsx` / `calendar.test.tsx` React DayPicker API/type drift. No POS sync contract errors remain after the `sourceEventType` schema validator fix.

## Review loop
- Plan reviewers: feasibility, coherence, scope, security all approved.
- PR1 reviewers: correctness, data integrity, and testing approved after targeted follow-up fixes.

## Browser validation
- Not run per requester direction; browser validation is left to the requester.
