### PR TITLE
fix: harden POS sync settlement contract

### DIFF
--- a/docs/solutions/logic-errors/athena-pos-sync-settlement-contract-2026-06-27.md
+++ b/docs/solutions/logic-errors/athena-pos-sync-settlement-contract-2026-06-27.md
@@ -1,0 +1,69 @@
+---
+title: Athena POS Sync Settlement Contract
+date: 2026-06-27
+category: logic-errors
+module: athena-webapp
+problem_type: logic_error
+component: pos-local-sync
+symptoms:
+  - "Expense sync could share cursor state with POS drawer sync"
+  - "Rejected local closeout and reopen events could look locally settled"
+  - "Terminal recovery commands could execute without a server-issued claim identity"
+root_cause: local_sync_settlement_and_recovery_claim_state_used_implicit_cursor_and_command_identity
+resolution_type: code_fix
+severity: high
+tags:
+  - pos
+  - local-sync
+  - register-session
+  - terminal-recovery
+  - cash-controls
+---
+
+# Athena POS Sync Settlement Contract
+
+## Problem
+
+Local sync had two implicit identity boundaries. First, upload cursors were keyed
+around POS register sessions even though expense sync uses a different local
+session identity. That let POS and expense batches share cursor state and made
+ordering depend on incidental timestamps instead of durable upload sequence.
+
+Second, local runtime settlement treated some server outcomes as more final than
+they are. A rejected local closeout or reopen still needs manager review and
+should remain locally pending. Terminal recovery commands also needed stronger
+claim identity; command type and id alone are not enough to prove the local
+terminal is executing the server-issued claim instance.
+
+## Solution
+
+Make settlement identity explicit across the local and cloud contract:
+
+- Carry `syncScope`, `localSyncCursorId`, and optional
+  `localExpenseSessionId` through local batching, public sync, Convex cursor
+  persistence, and result handling. Keep `localRegisterSessionId` for legacy POS
+  compatibility.
+- Batch local uploads by terminal, scope, cursor id, and durable upload
+  sequence before `createdAt`; do not let later local rows starve earlier rows.
+- Treat `projected`, `conflicted`, `held`, and `rejected` as distinct local
+  outcomes. `rejected` remains reviewable/unsynced and must not settle embedded
+  local-only precursors.
+- Do not upload newly generated `register.reopened` events. Existing uploaded
+  reopen rows remain reviewable so historical data can be resolved safely.
+- Require a server-issued recovery command `executionId` before local execution
+  and include that execution id in acknowledgement, including non-`update_app`
+  commands.
+- When opening a replacement drawer after closeout review, carry the prior
+  Cash Controls register-session target so support surfaces identify the cloud
+  drawer rather than only the local id.
+
+## Prevention
+
+- Add cursor tests for mixed POS and expense uploads, inverted created-at
+  ordering, held rows, and scoped public sync return validation.
+- Keep runtime tests for every server outcome: projected, conflicted, held,
+  rejected, and rejected-with-local-precursors.
+- Test recovery command execution and acknowledgement with server-issued
+  execution ids for every command type, not only app updates.
+- Keep closeout and deposit tests in the validation set whenever local closeout
+  settlement changes, even if Cash Controls code is not edited directly.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8093 nodes · 9525 edges · 2063 communities detected
+- 8098 nodes · 9532 edges · 2063 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2225,16 +2225,16 @@ Cohesion: 0.13
 Nodes (21): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), formatPendingApprovalsLabel(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate() (+13 more)
 
 ### Community 31 - "Community 31"
+Cohesion: 0.19
+Nodes (27): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), isExpenseLocalSyncEvent(), isSyncablePosLocalEvent() (+19 more)
+
+### Community 32 - "Community 32"
 Cohesion: 0.14
 Nodes (23): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+15 more)
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
-
-### Community 33 - "Community 33"
-Cohesion: 0.2
-Nodes (27): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), isExpenseLocalSyncEvent(), isSyncablePosLocalEvent() (+19 more)
 
 ### Community 34 - "Community 34"
 Cohesion: 0.13
@@ -2837,12 +2837,12 @@ Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
 ### Community 184 - "Community 184"
-Cohesion: 0.25
-Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
+Cohesion: 0.28
+Nodes (4): comparePendingEvents(), getPendingEventUploadSequence(), selectNextOrderedBatch(), selectOrderedBatches()
 
 ### Community 185 - "Community 185"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+Cohesion: 0.25
+Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 186 - "Community 186"
 Cohesion: 0.42
@@ -2857,296 +2857,296 @@ Cohesion: 0.22
 Nodes (0):
 
 ### Community 189 - "Community 189"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
-
-### Community 190 - "Community 190"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
+### Community 190 - "Community 190"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
 ### Community 191 - "Community 191"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+
+### Community 192 - "Community 192"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 201 - "Community 201"
-Cohesion: 0.5
-Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
 ### Community 202 - "Community 202"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.5
+Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
 ### Community 203 - "Community 203"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 204 - "Community 204"
-Cohesion: 0.36
-Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 205 - "Community 205"
 Cohesion: 0.36
-Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
 
 ### Community 206 - "Community 206"
+Cohesion: 0.36
+Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+
+### Community 207 - "Community 207"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.29
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 209 - "Community 209"
+### Community 210 - "Community 210"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
 Cohesion: 0.29
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
-### Community 213 - "Community 213"
+### Community 214 - "Community 214"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 214 - "Community 214"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 215 - "Community 215"
 Cohesion: 0.39
-Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 216 - "Community 216"
+Cohesion: 0.39
+Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+
+### Community 217 - "Community 217"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.29
 Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.38
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.33
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
-
-### Community 246 - "Community 246"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 247 - "Community 247"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 248 - "Community 248"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 249 - "Community 249"
 Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 250 - "Community 250"
 Cohesion: 0.33
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 251 - "Community 251"
-Cohesion: 0.29
-Nodes (1): ResizeObserverStub
+Cohesion: 0.33
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 252 - "Community 252"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
 ### Community 253 - "Community 253"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 254 - "Community 254"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 256 - "Community 256"
-Cohesion: 0.52
-Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 257 - "Community 257"
 Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 258 - "Community 258"
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+
+### Community 259 - "Community 259"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.38
 Nodes (3): getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusSignature()
-
-### Community 261 - "Community 261"
-Cohesion: 0.33
-Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.29
@@ -3666,23 +3666,23 @@ Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadi
 
 ### Community 391 - "Community 391"
 Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
 ### Community 392 - "Community 392"
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+
+### Community 393 - "Community 393"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 393 - "Community 393"
+### Community 394 - "Community 394"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 394 - "Community 394"
+### Community 395 - "Community 395"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
-
-### Community 395 - "Community 395"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 396 - "Community 396"
 Cohesion: 0.4
@@ -3693,132 +3693,132 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 398 - "Community 398"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 399 - "Community 399"
 Cohesion: 0.5
-Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 400 - "Community 400"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
 ### Community 401 - "Community 401"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 402 - "Community 402"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 403 - "Community 403"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 404 - "Community 404"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 405 - "Community 405"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 405 - "Community 405"
+### Community 406 - "Community 406"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 406 - "Community 406"
+### Community 407 - "Community 407"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 407 - "Community 407"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 408 - "Community 408"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 409 - "Community 409"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 410 - "Community 410"
-Cohesion: 0.6
-Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
-
-### Community 411 - "Community 411"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 411 - "Community 411"
+Cohesion: 0.6
+Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
+
 ### Community 412 - "Community 412"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 413 - "Community 413"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 413 - "Community 413"
+### Community 414 - "Community 414"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 414 - "Community 414"
+### Community 415 - "Community 415"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 415 - "Community 415"
+### Community 416 - "Community 416"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 416 - "Community 416"
+### Community 417 - "Community 417"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 417 - "Community 417"
+### Community 418 - "Community 418"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 418 - "Community 418"
+### Community 419 - "Community 419"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 419 - "Community 419"
+### Community 420 - "Community 420"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 420 - "Community 420"
+### Community 421 - "Community 421"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 421 - "Community 421"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 422 - "Community 422"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 423 - "Community 423"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
-
-### Community 424 - "Community 424"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 424 - "Community 424"
+Cohesion: 0.67
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 425 - "Community 425"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 426 - "Community 426"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 427 - "Community 427"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 427 - "Community 427"
+### Community 428 - "Community 428"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 428 - "Community 428"
-Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 429 - "Community 429"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 430 - "Community 430"
 Cohesion: 0.5
@@ -3837,68 +3837,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 434 - "Community 434"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 435 - "Community 435"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 435 - "Community 435"
+### Community 436 - "Community 436"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 436 - "Community 436"
+### Community 437 - "Community 437"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 437 - "Community 437"
+### Community 438 - "Community 438"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 438 - "Community 438"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 439 - "Community 439"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 440 - "Community 440"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 441 - "Community 441"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 442 - "Community 442"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 442 - "Community 442"
+### Community 443 - "Community 443"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 443 - "Community 443"
+### Community 444 - "Community 444"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 444 - "Community 444"
+### Community 445 - "Community 445"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 445 - "Community 445"
+### Community 446 - "Community 446"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 446 - "Community 446"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 447 - "Community 447"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 448 - "Community 448"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 449 - "Community 449"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 450 - "Community 450"
 Cohesion: 0.5
@@ -3909,24 +3909,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 452 - "Community 452"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 453 - "Community 453"
 Cohesion: 0.67
 Nodes (2): buildCtx(), buildQueryCtx()
 
-### Community 453 - "Community 453"
+### Community 454 - "Community 454"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 454 - "Community 454"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
 
 ### Community 455 - "Community 455"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 456 - "Community 456"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 457 - "Community 457"
 Cohesion: 0.5
@@ -3941,36 +3941,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 460 - "Community 460"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 461 - "Community 461"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 461 - "Community 461"
+### Community 462 - "Community 462"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 462 - "Community 462"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 463 - "Community 463"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 464 - "Community 464"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 465 - "Community 465"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 466 - "Community 466"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 467 - "Community 467"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 468 - "Community 468"
 Cohesion: 0.5
@@ -3981,32 +3981,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 470 - "Community 470"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 471 - "Community 471"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 471 - "Community 471"
+### Community 472 - "Community 472"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 472 - "Community 472"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 473 - "Community 473"
 Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 474 - "Community 474"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 475 - "Community 475"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 476 - "Community 476"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 477 - "Community 477"
 Cohesion: 0.5
@@ -4037,12 +4037,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 484 - "Community 484"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
-
-### Community 485 - "Community 485"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 485 - "Community 485"
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 486 - "Community 486"
 Cohesion: 0.5
@@ -4053,12 +4053,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 488 - "Community 488"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 489 - "Community 489"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 489 - "Community 489"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 490 - "Community 490"
 Cohesion: 0.5
@@ -4069,88 +4069,88 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 492 - "Community 492"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 493 - "Community 493"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 493 - "Community 493"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 494 - "Community 494"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 495 - "Community 495"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 496 - "Community 496"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 497 - "Community 497"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 498 - "Community 498"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 499 - "Community 499"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 499 - "Community 499"
+### Community 500 - "Community 500"
 Cohesion: 0.67
 Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
-### Community 500 - "Community 500"
+### Community 501 - "Community 501"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 501 - "Community 501"
+### Community 502 - "Community 502"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 502 - "Community 502"
+### Community 503 - "Community 503"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 503 - "Community 503"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 504 - "Community 504"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 505 - "Community 505"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 506 - "Community 506"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 507 - "Community 507"
-Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
-
-### Community 508 - "Community 508"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 508 - "Community 508"
+Cohesion: 0.67
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+
 ### Community 509 - "Community 509"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 510 - "Community 510"
 Cohesion: 0.83
 Nodes (3): completedEvent(), event(), item()
 
-### Community 510 - "Community 510"
+### Community 511 - "Community 511"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 511 - "Community 511"
-Cohesion: 0.83
-Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
-
 ### Community 512 - "Community 512"
 Cohesion: 0.83
-Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
+Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
 ### Community 513 - "Community 513"
 Cohesion: 0.83

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2135
-- Graph nodes: 8093
-- Graph edges: 9525
+- Graph nodes: 8098
+- Graph edges: 9532
 - Communities: 2063
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (15 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 191) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 192) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
@@ -51,6 +51,8 @@ describe("createLocalSyncIngestionService", () => {
       }),
     ]);
     expect(result.data.syncCursor).toEqual({
+      syncScope: "pos",
+      localSyncCursorId: "local-register-1",
       localRegisterSessionId: "local-register-1",
       acceptedThroughSequence: 2,
     });
@@ -94,6 +96,8 @@ describe("createLocalSyncIngestionService", () => {
       }),
     ]);
     expect(result.data.syncCursor).toEqual({
+      syncScope: "pos",
+      localSyncCursorId: "local-register-1",
       localRegisterSessionId: "local-register-1",
       acceptedThroughSequence: 1,
     });
@@ -502,7 +506,7 @@ describe("createLocalSyncIngestionService", () => {
         code: "out_of_order",
       }),
     ]);
-    expect(result.data.syncCursor).toEqual({
+    expect(result.data.syncCursor).toMatchObject({
       localRegisterSessionId: "local-register-1",
       acceptedThroughSequence: 0,
     });
@@ -533,7 +537,7 @@ describe("createLocalSyncIngestionService", () => {
       kind: "user_error",
       error: {
         code: "validation_failed",
-        message: "POS sync batches must contain one local register session.",
+        message: "POS sync batches must contain one local sync cursor.",
       },
     });
     expect(repository.events).toEqual([]);
@@ -563,7 +567,10 @@ describe("createLocalSyncIngestionService", () => {
       },
     ]);
     expect(result.data.syncCursor).toEqual({
+      syncScope: "expense",
+      localSyncCursorId: "local-expense-session-1",
       localRegisterSessionId: "local-expense-session-1",
+      localExpenseSessionId: "local-expense-session-1",
       acceptedThroughSequence: 1,
     });
     expect(repository.events).toEqual([
@@ -627,7 +634,10 @@ describe("createLocalSyncIngestionService", () => {
       }),
     ]);
     expect(retry.data.syncCursor).toEqual({
+      syncScope: "expense",
+      localSyncCursorId: "local-expense-session-1",
       localRegisterSessionId: "local-expense-session-1",
+      localExpenseSessionId: "local-expense-session-1",
       acceptedThroughSequence: 1,
     });
     expect(repository.events).toEqual([
@@ -638,6 +648,56 @@ describe("createLocalSyncIngestionService", () => {
       }),
     ]);
     expect(repository.createdExpenseTransactions).toHaveLength(1);
+  });
+
+  it("keeps POS register and expense cursors separate when their local ids match", async () => {
+    const repository = createFakeSyncRepository();
+    const service = createLocalSyncIngestionService({
+      repository,
+      projectionRepository: repository,
+      now: () => 100,
+    });
+    const sharedLocalId = "shared-local-session";
+
+    const posResult = await service.ingestBatch(
+      buildBatch({
+        events: [
+          buildRegisterOpenedEvent({
+            localRegisterSessionId: sharedLocalId,
+            sequence: 1,
+          }),
+        ],
+      }),
+    );
+    const expenseResult = await service.ingestBatch(
+      buildBatch({
+        events: [
+          buildExpenseRecordedEvent({
+            localExpenseSessionId: sharedLocalId,
+            sequence: 1,
+          }),
+        ],
+      }),
+    );
+
+    expect(posResult.kind).toBe("ok");
+    expect(expenseResult.kind).toBe("ok");
+    if (posResult.kind !== "ok" || expenseResult.kind !== "ok") {
+      throw new Error("Expected ok results");
+    }
+    expect(posResult.data.syncCursor).toEqual({
+      syncScope: "pos",
+      localSyncCursorId: sharedLocalId,
+      localRegisterSessionId: sharedLocalId,
+      acceptedThroughSequence: 1,
+    });
+    expect(expenseResult.data.syncCursor).toEqual({
+      syncScope: "expense",
+      localSyncCursorId: sharedLocalId,
+      localRegisterSessionId: sharedLocalId,
+      localExpenseSessionId: sharedLocalId,
+      acceptedThroughSequence: 1,
+    });
   });
 
   it("rejects mixed POS and expense sync batches before recording events", async () => {
@@ -861,7 +921,7 @@ describe("createLocalSyncIngestionService", () => {
         status: "projected",
       }),
     ]);
-    expect(retry.data.syncCursor).toEqual({
+    expect(retry.data.syncCursor).toMatchObject({
       localRegisterSessionId: "local-register-1",
       acceptedThroughSequence: 2,
     });
@@ -1030,7 +1090,7 @@ describe("createLocalSyncIngestionService", () => {
         }),
       ]),
     );
-    expect(result.data.syncCursor).toEqual({
+    expect(result.data.syncCursor).toMatchObject({
       localRegisterSessionId: "local-register-1",
       acceptedThroughSequence: 2,
     });
@@ -1129,7 +1189,7 @@ describe("createLocalSyncIngestionService", () => {
       expect.objectContaining({ sequence: 2, status: "projected" }),
       expect.objectContaining({ sequence: 3, status: "projected" }),
     ]);
-    expect(result.data.syncCursor).toEqual({
+    expect(result.data.syncCursor).toMatchObject({
       localRegisterSessionId: "local-register-1",
       acceptedThroughSequence: 3,
     });
@@ -1264,7 +1324,7 @@ describe("createLocalSyncIngestionService", () => {
     ]);
     expect(repository.createdRegisterSessions).toHaveLength(0);
     expect(repository.createdTransactions).toHaveLength(1);
-    expect(result.data.syncCursor).toEqual({
+    expect(result.data.syncCursor).toMatchObject({
       localRegisterSessionId: "local-register-1",
       acceptedThroughSequence: 1,
     });
@@ -2833,25 +2893,129 @@ describe("createLocalSyncIngestionService", () => {
     await repository.updateAcceptedThroughSequence({
       storeId: "store-1" as never,
       terminalId: "terminal-1" as never,
-      localRegisterSessionId: "local-register-1",
+      cursor: {
+        syncScope: "pos",
+        localSyncCursorId: "local-register-1",
+        localRegisterSessionId: "local-register-1",
+      },
       acceptedThroughSequence: 42,
       updatedAt: 100,
     });
     await repository.updateAcceptedThroughSequence({
       storeId: "store-1" as never,
       terminalId: "terminal-1" as never,
-      localRegisterSessionId: "local-register-1",
+      cursor: {
+        syncScope: "pos",
+        localSyncCursorId: "local-register-1",
+        localRegisterSessionId: "local-register-1",
+      },
       acceptedThroughSequence: 64,
       updatedAt: 200,
+    });
+    await repository.updateAcceptedThroughSequence({
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      cursor: {
+        syncScope: "expense",
+        localSyncCursorId: "local-register-1",
+        localExpenseSessionId: "local-register-1",
+      },
+      acceptedThroughSequence: 7,
+      updatedAt: 250,
     });
 
     await expect(
       repository.getAcceptedThroughSequence({
         storeId: "store-1" as never,
         terminalId: "terminal-1" as never,
-        localRegisterSessionId: "local-register-1",
+        cursor: {
+          syncScope: "pos",
+          localSyncCursorId: "local-register-1",
+          localRegisterSessionId: "local-register-1",
+        },
       }),
     ).resolves.toBe(64);
+    await expect(
+      repository.getAcceptedThroughSequence({
+        storeId: "store-1" as never,
+        terminalId: "terminal-1" as never,
+        cursor: {
+          syncScope: "expense",
+          localSyncCursorId: "local-register-1",
+          localExpenseSessionId: "local-register-1",
+        },
+      }),
+    ).resolves.toBe(7);
+
+    const crowdedCursorCtx = createFakeConvexCtx({
+      posLocalSyncCursor: [
+        ...Array.from({ length: 101 }, (_, index) => ({
+          _id: `cursor-old-${index}`,
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          syncScope: "pos",
+          localSyncCursorId: `old-local-register-${index}`,
+          localRegisterSessionId: `old-local-register-${index}`,
+          acceptedThroughSequence: index,
+          updatedAt: index,
+        })),
+        {
+          _id: "cursor-target",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          syncScope: "pos",
+          localSyncCursorId: "target-local-register",
+          localRegisterSessionId: "target-local-register",
+          acceptedThroughSequence: 91,
+          updatedAt: 200,
+        },
+        {
+          _id: "cursor-legacy-pos",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          localRegisterSessionId: "shared-local-id",
+          acceptedThroughSequence: 33,
+          updatedAt: 100,
+        },
+      ],
+    });
+    const crowdedRepository = createConvexLocalSyncRepository(
+      crowdedCursorCtx as never,
+    );
+
+    await expect(
+      crowdedRepository.getAcceptedThroughSequence({
+        storeId: "store-1" as never,
+        terminalId: "terminal-1" as never,
+        cursor: {
+          syncScope: "pos",
+          localSyncCursorId: "target-local-register",
+          localRegisterSessionId: "target-local-register",
+        },
+      }),
+    ).resolves.toBe(91);
+    await expect(
+      crowdedRepository.getAcceptedThroughSequence({
+        storeId: "store-1" as never,
+        terminalId: "terminal-1" as never,
+        cursor: {
+          syncScope: "pos",
+          localSyncCursorId: "shared-local-id",
+          localRegisterSessionId: "shared-local-id",
+        },
+      }),
+    ).resolves.toBe(33);
+    await expect(
+      crowdedRepository.getAcceptedThroughSequence({
+        storeId: "store-1" as never,
+        terminalId: "terminal-1" as never,
+        cursor: {
+          syncScope: "expense",
+          localSyncCursorId: "shared-local-id",
+          localExpenseSessionId: "shared-local-id",
+        },
+      }),
+    ).resolves.toBe(0);
     await expect(
       repository.findMapping({
         storeId: "store-1" as never,
@@ -3757,7 +3921,7 @@ function createFakeSyncRepository(
 	    registerSessionId: string;
 	    patch: unknown;
 	  }> = [];
-  const acceptedThroughSequenceByRegister = new Map<string, number>();
+  const acceptedThroughSequenceByCursor = new Map<string, number>();
   const terminal = overrides.terminal ?? {
     _id: "terminal-1",
     storeId: "store-1",
@@ -3963,12 +4127,14 @@ function createFakeSyncRepository(
     },
     async getAcceptedThroughSequence(args) {
       return (
-        acceptedThroughSequenceByRegister.get(args.localRegisterSessionId) ?? 0
+        acceptedThroughSequenceByCursor.get(
+          `${args.cursor.syncScope}:${args.cursor.localSyncCursorId}`,
+        ) ?? 0
       );
     },
     async updateAcceptedThroughSequence(args) {
-      acceptedThroughSequenceByRegister.set(
-        args.localRegisterSessionId,
+      acceptedThroughSequenceByCursor.set(
+        `${args.cursor.syncScope}:${args.cursor.localSyncCursorId}`,
         args.acceptedThroughSequence,
       );
     },

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts
@@ -6,6 +6,7 @@ import { projectLocalSyncEvent } from "./projectLocalEvents";
 import { hashPosLocalStaffProofToken } from "./staffProof";
 import type {
   LocalSyncConflictRecord,
+  LocalSyncCursorIdentity,
   LocalSyncEventRecord,
   LocalSyncIngestionRepository,
   LocalSyncMappingRecord,
@@ -45,7 +46,10 @@ export type PosLocalSyncResult = {
   mappings: LocalSyncMappingRecord[];
   conflicts: LocalSyncConflictRecord[];
   syncCursor: {
+    syncScope?: "pos" | "expense";
+    localSyncCursorId?: string;
     localRegisterSessionId: string | null;
+    localExpenseSessionId?: string | null;
     acceptedThroughSequence: number;
   };
 };
@@ -131,8 +135,9 @@ export function createLocalSyncIngestionService(
       const held: PosLocalSyncHeldOutcome[] = [];
       const mappings: LocalSyncMappingRecord[] = [];
       const conflicts: LocalSyncConflictRecord[] = [];
-      let cursorRegisterSessionId: string | null =
-        batch.events[0] ? getLocalSyncCursorIdentity(batch.events[0]) : null;
+      let cursorIdentity: LocalSyncCursorIdentity | null = batch.events[0]
+        ? getLocalSyncCursorIdentity(batch.events[0])
+        : null;
       const syncScopes = new Set(batch.events.map(getLocalSyncScope));
       if (syncScopes.size > 1) {
         return userError({
@@ -141,28 +146,30 @@ export function createLocalSyncIngestionService(
         });
       }
 
-      const registerSessionIds = new Set(
-        batch.events.map(getLocalSyncCursorIdentity),
+      const cursorIds = new Set(
+        batch.events.map(
+          (event) => getLocalSyncCursorIdentity(event).localSyncCursorId,
+        ),
       );
-      if (registerSessionIds.size > 1) {
+      if (cursorIds.size > 1) {
         return userError({
           code: "validation_failed",
-          message: "POS sync batches must contain one local register session.",
+          message: "POS sync batches must contain one local sync cursor.",
         });
       }
       let acceptedThroughSequence =
-        cursorRegisterSessionId === null
+        cursorIdentity === null
           ? 0
           : await dependencies.repository.getAcceptedThroughSequence({
               storeId: batch.storeId,
               terminalId: batch.terminalId,
-              localRegisterSessionId: cursorRegisterSessionId,
+              cursor: cursorIdentity,
             });
 
       for (const event of [...batch.events].sort(
         (left, right) => left.sequence - right.sequence,
       )) {
-        cursorRegisterSessionId = getLocalSyncCursorIdentity(event);
+        cursorIdentity = getLocalSyncCursorIdentity(event);
         const existing = await dependencies.repository.findEvent({
           storeId: batch.storeId,
           terminalId: batch.terminalId,
@@ -352,7 +359,8 @@ export function createLocalSyncIngestionService(
             occurredAt: event.occurredAt,
             staffProfileId: event.staffProfileId,
             syncScope: getLocalSyncScope(event),
-            localRegisterSessionId: getLocalSyncCursorIdentity(event),
+            localRegisterSessionId:
+              getLocalSyncCursorIdentity(event).localSyncCursorId,
             ...(getLocalSyncScope(event) === "expense"
               ? { localExpenseSessionId: event.localExpenseSessionId ?? "" }
               : {}),
@@ -399,11 +407,11 @@ export function createLocalSyncIngestionService(
         );
       }
 
-      if (cursorRegisterSessionId !== null) {
+      if (cursorIdentity !== null) {
         await dependencies.repository.updateAcceptedThroughSequence({
           storeId: batch.storeId,
           terminalId: batch.terminalId,
-          localRegisterSessionId: cursorRegisterSessionId,
+          cursor: cursorIdentity,
           acceptedThroughSequence,
           updatedAt: dependencies.now(),
         });
@@ -415,7 +423,22 @@ export function createLocalSyncIngestionService(
         mappings: mappings.map(toSyncResultMapping),
         conflicts: conflicts.map(toSyncResultConflict),
         syncCursor: {
-          localRegisterSessionId: cursorRegisterSessionId,
+          ...(cursorIdentity
+            ? {
+                syncScope: cursorIdentity.syncScope,
+                localSyncCursorId: cursorIdentity.localSyncCursorId,
+              }
+            : {}),
+          localRegisterSessionId:
+            cursorIdentity?.localRegisterSessionId ??
+            cursorIdentity?.localSyncCursorId ??
+            null,
+          ...(cursorIdentity?.syncScope === "expense"
+            ? {
+                localExpenseSessionId:
+                  cursorIdentity.localExpenseSessionId ?? null,
+              }
+            : {}),
           acceptedThroughSequence,
         },
       });
@@ -434,10 +457,25 @@ function getLocalSyncScope(event: PosLocalSyncEventInput): "pos" | "expense" {
     : "pos";
 }
 
-function getLocalSyncCursorIdentity(event: PosLocalSyncEventInput): string {
-  return getLocalSyncScope(event) === "expense"
-    ? event.localExpenseSessionId ?? ""
-    : event.localRegisterSessionId ?? "";
+function getLocalSyncCursorIdentity(
+  event: PosLocalSyncEventInput,
+): LocalSyncCursorIdentity {
+  const syncScope = getLocalSyncScope(event);
+  if (syncScope === "expense") {
+    const localExpenseSessionId = event.localExpenseSessionId ?? "";
+    return {
+      syncScope,
+      localSyncCursorId: localExpenseSessionId,
+      localExpenseSessionId,
+    };
+  }
+
+  const localRegisterSessionId = event.localRegisterSessionId ?? "";
+  return {
+    syncScope,
+    localSyncCursorId: localRegisterSessionId,
+    localRegisterSessionId,
+  };
 }
 
 function prepareLocalSyncEventForProjection(input: {
@@ -474,7 +512,7 @@ async function buildLocalSyncEventRecordInput(
     terminalId: batch.terminalId,
     syncScope: getLocalSyncScope(event),
     localEventId: event.localEventId,
-    localRegisterSessionId: getLocalSyncCursorIdentity(event),
+    localRegisterSessionId: getLocalSyncCursorIdentity(event).localSyncCursorId,
     ...(getLocalSyncScope(event) === "expense"
       ? { localExpenseSessionId: event.localExpenseSessionId ?? "" }
       : {}),
@@ -500,7 +538,7 @@ function validateLocalSyncEventEnvelope(
 ): string | null {
   const scope = getLocalSyncScope(event);
   const localSyncIdentity = getLocalSyncCursorIdentity(event);
-  if (!event.localEventId.trim() || !localSyncIdentity.trim()) {
+  if (!event.localEventId.trim() || !localSyncIdentity.localSyncCursorId.trim()) {
     if (scope === "expense") {
       return "Expense sync event is missing required local identifiers.";
     }
@@ -658,8 +696,10 @@ export function parseStoredLocalSyncEvent(
   }
 
   return parseLocalSyncEvent(repository, {
+    syncScope: event.syncScope,
     localEventId: event.localEventId,
     localRegisterSessionId: event.localRegisterSessionId,
+    localExpenseSessionId: event.localExpenseSessionId,
     sequence: event.sequence,
     eventType: event.eventType,
     occurredAt: event.occurredAt,
@@ -1507,7 +1547,8 @@ function isSameLocalEvent(
 
   return (
     (existing.syncScope ?? "pos") === getLocalSyncScope(incoming) &&
-    existing.localRegisterSessionId === getLocalSyncCursorIdentity(incoming) &&
+    existing.localRegisterSessionId ===
+      getLocalSyncCursorIdentity(incoming).localSyncCursorId &&
     sequenceMatches &&
     existing.eventType === incoming.eventType &&
     existing.occurredAt === incoming.occurredAt &&

--- a/packages/athena-webapp/convex/pos/application/sync/types.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/types.ts
@@ -281,9 +281,19 @@ export type LocalSyncCursorRecord = {
   _id: string;
   storeId: Id<"store">;
   terminalId: Id<"posTerminal">;
+  syncScope?: "pos" | "expense";
+  localSyncCursorId?: string;
   localRegisterSessionId: string;
+  localExpenseSessionId?: string;
   acceptedThroughSequence: number;
   updatedAt: number;
+};
+
+export type LocalSyncCursorIdentity = {
+  syncScope: "pos" | "expense";
+  localSyncCursorId: string;
+  localRegisterSessionId?: string;
+  localExpenseSessionId?: string;
 };
 
 export type PosSyncOperationalRole = "cashier" | "manager";
@@ -751,12 +761,12 @@ export type LocalSyncIngestionRepository = {
   getAcceptedThroughSequence(args: {
     storeId: Id<"store">;
     terminalId: Id<"posTerminal">;
-    localRegisterSessionId: string;
+    cursor: LocalSyncCursorIdentity;
   }): Promise<number>;
   updateAcceptedThroughSequence(args: {
     storeId: Id<"store">;
     terminalId: Id<"posTerminal">;
-    localRegisterSessionId: string;
+    cursor: LocalSyncCursorIdentity;
     acceptedThroughSequence: number;
     updatedAt: number;
   }): Promise<void>;

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts
@@ -49,14 +49,18 @@ describe("terminal command service", () => {
       terminalId,
     });
     expect(claimed.kind).toBe("ok");
+    const executionId =
+      claimed.kind === "ok" ? claimed.data.executionId : undefined;
+    expect(executionId).toBe(`command-1:${now + 100}`);
     expect(repository.patchCommand).toHaveBeenCalledWith(
       commandId,
-      expect.objectContaining({ status: "claimed" }),
+      expect.objectContaining({ executionId, status: "claimed" }),
     );
 
     const acknowledged = await acknowledgeTerminalRecoveryCommand(repository, {
       acknowledgedAt: now + 200,
       commandId,
+      executionId,
       message: "Sync retry scheduled.",
       result: "completed",
       storeId,
@@ -566,6 +570,7 @@ describe("terminal command service", () => {
     const repository = buildRepository({
       commands: [
         buildCommand({
+          executionId: "command-1:2000000",
           status: "claimed",
         }),
       ],
@@ -574,6 +579,7 @@ describe("terminal command service", () => {
     const result = await acknowledgeTerminalRecoveryCommand(repository, {
       acknowledgedAt: now,
       commandId: "command-1" as Id<"posTerminalRecoveryCommand">,
+      executionId: "command-1:2000000",
       message: `staffProofToken=abc123 syncSecretHash=def456 paymentToken=ghi789 PIN 1234 payment=card customer Jane payload raw ${"a".repeat(40)} ${"details ".repeat(80)}`,
       result: "failed",
       storeId,
@@ -702,6 +708,50 @@ describe("terminal command service", () => {
         message: "This terminal recovery command cannot be acknowledged.",
       },
       kind: "user_error",
+    });
+  });
+
+  it("requires the claim execution id for non-update acknowledgements", async () => {
+    const repository = buildRepository({
+      commands: [
+        buildCommand({
+          executionId: "command-1:2000100",
+          status: "claimed",
+        }),
+      ],
+    });
+
+    await expect(
+      acknowledgeTerminalRecoveryCommand(repository, {
+        acknowledgedAt: now + 200,
+        commandId: "command-1" as Id<"posTerminalRecoveryCommand">,
+        result: "completed",
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toMatchObject({
+      error: {
+        code: "precondition_failed",
+        message: "This terminal recovery command claim is stale.",
+      },
+      kind: "user_error",
+    });
+    expect(repository.patchCommand).not.toHaveBeenCalled();
+
+    await expect(
+      acknowledgeTerminalRecoveryCommand(repository, {
+        acknowledgedAt: now + 300,
+        commandId: "command-1" as Id<"posTerminalRecoveryCommand">,
+        executionId: "command-1:2000100",
+        result: "completed",
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toMatchObject({
+      kind: "ok",
+      data: {
+        status: "completed",
+      },
     });
   });
 

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts
@@ -196,10 +196,7 @@ export async function claimTerminalRecoveryCommand(
   }
 
   if (command.status === "pending") {
-    const executionId =
-      command.commandType === "update_app"
-        ? buildExecutionId(command._id, args.claimedAt)
-        : undefined;
+    const executionId = buildExecutionId(command._id, args.claimedAt);
     await repository.patchCommand(command._id, pruneUndefined({
       claimedAt: args.claimedAt,
       executionId,
@@ -217,9 +214,7 @@ export async function claimTerminalRecoveryCommand(
 
   const executionId =
     command.executionId ??
-    (command.commandType === "update_app"
-      ? buildExecutionId(command._id, args.claimedAt)
-      : undefined);
+    buildExecutionId(command._id, args.claimedAt);
   const expectedEvidence =
     command.commandType === "update_app" &&
     command.expectedEvidence.appUpdateCommandExecutionId === undefined
@@ -253,25 +248,17 @@ export async function acknowledgeTerminalRecoveryCommand(
   if (!command) {
     return notFound();
   }
-  if (command.status !== "claimed" && command.status !== "pending") {
+  if (command.status !== "claimed") {
     return userError({
       code: "precondition_failed",
       message: "This terminal recovery command cannot be acknowledged.",
     });
   }
-  if (command.commandType === "update_app") {
-    if (command.status !== "claimed") {
-      return userError({
-        code: "precondition_failed",
-        message: "This terminal recovery command must be claimed before acknowledgement.",
-      });
-    }
-    if (!command.executionId || args.executionId !== command.executionId) {
-      return userError({
-        code: "precondition_failed",
-        message: "This terminal recovery command claim is stale.",
-      });
-    }
+  if (!command.executionId || args.executionId !== command.executionId) {
+    return userError({
+      code: "precondition_failed",
+      message: "This terminal recovery command claim is stale.",
+    });
   }
 
   const status = args.result;

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
@@ -65,6 +65,38 @@ export function createConvexLocalSyncRepository(
       ? (normalized as Id<TableName>)
       : null;
   };
+  const findLocalSyncCursor = async (args: {
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+    cursor: {
+      syncScope: "pos" | "expense";
+      localSyncCursorId: string;
+    };
+  }): Promise<LocalSyncCursorRecord | null> => {
+    const scoped = (await ctx.db
+      .query("posLocalSyncCursor")
+      .withIndex("by_store_terminal_scope_cursor", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("terminalId", args.terminalId)
+          .eq("syncScope", args.cursor.syncScope)
+          .eq("localSyncCursorId", args.cursor.localSyncCursorId),
+      )
+      .unique()) as LocalSyncCursorRecord | null;
+    if (scoped) return scoped;
+    if (args.cursor.syncScope !== "pos") return null;
+
+    const legacy = (await ctx.db
+      .query("posLocalSyncCursor")
+      .withIndex("by_store_terminal_register", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("terminalId", args.terminalId)
+          .eq("localRegisterSessionId", args.cursor.localSyncCursorId),
+      )
+      .unique()) as LocalSyncCursorRecord | null;
+    return legacy && legacy.syncScope === undefined ? legacy : null;
+  };
 
   return {
     getTerminal(terminalId) {
@@ -205,29 +237,18 @@ export function createConvexLocalSyncRepository(
       );
     },
     async getAcceptedThroughSequence(args) {
-      const cursor = (await ctx.db
-        .query("posLocalSyncCursor")
-        .withIndex("by_store_terminal_register", (q) =>
-          q
-            .eq("storeId", args.storeId)
-            .eq("terminalId", args.terminalId)
-            .eq("localRegisterSessionId", args.localRegisterSessionId),
-        )
-        .unique()) as LocalSyncCursorRecord | null;
+      const cursor = await findLocalSyncCursor(args);
       return cursor?.acceptedThroughSequence ?? 0;
     },
     async updateAcceptedThroughSequence(args) {
-      const existing = (await ctx.db
-        .query("posLocalSyncCursor")
-        .withIndex("by_store_terminal_register", (q) =>
-          q
-            .eq("storeId", args.storeId)
-            .eq("terminalId", args.terminalId)
-            .eq("localRegisterSessionId", args.localRegisterSessionId),
-        )
-        .unique()) as LocalSyncCursorRecord | null;
+      const existing = await findLocalSyncCursor(args);
       if (existing) {
         await ctx.db.patch("posLocalSyncCursor", existing._id as Id<"posLocalSyncCursor">, {
+          syncScope: args.cursor.syncScope,
+          localSyncCursorId: args.cursor.localSyncCursorId,
+          localRegisterSessionId:
+            args.cursor.localRegisterSessionId ?? args.cursor.localSyncCursorId,
+          localExpenseSessionId: args.cursor.localExpenseSessionId,
           acceptedThroughSequence: args.acceptedThroughSequence,
           updatedAt: args.updatedAt,
         });
@@ -237,7 +258,11 @@ export function createConvexLocalSyncRepository(
       await ctx.db.insert("posLocalSyncCursor", {
         storeId: args.storeId,
         terminalId: args.terminalId,
-        localRegisterSessionId: args.localRegisterSessionId,
+        syncScope: args.cursor.syncScope,
+        localSyncCursorId: args.cursor.localSyncCursorId,
+        localRegisterSessionId:
+          args.cursor.localRegisterSessionId ?? args.cursor.localSyncCursorId,
+        localExpenseSessionId: args.cursor.localExpenseSessionId,
         acceptedThroughSequence: args.acceptedThroughSequence,
         updatedAt: args.updatedAt,
       });

--- a/packages/athena-webapp/convex/pos/public/sync.test.ts
+++ b/packages/athena-webapp/convex/pos/public/sync.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { assertConformsToExportedReturns } from "../../lib/returnValidatorContract";
 
 const mocks = vi.hoisted(() => ({
   requireAuthenticatedAthenaUserWithCtx: vi.fn(),
@@ -185,7 +186,10 @@ describe("POS local sync public mutation", () => {
           },
         ],
         syncCursor: {
+          syncScope: "expense",
+          localSyncCursorId: "expense-session-1",
           localRegisterSessionId: "local-register-1",
+          localExpenseSessionId: "expense-session-1",
           acceptedThroughSequence: 1,
         },
       },
@@ -199,9 +203,17 @@ describe("POS local sync public mutation", () => {
       events: [buildEvent()],
     });
 
+    assertConformsToExportedReturns(ingestLocalEvents, result);
     expect(result).toMatchObject({
       kind: "ok",
       data: {
+        syncCursor: {
+          syncScope: "expense",
+          localSyncCursorId: "expense-session-1",
+          localRegisterSessionId: "local-register-1",
+          localExpenseSessionId: "expense-session-1",
+          acceptedThroughSequence: 1,
+        },
         conflicts: [
           expect.objectContaining({
             conflictType: "duplicate_local_id",

--- a/packages/athena-webapp/convex/pos/public/sync.ts
+++ b/packages/athena-webapp/convex/pos/public/sync.ts
@@ -70,7 +70,10 @@ const localSyncResultValidator = commandResultValidator(
     mappings: v.array(localSyncMappingValidator),
     conflicts: v.array(localSyncConflictValidator),
     syncCursor: v.object({
+      syncScope: v.optional(v.union(v.literal("pos"), v.literal("expense"))),
+      localSyncCursorId: v.optional(v.string()),
       localRegisterSessionId: v.union(v.string(), v.null()),
+      localExpenseSessionId: v.optional(v.union(v.string(), v.null())),
       acceptedThroughSequence: v.number(),
     }),
   }),

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -664,6 +664,12 @@ const schema = defineSchema({
     .index("by_store_status", ["storeId", "status"])
     .index("by_localEventId", ["localEventId"]),
   posLocalSyncCursor: defineTable(posLocalSyncCursorSchema)
+    .index("by_store_terminal_scope_cursor", [
+      "storeId",
+      "terminalId",
+      "syncScope",
+      "localSyncCursorId",
+    ])
     .index("by_store_terminal_register", [
       "storeId",
       "terminalId",

--- a/packages/athena-webapp/convex/schemas/pos/posLocalSyncCursor.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posLocalSyncCursor.ts
@@ -3,7 +3,10 @@ import { v } from "convex/values";
 export const posLocalSyncCursorSchema = v.object({
   storeId: v.id("store"),
   terminalId: v.id("posTerminal"),
+  syncScope: v.optional(v.union(v.literal("pos"), v.literal("expense"))),
+  localSyncCursorId: v.optional(v.string()),
   localRegisterSessionId: v.string(),
+  localExpenseSessionId: v.optional(v.string()),
   acceptedThroughSequence: v.number(),
   updatedAt: v.number(),
 });

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
@@ -848,13 +848,13 @@ describe("posLocalStore", () => {
       "pending",
       "pending",
       "pending",
-      "pending",
+      "synced",
     ]);
     expect(
       events.value.map(
         (event) => (event as { uploadSequence?: number }).uploadSequence,
       ),
-    ).toEqual([1, undefined, undefined, 2, 3, 4, 5]);
+    ).toEqual([1, undefined, undefined, 2, 3, 4, undefined]);
   });
 
   it("treats pending checkout item definitions as uploadable without storing unsafe local metadata", async () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
@@ -76,7 +76,6 @@ export function canUploadPosLocalEventType(type: PosLocalEventType): boolean {
     type === "transaction.completed" ||
     type === "cart.cleared" ||
     type === "register.closeout_started" ||
-    type === "register.reopened" ||
     type === "expense.completed"
   );
 }

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.test.ts
@@ -14,11 +14,11 @@ describe("syncContract", () => {
       buildLocalEvent({ type: "transaction.completed" }),
       buildLocalEvent({ type: "cart.cleared" }),
       buildLocalEvent({ type: "register.closeout_started" }),
-      buildLocalEvent({ type: "register.reopened" }),
     ];
     const localOnlyEvents = [
       buildLocalEvent({ type: "session.started" }),
       buildLocalEvent({ type: "cart.item_added" }),
+      buildLocalEvent({ type: "register.reopened" }),
       buildLocalEvent({ localRegisterSessionId: undefined }),
       buildLocalEvent({ staffProfileId: undefined }),
     ];
@@ -30,9 +30,9 @@ describe("syncContract", () => {
       true,
       true,
       true,
-      true,
     ]);
     expect(localOnlyEvents.map(isSyncablePosLocalEvent)).toEqual([
+      false,
       false,
       false,
       false,
@@ -50,7 +50,7 @@ describe("syncContract", () => {
     ]);
   });
 
-  it("maps register lifecycle events to server upload events with syncable sequence numbers", () => {
+  it("maps syncable register lifecycle events to server upload events with syncable sequence numbers", () => {
     const events: PosLocalEventRecord[] = [
       buildLocalEvent({
         localEventId: "event-open",
@@ -99,15 +99,19 @@ describe("syncContract", () => {
           notes: "Closed",
         }),
       }),
-      expect.objectContaining({
-        localEventId: "event-reopen",
-        sequence: 3,
-        eventType: "register_reopened",
-        payload: expect.objectContaining({
-          reason: "Corrected count",
-        }),
-      }),
     ]);
+  });
+
+  it("does not select local reopen events for upload before manager-review replay exists", () => {
+    const event = buildLocalEvent({
+      localEventId: "event-reopen",
+      sequence: 1,
+      type: "register.reopened",
+      payload: { reason: "Corrected count" },
+    });
+
+    expect(isSyncablePosLocalEvent(event)).toBe(false);
+    expect(buildPosLocalSyncUploadEvents([event], [event])).toEqual([]);
   });
 
   it("maps clear-only sales to syncable sale clear events", () => {
@@ -882,6 +886,41 @@ describe("syncContract", () => {
     ]);
   });
 
+  it("orders upload payloads by stored upload sequence when local event order disagrees", () => {
+    const events: PosLocalEventRecord[] = [
+      buildLocalEvent({
+        localEventId: "event-created-first-upload-second",
+        sequence: 10,
+        type: "register.closeout_started",
+        uploadSequence: 2,
+      }),
+      buildLocalEvent({
+        localEventId: "event-created-second-upload-first",
+        sequence: 20,
+        type: "register.opened",
+        uploadSequence: 1,
+      }),
+    ];
+
+    expect(
+      buildPosLocalSyncUploadEvents([events[0], events[1]], events).map(
+        (event) => ({
+          localEventId: event.localEventId,
+          sequence: event.sequence,
+        }),
+      ),
+    ).toEqual([
+      {
+        localEventId: "event-created-second-upload-first",
+        sequence: 1,
+      },
+      {
+        localEventId: "event-created-first-upload-second",
+        sequence: 2,
+      },
+    ]);
+  });
+
   it("normalizes local payment payloads before upload", () => {
     const events: PosLocalEventRecord[] = [
       buildLocalEvent({
@@ -1067,7 +1106,6 @@ function isUploadSequenceEventType(type: PosLocalEventRecord["type"]) {
     type === "cart.cleared" ||
     type === "transaction.completed" ||
     type === "register.closeout_started" ||
-    type === "register.reopened" ||
     type === "expense.completed"
   );
 }

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.ts
@@ -33,9 +33,7 @@ export function buildPosLocalSyncUploadEvents(
   );
   const uploadEvents: PosLocalUploadEvent[] = [];
 
-  for (const event of [...eventsToUpload].sort(
-    (left, right) => left.sequence - right.sequence,
-  )) {
+  for (const event of [...eventsToUpload].sort(compareUploadEvents)) {
     if (!isSyncablePosLocalEvent(event, uploadSupport)) continue;
     const uploadEvent = toUploadEvent(event, orderedEvents);
     if (!uploadEvent) continue;
@@ -45,6 +43,25 @@ export function buildPosLocalSyncUploadEvents(
   }
 
   return uploadEvents;
+}
+
+function compareUploadEvents(
+  left: PosLocalEventRecord,
+  right: PosLocalEventRecord,
+): number {
+  const leftUploadSequence =
+    typeof left.uploadSequence === "number"
+      ? left.uploadSequence
+      : left.sequence;
+  const rightUploadSequence =
+    typeof right.uploadSequence === "number"
+      ? right.uploadSequence
+      : right.sequence;
+  if (leftUploadSequence !== rightUploadSequence) {
+    return leftUploadSequence - rightUploadSequence;
+  }
+
+  return left.sequence - right.sequence;
 }
 
 export function isSyncablePosLocalEvent(
@@ -201,21 +218,6 @@ function toUploadEvent(
         countedCash:
           typeof payload.countedCash === "number" ? payload.countedCash : undefined,
         notes: nullableStringToOptional(payload.notes),
-      },
-    };
-  }
-
-  if (event.type === "register.reopened") {
-    const payload = asRecord(event.payload);
-    return {
-      localEventId: event.localEventId,
-      localRegisterSessionId: event.localRegisterSessionId,
-      eventType: "register_reopened",
-      occurredAt: event.createdAt,
-      staffProfileId: event.staffProfileId,
-      ...(event.staffProofToken ? { staffProofToken: event.staffProofToken } : {}),
-      payload: {
-        reason: nullableStringToOptional(payload.reason),
       },
     };
   }

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.test.ts
@@ -110,6 +110,78 @@ describe("syncScheduler", () => {
     expect(markSynced).toHaveBeenNthCalledWith(2, ["newer-1"]);
   });
 
+  it("orders batches by upload sequence before created time", async () => {
+    const uploadBatch = vi.fn().mockResolvedValue({ syncedEventIds: [] });
+    const scheduler = createPosLocalSyncScheduler({
+      loadPendingEvents: vi.fn().mockResolvedValue([
+        baseEvent({
+          id: "upload-2-created-first",
+          createdAt: 1_000,
+          sequence: 20,
+          uploadSequence: 2,
+        }),
+        baseEvent({
+          id: "upload-1-created-later",
+          createdAt: 2_000,
+          sequence: 10,
+          uploadSequence: 1,
+        }),
+      ]),
+      uploadBatch,
+      markSynced: vi.fn().mockResolvedValue(undefined),
+      isOnline: () => true,
+      maxBatchSize: 10,
+    });
+
+    scheduler.trigger("route-entry");
+    await vi.runAllTimersAsync();
+
+    expect(
+      uploadBatch.mock.calls[0]?.[0].map(
+        (event: PosLocalPendingEvent) => event.id,
+      ),
+    ).toEqual(["upload-1-created-later", "upload-2-created-first"]);
+  });
+
+  it("keeps expense sessions in separate cursor batches", async () => {
+    const uploadBatch = vi.fn().mockResolvedValue({ syncedEventIds: [] });
+    const scheduler = createPosLocalSyncScheduler({
+      loadPendingEvents: vi.fn().mockResolvedValue([
+        baseEvent({
+          id: "expense-1",
+          syncScope: "expense",
+          localRegisterSessionId: "",
+          localExpenseSessionId: "expense-session-1",
+          sequence: 1,
+          uploadSequence: 1,
+        }),
+        baseEvent({
+          id: "expense-2",
+          syncScope: "expense",
+          localRegisterSessionId: "",
+          localExpenseSessionId: "expense-session-2",
+          sequence: 2,
+          uploadSequence: 1,
+        }),
+      ]),
+      uploadBatch,
+      markSynced: vi.fn().mockResolvedValue(undefined),
+      isOnline: () => true,
+      maxBatchSize: 10,
+    });
+
+    scheduler.trigger("route-entry");
+    await vi.runAllTimersAsync();
+
+    expect(uploadBatch).toHaveBeenCalledTimes(2);
+    expect(uploadBatch.mock.calls[0]?.[0]).toEqual([
+      expect.objectContaining({ id: "expense-1" }),
+    ]);
+    expect(uploadBatch.mock.calls[1]?.[0]).toEqual([
+      expect.objectContaining({ id: "expense-2" }),
+    ]);
+  });
+
   it("keeps events pending after failure, applies backoff, and lets manual retry bypass it", async () => {
     const uploadBatch = vi
       .fn()
@@ -225,6 +297,31 @@ describe("syncScheduler", () => {
     await vi.runAllTimersAsync();
 
     expect(markNeedsReview).toHaveBeenCalledWith(["event-conflicted"]);
+    expect(markSynced).toHaveBeenCalledWith(["event-1"]);
+  });
+
+  it("marks server-rejected events through the rejected settlement path", async () => {
+    const markRejected = vi.fn().mockResolvedValue(undefined);
+    const markNeedsReview = vi.fn().mockResolvedValue(undefined);
+    const markSynced = vi.fn().mockResolvedValue(undefined);
+    const scheduler = createPosLocalSyncScheduler({
+      loadPendingEvents: vi.fn().mockResolvedValue([baseEvent({})]),
+      uploadBatch: vi.fn().mockResolvedValue({
+        rejectedEventIds: ["event-rejected"],
+        reviewEventIds: ["event-conflicted"],
+        syncedEventIds: ["event-1"],
+      }),
+      markRejected,
+      markNeedsReview,
+      markSynced,
+      isOnline: () => true,
+    });
+
+    scheduler.trigger("route-entry");
+    await vi.runAllTimersAsync();
+
+    expect(markNeedsReview).toHaveBeenCalledWith(["event-conflicted"]);
+    expect(markRejected).toHaveBeenCalledWith(["event-rejected"]);
     expect(markSynced).toHaveBeenCalledWith(["event-1"]);
   });
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts
@@ -11,9 +11,12 @@ export type PosLocalSyncTrigger =
 export interface PosLocalPendingEvent {
   id: string;
   terminalId: string;
+  syncScope?: "pos" | "expense";
   localRegisterSessionId: string;
+  localExpenseSessionId?: string;
   createdAt: number;
   sequence: number;
+  uploadSequence?: number;
 }
 
 export interface PosLocalSyncStatus {
@@ -42,9 +45,11 @@ export interface CreatePosLocalSyncSchedulerOptions {
     metadata: { trigger: PosLocalSyncTrigger },
   ): Promise<{
     heldEventIds?: string[];
+    rejectedEventIds?: string[];
     reviewEventIds?: string[];
     syncedEventIds: string[];
   }>;
+  markRejected?(eventIds: string[]): Promise<void>;
   markNeedsReview?(eventIds: string[]): Promise<void>;
   markSynced(eventIds: string[]): Promise<void>;
   isOnline(): boolean;
@@ -177,13 +182,17 @@ export function createPosLocalSyncScheduler(
         if (result.reviewEventIds?.length) {
           await options.markNeedsReview?.(result.reviewEventIds);
         }
+        if (result.rejectedEventIds?.length) {
+          await options.markRejected?.(result.rejectedEventIds);
+        }
         if (result.syncedEventIds.length) {
           await options.markSynced(result.syncedEventIds);
         }
         if (result.heldEventIds?.length) {
           if (
             result.syncedEventIds.length > 0 ||
-            (result.reviewEventIds?.length ?? 0) > 0
+            (result.reviewEventIds?.length ?? 0) > 0 ||
+            (result.rejectedEventIds?.length ?? 0) > 0
           ) {
             rerunRequested = true;
             return;
@@ -307,7 +316,7 @@ export function selectOrderedBatches(
       .filter(
         (event) =>
           event.terminalId === first.terminalId &&
-          event.localRegisterSessionId === first.localRegisterSessionId,
+          getPendingEventCursorKey(event) === getPendingEventCursorKey(first),
       )
       .slice(0, maxBatchSize);
     batches.push(batch);
@@ -328,6 +337,12 @@ function comparePendingEvents(
   left: PosLocalPendingEvent,
   right: PosLocalPendingEvent,
 ): number {
+  const leftUploadSequence = getPendingEventUploadSequence(left);
+  const rightUploadSequence = getPendingEventUploadSequence(right);
+  if (leftUploadSequence !== rightUploadSequence) {
+    return leftUploadSequence - rightUploadSequence;
+  }
+
   if (left.createdAt !== right.createdAt) {
     return left.createdAt - right.createdAt;
   }
@@ -337,6 +352,22 @@ function comparePendingEvents(
   }
 
   return left.id.localeCompare(right.id);
+}
+
+function getPendingEventCursorKey(event: PosLocalPendingEvent): string {
+  const scope = event.syncScope === "expense" ? "expense" : "pos";
+  const cursorId =
+    scope === "expense"
+      ? event.localExpenseSessionId || event.localRegisterSessionId
+      : event.localRegisterSessionId;
+
+  return `${event.terminalId}:${scope}:${cursorId}`;
+}
+
+function getPendingEventUploadSequence(event: PosLocalPendingEvent): number {
+  return typeof event.uploadSequence === "number"
+    ? event.uploadSequence
+    : event.sequence;
 }
 
 function getCurrentBackoffDelay(nowMs: number, until: number | null): number {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { derivePosLocalSyncStatus } from "./syncStatus";
+import {
+  derivePosLocalSyncStatus,
+  mapServerSettlementOutcomeToLocalState,
+} from "./syncStatus";
 import type { PosLocalEventRecord } from "./posLocalStore";
 
 function event(
@@ -145,6 +148,31 @@ describe("derivePosLocalSyncStatus", () => {
       failedCount: 0,
       lastLocalSequence: 3,
       nextPendingSequence: null,
+    });
+  });
+});
+
+describe("mapServerSettlementOutcomeToLocalState", () => {
+  it("keeps server settlement outcomes distinct for local status presentation", () => {
+    expect(mapServerSettlementOutcomeToLocalState("projected")).toEqual({
+      state: "synced",
+      label: "Synced",
+      settlesLocalPrecursors: true,
+    });
+    expect(mapServerSettlementOutcomeToLocalState("conflicted")).toEqual({
+      state: "needs_review",
+      label: "Needs manager review",
+      settlesLocalPrecursors: false,
+    });
+    expect(mapServerSettlementOutcomeToLocalState("held")).toEqual({
+      state: "pending",
+      label: "Waiting for earlier POS history",
+      settlesLocalPrecursors: false,
+    });
+    expect(mapServerSettlementOutcomeToLocalState("rejected")).toEqual({
+      state: "needs_review",
+      label: "Sync rejected; review required",
+      settlesLocalPrecursors: false,
     });
   });
 });

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.ts
@@ -16,6 +16,54 @@ export interface PosLocalSyncStatus {
   nextPendingSequence: number | null;
 }
 
+export type PosLocalServerSettlementOutcome =
+  | "projected"
+  | "conflicted"
+  | "held"
+  | "rejected";
+
+export type PosLocalSettlementState = Pick<
+  PosLocalSyncStatus,
+  "state"
+> & {
+  label: string;
+  settlesLocalPrecursors: boolean;
+};
+
+export function mapServerSettlementOutcomeToLocalState(
+  outcome: PosLocalServerSettlementOutcome,
+): PosLocalSettlementState {
+  if (outcome === "projected") {
+    return {
+      state: "synced",
+      label: "Synced",
+      settlesLocalPrecursors: true,
+    };
+  }
+
+  if (outcome === "conflicted") {
+    return {
+      state: "needs_review",
+      label: "Needs manager review",
+      settlesLocalPrecursors: false,
+    };
+  }
+
+  if (outcome === "held") {
+    return {
+      state: "pending",
+      label: "Waiting for earlier POS history",
+      settlesLocalPrecursors: false,
+    };
+  }
+
+  return {
+    state: "needs_review",
+    label: "Sync rejected; review required",
+    settlesLocalPrecursors: false,
+  };
+}
+
 export function derivePosLocalSyncStatus(input: {
   events: PosLocalEventRecord[];
   lastSyncedSequence?: number;

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts
@@ -27,6 +27,7 @@ function buildCommand(
 ): PosTerminalRecoveryCommand {
   return {
     commandId: "command-1",
+    executionId: "command-1:1000",
     storeId: "store-1",
     terminalId: "terminal-cloud-1",
     type: "report_diagnostics",
@@ -58,6 +59,23 @@ function buildLocalEvent(
 }
 
 describe("terminalRecoveryCommands", () => {
+  it("does not execute unclaimed commands without a server-issued execution id", async () => {
+    const result = await executeTerminalRecoveryCommand({
+      command: buildCommand({ executionId: undefined }),
+      store: createPosLocalStore({
+        adapter: createMemoryPosLocalStorageAdapter(),
+      }),
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(result).toMatchObject({
+      message: "Terminal evidence changed before this recovery command could run.",
+      status: "precondition_failed",
+    });
+  });
+
   it("repairs the terminal seed and clears terminal integrity only after the seed write succeeds", async () => {
     const store = createPosLocalStore({
       adapter: createMemoryPosLocalStorageAdapter(),
@@ -656,6 +674,7 @@ describe("terminalRecoveryCommands", () => {
       command: {
         _id: "backend-command-1",
         commandType: "clear_stale_drawer_authority",
+        executionId: "backend-command-1:1000",
         payload: {
           cloudRegisterSessionId: "register-cloud-1",
           expectedBlockerType: "cloud_closed",
@@ -714,6 +733,7 @@ describe("terminalRecoveryCommands", () => {
           drawerAuthorityStatus: "healthy",
           localRegisterSessionId: "register-local-1",
         },
+        executionId: "backend-command-1:1000",
         storeId: "store-1",
         terminalId: "terminal-cloud-1",
       },

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts
@@ -148,6 +148,9 @@ export async function executeTerminalRecoveryCommand(
       type: commandType,
     };
   }
+  if (typeof command.executionId !== "string" || command.executionId.length === 0) {
+    return preconditionFailed(command);
+  }
 
   try {
     switch (commandType) {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -59,6 +59,7 @@ import {
   collectLocallySettledSkippedReviewEventIds,
   collectSyncedLocalEventIds,
   collectServerHeldLocalEventIds,
+  collectServerRejectedLocalEventIds,
   collectServerReviewLocalEventIds,
   collectServerSettledLocalEventIds,
   collectServerSyncedLocalEventIds,
@@ -4258,7 +4259,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     ).toEqual([1, 2]);
   });
 
-  it("keeps server-conflicted events in review and settles server-rejected events locally", () => {
+  it("maps projected, conflicted, held, and rejected server outcomes distinctly", () => {
     expect(
       collectServerSyncedLocalEventIds([
         { localEventId: "event-checkout", status: "conflicted" },
@@ -4276,13 +4277,21 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       ]),
     ).toEqual(["event-checkout"]);
     expect(
+      collectServerRejectedLocalEventIds([
+        { localEventId: "event-checkout", status: "conflicted" },
+        { localEventId: "event-open", status: "projected" },
+        { localEventId: "event-held", status: "held" },
+        { localEventId: "event-rejected", status: "rejected" },
+      ]),
+    ).toEqual(["event-rejected"]);
+    expect(
       collectServerSettledLocalEventIds([
         { localEventId: "event-checkout", status: "conflicted" },
         { localEventId: "event-open", status: "projected" },
         { localEventId: "event-held", status: "held" },
         { localEventId: "event-rejected", status: "rejected" },
       ]),
-    ).toEqual(["event-open", "event-rejected"]);
+    ).toEqual(["event-open"]);
     expect(
       collectServerHeldLocalEventIds([
         { localEventId: "event-held" },
@@ -4433,7 +4442,156 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     });
   });
 
-  it("marks rejected runtime sale responses and embedded local events as settled", async () => {
+  it("uploads completed expense events with different local sessions in separate ingest calls", async () => {
+    const expenseOne = buildLocalEvent({
+      localEventId: "event-expense-1",
+      localExpenseSessionId: "expense-session-1",
+      localRegisterSessionId: undefined,
+      payload: {
+        localExpenseSessionId: "expense-session-1",
+        localExpenseEventId: "expense-event-1",
+        subtotal: 25,
+        tax: 0,
+        total: 25,
+        items: [
+          {
+            localItemId: "expense-line-1",
+            productId: "product-1",
+            productSkuId: "sku-1",
+            productName: "Repair kit",
+            productSku: "KIT-1",
+            quantity: 1,
+            price: 25,
+          },
+        ],
+      },
+      sequence: 42,
+      type: "expense.completed",
+      uploadSequence: 1,
+    });
+    const expenseTwo = buildLocalEvent({
+      localEventId: "event-expense-2",
+      localExpenseSessionId: "expense-session-2",
+      localRegisterSessionId: undefined,
+      payload: {
+        localExpenseSessionId: "expense-session-2",
+        localExpenseEventId: "expense-event-2",
+        subtotal: 10,
+        tax: 0,
+        total: 10,
+        items: [
+          {
+            localItemId: "expense-line-2",
+            productId: "product-1",
+            productSkuId: "sku-1",
+            productName: "Repair kit",
+            productSku: "KIT-1",
+            quantity: 1,
+            price: 10,
+          },
+        ],
+      },
+      sequence: 43,
+      type: "expense.completed",
+      uploadSequence: 1,
+    });
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [expenseOne, expenseTwo],
+      })),
+      listEventsForUpload: vi.fn(async () => ({
+        ok: true,
+        value: [expenseOne, expenseTwo],
+      })),
+      markEventsNeedsReview: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+    };
+    mocks.ingestLocalEvents
+      .mockResolvedValueOnce({
+        kind: "ok",
+        data: {
+          accepted: [
+            { localEventId: "event-expense-1", sequence: 1, status: "projected" },
+          ],
+          held: [],
+          mappings: [],
+          conflicts: [],
+          syncCursor: {
+            syncScope: "expense",
+            localSyncCursorId: "expense-session-1",
+            localRegisterSessionId: "expense-session-1",
+            localExpenseSessionId: "expense-session-1",
+            acceptedThroughSequence: 1,
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        kind: "ok",
+        data: {
+          accepted: [
+            { localEventId: "event-expense-2", sequence: 1, status: "projected" },
+          ],
+          held: [],
+          mappings: [],
+          conflicts: [],
+          syncCursor: {
+            syncScope: "expense",
+            localSyncCursorId: "expense-session-2",
+            localRegisterSessionId: "expense-session-2",
+            localExpenseSessionId: "expense-session-2",
+            acceptedThroughSequence: 1,
+          },
+        },
+      });
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        mode: "drain-enabled",
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.ingestLocalEvents.mock.calls.length).toBeGreaterThanOrEqual(2),
+    );
+    expect(mocks.ingestLocalEvents.mock.calls[0]?.[0].events).toEqual([
+      expect.objectContaining({
+        localEventId: "event-expense-1",
+        localExpenseSessionId: "expense-session-1",
+        sequence: 1,
+      }),
+    ]);
+    expect(mocks.ingestLocalEvents.mock.calls[1]?.[0].events).toEqual([
+      expect.objectContaining({
+        localEventId: "event-expense-2",
+        localExpenseSessionId: "expense-session-2",
+        sequence: 1,
+      }),
+    ]);
+  });
+
+  it("marks rejected runtime sale responses reviewable without settling embedded local events", async () => {
     mocks.ingestLocalEvents.mockResolvedValue({
       kind: "ok",
       data: {
@@ -4552,12 +4710,13 @@ describe("usePosLocalSyncRuntimeStatus", () => {
 
     await waitFor(() => expect(mocks.ingestLocalEvents).toHaveBeenCalled());
     await waitFor(() =>
-      expect(store.markEventsSynced).toHaveBeenCalledWith(
+      expect(store.markEventsNeedsReview).toHaveBeenCalledWith(
         ["event-checkout", "event-session", "event-cart", "event-payment"],
+        "Sync rejected; review required",
         { uploaded: true },
       ),
     );
-    expect(store.markEventsNeedsReview).not.toHaveBeenCalled();
+    expect(store.markEventsSynced).not.toHaveBeenCalled();
   });
 
   it("presents unsynced closeout events as locally closed pending sync", () => {
@@ -5100,6 +5259,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     await waitFor(() =>
       expect(mocks.acknowledgeTerminalRecoveryCommand).toHaveBeenCalledWith({
         commandId: "command-1",
+        executionId: "command-1:2000100",
         message: undefined,
         result: "completed",
         storeId: "store-1",
@@ -5420,6 +5580,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     await waitFor(() =>
       expect(mocks.acknowledgeTerminalRecoveryCommand).toHaveBeenCalledWith({
         commandId: "command-1",
+        executionId: "command-1:2000100",
         message: undefined,
         result: "completed",
         storeId: "store-1",
@@ -5520,6 +5681,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     await waitFor(() =>
       expect(mocks.acknowledgeTerminalRecoveryCommand).toHaveBeenCalledWith({
         commandId: "command-1",
+        executionId: "command-1:2000100",
         message: "Staff authority refreshed.",
         result: "completed",
         storeId: "store-1",
@@ -5570,6 +5732,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     await waitFor(() =>
       expect(mocks.acknowledgeTerminalRecoveryCommand).toHaveBeenCalledWith({
         commandId: "command-1",
+        executionId: "command-1:2000100",
         message:
           "Drawer repair expected a blocked drawer authority record, but this terminal no longer reported that same block.",
         result: "precondition_failed",
@@ -5614,6 +5777,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     );
     expect(mocks.acknowledgeTerminalRecoveryCommand).toHaveBeenCalledWith({
       commandId: "command-1",
+      executionId: "command-1:2000100",
       message: undefined,
       result: "completed",
       storeId: "store-1",
@@ -5684,6 +5848,7 @@ function buildRecoveryCommand(overrides: Record<string, unknown> = {}) {
     commandType: "retry_sync",
     expectedEvidence: {},
     expiresAt: Date.now() + 60_000,
+    executionId: "command-1:2000100",
     issuedAt: 1,
     issuedByUserId: "user-1",
     status: "pending",

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -39,7 +39,10 @@ import {
   createPosLocalSyncScheduler,
   type PosLocalSyncTrigger,
 } from "./syncScheduler";
-import { derivePosLocalSyncStatus } from "./syncStatus";
+import {
+  derivePosLocalSyncStatus,
+  mapServerSettlementOutcomeToLocalState,
+} from "./syncStatus";
 import { readScopedPosLocalEvents } from "./localRegisterReader";
 import {
   isPosLocalEventInTerminalScope,
@@ -492,9 +495,15 @@ export function usePosLocalSyncRuntimeStatus(input: {
             return uploadableEvents.map((event) => ({
               id: event.localEventId,
               terminalId: event.terminalId,
+              syncScope:
+                event.type === "expense.completed"
+                  ? ("expense" as const)
+                  : ("pos" as const),
               localRegisterSessionId: event.localRegisterSessionId ?? "",
+              localExpenseSessionId: event.localExpenseSessionId,
               createdAt: event.createdAt,
               sequence: event.sequence,
+              uploadSequence: event.uploadSequence,
             }));
           },
           onStatusChange: (status) => {
@@ -653,14 +662,22 @@ export function usePosLocalSyncRuntimeStatus(input: {
             const reviewEventIds = collectServerReviewLocalEventIds(
               result.data.accepted,
             );
+            const rejectedEventIds = collectServerRejectedLocalEventIds(
+              result.data.accepted,
+            );
             setDebug((current) => ({
               ...current,
               lastHeldEventCount: result.data.held.length,
-              lastReviewEventCount: reviewEventIds.length,
+              lastReviewEventCount:
+                reviewEventIds.length + rejectedEventIds.length,
             }));
             const localReviewEventIds = collectReviewLocalEventIds(
               latestEvents.value.events,
               reviewEventIds,
+            );
+            const localRejectedEventIds = collectReviewLocalEventIds(
+              latestEvents.value.events,
+              rejectedEventIds,
             );
             await persistDrawerAuthorityBlockForReviewEvents({
               events: latestEvents.value.events,
@@ -692,6 +709,10 @@ export function usePosLocalSyncRuntimeStatus(input: {
 
             return {
               heldEventIds: collectServerHeldLocalEventIds(result.data.held),
+              rejectedEventIds: withoutEventIds(
+                localRejectedEventIds,
+                locallySettledEventIds,
+              ),
               syncedEventIds: localSyncedEventIds,
               reviewEventIds: withoutEventIds(
                 localReviewEventIds,
@@ -704,6 +725,25 @@ export function usePosLocalSyncRuntimeStatus(input: {
             const result = await store.markEventsNeedsReview(
               eventIds,
               "Cloud sync needs review before this local event can finish.",
+              { uploaded: true },
+            );
+            if (shouldStop()) {
+              return;
+            }
+            assertPosLocalStoreOk(result);
+            if (!(await refreshEvents())) {
+              return;
+            }
+            if (shouldStop()) {
+              return;
+            }
+            onLocalEventsChanged?.();
+          },
+          markRejected: async (eventIds) => {
+            if (eventIds.length === 0) return;
+            const result = await store.markEventsNeedsReview(
+              eventIds,
+              mapServerSettlementOutcomeToLocalState("rejected").label,
               { uploaded: true },
             );
             if (shouldStop()) {
@@ -1883,9 +1923,7 @@ export function collectServerSettledLocalEventIds(
   }>,
 ) {
   return acceptedEvents
-    .filter(
-      (event) => event.status === "projected" || event.status === "rejected",
-    )
+    .filter((event) => event.status === "projected")
     .map((event) => event.localEventId);
 }
 
@@ -1897,6 +1935,17 @@ export function collectServerReviewLocalEventIds(
 ) {
   return acceptedEvents
     .filter((event) => event.status === "conflicted")
+    .map((event) => event.localEventId);
+}
+
+export function collectServerRejectedLocalEventIds(
+  acceptedEvents: Array<{
+    localEventId: string;
+    status: string;
+  }>,
+) {
+  return acceptedEvents
+    .filter((event) => event.status === "rejected")
     .map((event) => event.localEventId);
 }
 

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -3401,6 +3401,10 @@ describe("useRegisterViewModel", () => {
     expect(result.current.drawerGate?.onSubmitCloseout).toBeUndefined();
     expect(result.current.drawerGate?.onReopenRegister).toBeUndefined();
     expect(result.current.drawerGate?.closeoutSubmittedReason).toBeUndefined();
+    expect(result.current.drawerGate?.canOpenCashControls).toBe(true);
+    expect(result.current.drawerGate?.cashControlsRegisterSessionId).toBe(
+      "drawer-1",
+    );
     expect(
       result.current.drawerGate?.hasPendingCloseoutApproval,
     ).toBeUndefined();
@@ -3445,6 +3449,10 @@ describe("useRegisterViewModel", () => {
     expect(result.current.drawerGate?.onSubmit).toEqual(expect.any(Function));
     expect(result.current.drawerGate?.onReopenRegister).toBeUndefined();
     expect(result.current.drawerGate?.closeoutSubmittedReason).toBeUndefined();
+    expect(result.current.drawerGate?.canOpenCashControls).toBe(true);
+    expect(result.current.drawerGate?.cashControlsRegisterSessionId).toBe(
+      "drawer-1",
+    );
     expect(
       result.current.drawerGate?.closeoutSecondaryActionLabel,
     ).toBeUndefined();
@@ -3831,6 +3839,71 @@ describe("useRegisterViewModel", () => {
     expect(mockMarkLocalEventsSynced).toHaveBeenCalledWith(["local-event-1"], {
       uploaded: true,
     });
+  });
+
+  it("keeps zero-variance cloud-backed closeouts pending when the cloud closeout fails", async () => {
+    mockSubmitRegisterSessionCloseout.mockResolvedValueOnce(
+      userError({
+        code: "precondition_failed",
+        message: "Register session changed before closeout could finish.",
+      }),
+    );
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: {
+        _id: "staff-1",
+        firstName: "Ama",
+        lastName: "Kusi",
+        activeRoles: ["manager"],
+      },
+      activeRegisterSession: {
+        _id: "drawer-1",
+        status: "open",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now(),
+      },
+      activeSession: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+
+    act(() => {
+      result.current.closeoutControl?.onRequestCloseout();
+    });
+
+    act(() => {
+      result.current.drawerGate?.onCloseoutCountedCashChange?.("50.00");
+    });
+
+    await act(async () => {
+      await result.current.drawerGate?.onSubmitCloseout?.();
+    });
+
+    expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "register.closeout_started",
+        localRegisterSessionId: "drawer-1",
+      }),
+    );
+    expect(mockSubmitRegisterSessionCloseout).toHaveBeenCalled();
+    expect(mockMarkLocalEventsSynced).not.toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith(
+      "Closeout saved locally. Athena will finish it after sync.",
+    );
+    expect(toast.success).not.toHaveBeenCalledWith("Register closed.");
   });
 
   it("opens the closeout drawer gate from an active empty register", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -3061,7 +3061,10 @@ export function useRegisterViewModel(): RegisterViewModel {
     const cloudRegisterSessionId = getCloseoutCloudRegisterSessionId(
       activeCloseoutRegisterSession,
     );
+    let attemptedDirectCloudCloseout = false;
+    let directCloudCloseoutMarkedSynced = false;
     if (!hasCloseoutVariance && cloudRegisterSessionId) {
+      attemptedDirectCloudCloseout = true;
       const closeoutResult = await runCommand(() =>
         submitRegisterSessionCloseout({
           actorStaffProfileId: staffProfileId,
@@ -3079,6 +3082,7 @@ export function useRegisterViewModel(): RegisterViewModel {
           { uploaded: true },
         );
         if (markSyncedResult.ok) {
+          directCloudCloseoutMarkedSynced = true;
           noteLocalRegisterEventChanged();
         }
       }
@@ -3098,7 +3102,11 @@ export function useRegisterViewModel(): RegisterViewModel {
       setLocalOperableRegisterSession(null);
     }
     requestBootstrap();
-    toast.success("Register closed.");
+    toast.success(
+      attemptedDirectCloudCloseout && !directCloudCloseoutMarkedSynced
+        ? "Closeout saved locally. Athena will finish it after sync."
+        : "Register closed.",
+    );
   }, [
     activeStoreId,
     activeCloseoutRegisterSession,
@@ -5298,6 +5306,11 @@ export function useRegisterViewModel(): RegisterViewModel {
               registerNumber,
               currency: activeStoreCurrency,
               canOpenCashControls: isCashierManager,
+              cashControlsRegisterSessionId:
+                activeCloseoutCloudRegisterSessionId ??
+                (activeCloseoutCloudRegisterSessionCode as
+                  | Id<"registerSession">
+                  | undefined),
               canOpenDrawer: canSignedInStaffOpenDrawer,
               openingFloat: drawerOpeningFloat,
               notes: drawerNotes,


### PR DESCRIPTION
## Summary
- Harden POS sync cursor identity with scoped cursor ids so POS and expense streams cannot collide.
- Keep rejected/local-only settlement states reviewable instead of presenting them as synced success.
- Preserve prior closeout Cash Controls targets during replacement drawer setup and require server-issued recovery execution ids before local ack.
- Add the follow-up solution note for POS sync settlement regressions.

## Plan artifacts
- docs/plans/2026-06-27-002-fix-pos-sync-contract-plan.md
- docs/plans/2026-06-27-002-fix-pos-sync-contract-plan.html

## Tracking
- V26-884: PR2 sync cursor/settlement vocabulary
- V26-885: PR2 reopen/closeout/Cash Controls truthfulness
- Depends on PR #576, already merged into main.

## Review
- Correctness reviewer: approved after exact cursor lookup, scoped legacy fallback, and register.reopened uploadability fixes.
- Data integrity reviewer: approved.
- Security reviewer: approved.
- Testing reviewer: approved.

## Validation
- bun run --filter @athena/webapp test -- src/lib/pos/infrastructure/local/syncScheduler.test.ts src/lib/pos/infrastructure/local/syncContract.test.ts src/lib/pos/infrastructure/local/syncStatus.test.ts src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts src/lib/pos/infrastructure/local/posLocalStore.test.ts src/lib/pos/presentation/register/useRegisterViewModel.test.ts convex/pos/application/sync/ingestLocalEvents.test.ts convex/pos/public/sync.test.ts convex/pos/application/terminalRecovery/terminalCommandService.test.ts
- bun run --filter @athena/webapp test -- convex/cashControls/closeouts.test.ts convex/cashControls/deposits.test.ts convex/pos/application/sync/projectLocalEvents.test.ts src/lib/pos/presentation/syncStatusPresentation.test.ts src/lib/pos/infrastructure/local/localCommandGateway.test.ts
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json failed only on pre-existing react-day-picker API/type drift in packages/athena-webapp/src/components/ui/calendar.tsx and calendar.test.tsx after this branch fixture errors were fixed.
- bun run compound:check
- bun run graphify:check
- git diff --check
