### PR TITLE
fix(pos): refresh terminal runtime status

### DIFF
--- a/docs/solutions/architecture/athena-pos-terminal-runtime-status-freshness-2026-06-27.md
+++ b/docs/solutions/architecture/athena-pos-terminal-runtime-status-freshness-2026-06-27.md
@@ -1,0 +1,58 @@
+---
+title: Athena POS Terminal Runtime Status Freshness
+date: 2026-06-27
+category: architecture
+module: athena-webapp
+problem_type: architecture_pattern
+component: pos-terminal-health
+resolution_type: workflow_improvement
+severity: medium
+tags:
+  - pos
+  - terminal-health
+  - local-sync
+  - runtime-status
+---
+
+# Athena POS Terminal Runtime Status Freshness
+
+## Problem
+
+Terminal Health detail pages can receive large support evidence sets when a
+terminal has many unresolved sync conflicts, local review events, or recovery
+blockers. Rendering every row at once makes the support page noisy and harder to
+scan, even though operators usually need the first few items before deciding on
+the next action.
+
+Runtime status publishing also needs a freshness boundary separate from semantic
+runtime changes. If the browser terminal is healthy but the material runtime
+payload does not change, the cloud can age out the last check-in even though the
+terminal is still alive.
+
+## Solution
+
+Keep the detail page support-first:
+
+- Render only the first few conflict, local review, and recovery blocker rows by
+  default.
+- Add explicit expand controls per list so support staff can inspect the full
+  evidence set without making the default page overwhelming.
+- Keep local runtime review evidence distinct from cloud conflicts; list caps
+  should not collapse either source into generic manager-review copy.
+
+Publish runtime freshness independently from material runtime changes:
+
+- Start a scoped heartbeat only after store id, terminal id, and sync-secret hash
+  are available.
+- Increment the runtime observation token on the heartbeat so the existing
+  publish contract can refresh the check-in without inventing fake runtime
+  changes.
+- Keep the heartbeat non-blocking; failed check-ins remain diagnostic evidence
+  and must not block cashier actions or local sync.
+
+## Prevention
+
+When changing terminal health detail lists, cover both capped and expanded
+states in component tests. When changing runtime check-in freshness, cover the
+timer boundary directly so the test proves unchanged runtime material can still
+publish after the freshness interval.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8163 nodes · 9625 edges · 2072 communities detected
+- 8164 nodes · 9626 edges · 2072 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2706,72 +2706,72 @@ Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
 ### Community 149 - "Community 149"
+Cohesion: 0.25
+Nodes (5): getRuntimeStatusPublishMaterialSignature(), getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusPublishMaterial(), normalizeRuntimeStatusSignature()
+
+### Community 150 - "Community 150"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.25
 Nodes (7): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.33
 Nodes (7): createAthenaProviderError(), createProviderFailureResult(), getProviderFailureDiagnostic(), invokeStructuredTextProvider(), isJsonObject(), isJsonValue(), sanitizeDiagnostic()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.31
 Nodes (7): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
-
-### Community 165 - "Community 165"
-Cohesion: 0.29
-Nodes (5): getRuntimeStatusPublishMaterialSignature(), getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusPublishMaterial(), normalizeRuntimeStatusSignature()
 
 ### Community 166 - "Community 166"
 Cohesion: 0.22
@@ -3498,76 +3498,76 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 347 - "Community 347"
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+
+### Community 348 - "Community 348"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 348 - "Community 348"
+### Community 349 - "Community 349"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 349 - "Community 349"
+### Community 350 - "Community 350"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
-
-### Community 350 - "Community 350"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 351 - "Community 351"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 352 - "Community 352"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 353 - "Community 353"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 353 - "Community 353"
+### Community 354 - "Community 354"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
-
-### Community 354 - "Community 354"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 355 - "Community 355"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 356 - "Community 356"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 357 - "Community 357"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 357 - "Community 357"
+### Community 358 - "Community 358"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 358 - "Community 358"
+### Community 359 - "Community 359"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 359 - "Community 359"
+### Community 360 - "Community 360"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 360 - "Community 360"
+### Community 361 - "Community 361"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 361 - "Community 361"
+### Community 362 - "Community 362"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 362 - "Community 362"
+### Community 363 - "Community 363"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 363 - "Community 363"
+### Community 364 - "Community 364"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
-
-### Community 364 - "Community 364"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 365 - "Community 365"
 Cohesion: 0.4
@@ -3578,12 +3578,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 367 - "Community 367"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 368 - "Community 368"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 368 - "Community 368"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 369 - "Community 369"
 Cohesion: 0.4
@@ -3598,20 +3598,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 372 - "Community 372"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 373 - "Community 373"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 373 - "Community 373"
+### Community 374 - "Community 374"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 374 - "Community 374"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 375 - "Community 375"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 376 - "Community 376"
 Cohesion: 0.4
@@ -3630,88 +3630,88 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 380 - "Community 380"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 381 - "Community 381"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 381 - "Community 381"
+### Community 382 - "Community 382"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 382 - "Community 382"
+### Community 383 - "Community 383"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 383 - "Community 383"
+### Community 384 - "Community 384"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 384 - "Community 384"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 385 - "Community 385"
 Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 386 - "Community 386"
 Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
 ### Community 387 - "Community 387"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 388 - "Community 388"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 388 - "Community 388"
+### Community 389 - "Community 389"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 389 - "Community 389"
+### Community 390 - "Community 390"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 390 - "Community 390"
+### Community 391 - "Community 391"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 391 - "Community 391"
+### Community 392 - "Community 392"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 392 - "Community 392"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 393 - "Community 393"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 394 - "Community 394"
 Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 395 - "Community 395"
 Cohesion: 0.6
-Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
 ### Community 396 - "Community 396"
 Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
 ### Community 397 - "Community 397"
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+
+### Community 398 - "Community 398"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 398 - "Community 398"
+### Community 399 - "Community 399"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 399 - "Community 399"
+### Community 400 - "Community 400"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
-
-### Community 400 - "Community 400"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 401 - "Community 401"
 Cohesion: 0.4
@@ -3722,44 +3722,44 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 403 - "Community 403"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 404 - "Community 404"
 Cohesion: 0.5
-Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 405 - "Community 405"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
 ### Community 406 - "Community 406"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 407 - "Community 407"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 408 - "Community 408"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 409 - "Community 409"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 410 - "Community 410"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 410 - "Community 410"
+### Community 411 - "Community 411"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 411 - "Community 411"
+### Community 412 - "Community 412"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 412 - "Community 412"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 413 - "Community 413"
 Cohesion: 0.7

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2144
-- Graph nodes: 8163
-- Graph edges: 9625
+- Graph nodes: 8164
+- Graph edges: 9626
 - Communities: 2072
 
 ## Graph Hotspots

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -1367,6 +1367,45 @@ describe("POSTerminalDetailViewContent", () => {
     ).toHaveAttribute("href", "/wigclub/store/osu/operations/open-work");
   });
 
+  it("limits long recovery blocker groups until expanded", () => {
+    const blockers = Array.from({ length: 8 }, (_, index) => ({
+      actionTarget: { type: "open_work" as const },
+      category: "manual_review" as const,
+      id: `manual-review-${index + 1}`,
+      summary: `Manual review summary ${index + 1}`,
+      title: "Manual review required",
+    }));
+
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [],
+          recovery: {
+            blockers,
+            readiness: {
+              status: "needs_manual_review",
+            },
+          },
+        }}
+        isLoading={false}
+        orgUrlSlug="wigclub"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    expect(screen.getByText("Manual review summary 5")).toBeInTheDocument();
+    expect(screen.queryByText("Manual review summary 6")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show 3 more" }));
+
+    expect(screen.getByText("Manual review summary 8")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show fewer" }));
+
+    expect(screen.queryByText("Manual review summary 6")).not.toBeInTheDocument();
+  });
+
   it("routes attention reasons to the available action surfaces", () => {
     render(
       <POSTerminalDetailViewContent
@@ -1642,6 +1681,47 @@ describe("POSTerminalDetailViewContent", () => {
     expect(
       screen.getByText("Terminal detail is not available right now"),
     ).toBeInTheDocument();
+  });
+
+  it("limits long conflict review lists until expanded", () => {
+    const conflicts = Array.from({ length: 8 }, (_, index) => ({
+      _id: `conflict-${index + 1}`,
+      conflictType: "inventory_review",
+      createdAt: Date.now() - index * 60_000,
+      localEventId: `local-conflict-${index + 1}`,
+      localRegisterSessionId: "local-session-1",
+      sequence: index + 1,
+      summary: `Inventory review summary ${index + 1}`,
+    }));
+
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          syncEvidence: {
+            ...detail.syncEvidence,
+            unresolvedConflictCount: conflicts.length,
+            unresolvedConflicts: conflicts,
+          },
+        }}
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByText("Inventory review summary 5")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Inventory review summary 6"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show 3 more" }));
+
+    expect(screen.getByText("Inventory review summary 8")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show fewer" }));
+
+    expect(
+      screen.queryByText("Inventory review summary 6"),
+    ).not.toBeInTheDocument();
   });
 
   it("renders the current aggregate sync evidence query shape", () => {

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
@@ -78,6 +78,8 @@ const posTerminalApi = api.inventory.posTerminal as unknown as {
   >;
 };
 
+const TERMINAL_DETAIL_LIST_VISIBLE_LIMIT = 5;
+
 type RemoteAssistClientSummary = {
   _id: Id<"remoteAssistClient"> | string;
   accessPolicy:
@@ -1051,11 +1053,28 @@ function ConflictSection({
   runtimeStatus: TerminalRuntimeStatus | null;
   syncEvidence: TerminalSyncEvidence;
 }) {
+  const [isConflictListExpanded, setIsConflictListExpanded] = useState(false);
+  const [isLocalReviewListExpanded, setIsLocalReviewListExpanded] =
+    useState(false);
   const localReviewEvents = runtimeStatus?.sync.reviewEvents ?? [];
   const runtimeReviewCount = runtimeStatus?.sync.reviewEventCount ?? 0;
   const missingRuntimeReviewDetails =
     runtimeReviewCount > 0 && localReviewEvents.length === 0;
   const unresolvedConflicts = syncEvidence.unresolvedConflicts ?? [];
+  const visibleConflicts = isConflictListExpanded
+    ? unresolvedConflicts
+    : unresolvedConflicts.slice(0, TERMINAL_DETAIL_LIST_VISIBLE_LIMIT);
+  const hiddenConflictCount = Math.max(
+    unresolvedConflicts.length - TERMINAL_DETAIL_LIST_VISIBLE_LIMIT,
+    0,
+  );
+  const visibleLocalReviewEvents = isLocalReviewListExpanded
+    ? localReviewEvents
+    : localReviewEvents.slice(0, TERMINAL_DETAIL_LIST_VISIBLE_LIMIT);
+  const hiddenLocalReviewCount = Math.max(
+    localReviewEvents.length - TERMINAL_DETAIL_LIST_VISIBLE_LIMIT,
+    0,
+  );
   const reviewCount = getReviewEvidenceCount(syncEvidence);
 
   return (
@@ -1071,20 +1090,34 @@ function ConflictSection({
               : "No unresolved cloud sync conflicts are currently reported. Local runtime review, pending sync, or stale check-ins may still need attention above."}
           </p>
         ) : (
-          unresolvedConflicts.map((conflict) => (
-            <div
-              className="rounded-md border border-warning/30 bg-warning/10 px-layout-md py-layout-sm"
-              key={conflict._id}
-            >
-              <p className="text-sm font-medium text-foreground">
-                {conflict.summary}
-              </p>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Sequence {conflict.sequence} /{" "}
-                {formatStatusLabel(conflict.conflictType)}
-              </p>
-            </div>
-          ))
+          <>
+            {visibleConflicts.map((conflict) => (
+              <div
+                className="rounded-md border border-warning/30 bg-warning/10 px-layout-md py-layout-sm"
+                key={conflict._id}
+              >
+                <p className="text-sm font-medium text-foreground">
+                  {conflict.summary}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Sequence {conflict.sequence} /{" "}
+                  {formatStatusLabel(conflict.conflictType)}
+                </p>
+              </div>
+            ))}
+            {hiddenConflictCount > 0 ? (
+              <Button
+                className="h-8 px-layout-sm text-xs"
+                onClick={() => setIsConflictListExpanded((current) => !current)}
+                type="button"
+                variant="outline"
+              >
+                {isConflictListExpanded
+                  ? "Show fewer"
+                  : `Show ${hiddenConflictCount} more`}
+              </Button>
+            ) : null}
+          </>
         )}
 
         {localReviewEvents.length > 0 ? (
@@ -1096,7 +1129,7 @@ function ConflictSection({
               <span>Status</span>
             </div>
             <div className="divide-y divide-border/80">
-              {localReviewEvents.map((event) => (
+              {visibleLocalReviewEvents.map((event) => (
                 <div
                   className="grid gap-layout-sm px-layout-md py-layout-sm text-sm md:grid-cols-[5rem_minmax(0,1fr)_8rem_7rem] md:items-center"
                   key={event.localEventId}
@@ -1124,6 +1157,22 @@ function ConflictSection({
                   </span>
                 </div>
               ))}
+              {hiddenLocalReviewCount > 0 ? (
+                <div className="px-layout-md py-layout-sm">
+                  <Button
+                    className="h-8 px-layout-sm text-xs"
+                    onClick={() =>
+                      setIsLocalReviewListExpanded((current) => !current)
+                    }
+                    type="button"
+                    variant="outline"
+                  >
+                    {isLocalReviewListExpanded
+                      ? "Show fewer"
+                      : `Show ${hiddenLocalReviewCount} more`}
+                  </Button>
+                </div>
+              ) : null}
             </div>
           </div>
         ) : null}
@@ -1586,6 +1635,11 @@ function RecoveryBlockerGroup({
   terminalId: Id<"posTerminal"> | string;
   title: string;
 }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const visibleLimit = 5;
+  const hiddenCount = Math.max(blockers.length - visibleLimit, 0);
+  const visibleBlockers = isExpanded ? blockers : blockers.slice(0, visibleLimit);
+
   return (
     <div className="rounded-md border border-border/80 bg-surface">
       <div className="border-b border-border/80 bg-surface-muted/40 px-layout-md py-layout-xs">
@@ -1599,35 +1653,51 @@ function RecoveryBlockerGroup({
             {emptyCopy}
           </p>
         ) : (
-          blockers.map((blocker) => (
-            <div
-              className="grid gap-layout-sm px-layout-md py-layout-sm md:grid-cols-[minmax(0,1fr)_auto] md:items-start"
-              key={blocker.id}
-            >
-              <div className="min-w-0">
-                <p className="text-sm font-medium text-foreground">
-                  {blocker.title}
-                </p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {blocker.summary}
-                </p>
-                {blocker.detail ? (
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    {blocker.detail}
+          <>
+            {visibleBlockers.map((blocker) => (
+              <div
+                className="grid gap-layout-sm px-layout-md py-layout-sm md:grid-cols-[minmax(0,1fr)_auto] md:items-start"
+                key={blocker.id}
+              >
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-foreground">
+                    {blocker.title}
                   </p>
-                ) : null}
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {blocker.summary}
+                  </p>
+                  {blocker.detail ? (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {blocker.detail}
+                    </p>
+                  ) : null}
+                </div>
+                <RecoveryBlockerAction
+                  blocker={blocker}
+                  onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+                  onResolveTerminalCloudRepair={onResolveTerminalCloudRepair}
+                  onResolveRegisterSessionReview={onResolveRegisterSessionReview}
+                  orgUrlSlug={orgUrlSlug}
+                  storeUrlSlug={storeUrlSlug}
+                  terminalId={terminalId}
+                />
               </div>
-              <RecoveryBlockerAction
-                blocker={blocker}
-                onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
-                onResolveTerminalCloudRepair={onResolveTerminalCloudRepair}
-                onResolveRegisterSessionReview={onResolveRegisterSessionReview}
-                orgUrlSlug={orgUrlSlug}
-                storeUrlSlug={storeUrlSlug}
-                terminalId={terminalId}
-              />
-            </div>
-          ))
+            ))}
+            {hiddenCount > 0 ? (
+              <div className="px-layout-md py-layout-sm">
+                <Button
+                  className="h-8 px-layout-sm text-xs"
+                  onClick={() => setIsExpanded((current) => !current)}
+                  type="button"
+                  variant="outline"
+                >
+                  {isExpanded
+                    ? "Show fewer"
+                    : `Show ${hiddenCount} more`}
+                </Button>
+              </div>
+            ) : null}
+          </>
         )}
       </div>
     </div>

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeStatusPublisher.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeStatusPublisher.ts
@@ -2,6 +2,23 @@ import type { PosTerminalRuntimeStatusPayload } from "./terminalRuntimeStatus";
 
 export const RUNTIME_STATUS_FRESHNESS_PUBLISH_INTERVAL_MS = 30_000;
 
+export function startRuntimeStatusFreshnessHeartbeat(
+  onHeartbeat: () => void,
+  timers: {
+    clearIntervalFn?: typeof clearInterval;
+    setIntervalFn?: typeof setInterval;
+  } = {},
+) {
+  const setIntervalFn = timers.setIntervalFn ?? setInterval;
+  const clearIntervalFn = timers.clearIntervalFn ?? clearInterval;
+  const heartbeatTimer = setIntervalFn(
+    onHeartbeat,
+    RUNTIME_STATUS_FRESHNESS_PUBLISH_INTERVAL_MS,
+  );
+
+  return () => clearIntervalFn(heartbeatTimer);
+}
+
 export type RuntimeCheckInNotReadyReason =
   | "missing_store"
   | "missing_sync_secret"

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   acknowledgeTerminalRecoveryCommand: vi.fn(),
@@ -77,6 +77,7 @@ import {
   RUNTIME_STATUS_FRESHNESS_PUBLISH_INTERVAL_MS,
   getRuntimeStatusPublishMaterialSignature,
   shouldPublishRuntimeStatus,
+  startRuntimeStatusFreshnessHeartbeat,
 } from "./runtimeStatusPublisher";
 import { buildPosLocalSyncUploadEvents } from "./syncContract";
 
@@ -117,6 +118,11 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       configurable: true,
       value: true,
     });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("reads local events through the terminal seed and exposes retry refresh", async () => {
@@ -3871,6 +3877,27 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       ),
     );
     expect(mocks.reportTerminalRuntimeStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts runtime check-in heartbeat wakeups on the freshness cadence", () => {
+    const heartbeat = vi.fn();
+    const setIntervalFn = vi.fn(() => "timer-1");
+    const clearIntervalFn = vi.fn();
+
+    const stopHeartbeat = startRuntimeStatusFreshnessHeartbeat(heartbeat, {
+      clearIntervalFn: clearIntervalFn as never,
+      setIntervalFn: setIntervalFn as never,
+    });
+
+    expect(setIntervalFn).toHaveBeenCalledWith(
+      heartbeat,
+      RUNTIME_STATUS_FRESHNESS_PUBLISH_INTERVAL_MS,
+    );
+    expect(heartbeat).not.toHaveBeenCalled();
+
+    stopHeartbeat();
+
+    expect(clearIntervalFn).toHaveBeenCalledWith("timer-1");
   });
 
   it("queues changed runtime check-ins while a previous publish is in flight", async () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -65,6 +65,7 @@ import {
   getRuntimeCheckInNotReadyReason,
   getRuntimeStatusPublishSignature,
   shouldPublishRuntimeStatus,
+  startRuntimeStatusFreshnessHeartbeat,
   withRuntimeCheckInPublishDebug as withCheckInPublishDebug,
 } from "./runtimeStatusPublisher";
 import {
@@ -968,6 +969,16 @@ export function usePosLocalSyncRuntimeStatus(input: {
     api.pos.public.terminals.listTerminalRecoveryCommands,
     recoveryCommandArgs,
   );
+
+  useEffect(() => {
+    if (!storeId || !runtimeStatusTerminalId || !runtimeStatusSyncSecretHash) {
+      return;
+    }
+
+    return startRuntimeStatusFreshnessHeartbeat(() => {
+      setRuntimeStatusObservationToken((current) => current + 1);
+    });
+  }, [runtimeStatusSyncSecretHash, runtimeStatusTerminalId, storeId]);
 
   useEffect(() => {
     const notReadyReason = getRuntimeCheckInNotReadyReason({


### PR DESCRIPTION
## Summary

Terminal detail pages now keep large support evidence sets scannable by showing the first 5 conflicts, local review items, and recovery blockers with explicit expand controls for the rest.

Runtime status publishing now has a freshness heartbeat once store, terminal, and sync-secret hash are available, so an unchanged but healthy POS terminal can refresh its cloud check-in without inventing semantic runtime changes.

## Validation

- `bun run test -- src/components/pos/terminals/POSTerminalDetailView.test.tsx src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
- `bun run pr:athena`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)