### PR TITLE
fix: restore EOD review row context

### DIFF
--- a/docs/solutions/logic-errors/athena-daily-close-row-metadata-redaction-2026-06-27.md
+++ b/docs/solutions/logic-errors/athena-daily-close-row-metadata-redaction-2026-06-27.md
@@ -1,0 +1,116 @@
+---
+title: Athena Daily Close Row Metadata Redaction
+date: 2026-06-27
+category: logic-errors
+module: athena-webapp
+problem_type: ui_bug
+component: frontend_stimulus
+symptoms:
+  - "EOD Review rows lost their rich metadata strip after broad-view redaction"
+  - "Redacted sale rows exposed a transaction number but linked through a redacted subject id"
+  - "Transaction summary rows could show only a register number without terminal context"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags:
+  - athena-webapp
+  - daily-close
+  - eod-review
+  - redaction
+  - links
+---
+
+# Athena Daily Close Row Metadata Redaction
+
+## Problem
+
+Daily close items are shared across full-admin and broad operational views. When
+the broad-view redaction boundary strips too much, EOD Review rows lose the
+operator context that makes them useful: terminal/register labels, source links,
+and compact detail metadata. When it strips too little, the same rows can leak
+financial close evidence to roles that should only see operational work state.
+
+## Symptoms
+
+- EOD Review rows collapsed to title and helper text with no metadata strip.
+- Sale rows with redacted subjects displayed a transaction number but crashed or
+  navigated incorrectly when the inline link was followed.
+- Register-related detail surfaces showed `Register 8` without the terminal
+  context operators use elsewhere.
+
+## What Didn't Work
+
+- Treating `metadata` as unsafe wholesale removed the same safe fields the UI
+  uses to render source context and link affordances.
+- Rebuilding transaction links from `subject.id` failed for broad-view sale rows
+  because the subject id is intentionally redacted.
+- Fixing the visible label in React alone was insufficient because the
+  transaction detail page did not receive the terminal display name from the
+  query payload.
+
+## Solution
+
+Make the redaction boundary field-aware instead of object-wide. Preserve safe
+daily-close row structure and remove only restricted financial metadata keys:
+
+```ts
+return {
+  ...item,
+  link: item.link,
+  metadata: redactDailyCloseMetadata(item.metadata),
+  subject: item.subject
+    ? {
+        ...item.subject,
+        id: "redacted",
+      }
+    : item.subject,
+};
+```
+
+In the EOD Review UI, prefer preserved item links for source navigation when a
+redacted subject id cannot be used. Render terminal/register context as one
+source affordance so the operator has a single link target for the source
+workflow.
+
+For transaction detail summaries, carry terminal display name through
+`getTransactionById` and format the register row value from both fields:
+
+```ts
+if (terminal && register) {
+  return `${terminal} / ${register}`;
+}
+```
+
+The row label already says `Register`, so the value should stay compact:
+`Codex / 8`, not `Codex / Register 8`.
+
+## Why This Works
+
+Daily close redaction is a projection contract, not a generic privacy filter.
+The UI needs safe operational context to help staff close the day, while
+restricted financial close evidence must remain unavailable in broad views.
+Preserving the row link and safe metadata keeps the scanner-friendly review
+surface intact without exposing cash values.
+
+Using the preserved link also respects the redaction model. If the server says
+`subject.id` is redacted, the client should not assume it can reconstruct a
+route from that field. The already-projected `item.link` is the safe navigation
+contract.
+
+## Prevention
+
+- Add broad-view snapshot tests that assert safe metadata and `item.link`
+  survive while financial metadata keys are removed.
+- Add component tests for redacted rows that click or inspect the inline source
+  link rather than only asserting visible transaction text.
+- Keep terminal/register display formatting close to the component boundary that
+  owns the row label. If the label already names the field, avoid repeating that
+  label inside the value.
+- When adding new metadata keys to daily close items, classify them as safe
+  operational context or restricted evidence in the redaction helper at the same
+  time.
+
+## Related Issues
+
+- `docs/solutions/logic-errors/athena-operational-status-surfaces-2026-05-10.md`
+- `docs/solutions/logic-errors/athena-pos-operations-metric-redaction-and-cash-allocation-2026-06-21.md`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8103 nodes · 9542 edges · 2063 communities detected
+- 8082 nodes · 9491 edges · 2063 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2101,16 +2101,16 @@
 ## Communities
 
 ### Community 0 - "Community 0"
-Cohesion: 0.04
-Nodes (52): buildDailyCloseExpenseSearch(), buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatTimestampMetadata(), getBucketConfigs() (+44 more)
-
-### Community 1 - "Community 1"
 Cohesion: 0.06
 Nodes (84): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectConvexQueryWriteBoundaryFindings(), collectConvexReturnValidatorContractFindings(), collectHandlerDbAliases() (+76 more)
 
-### Community 2 - "Community 2"
+### Community 1 - "Community 1"
 Cohesion: 0.05
 Nodes (70): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildApprovalRequestsById(), buildDailyCloseApprovalSubject() (+62 more)
+
+### Community 2 - "Community 2"
+Cohesion: 0.04
+Nodes (34): buildDailyCloseExpenseSearch(), buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), getBucketCountClassName(), getCarryForwardWorkItemId(), getDailyCloseSalesMetricLabels(), getDailyCloseStatus() (+26 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.09
@@ -2585,48 +2585,48 @@ Cohesion: 0.22
 Nodes (6): buildTrustedInventoryFinalizationPayload(), buildTrustedInventoryMoneyPayload(), getTrustedInventoryReviewValidationMessage(), isNonNegativeInteger(), parseVariantDisplayMoney(), resolveTrustedInventoryReviewState()
 
 ### Community 121 - "Community 121"
-Cohesion: 0.17
-Nodes (2): formatRegisterLabel(), getRegisterLabel()
+Cohesion: 0.18
+Nodes (4): formatProductLineMeta(), formatServiceLabel(), formatServiceLineMeta(), formatStoredAmount()
 
 ### Community 122 - "Community 122"
 Cohesion: 0.17
-Nodes (2): getNextTransactionPageSearch(), getNextTransactionTimeFilterSearch()
+Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
 ### Community 123 - "Community 123"
+Cohesion: 0.17
+Nodes (2): getNextTransactionPageSearch(), getNextTransactionTimeFilterSearch()
+
+### Community 124 - "Community 124"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.29
 Nodes (10): applyTheme(), emitThemeChange(), getStorage(), getStoredThemeMode(), getSystemTheme(), getThemeSnapshot(), initializeAthenaTheme(), isThemeMode() (+2 more)
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 130 - "Community 130"
-Cohesion: 0.2
-Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
-
 ### Community 131 - "Community 131"
 Cohesion: 0.2
-Nodes (4): formatProductLineMeta(), formatServiceLabel(), formatServiceLineMeta(), formatStoredAmount()
+Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
 ### Community 132 - "Community 132"
 Cohesion: 0.21
@@ -2849,20 +2849,20 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 187 - "Community 187"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 188 - "Community 188"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 189 - "Community 189"
+### Community 188 - "Community 188"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 190 - "Community 190"
+### Community 189 - "Community 189"
 Cohesion: 0.22
 Nodes (0):
+
+### Community 190 - "Community 190"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 191 - "Community 191"
 Cohesion: 0.39
@@ -3325,8 +3325,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 306 - "Community 306"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 307 - "Community 307"
 Cohesion: 0.33
@@ -3341,72 +3341,72 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 310 - "Community 310"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 311 - "Community 311"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
+
+### Community 311 - "Community 311"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 312 - "Community 312"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 313 - "Community 313"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 314 - "Community 314"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 315 - "Community 315"
+### Community 314 - "Community 314"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 316 - "Community 316"
+### Community 315 - "Community 315"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 317 - "Community 317"
+### Community 316 - "Community 316"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 317 - "Community 317"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 318 - "Community 318"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 319 - "Community 319"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 320 - "Community 320"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 321 - "Community 321"
+### Community 320 - "Community 320"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 322 - "Community 322"
+### Community 321 - "Community 321"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 322 - "Community 322"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 323 - "Community 323"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 324 - "Community 324"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 325 - "Community 325"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 326 - "Community 326"
+### Community 325 - "Community 325"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 326 - "Community 326"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 327 - "Community 327"
 Cohesion: 0.53
@@ -13048,11 +13048,11 @@ _Questions this graph is uniquely positioned to answer:_
 - **What connects `FakeMessageChannel`, `HelpRequested` to the rest of the system?**
   _2 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.04 - nodes in this community are weakly interconnected._
-- **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
-- **Should `Community 2` be split into smaller, more focused modules?**
+- **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.05 - nodes in this community are weakly interconnected._
+- **Should `Community 2` be split into smaller, more focused modules?**
+  _Cohesion score 0.04 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,14 +8,14 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2135
-- Graph nodes: 8103
-- Graph edges: 9542
+- Graph nodes: 8082
+- Graph edges: 9491
 - Communities: 2063
 
 ## Graph Hotspots
-- `DailyCloseView.tsx` (89 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `harness-inferential-review.ts` (85 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `dailyClose.ts` (82 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `harness-inferential-review.ts` (85 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
+- `dailyClose.ts` (83 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `DailyCloseView.tsx` (66 edges, Community 2) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `projectLocalEvents.ts` (65 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `dailyOperations.ts` (63 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,8 +17,8 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `DailyCloseView.tsx` (89 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `dailyClose.ts` (82 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (83 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `DailyCloseView.tsx` (66 edges, Community 2) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `projectLocalEvents.ts` (65 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `dailyOperations.ts` (63 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -1022,7 +1022,7 @@ describe("end-of-day review backend foundation", () => {
     );
   });
 
-  it("redacts active register blocker metadata on the exported snapshot query", async () => {
+  it("preserves active register blocker context on the exported snapshot query", async () => {
     const { db } = createDb({
       posTerminal: [
         {
@@ -1065,6 +1065,18 @@ describe("end-of-day review backend foundation", () => {
     expect(snapshot.blockers[0]).toMatchObject({
       category: "register_session",
       key: "blocker:register_session:0",
+      link: {
+        label: "View session",
+        params: { sessionId: "register-open" },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId",
+      },
+      metadata: {
+        openedAt: Date.UTC(2026, 4, 7, 10),
+        operatingScope: "Opened today",
+        register: "Register A1",
+        status: "open",
+        terminal: "terminal-1",
+      },
       subject: {
         id: "redacted",
         label: "Register A1",
@@ -1072,8 +1084,9 @@ describe("end-of-day review backend foundation", () => {
       },
       title: "Register session is still open",
     });
-    expect(snapshot.blockers[0]).not.toHaveProperty("link");
-    expect(snapshot.blockers[0]).not.toHaveProperty("metadata");
+    expect(snapshot.blockers[0].metadata).not.toHaveProperty("expectedCash");
+    expect(snapshot.blockers[0].metadata).not.toHaveProperty("countedCash");
+    expect(snapshot.blockers[0].metadata).not.toHaveProperty("variance");
   });
 
   it("redacts completed automation review evidence on the exported snapshot query", async () => {
@@ -1182,17 +1195,22 @@ describe("end-of-day review backend foundation", () => {
     expect(snapshot.reviewItems).toEqual([
       expect.objectContaining({
         key: "review:voided_sale:0",
+        metadata: {
+          voidedAt: Date.UTC(2026, 4, 7, 15),
+        },
         subject: expect.objectContaining({ id: "redacted" }),
       }),
     ]);
-    expect(snapshot.reviewItems[0]).not.toHaveProperty("metadata");
+    expect(snapshot.reviewItems[0].metadata).not.toHaveProperty("total");
     expect(snapshot.carryForwardItems).toEqual([
       expect.objectContaining({
         key: "carry_forward:operational_work_item:0",
+        metadata: {
+          workItemId: "work-1",
+        },
         subject: expect.objectContaining({ id: "redacted" }),
       }),
     ]);
-    expect(snapshot.carryForwardItems[0]).not.toHaveProperty("metadata");
     expect(snapshot.sourceSubjects).toEqual([]);
   });
 
@@ -3934,15 +3952,26 @@ describe("end-of-day review backend foundation", () => {
     expect(broadSnapshot.existingClose).toBeNull();
     expect(broadSnapshot.priorClose).toBeNull();
     expect(broadSnapshot.sourceSubjects).toEqual([]);
-    expect(broadSnapshot.reviewItems[0]).not.toHaveProperty("metadata");
+    const redactedReviewedSale = broadSnapshot.reviewItems.find(
+      (item) => item.category === "voided_sale",
+    );
+    expect(redactedReviewedSale?.metadata).toMatchObject({
+      paymentMethods: "cash",
+    });
+    expect(redactedReviewedSale?.metadata).not.toHaveProperty("total");
+    expect(redactedReviewedSale?.metadata).not.toHaveProperty("totalPaid");
     expect(broadSnapshot.carryForwardItems[0]).toMatchObject({
       key: "carry_forward:open_work:0",
+      metadata: {
+        priority: "normal",
+        status: "open",
+        type: "customer_follow_up",
+      },
       subject: {
         id: "redacted",
         type: "operational_work_item",
       },
     });
-    expect(broadSnapshot.carryForwardItems[0]).not.toHaveProperty("metadata");
 
     const trustedDetail = await getCompletedDailyCloseHistoryDetailWithCtx(
       { db } as unknown as QueryCtx,
@@ -3981,14 +4010,16 @@ describe("end-of-day review backend foundation", () => {
     ).toEqual([]);
     expect(broadDetail?.reportSnapshot.carryForwardItems[0]).toMatchObject({
       key: "carry_forward:open_work:0",
+      metadata: {
+        priority: "normal",
+        status: "open",
+        type: "customer_follow_up",
+      },
       subject: {
         id: "redacted",
         type: "operational_work_item",
       },
     });
-    expect(broadDetail?.reportSnapshot.carryForwardItems[0]).not.toHaveProperty(
-      "metadata",
-    );
     expect(broadDetail?.reportSnapshot.summary).toMatchObject({
       registerVarianceCount: 0,
       transactionCount: 1,
@@ -3997,9 +4028,15 @@ describe("end-of-day review backend foundation", () => {
       "netCashVariance",
     );
     expect(broadDetail?.reportSnapshot.summary).not.toHaveProperty("salesTotal");
-    expect(broadDetail?.reportSnapshot.reviewedItems[0]).not.toHaveProperty(
-      "metadata",
-    );
+    expect(broadDetail?.reportSnapshot.reviewedItems[0].metadata).toMatchObject({
+      paymentMethods: "cash",
+    });
+    expect(
+      broadDetail?.reportSnapshot.reviewedItems[0].metadata,
+    ).not.toHaveProperty("total");
+    expect(
+      broadDetail?.reportSnapshot.reviewedItems[0].metadata,
+    ).not.toHaveProperty("totalPaid");
     expect(broadDetail?.reportSnapshot.sourceSubjects).toEqual([]);
     expect(patches).toEqual([]);
   });

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -1693,10 +1693,35 @@ function completionAttributionForDailyClose(
   };
 }
 
+const broadViewRestrictedMetadataLabels = new Set([
+  "amount",
+  "changegiven",
+  "countedcash",
+  "expectedcash",
+  "total",
+  "totalpaid",
+  "variance",
+]);
+
+function normalizeBroadViewMetadataLabel(label: string) {
+  return label.replace(/[\s_-]+/g, "").toLowerCase();
+}
+
 function redactDailyCloseItemForBroadView(
   item: DailyCloseItem,
   index = 0,
 ): DailyCloseItem {
+  const safeMetadata = item.metadata
+    ? Object.fromEntries(
+        Object.entries(item.metadata).filter(
+          ([label]) =>
+            !broadViewRestrictedMetadataLabels.has(
+              normalizeBroadViewMetadataLabel(label),
+            ),
+        ),
+      )
+    : undefined;
+
   return {
     key: `${item.severity}:${item.category}:${index}`,
     severity: item.severity,
@@ -1708,6 +1733,10 @@ function redactDailyCloseItemForBroadView(
       id: "redacted",
       label: item.subject.label,
     },
+    ...(item.link ? { link: item.link } : {}),
+    ...(safeMetadata && Object.keys(safeMetadata).length > 0
+      ? { metadata: safeMetadata }
+      : {}),
   };
 }
 

--- a/packages/athena-webapp/convex/pos/application/getTransactions.test.ts
+++ b/packages/athena-webapp/convex/pos/application/getTransactions.test.ts
@@ -17,6 +17,7 @@ import {
   listCompletedTransactionsForDay,
   listTransactionItems,
 } from "../infrastructure/repositories/transactionRepository";
+import { getTerminalById } from "../infrastructure/repositories/terminalRepository";
 
 vi.mock("../infrastructure/repositories/transactionRepository", () => ({
   getCashierById: vi.fn(),
@@ -31,9 +32,14 @@ vi.mock("../infrastructure/repositories/transactionRepository", () => ({
   listTransactionsByStore: vi.fn(),
 }));
 
+vi.mock("../infrastructure/repositories/terminalRepository", () => ({
+  getTerminalById: vi.fn(),
+}));
+
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(getRegisterSessionById).mockResolvedValue(null as never);
+  vi.mocked(getTerminalById).mockResolvedValue(null as never);
   vi.mocked(listCompletedTransactionsForRange).mockResolvedValue([] as never);
   vi.mocked(listCompletedTransactionsSince).mockResolvedValue([] as never);
 });
@@ -1244,6 +1250,48 @@ describe("getTodaySummary", () => {
 });
 
 describe("getTransactionById", () => {
+  it("returns the terminal display name for transaction summaries", async () => {
+    vi.mocked(getPosTransactionById).mockResolvedValue({
+      _id: "txn-terminal" as Id<"posTransaction">,
+      storeId: "store-1" as Id<"store">,
+      transactionNumber: "POS-584065",
+      subtotal: 210000,
+      tax: 0,
+      total: 210000,
+      paymentMethod: "cash",
+      payments: [],
+      totalPaid: 210000,
+      status: "completed",
+      completedAt: 100,
+      customerId: undefined,
+      customerInfo: undefined,
+      notes: undefined,
+      registerNumber: "8",
+      terminalId: "terminal-1" as Id<"posTerminal">,
+    } as never);
+    vi.mocked(getTerminalById).mockResolvedValue({
+      _id: "terminal-1" as Id<"posTerminal">,
+      displayName: "Codex",
+    } as never);
+    vi.mocked(getCashierById).mockResolvedValue(null as never);
+    vi.mocked(getPosSessionById).mockResolvedValue(null as never);
+    vi.mocked(listTransactionItems).mockResolvedValue([] as never);
+
+    const result = await getTransactionById(
+      { db: mockCorrectionHistoryDb() } as never,
+      {
+        transactionId: "txn-terminal" as Id<"posTransaction">,
+      },
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        registerNumber: "8",
+        terminalName: "Codex",
+      }),
+    );
+  });
+
   it("ignores legacy transaction workflow trace ids when no session trace is available", async () => {
     vi.mocked(getPosTransactionById).mockResolvedValue({
       _id: "txn-1" as Id<"posTransaction">,

--- a/packages/athena-webapp/convex/pos/application/queries/getTransactions.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/getTransactions.ts
@@ -10,6 +10,7 @@ import {
   listTransactionItems,
   listTransactionsByStore,
 } from "../../infrastructure/repositories/transactionRepository";
+import { getTerminalById } from "../../infrastructure/repositories/terminalRepository";
 import { formatStaffDisplayName } from "../../../../shared/staffDisplayName";
 import { listReceiptDeliveriesForTransaction } from "../../../customerMessaging/repository";
 import { statusIsRetryable } from "../../../customerMessaging/domain";
@@ -432,6 +433,7 @@ export async function getTransactionById(
     registerSession?.registerNumber;
   const terminalId =
     transaction.terminalId ?? session?.terminalId ?? registerSession?.terminalId;
+  const terminal = terminalId ? await getTerminalById(ctx, terminalId) : null;
   const items = await listTransactionItems(ctx, transaction._id);
   const serviceLines = await listMixedServiceLinesForTransaction(ctx, {
     _id: transaction._id,
@@ -536,6 +538,7 @@ export async function getTransactionById(
     registerSessionId,
     registerSessionStatus: registerSession?.status,
     terminalId,
+    terminalName: terminal?.displayName,
     paymentMethod: transaction.paymentMethod,
     payments: transaction.payments,
     totalPaid: transaction.totalPaid ?? transaction.total,

--- a/packages/athena-webapp/convex/pos/public/transactions.test.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.test.ts
@@ -88,6 +88,49 @@ describe("POS public transaction query validators", () => {
     assertConformsToExportedReturns(completeTransaction, validationError);
     assertConformsToExportedReturns(getCompletedTransactions, []);
     assertConformsToExportedReturns(getTransactionById, null);
+    assertConformsToExportedReturns(getTransactionById, {
+      _id: "txn-1" as Id<"posTransaction">,
+      adjustmentSummary: {
+        appliedCount: 0,
+        effectiveNetTotal: 210000,
+        hasAdjustments: false,
+        originalTotal: 210000,
+        pendingCount: 0,
+        totalAppliedAdjustmentDelta: 0,
+      },
+      adjustments: [],
+      cashier: null,
+      changeGiven: 0,
+      completedAt: 1,
+      correctionHistory: [],
+      customer: null,
+      customerInfo: undefined,
+      effectiveNetTotal: 210000,
+      hasTrace: false,
+      items: [],
+      notes: undefined,
+      originalTotal: 210000,
+      paymentMethod: "cash",
+      payments: [{ amount: 210000, method: "cash", timestamp: 1 }],
+      pendingVoidApprovalRequest: null,
+      receiptDeliveryHistory: [],
+      registerNumber: "8",
+      registerSessionId: "register-session-1" as Id<"registerSession">,
+      registerSessionStatus: "closed",
+      serviceLineCount: 0,
+      serviceLines: [],
+      servicePaymentTotal: 0,
+      sessionTraceId: null,
+      status: "completed",
+      subtotal: 210000,
+      tax: 0,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      terminalName: "Codex",
+      total: 210000,
+      totalAppliedAdjustmentDelta: 0,
+      totalPaid: 210000,
+      transactionNumber: "584065",
+    });
     assertConformsToExportedReturns(voidTransaction, validationError);
     assertConformsToExportedReturns(createTransactionFromSession, validationError);
     assertConformsToExportedReturns(correctTransactionCustomer, validationError);

--- a/packages/athena-webapp/convex/pos/public/transactions.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.ts
@@ -550,6 +550,7 @@ export const getTransactionById = query({
       registerSessionId: v.optional(v.id("registerSession")),
       registerSessionStatus: v.optional(v.string()),
       terminalId: v.optional(v.id("posTerminal")),
+      terminalName: v.optional(v.string()),
       paymentMethod: v.optional(v.string()),
       payments: v.array(paymentValidator),
       totalPaid: v.number(),

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -374,8 +374,18 @@ describe("DailyCloseViewContent", () => {
     expect(screen.getByText("Register Session")).toBeInTheDocument();
     expect(screen.queryByText("Register 1")).not.toBeInTheDocument();
     expect(
-      screen.getAllByText("Front counter terminal / Register 1"),
+      screen.getAllByText((_, element) =>
+        Boolean(
+          element?.textContent?.includes("Front counter terminal / Register 1"),
+        ),
+      ),
     ).not.toHaveLength(0);
+    expect(
+      screen.getByRole("link", { name: "Front counter terminal / Register 1" }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/cash-controls/registers/session-1?o=%252F",
+    );
     expect(screen.getAllByText("Operating Scope")).not.toHaveLength(0);
     expect(screen.getByText("Carried over from prior day")).toBeInTheDocument();
     expect(screen.getByText("Opened At")).toBeInTheDocument();
@@ -392,6 +402,12 @@ describe("DailyCloseViewContent", () => {
       "/wigclub/store/osu/operations/approvals?o=%252F",
     );
     expect(screen.getByText("Payment method correction")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Payment method correction" }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/operations/approvals?o=%252F",
+    );
     expect(screen.getByText("Ato Kwamina")).toBeInTheDocument();
     expect(
       screen.getAllByText((_, element) =>
@@ -1073,6 +1089,44 @@ describe("DailyCloseViewContent", () => {
     ).toHaveAttribute(
       "href",
       "/wigclub/store/osu/pos/expense-reports/expense-1?o=%252F",
+    );
+  });
+
+  it("uses the preserved item link when redacted sale rows expose only a transaction number", () => {
+    renderContent({
+      ...readySnapshot,
+      readyItems: [
+        {
+          category: "sale",
+          description: "Completed sale is included in the end of day review.",
+          id: "ready-redacted-sale",
+          link: {
+            label: "View transaction",
+            params: { transactionId: "txn-real-584065" },
+            to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId",
+          },
+          metadata: {
+            paymentMethods: "Cash",
+            terminal: "Codex / Register 8",
+            transaction: "584065",
+          },
+          subject: {
+            id: "redacted",
+            label: "TXN-584065",
+            type: "pos_transaction",
+          },
+          title: "Completed sale",
+        },
+      ],
+      blockers: [],
+      carryForwardItems: [],
+      reviewItems: [],
+      status: "ready",
+    });
+
+    expect(screen.getByRole("link", { name: "#584065" })).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/pos/transactions/txn-real-584065?o=%252F",
     );
   });
 

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -1149,6 +1149,68 @@ function getMetadataValue(metadata: Record<string, unknown>, label: string) {
   );
 }
 
+const sourceLinkMetadataLabels = new Set([
+  "approval",
+  "session",
+]);
+
+function renderItemSourceLink({
+  children,
+  item,
+  orgUrlSlug,
+  storeUrlSlug,
+}: {
+  children: ReactNode;
+  item: DailyCloseItem;
+  orgUrlSlug: string;
+  storeUrlSlug: string;
+}) {
+  if (!item.link) return children;
+
+  const className =
+    "inline-flex min-w-0 items-center gap-1 text-foreground underline-offset-4 transition-colors hover:text-primary hover:underline";
+
+  if (item.link.href) {
+    return (
+      <a className={className} href={item.link.href}>
+        <span className="truncate">{children}</span>
+        <ArrowUpRight aria-hidden="true" className="h-3 w-3 shrink-0" />
+      </a>
+    );
+  }
+
+  if (item.link.to) {
+    return (
+      <Link
+        className={className}
+        params={
+          {
+            orgUrlSlug,
+            storeUrlSlug,
+            ...(item.link.params ?? {}),
+          } as never
+        }
+        search={
+          {
+            o: getOrigin(),
+            ...(item.link.search ?? {}),
+          } as never
+        }
+        to={item.link.to as never}
+      >
+        <span className="truncate">{children}</span>
+        <ArrowUpRight aria-hidden="true" className="h-3 w-3 shrink-0" />
+      </Link>
+    );
+  }
+
+  return children;
+}
+
+function isUsableRouteIdentifier(value?: string) {
+  return Boolean(value && value !== "redacted");
+}
+
 function formatMetadataValue(label: string, value: unknown, currency: string) {
   if (value === null || value === undefined || value === "") return "Not set";
 
@@ -1234,14 +1296,25 @@ function formatMetadataDisplayValue({
   ) : (
     formattedValue
   );
-  const transactionId =
-    getMetadataStringValue(item.metadata, "transactionId") ??
-    (item.subject?.type === "pos_transaction" ? item.subject.id : undefined);
-  const reportId =
-    getMetadataStringValue(item.metadata, "reportId") ??
-    (item.subject?.type === "expense_transaction"
-      ? item.subject.id
-      : undefined);
+  const transactionMetadataId = getMetadataStringValue(
+    item.metadata,
+    "transactionId",
+  );
+  const subjectTransactionId =
+    item.subject?.type === "pos_transaction" ? item.subject.id : undefined;
+  const transactionId = isUsableRouteIdentifier(transactionMetadataId)
+    ? transactionMetadataId
+    : isUsableRouteIdentifier(subjectTransactionId)
+      ? subjectTransactionId
+      : undefined;
+  const reportMetadataId = getMetadataStringValue(item.metadata, "reportId");
+  const subjectReportId =
+    item.subject?.type === "expense_transaction" ? item.subject.id : undefined;
+  const reportId = isUsableRouteIdentifier(reportMetadataId)
+    ? reportMetadataId
+    : isUsableRouteIdentifier(subjectReportId)
+      ? subjectReportId
+      : undefined;
 
   if (normalizeMetadataLabel(label) === "transaction" && transactionId) {
     return (
@@ -1263,6 +1336,15 @@ function formatMetadataDisplayValue({
     );
   }
 
+  if (normalizeMetadataLabel(label) === "transaction" && item.link) {
+    return renderItemSourceLink({
+      children: visibleValue,
+      item,
+      orgUrlSlug,
+      storeUrlSlug,
+    });
+  }
+
   if (normalizeMetadataLabel(label) === "report" && reportId) {
     return (
       <Link
@@ -1281,6 +1363,27 @@ function formatMetadataDisplayValue({
         <ArrowUpRight aria-hidden="true" className="h-3 w-3" />
       </Link>
     );
+  }
+
+  if (normalizeMetadataLabel(label) === "report" && item.link) {
+    return renderItemSourceLink({
+      children: visibleValue,
+      item,
+      orgUrlSlug,
+      storeUrlSlug,
+    });
+  }
+
+  if (
+    item.link &&
+    sourceLinkMetadataLabels.has(normalizeMetadataLabel(label))
+  ) {
+    return renderItemSourceLink({
+      children: visibleValue,
+      item,
+      orgUrlSlug,
+      storeUrlSlug,
+    });
   }
 
   if (normalizeMetadataLabel(label) === "variance") {
@@ -1346,11 +1449,19 @@ function getMetadataEntries(
     const hasExplicitRegister = entries.some(
       (entry) => normalizeMetadataLabel(entry.label) === "register",
     );
-    const appendRegister = (value: ReactNode, nextRegisterLabel: ReactNode) => (
-      <>
-        {value} / {nextRegisterLabel}
-      </>
-    );
+    const withSourceLink = (value: ReactNode) =>
+      renderItemSourceLink({
+        children: value,
+        item,
+        orgUrlSlug,
+        storeUrlSlug,
+      });
+    const appendRegister = (value: ReactNode, nextRegisterLabel: ReactNode) =>
+      withSourceLink(
+        <>
+          {value} / {nextRegisterLabel}
+        </>,
+      );
 
     let combinedEntries = entries.map((entry) =>
       registerLabel &&
@@ -1396,7 +1507,7 @@ function getMetadataEntries(
         ...combinedEntries,
         {
           label: "Register",
-          value: registerLabel,
+          value: withSourceLink(registerLabel),
         },
       ];
     }

--- a/packages/athena-webapp/src/components/pos/OrderSummary.test.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.test.tsx
@@ -358,6 +358,33 @@ describe("OrderSummary completed transaction summary", () => {
     expect(screen.queryByText("Tax")).not.toBeInTheDocument();
   });
 
+  it("shows terminal context with the register number in completed sale summaries", () => {
+    render(
+      <OrderSummary
+        cartItems={[]}
+        completedOrderNumber="404923"
+        completedTransactionData={{
+          paymentMethod: "cash",
+          completedAt: new Date("2026-04-25T18:08:00.000Z"),
+          cartItems: [],
+          customerInfo: undefined,
+          subtotal: 115000,
+          tax: 0,
+          total: 115000,
+        }}
+        isTransactionCompleted
+        payments={[
+          { id: "payment-1", method: "cash", amount: 115000, timestamp: 1 },
+        ]}
+        registerNumber="8"
+        terminalName="Codex"
+      />,
+    );
+
+    expect(screen.getByText("Register")).toBeInTheDocument();
+    expect(screen.getByText("Codex / 8")).toBeInTheDocument();
+  });
+
   it("shows completed subtotal and total in rail summaries", () => {
     render(
       <OrderSummary

--- a/packages/athena-webapp/src/components/pos/OrderSummary.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.tsx
@@ -109,6 +109,7 @@ interface OrderSummaryProps {
     phone?: string;
   };
   registerNumber?: string;
+  terminalName?: string;
   subtotal?: number;
   tax?: number;
   total?: number;
@@ -183,10 +184,28 @@ export function clearAttemptedOrderSummaryAutoPrintReceiptKeysForTest() {
   attemptedAutoPrintReceiptKeys.clear();
 }
 
+function formatRegisterSummaryValue({
+  registerNumber,
+  terminalName,
+}: {
+  registerNumber?: string | null;
+  terminalName?: string | null;
+}) {
+  const register = registerNumber?.trim();
+  const terminal = terminalName?.trim();
+
+  if (terminal && register) {
+    return `${terminal} / ${register}`;
+  }
+
+  return register || terminal || "Unassigned";
+}
+
 export function OrderSummary({
   cartItems,
   customerInfo,
   registerNumber,
+  terminalName,
   subtotal: propSubtotal,
   total: propTotal,
   payments = [],
@@ -383,7 +402,10 @@ export function OrderSummary({
     },
     {
       label: "Register",
-      value: registerNumber ? `${registerNumber}` : "Unassigned",
+      value: formatRegisterSummaryValue({
+        registerNumber,
+        terminalName,
+      }),
     },
     {
       label: "Cashier",

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
@@ -320,6 +320,8 @@ vi.mock("../OrderSummary", () => ({
     completedAdjustmentSummary,
     completedTransactionData,
     onReceiptPrinted,
+    registerNumber,
+    terminalName,
   }: {
     completedAdjustmentSummary?: {
       originalTotal: number;
@@ -329,8 +331,15 @@ vi.mock("../OrderSummary", () => ({
     } | null;
     completedTransactionData?: { total: number; transactionId?: string } | null;
     onReceiptPrinted?: (transactionId: string) => void | Promise<void>;
+    registerNumber?: string;
+    terminalName?: string;
   }) => (
     <div data-testid="order-summary">
+      {terminalName || registerNumber ? (
+        <span>
+          register summary {terminalName} / {registerNumber}
+        </span>
+      ) : null}
       {completedTransactionData?.transactionId && onReceiptPrinted ? (
         <button
           onClick={() =>
@@ -1565,6 +1574,19 @@ describe("TransactionView", () => {
     expect(
       screen.queryByLabelText("Payment method update reason"),
     ).not.toBeInTheDocument();
+  });
+
+  it("passes terminal context to the completed transaction summary", () => {
+    useParamsMock.mockReturnValue({ transactionId: "txn_terminal" });
+    useQueryMock.mockReturnValue({
+      ...baseTransaction,
+      registerNumber: "8",
+      terminalName: "Codex",
+    });
+
+    render(<TransactionView />);
+
+    expect(screen.getByText("register summary Codex / 8")).toBeInTheDocument();
   });
 
   it("disables payment method correction when change was given", async () => {

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
@@ -2450,6 +2450,7 @@ export function TransactionView() {
                 readOnly
                 presentation="rail"
                 registerNumber={transaction.registerNumber}
+                terminalName={transaction.terminalName}
                 completedOrderNumber={transaction.transactionNumber}
                 completedTransactionData={completedData}
                 completedAdjustmentSummary={


### PR DESCRIPTION
## Summary

EOD Review rows now keep the operational context operators need while broad-reader redaction still strips restricted financial evidence. The daily-close snapshot redaction preserves safe row metadata and source links, the review UI renders the restored metadata strip with link-out affordances, and redacted sale rows use the preserved item link instead of trying to route through a redacted subject id.

The transaction detail summary now receives terminal display names from `getTransactionById` and renders the Register row as `Codex / 8`, keeping the value compact because the row label already says Register.

## Why

The previous redaction pass treated row metadata and links as unsafe wholesale. That removed useful operator context from every row rendered by the EOD component and made redacted sale links fragile. The fixed boundary is field-aware: safe operational metadata remains, financial keys are removed, and projected links remain the client navigation contract.

## Validation

- `bun run pr:athena`
- Focused coverage added for daily-close broad-view metadata redaction, EOD row link rendering, redacted transaction links, transaction terminal/register display, and the public Convex return validator contract.

## Notes

- Added `docs/solutions/logic-errors/athena-daily-close-row-metadata-redaction-2026-06-27.md` to document the reusable redaction pattern.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)