### PR TITLE
fix(pos): throttle runtime status heartbeats

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8098 nodes · 9532 edges · 2063 communities detected
+- 8101 nodes · 9537 edges · 2063 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2745,408 +2745,408 @@ Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
 
 ### Community 161 - "Community 161"
+Cohesion: 0.29
+Nodes (5): getRuntimeStatusPublishMaterialSignature(), getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusPublishMaterial(), normalizeRuntimeStatusSignature()
+
+### Community 162 - "Community 162"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.27
 Nodes (5): clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), runProcess(), writePrAthenaProviderEvidence()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.25
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.22
 Nodes (0):
-
-### Community 172 - "Community 172"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 173 - "Community 173"
 Cohesion: 0.39
-Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 174 - "Community 174"
+Cohesion: 0.39
+Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
+
+### Community 175 - "Community 175"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.33
 Nodes (6): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), saveProduct(), updateVariantSku()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.28
 Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.28
 Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.25
 Nodes (2): isValidMessageBlocker(), isValidPriority()
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.28
 Nodes (4): comparePendingEvents(), getPendingEventUploadSequence(), selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
-### Community 186 - "Community 186"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
 ### Community 187 - "Community 187"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
-### Community 188 - "Community 188"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 189 - "Community 189"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 190 - "Community 190"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
+### Community 188 - "Community 188"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
+
+### Community 189 - "Community 189"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
+### Community 190 - "Community 190"
+Cohesion: 0.22
+Nodes (0):
+
 ### Community 191 - "Community 191"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 192 - "Community 192"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 202 - "Community 202"
-Cohesion: 0.5
-Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
 ### Community 203 - "Community 203"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.5
+Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
 ### Community 204 - "Community 204"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 205 - "Community 205"
-Cohesion: 0.36
-Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 206 - "Community 206"
 Cohesion: 0.36
-Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
 
 ### Community 207 - "Community 207"
+Cohesion: 0.36
+Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+
+### Community 208 - "Community 208"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.29
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 209 - "Community 209"
+### Community 210 - "Community 210"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 213 - "Community 213"
+### Community 214 - "Community 214"
 Cohesion: 0.29
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
-### Community 214 - "Community 214"
+### Community 215 - "Community 215"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 215 - "Community 215"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 216 - "Community 216"
 Cohesion: 0.39
-Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 217 - "Community 217"
+Cohesion: 0.39
+Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+
+### Community 218 - "Community 218"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.29
 Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.38
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.33
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 246 - "Community 246"
+### Community 247 - "Community 247"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
-
-### Community 247 - "Community 247"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 248 - "Community 248"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 249 - "Community 249"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 250 - "Community 250"
 Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 251 - "Community 251"
 Cohesion: 0.33
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 252 - "Community 252"
-Cohesion: 0.29
-Nodes (1): ResizeObserverStub
+Cohesion: 0.33
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 253 - "Community 253"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
 ### Community 254 - "Community 254"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 255 - "Community 255"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 257 - "Community 257"
-Cohesion: 0.52
-Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 258 - "Community 258"
 Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 259 - "Community 259"
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+
+### Community 260 - "Community 260"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 261 - "Community 261"
-Cohesion: 0.38
-Nodes (3): getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusSignature()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.29

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2135
-- Graph nodes: 8098
-- Graph edges: 9532
+- Graph nodes: 8101
+- Graph edges: 9537
 - Communities: 2063
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (15 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 192) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 193) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (4 edges, Community 93) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeStatusPublisher.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeStatusPublisher.ts
@@ -1,5 +1,7 @@
 import type { PosTerminalRuntimeStatusPayload } from "./terminalRuntimeStatus";
 
+export const RUNTIME_STATUS_FRESHNESS_PUBLISH_INTERVAL_MS = 30_000;
+
 export type RuntimeCheckInNotReadyReason =
   | "missing_store"
   | "missing_sync_secret"
@@ -41,18 +43,42 @@ export function getRuntimeStatusPublishSignature(input: {
   storeId: string;
   terminalId: string;
 }) {
-  const stableStatus: Partial<PosTerminalRuntimeStatusPayload> = {
-    ...normalizeRuntimeStatusSignature(input.runtimeStatus),
-  };
-  delete stableStatus.reportedAt;
-  delete stableStatus.snapshots;
-
   return JSON.stringify({
     observationToken: input.observationToken,
-    runtimeStatus: stableStatus,
+    runtimeStatus: normalizeRuntimeStatusPublishMaterial(input.runtimeStatus),
     storeId: input.storeId,
     terminalId: input.terminalId,
   });
+}
+
+export function getRuntimeStatusPublishMaterialSignature(input: {
+  runtimeStatus: PosTerminalRuntimeStatusPayload;
+  storeId: string;
+  terminalId: string;
+}) {
+  return JSON.stringify({
+    runtimeStatus: normalizeRuntimeStatusPublishMaterial(input.runtimeStatus),
+    storeId: input.storeId,
+    terminalId: input.terminalId,
+  });
+}
+
+export function shouldPublishRuntimeStatus(input: {
+  lastMaterialSignature: string | null;
+  lastPublishedAt: number | null;
+  lastPublishSignature: string | null;
+  materialSignature: string;
+  now: number;
+  publishSignature: string;
+  freshnessIntervalMs?: number;
+}) {
+  if (input.publishSignature === input.lastPublishSignature) return false;
+  if (input.materialSignature !== input.lastMaterialSignature) return true;
+  if (input.lastPublishedAt === null) return true;
+
+  const freshnessIntervalMs =
+    input.freshnessIntervalMs ?? RUNTIME_STATUS_FRESHNESS_PUBLISH_INTERVAL_MS;
+  return input.now - input.lastPublishedAt >= freshnessIntervalMs;
 }
 
 function normalizeRuntimeStatusSignature(
@@ -67,6 +93,62 @@ function normalizeRuntimeStatusSignature(
       observedAt: 0,
     },
   };
+}
+
+function normalizeRuntimeStatusPublishMaterial(
+  runtimeStatus: PosTerminalRuntimeStatusPayload,
+) {
+  const stableStatus: Partial<PosTerminalRuntimeStatusPayload> = {
+    ...normalizeRuntimeStatusSignature(runtimeStatus),
+  };
+  delete stableStatus.reportedAt;
+  delete stableStatus.snapshots;
+
+  if (stableStatus.appShell) {
+    stableStatus.appShell = {
+      ...stableStatus.appShell,
+      observedAt: 0,
+    };
+  }
+  if (stableStatus.activeRegisterSession) {
+    stableStatus.activeRegisterSession = {
+      ...stableStatus.activeRegisterSession,
+      observedAt: 0,
+    };
+  }
+  if (stableStatus.appUpdate) {
+    stableStatus.appUpdate = {
+      ...stableStatus.appUpdate,
+      observedAt: 0,
+    };
+  }
+  if (stableStatus.saleAuthority) {
+    stableStatus.saleAuthority = {
+      ...stableStatus.saleAuthority,
+      observedAt: 0,
+    };
+  }
+  if (stableStatus.drawerAuthority) {
+    stableStatus.drawerAuthority = {
+      ...stableStatus.drawerAuthority,
+      observedAt: 0,
+    };
+  }
+  if (stableStatus.terminalIntegrity) {
+    stableStatus.terminalIntegrity = {
+      ...stableStatus.terminalIntegrity,
+      observedAt: 0,
+    };
+  }
+  if (stableStatus.sync) {
+    stableStatus.sync = { ...stableStatus.sync };
+    delete (stableStatus.sync as Partial<PosTerminalRuntimeStatusPayload["sync"]>)
+      .lastTrigger;
+    delete (stableStatus.sync as Partial<PosTerminalRuntimeStatusPayload["sync"]>)
+      .status;
+  }
+
+  return stableStatus;
 }
 
 export function getRuntimeCheckInNotReadyReason(input: {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -73,6 +73,11 @@ import type {
   PosLocalEventRecord,
   PosTerminalIntegrityState,
 } from "./posLocalStore";
+import {
+  RUNTIME_STATUS_FRESHNESS_PUBLISH_INTERVAL_MS,
+  getRuntimeStatusPublishMaterialSignature,
+  shouldPublishRuntimeStatus,
+} from "./runtimeStatusPublisher";
 import { buildPosLocalSyncUploadEvents } from "./syncContract";
 
 function deferred<T>() {
@@ -4136,6 +4141,136 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         terminalId: "terminal-cloud-1",
       }),
     );
+  });
+
+  it("normalizes volatile runtime observation timestamps in material publish signatures", () => {
+    const runtimeStatus = {
+      activeRegisterSession: {
+        cloudRegisterSessionId: "register-session-1",
+        localRegisterSessionId: "register-session-1",
+        observedAt: 100,
+        openedAt: 50,
+        registerNumber: "1",
+        status: "active",
+      },
+      appShell: {
+        observedAt: 100,
+        ready: true,
+      },
+      appUpdate: {
+        canApply: false,
+        detectorStatus: "ok",
+        observedAt: 100,
+        stagingStatus: "unknown",
+        status: "current",
+      },
+      localStore: {
+        available: true,
+        terminalSeedReady: true,
+      },
+      reportedAt: 100,
+      saleAuthority: {
+        observedAt: 100,
+        staffProfileId: "staff-1",
+        status: "ready",
+        transactionMode: "products_and_services",
+      },
+      snapshots: {
+        availabilityAgeMs: 100,
+        catalogAgeMs: 200,
+      },
+      source: "sync-runtime",
+      staffAuthority: {
+        staffProfileId: "staff-1",
+        status: "ready",
+      },
+      sync: {
+        failedEventCount: 0,
+        lastTrigger: "route-entry",
+        localOnlyEventCount: 0,
+        pendingEventCount: 0,
+        reviewEventCount: 105,
+        status: "syncing",
+        uploadableEventCount: 34,
+      },
+    };
+
+    expect(
+      getRuntimeStatusPublishMaterialSignature({
+        runtimeStatus: runtimeStatus as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    ).toEqual(
+      getRuntimeStatusPublishMaterialSignature({
+        runtimeStatus: {
+          ...runtimeStatus,
+          activeRegisterSession: {
+            ...runtimeStatus.activeRegisterSession,
+            observedAt: 200,
+          },
+          appShell: {
+            ...runtimeStatus.appShell,
+            observedAt: 200,
+          },
+          appUpdate: {
+            ...runtimeStatus.appUpdate,
+            observedAt: 200,
+          },
+          reportedAt: 200,
+          saleAuthority: {
+            ...runtimeStatus.saleAuthority,
+            observedAt: 200,
+          },
+          snapshots: {
+            availabilityAgeMs: 300,
+            catalogAgeMs: 400,
+          },
+          sync: {
+            ...runtimeStatus.sync,
+            lastTrigger: "foreground-interval",
+            status: "needs_review",
+          },
+        } as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+  });
+
+  it("throttles freshness-only runtime check-ins without delaying material changes", () => {
+    expect(
+      shouldPublishRuntimeStatus({
+        lastMaterialSignature: "material-a",
+        lastPublishedAt: 1_000,
+        lastPublishSignature: "publish-a",
+        materialSignature: "material-a",
+        now: 1_500,
+        publishSignature: "publish-b",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldPublishRuntimeStatus({
+        lastMaterialSignature: "material-a",
+        lastPublishedAt: 1_000,
+        lastPublishSignature: "publish-a",
+        materialSignature: "material-a",
+        now: 1_000 + RUNTIME_STATUS_FRESHNESS_PUBLISH_INTERVAL_MS,
+        publishSignature: "publish-b",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldPublishRuntimeStatus({
+        lastMaterialSignature: "material-a",
+        lastPublishedAt: 1_000,
+        lastPublishSignature: "publish-a",
+        materialSignature: "material-b",
+        now: 1_500,
+        publishSignature: "publish-b",
+      }),
+    ).toBe(true);
   });
 
   it("drains persisted-proof multi-staff local history from the hub in stored upload order", async () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -60,9 +60,11 @@ import {
 } from "./localSyncDrainCoordinator";
 import { refreshAndStoreTerminalStaffAuthority } from "./terminalStaffAuthorityRefresh";
 import {
+  getRuntimeStatusPublishMaterialSignature,
   getRuntimeBrowserInfo,
   getRuntimeCheckInNotReadyReason,
   getRuntimeStatusPublishSignature,
+  shouldPublishRuntimeStatus,
   withRuntimeCheckInPublishDebug as withCheckInPublishDebug,
 } from "./runtimeStatusPublisher";
 import {
@@ -263,8 +265,11 @@ export function usePosLocalSyncRuntimeStatus(input: {
     [input.appSessionRecovery],
   );
   const lastRuntimeStatusSignatureRef = useRef<string | null>(null);
+  const lastRuntimeStatusMaterialSignatureRef = useRef<string | null>(null);
+  const lastRuntimeStatusPublishedAtRef = useRef<number | null>(null);
   const runtimeStatusPublishInFlightRef = useRef(false);
   const queuedRuntimeStatusSignatureRef = useRef<string | null>(null);
+  const forceNextRuntimeStatusPublishRef = useRef(false);
   const isRuntimeStatusPublisherMountedRef = useRef(true);
   const observedRecoveryCommandIdsRef = useRef<Set<string>>(new Set());
   const requestRetry = useCallback(() => {
@@ -998,15 +1003,36 @@ export function usePosLocalSyncRuntimeStatus(input: {
       storeId: checkInStoreId,
       terminalId: checkInTerminalId,
     });
-    if (signature === lastRuntimeStatusSignatureRef.current) return;
+    const materialSignature = getRuntimeStatusPublishMaterialSignature({
+      runtimeStatus,
+      storeId: checkInStoreId,
+      terminalId: checkInTerminalId,
+    });
     if (runtimeStatusPublishInFlightRef.current) {
       queuedRuntimeStatusSignatureRef.current = signature;
       return;
     }
+    const forcePublish = forceNextRuntimeStatusPublishRef.current;
+    if (
+      !forcePublish &&
+      !shouldPublishRuntimeStatus({
+        lastMaterialSignature: lastRuntimeStatusMaterialSignatureRef.current,
+        lastPublishedAt: lastRuntimeStatusPublishedAtRef.current,
+        lastPublishSignature: lastRuntimeStatusSignatureRef.current,
+        materialSignature,
+        now: Date.now(),
+        publishSignature: signature,
+      })
+    ) {
+      return;
+    }
+    forceNextRuntimeStatusPublishRef.current = false;
     lastRuntimeStatusSignatureRef.current = signature;
+    lastRuntimeStatusMaterialSignatureRef.current = materialSignature;
     runtimeStatusPublishInFlightRef.current = true;
 
     const attemptedAt = Date.now();
+    lastRuntimeStatusPublishedAtRef.current = attemptedAt;
     setDebug((current) =>
       withCheckInPublishDebug(current, {
         checkInPublishAttemptedAt: attemptedAt,
@@ -1157,6 +1183,15 @@ export function usePosLocalSyncRuntimeStatus(input: {
                   storeId: checkInStoreId,
                   terminalId: checkInTerminalId,
                 });
+              lastRuntimeStatusMaterialSignatureRef.current =
+                getRuntimeStatusPublishMaterialSignature({
+                  runtimeStatus: buildPosTerminalRuntimeStatus({
+                    ...runtimeStatusInput,
+                    terminalIntegrity,
+                  }),
+                  storeId: checkInStoreId,
+                  terminalId: checkInTerminalId,
+                });
               setRuntimeReadiness((current) => ({
                 ...current,
                 terminalIntegrity,
@@ -1200,10 +1235,12 @@ export function usePosLocalSyncRuntimeStatus(input: {
         const queuedSignature = queuedRuntimeStatusSignatureRef.current;
         queuedRuntimeStatusSignatureRef.current = null;
         if (
-          queuedSignature &&
-          queuedSignature !== lastRuntimeStatusSignatureRef.current &&
+          ((queuedSignature &&
+            queuedSignature !== lastRuntimeStatusSignatureRef.current) ||
+            isStale) &&
           isRuntimeStatusPublisherMountedRef.current
         ) {
+          forceNextRuntimeStatusPublishRef.current = true;
           setRuntimeStatusObservationToken((current) => current + 1);
         }
       });


### PR DESCRIPTION
## Summary
- Rate-limit freshness-only POS runtime check-ins so stable terminals do not republish every local observation.
- Normalize volatile runtime evidence timestamps and transient sync fields out of material publish signatures.
- Preserve the existing latest-wins retry path for stale in-flight check-ins so repair directives still apply immediately.

## Why
M Supplies was patching its latest runtime status and Remote Assist presence every few seconds even though the runtime payload stayed materially unchanged. The publisher now separates material evidence changes from freshness heartbeats and keeps the freshness cadence at 30 seconds.

## Validation
- `bun run --filter '@athena/webapp' test -- src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
- `bun run --filter '@athena/webapp' lint:frontend:changed`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run graphify:check`
- Pre-push: full Athena validation passed, including webapp build, full `@athena/webapp` tests, POS mapped slices, offline POS e2e specs, prod POS smoke, and harness behavior scenarios.
