### PR TITLE
fix(pos): reconcile terminal health review evidence

### DIFF
--- a/docs/plans/2026-06-27-004-feat-terminal-health-reconciliation-plan.html
+++ b/docs/plans/2026-06-27-004-feat-terminal-health-reconciliation-plan.html
@@ -1,0 +1,355 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Plan: Add Terminal Health Reconciliation Lanes</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f7f7f4;
+        --panel: #ffffff;
+        --ink: #151720;
+        --muted: #616775;
+        --line: #deded8;
+        --accent: #1f6f68;
+        --accent-soft: #e3f0ee;
+        --warn: #8a5a12;
+        --warn-soft: #fff4dc;
+        --danger: #9f2d2d;
+        --danger-soft: #fae6e6;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+        font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      main {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 40px 24px 56px;
+      }
+
+      header {
+        border-bottom: 1px solid var(--line);
+        margin-bottom: 24px;
+        padding-bottom: 20px;
+      }
+
+      h1,
+      h2,
+      h3 {
+        line-height: 1.2;
+        margin: 0;
+      }
+
+      h1 {
+        font-size: clamp(2rem, 4vw, 3.25rem);
+        letter-spacing: 0;
+      }
+
+      h2 {
+        font-size: 1.25rem;
+        margin-bottom: 12px;
+      }
+
+      h3 {
+        font-size: 1rem;
+        margin-bottom: 8px;
+      }
+
+      p {
+        margin: 0 0 12px;
+      }
+
+      a {
+        color: var(--accent);
+      }
+
+      code {
+        background: #f1f1ed;
+        border: 1px solid var(--line);
+        border-radius: 4px;
+        padding: 0 4px;
+      }
+
+      section {
+        margin-top: 24px;
+      }
+
+      .meta {
+        color: var(--muted);
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px 16px;
+        margin-top: 14px;
+      }
+
+      .grid {
+        display: grid;
+        gap: 14px;
+      }
+
+      .grid.two {
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+
+      .card {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 16px;
+      }
+
+      .callout {
+        background: var(--accent-soft);
+        border-left: 4px solid var(--accent);
+      }
+
+      .warning {
+        background: var(--warn-soft);
+        border-left: 4px solid var(--warn);
+      }
+
+      .danger {
+        background: var(--danger-soft);
+        border-left: 4px solid var(--danger);
+      }
+
+      ul {
+        margin: 0;
+        padding-left: 20px;
+      }
+
+      li + li {
+        margin-top: 6px;
+      }
+
+      table {
+        border-collapse: collapse;
+        width: 100%;
+      }
+
+      th,
+      td {
+        border: 1px solid var(--line);
+        padding: 10px;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      th {
+        background: #efefea;
+      }
+
+      .unit {
+        display: grid;
+        gap: 8px;
+      }
+
+      .unit strong {
+        color: var(--accent);
+      }
+
+      .toc {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .toc a {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        padding: 6px 10px;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>feat: Add Terminal Health Reconciliation Lanes</h1>
+        <div class="meta">
+          <span>Type: feat</span>
+          <span>Status: active</span>
+          <span>Date: 2026-06-27</span>
+          <span>Source: <a href="./2026-06-27-004-feat-terminal-health-reconciliation-plan.md">markdown plan</a></span>
+        </div>
+      </header>
+
+      <nav class="toc" aria-label="Plan sections">
+        <a href="#summary">Summary</a>
+        <a href="#requirements">Requirements</a>
+        <a href="#decisions">Decisions</a>
+        <a href="#lanes">Lanes</a>
+        <a href="#units">Units</a>
+        <a href="#risks">Risks</a>
+      </nav>
+
+      <section id="summary" class="card callout">
+        <h2>Summary</h2>
+        <p>
+          Add a reusable explanation model for terminal health that reconciles sale readiness,
+          support recovery, sync review backlog, and next action lanes from
+          <code>TerminalOperationalState</code>. The plan keeps the motivating incident as a
+          representative fixture, not a special-case implementation.
+        </p>
+      </section>
+
+      <section class="grid two">
+        <article class="card">
+          <h2>Problem</h2>
+          <p>
+            Terminal Health can show a fresh online runtime and sale-ready evidence while still
+            marking a terminal as needing attention because sync review or cloud conflict evidence
+            remains unresolved.
+          </p>
+          <p>
+            Today those facts are split across attention reasons, support recovery, and conflict
+            lists. The plan adds one server-owned explanation of the relationship between them.
+          </p>
+        </article>
+
+        <article class="card warning">
+          <h2>Safety Boundary</h2>
+          <p>
+            Business facts remain manual. Sale, payment, inventory, closeout, variance, customer,
+            staff proof, and unknown conflicts must never become automatic repair candidates.
+          </p>
+        </article>
+      </section>
+
+      <section id="requirements" class="card">
+        <h2>Requirements Digest</h2>
+        <ul>
+          <li>Derive a health explanation with lane, next step, sale impact, support action, and bounded evidence.</li>
+          <li>Keep <code>terminalHealth</code>, <code>salesReadiness</code>, and <code>supportRecovery</code> distinct.</li>
+          <li>Preserve manual review and safe cloud repair boundaries.</li>
+          <li>Use capped summaries or pagination for large review/conflict backlogs.</li>
+          <li>Make public contract fields, literals, access boundaries, and sync-secret separation explicit.</li>
+          <li>Keep roster/detail explanations additive and keep recovery preview behaviorally consistent without changing its shape.</li>
+          <li>Use calm operational copy and avoid raw backend wording or internal ids.</li>
+        </ul>
+      </section>
+
+      <section id="decisions" class="card">
+        <h2>Key Decisions</h2>
+        <ul>
+          <li>Extend <code>TerminalOperationalState</code> instead of adding UI-only inference.</li>
+          <li>Use a review-first roster headline plus compact sale-continuity copy when sales can continue.</li>
+          <li>Manual review remains primary in mixed manual-review plus safe-repair states.</li>
+          <li>Generic local review becomes terminal-local retry or diagnostics, not manual business review.</li>
+          <li>Unsafe cloud repair skips stay visible as manual-review or diagnostic evidence.</li>
+          <li>App update remains outside <code>operationalExplanation.lane</code>.</li>
+          <li>Health summaries return bounded evidence and sampling metadata, not unbounded lists.</li>
+        </ul>
+      </section>
+
+      <section id="lanes" class="card">
+        <h2>Lane Matrix</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Lane</th>
+              <th>Meaning</th>
+              <th>Owner</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>sale_ready_with_review_backlog</code></td>
+              <td>Support review needed; cashier can continue.</td>
+              <td>Existing owner resolved from evidence.</td>
+            </tr>
+            <tr>
+              <td><code>needs_manual_review</code></td>
+              <td>Business or review facts need a human workflow.</td>
+              <td>Cash Controls or Operations/Open Work.</td>
+            </tr>
+            <tr>
+              <td><code>needs_terminal_action</code></td>
+              <td>Matching terminal must repair local state or retry sync.</td>
+              <td>Terminal command/runtime.</td>
+            </tr>
+            <tr>
+              <td><code>needs_cloud_repair</code></td>
+              <td>Safe cloud repair policy can resolve stale duplicate lifecycle evidence.</td>
+              <td>Support cloud repair.</td>
+            </tr>
+            <tr>
+              <td><code>stale_runtime</code></td>
+              <td>Runtime evidence is stale or absent.</td>
+              <td>Diagnostic / wait for check-in.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="card">
+        <h2>Public Contract</h2>
+        <p>
+          <code>operationalExplanation</code> is additive on terminal health list/detail
+          responses. It keeps existing fields intact and uses fixed public literals for lane,
+          severity, blocking domain, sale impact, support action, owner, evidence references,
+          secondary actions, and sampling metadata.
+        </p>
+        <ul>
+          <li><code>previewTerminalRecovery</code> keeps returning only <code>TerminalRecoveryPreview</code>; tests prove recovery-preview consistency with list/detail.</li>
+          <li>Required access stays staff/user-role based; terminal sync secrets never authorize support-facing reads.</li>
+          <li>Evidence references are display-safe only and exclude raw payloads, secrets, payment/customer data, and staff proof/PIN material.</li>
+          <li>Operations/Open Work ownership is definitive only when resolved through bounded indexed reads; otherwise <code>targetResolutionIncomplete</code> is true.</li>
+        </ul>
+      </section>
+
+      <section id="units">
+        <h2>Implementation Units</h2>
+        <div class="grid">
+          <article class="card unit">
+            <strong>U1. Characterize Current Terminal Health Cases</strong>
+            <span>Lock in sale readiness, support recovery, and health distinctions before policy changes.</span>
+          </article>
+          <article class="card unit">
+            <strong>U2. Add Bounded Sync Review Evidence Summary</strong>
+            <span>Group large review backlogs by type, owner, and actionability with named caps and indexed reads.</span>
+          </article>
+          <article class="card unit">
+            <strong>U3. Add Operational Explanation Policy</strong>
+            <span>Derive lane, sale impact, next step, support action, severity, and bounded evidence while resolving generic local-review ambiguity.</span>
+          </article>
+          <article class="card unit">
+            <strong>U4. Project And Validate The Public Contract</strong>
+            <span>Expose the explanation through terminal queries, Convex validators, and frontend types.</span>
+          </article>
+          <article class="card unit">
+            <strong>U5. Update Roster And Detail Presentation</strong>
+            <span>Use the same explanation in roster and detail, including required sale-continuity copy for sale-ready review backlog.</span>
+          </article>
+          <article class="card unit">
+            <strong>U6. Strengthen Regression Coverage And Documentation</strong>
+            <span>Document the lane boundary and harden cloud repair/manual review tests.</span>
+          </article>
+        </div>
+      </section>
+
+      <section id="risks" class="card danger">
+        <h2>Primary Risks</h2>
+        <ul>
+          <li>Hiding a true sale blocker behind review copy.</li>
+          <li>Encouraging unsafe cleanup of business facts.</li>
+          <li>Understating huge backlogs when summaries are bounded.</li>
+          <li>Drifting public validators from query return shape.</li>
+          <li>Letting roster and detail copy diverge.</li>
+          <li>Letting sync-secret terminal proof become an accidental read credential.</li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/plans/2026-06-27-004-feat-terminal-health-reconciliation-plan.md
+++ b/docs/plans/2026-06-27-004-feat-terminal-health-reconciliation-plan.md
@@ -1,0 +1,523 @@
+---
+title: "feat: Add Terminal Health Reconciliation Lanes"
+type: feat
+status: active
+date: 2026-06-27
+---
+
+# feat: Add Terminal Health Reconciliation Lanes
+
+## Summary
+
+Add a reusable terminal-health explanation model that reconciles sale readiness, support recovery, sync review backlog, and next action lanes from `TerminalOperationalState`. The goal is to make any terminal show why it is not fully healthy, what workflow owns the next step, and whether sales can continue, without encoding a one-off incident exception.
+
+---
+
+## Problem Frame
+
+Terminal Health can currently show a fresh online runtime and sale-ready evidence while still marking the terminal as needing attention because sync review or cloud conflict evidence remains unresolved. The current UI surfaces those facts across attention reasons, support recovery, and conflict lists, but it does not provide one reusable explanation of the relationship between those facts.
+
+That makes large backlogs hard to interpret: support can see that something needs review, but not quickly distinguish terminal-local repair, manual business review, safe cloud repair, diagnostic-only evidence, and sale impact.
+
+---
+
+## Requirements
+
+- R1. Add a server-derived terminal health explanation that names the current blocker lane, next step, sale impact, support action, and bounded evidence counts.
+- R2. Keep `terminalHealth`, `salesReadiness`, and `supportRecovery` distinct. A terminal may be sale-ready and still need review work.
+- R3. Generalize beyond the motivating incident. The model must work for any terminal with runtime, sync, register, command, cloud-repair, or manual-review evidence.
+- R4. Preserve the existing safety boundary: sale, payment, inventory, closeout, variance, customer, staff proof, and unknown business facts are never auto-repaired.
+- R5. Keep safe cloud repair narrow to allow-listed stale duplicate register/drawer-open conflicts that are projection-safe and scoped by precondition hash.
+- R6. Keep review ownership explicit: Cash Controls, Operations/Open Work, terminal-local command, safe cloud repair, wait-for-check-in, or diagnostic-only.
+- R7. Use bounded summaries and paginated or capped drill-ins. Do not return unbounded conflict or local-review lists from terminal-health queries.
+- R8. Preserve roster/detail parity and recovery-preview consistency. List rows and detail pages must expose the same `operationalExplanation`; `previewTerminalRecovery` keeps its existing return shape and must remain behaviorally consistent through its `recoveryPreview` readiness/actions.
+- R9. Keep public Convex validators, frontend types, and UI presentation in lockstep for every returned field.
+- R10. Use calm operational copy and normalize backend conflict wording before it reaches operators.
+- R11. Add regression coverage for online/sale-ready terminals with unresolved review backlog, mixed manual-review plus safe-repair evidence, terminal-local repair, stale runtime, and healthy/no-action cases.
+- R12. Preserve the existing public access boundary for terminal health: staff/user role authorization remains server-derived, store/terminal scoped, and never satisfied by terminal sync-secret proof.
+- R13. Keep `operationalExplanation` additive. Existing fields and semantics for `health`, `runtimeAgeMs`, `runtimeStatus`, `attentionReasons`, `recoveryPreview`, `registerSessionLink`, and `syncEvidence` must remain present.
+
+---
+
+## Scope Boundaries
+
+- This plan does not implement terminal-specific cleanup, manual data mutation, or a one-off incident recovery script.
+- This plan does not auto-resolve business conflicts, approve manager review, reject sync items, or change Cash Controls/Operations decision authority.
+- This plan does not expand safe cloud repair beyond the existing duplicate register/drawer-open allow list.
+- This plan does not redesign runtime heartbeat cadence, Remote Assist, app update commands, terminal command execution, or local IndexedDB repair behavior.
+- This plan does not persist a new terminal operational-state table. The explanation is computed from current read facts.
+- This plan does not require browser validation from Codex; the user owns browser validation for this thread.
+- This plan does not create a new credential path. Terminal sync secrets remain limited to terminal check-in/command claim/ack channels and cannot authorize staff/support health reads.
+
+### Deferred to Follow-Up Work
+
+- Fleet-wide batch remediation or scheduling once the explanation lanes are stable.
+- Persisted aggregate counters for exact all-time conflict counts if bounded read-time summaries are not enough.
+- New Cash Controls or Operations review workflows beyond linking to the existing owner.
+- Automatic self-heal decisions based on the new explanation model.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/convex/pos/application/terminalOperationalState/types.ts` defines `TerminalOperationalState`, `TerminalSalesReadiness`, `TerminalSupportRecovery`, attention reasons, recovery preview, and diagnostic evidence.
+- `packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.ts` is the pure policy boundary that derives attention reasons, support recovery, sales readiness, health, terminal actions, and manual review.
+- `packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.ts` gathers query-safe runtime, sync, and register facts.
+- `packages/athena-webapp/convex/pos/application/queries/terminals.ts` projects terminal health summaries, recovery preview, app update evidence, command status, and cloud repair preview.
+- `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts` reads latest runtime status, terminal sync evidence, cursors, unresolved conflicts, and register-session evidence.
+- `packages/athena-webapp/convex/pos/public/terminals.ts` is the public Convex contract and validator boundary for terminal health.
+- `packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts` contains the safe cloud repair allow list and business-fact exclusion policy.
+- `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts` turns server evidence into roster/detail/recovery copy and actions.
+- `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx` consumes roster health summaries.
+- `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx` consumes detail health, support recovery, sync evidence, and conflict/review evidence.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-terminal-operational-state-aggregate-2026-06-27.md` establishes `TerminalOperationalState` as the computed, query-safe, non-actuating read boundary.
+- `docs/solutions/architecture/athena-pos-terminal-recovery-readiness-boundary-2026-06-14.md` keeps sale readiness, support recovery, and diagnostics separate.
+- `docs/solutions/architecture/athena-pos-remote-terminal-health-recovery-2026-06-11.md` keeps terminal recovery as orchestration verified by fresh runtime evidence, not force-clear.
+- `docs/solutions/logic-errors/athena-pos-sync-review-workspace-boundaries-2026-06-19.md` states that sync review is workflow-owned state, not a generic terminal count.
+- `docs/solutions/logic-errors/athena-cash-controls-sale-sync-review-evidence-2026-06-18.md` keeps sale/payment review evidence with manager workflows.
+- `docs/solutions/logic-errors/athena-pos-drawer-sync-contract-2026-06-27.md` requires drawer authority to match the active drawer identity before it blocks sales.
+- `docs/solutions/logic-errors/athena-pos-register-sync-repair-and-runtime-reconciliation-2026-06-26.md` keeps runtime reconciliation in heartbeat/command-gateway paths, not the sale hot path.
+- `docs/product-copy-tone.md` requires calm, operational copy that leads with state and names the next action.
+
+### External References
+
+External research was skipped. The work is specific to Athena's Convex POS runtime, terminal health, local-first sync, and existing recovery policy.
+
+---
+
+## Key Technical Decisions
+
+- **Extend `TerminalOperationalState`, not the UI alone:** The explanation belongs at the server read boundary so roster, detail, recovery preview, tests, and future support tooling share one classification.
+- **Add `operationalExplanation` as a projection-safe model:** The model should include lane/status, headline, detail, next step, blocking domain, sale impact, support action, severity, and capped evidence references.
+- **Keep the roster review-first but sale-impact explicit:** If `supportRecovery` needs manual review, roster should foreground review and also show a compact sale-impact signal. For `sale_ready_with_review_backlog`, the row must communicate both "Review needed" and "Sales can continue" or equivalent calm operational copy.
+- **Manual review outranks terminal action and safe repair:** Mixed states must not encourage repair before business review. Safe repair may appear as a secondary action only when scoped to safe ids that cannot mutate review facts.
+- **Split generic local review from business manual review:** Current policy treats `local_review` as both retryable terminal action and manual review. This work must resolve that contradiction by making generic local review a terminal-local settlement/diagnostic lane, while cloud held/rejected/business conflicts remain manual review.
+- **Unsafe cloud repair skips remain visible:** Skipped conflicts with unsafe or business facts should produce manual-review evidence. Non-actionable stale evidence may also appear as diagnostic evidence.
+- **Bounded aggregation over full lists:** Health summaries should return capped examples, grouped counts from bounded scans, `hasMore` markers, and clear sampling language. Exact all-time counts can be deferred to persisted counters if needed.
+- **App update stays separate:** App update action/status can remain available outside `operationalExplanation.lane`, but it must not redefine terminal health, sale readiness, or support recovery.
+- **Public validator parity is part of the feature:** New fields must land with Convex validators, frontend types, and tests in the same implementation slice.
+- **Open Work ownership is best-effort until indexed:** Inventory review can route to Operations/Open Work only when an open work target is resolved within bounded indexed reads. Without an indexed ownership lookup, summaries must expose `targetResolutionIncomplete` rather than claiming definitive Operations ownership.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should sale-ready plus review backlog show as healthy?** No. It should remain `needs_attention`, but the explanation should distinguish review backlog from sale blocking.
+- **Should roster say "Needs review" or "Sale ready, review needed"?** Use a review-first headline on the roster, but include a compact sale-impact signal on the row. For `sale_ready_with_review_backlog`, list and detail must both make clear that sales can continue.
+- **Should safe repair be visible when manual review also exists?** Manual review is primary. Safe repair may be secondary only when scoped to safe ids and impossible to affect business facts.
+- **Should local runtime review route to Cash Controls?** No. Only explicit action targets should route to Cash Controls or Operations. Generic local review is terminal-local retry/settlement or diagnostic guidance, and U3 must remove or separate the current `local_review` manual-review classification.
+- **Where do unmapped cloud conflicts route?** Inventory review with a resolved open work target routes to Operations/Open Work. Mapped register-session conflicts route to Cash Controls. Unmapped cloud conflicts route to manual review with a generic open-work/manual-review next step, not Cash Controls.
+
+### Deferred to Implementation
+
+- Internal helper names may change, but the public enum literals in the Operational Explanation Contract are fixed for this feature.
+- The exact conflict summary scan limit may be tuned during implementation, provided it is a named cap, uses index-scoped `take(cap + 1)` or pagination-style bounded reads, and exposes `hasMore` or equivalent sampling semantics.
+- Whether a separate paginated conflict drill-in query is needed in the first slice depends on whether existing capped UI plus new summary lanes provides enough operator context.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  Runtime["Runtime status"]
+  Sync["Sync events, cursors, conflicts"]
+  Register["Register lifecycle"]
+  Commands["Recovery commands"]
+  Repair["Cloud repair preview"]
+  Facts["collectTerminalOperationalFacts"]
+  State["TerminalOperationalState"]
+  Explanation["operationalExplanation"]
+  Public["TerminalHealthSummary validators"]
+  Presentation["terminalHealthPresentation"]
+  Roster["Terminal roster"]
+  Detail["Terminal detail"]
+
+  Runtime --> Facts
+  Sync --> Facts
+  Register --> Facts
+  Commands --> State
+  Repair --> State
+  Facts --> State
+  State --> Explanation
+  Explanation --> Public
+  Public --> Presentation
+  Presentation --> Roster
+  Presentation --> Detail
+```
+
+### Lane Matrix
+
+| Lane | Meaning | Primary owner | Sale impact posture |
+| --- | --- | --- | --- |
+| `healthy` | No current support or review blocker | None | Derived from sales readiness |
+| `sale_ready_with_review_backlog` | Support review needed; cashier can continue | Existing owner resolved from evidence | Can transact now |
+| `needs_manual_review` | Business/review facts require a human workflow | Cash Controls or Operations/Open Work | Depends on sales readiness |
+| `needs_terminal_action` | Matching terminal must repair local state or retry sync | Terminal command/runtime | Usually blocked or degraded |
+| `needs_cloud_repair` | Existing safe cloud repair policy can resolve stale duplicate lifecycle evidence | Support cloud repair | Usually no sale impact unless paired with runtime issue |
+| `sync_failed` | Local sync failed or unavailable | Terminal command/runtime | Degraded; may require retry |
+| `stale_runtime` | Runtime evidence is stale or absent | Diagnostic / wait for check-in | Unknown, stale, or offline |
+
+### Ownership Matrix
+
+| Evidence | Next lane | Notes |
+| --- | --- | --- |
+| Inventory review with open work target | Operations/Open Work | Do not route to Cash Controls. |
+| Mapped register-session review | Cash Controls | Use existing action target and resolver policy. |
+| Generic local review count | Terminal sync retry or diagnostic | Only when the matching terminal owns settlement evidence; do not invent a cloud manager action. |
+| Payment, sale, closeout, variance, customer facts | Manual review | Never auto-repair. |
+| Stale duplicate register/drawer-open with safe projection | Cloud repair | Existing precondition hash still governs mutation. |
+| Local store unavailable, seed missing, terminal integrity, drawer authority | Terminal command | Requires matching terminal and fresh verification. |
+| App update state | Existing app update presentation/action | Separate from `operationalExplanation.lane` and health/recovery. |
+
+---
+
+## Operational Explanation Contract
+
+`operationalExplanation` is additive on `TerminalHealthSummary` for `listTerminalHealthSummaries`, `getTerminalHealthSummary`, `listTerminalHealth`, and `getTerminalHealthDetail`. It does not replace `attentionReasons`, `recoveryPreview`, or existing sync evidence fields. `previewTerminalRecovery` keeps returning only `TerminalRecoveryPreview` in this plan; it should not add `operationalExplanation`. Consistency with list/detail is proven by asserting that `previewTerminalRecovery.recoveryPreview` matches the same fixture's list/detail `recoveryPreview`, while list/detail carry the explanation.
+
+Existing public fields remain present with their current types and meanings:
+
+| Existing field | Compatibility rule |
+| --- | --- |
+| `health` | Still reports terminal health state and remains distinct from sale impact. |
+| `runtimeAgeMs` | Still reports latest runtime age or `null`. |
+| `runtimeStatus` | Still reports the sanitized runtime snapshot or `null`. |
+| `attentionReasons` | Still reports existing attention reasons; explanation is an additive summary. |
+| `recoveryPreview` | Still reports support recovery state/actions; explanation must agree with it. |
+| `registerSessionLink` | Still reports active/open register-session link or `null`. |
+| `syncEvidence` | Still reports bounded sync evidence; explanation may summarize it. |
+
+### Public Shape
+
+All fields below are public-contract fields and must be represented in Convex validators and frontend types. Required fields must always be present; optional fields must be omitted rather than returned as `undefined`; empty arrays are valid where listed.
+
+| Field | Required | Values / shape | Default for partial data |
+| --- | --- | --- | --- |
+| `lane` | Yes | `"healthy"`, `"sale_ready_with_review_backlog"`, `"needs_manual_review"`, `"needs_terminal_action"`, `"needs_cloud_repair"`, `"sync_failed"`, `"stale_runtime"`, `"unknown"` | `"unknown"` |
+| `severity` | Yes | `"info"`, `"warning"`, `"danger"` | `"info"` |
+| `headline` | Yes | Normalized operator-facing string | `"Terminal status needs review."` |
+| `detail` | Yes | Normalized operator-facing string | `"Athena does not have enough current evidence to explain this terminal."` |
+| `nextStep` | Yes | Normalized operator-facing string | `"Refresh terminal health or wait for the next check-in."` |
+| `blockingDomain` | Yes | `"none"`, `"runtime"`, `"local_review"`, `"cloud_review"`, `"manual_business_review"`, `"safe_cloud_repair"`, `"terminal_command"`, `"app_update"`, `"diagnostic"` | `"diagnostic"` |
+| `saleImpact` | Yes | `"can_transact_now"`, `"can_continue_local_sales"`, `"open_drawer_or_sign_in"`, `"blocked"`, `"unknown"` | `"unknown"` |
+| `supportAction` | Yes | `"none"`, `"review_cash_controls"`, `"review_open_work"`, `"resolve_safe_cloud_repair"`, `"run_terminal_command"`, `"retry_terminal_sync"`, `"wait_for_check_in"`, `"diagnostic_only"` | `"diagnostic_only"` |
+| `primaryOwner` | Yes | `"none"`, `"cash_controls"`, `"operations"`, `"terminal"`, `"support"`, `"system"` | `"system"` |
+| `evidenceReferences` | Yes | Array of display-safe references with `kind`, `label`, optional `count`, optional `sequence`, optional `hasMore` | `[]` |
+| `secondaryActions` | Yes | Array of actions with `supportAction`, `label`, and optional action target/action id | `[]` |
+| `summaryMeta` | Yes | `{ sampledCount: number, cap: number, hasMore: boolean, targetResolutionIncomplete: boolean }` | `{ sampledCount: 0, cap: 0, hasMore: false, targetResolutionIncomplete: false }` |
+
+Evidence references are display-safe only. They may include normalized labels, event sequence numbers, public work/register-session identifiers already used by existing action targets, and counts. They must not include raw sync payloads, raw conflict `details`, payment/customer data, staff proof/PIN material, browser fingerprints, sync secrets, or backend exception text.
+
+### Public Convex Access Boundary
+
+Every public query touched by this plan must document and test its access boundary:
+
+| Query / alias | Required access | Scope rule | Response posture |
+| --- | --- | --- | --- |
+| `listTerminalHealthSummaries` / `listTerminalHealth` | Authenticated Athena user with existing POS terminal-health access for the store (`full_admin` or `pos_only` as currently enforced) | Store id must be authorized for the authenticated user | Roster-safe summary; no support-only secrets or raw payloads |
+| `getTerminalHealthSummary` / `getTerminalHealthDetail` | Same existing terminal-health access for the store | Terminal id must belong to the requested store | Detail-safe support evidence; still sanitized |
+| `previewTerminalRecovery` | Existing POS terminal recovery preview access for the store | Terminal id must belong to the requested store | Recovery preview only; no mutation authority |
+
+Terminal sync secrets are not credentials for these public reads. A sync-secret-only terminal caller may submit runtime status or claim/ack scoped commands through existing terminal channels, but cannot read terminal health detail, roster health, or recovery preview unless also authenticated as an authorized Athena user. New explanation code must not log raw payloads, staff proof/PIN material, payment/customer data, browser fingerprints, sync secrets, or backend exception text.
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 Characterize current cases"]
+  U2["U2 Add bounded evidence summary"]
+  U3["U3 Add operational explanation policy"]
+  U4["U4 Project and validate public contract"]
+  U5["U5 Update presentation and UI parity"]
+  U6["U6 Strengthen tests and docs"]
+
+  U1 --> U2
+  U2 --> U3
+  U3 --> U4
+  U4 --> U5
+  U5 --> U6
+```
+
+- U1. **Characterize Current Terminal Health Cases**
+
+**Goal:** Lock in the existing health/recovery distinctions before adding the new explanation field.
+
+**Requirements:** R2, R3, R4, R5, R8, R11.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/queries/terminals.test.ts`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts`
+
+**Approach:**
+- Add fixtures for healthy idle, drawer open, able to transact, stale runtime, safe cloud repair, terminal-local action, manual review, and mixed manual-review plus safe-repair evidence.
+- Include a generalized incident-shaped case: fresh runtime, active register/session evidence, sale authority ready, and unresolved sync review backlog.
+- Assert the existing separation between `terminalHealth`, `salesReadiness`, and `supportRecovery`.
+
+**Execution note:** Start with characterization tests before changing policy. This area has several prior drift regressions.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts`
+- `docs/solutions/architecture/athena-pos-terminal-recovery-readiness-boundary-2026-06-14.md`
+
+**Test scenarios:**
+- Happy path: no blockers returns online/healthy evidence and no support action.
+- Edge case: fresh runtime plus review backlog returns `needs_attention` without losing sale-ready evidence.
+- Edge case: manual review plus safe duplicate conflict keeps manual review primary.
+- Error path: stale runtime does not create a cloud repair lane by itself.
+- Integration: query summaries and recovery preview continue to agree before adding the new field.
+
+**Verification:**
+- Current behavior is covered well enough that the new explanation can be added without guessing at existing semantics.
+
+- U2. **Add Bounded Sync Review Evidence Summary**
+
+**Goal:** Give the policy enough bounded evidence to describe large review backlogs by lane and owner without returning unbounded conflict lists.
+
+**Requirements:** R1, R3, R6, R7, R10, R11.
+
+**Dependencies:** U1.
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/domain/terminalSyncEvidence.ts`
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/terminalOperationalState/facts.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.ts`
+- Test: `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts`
+
+**Approach:**
+- Extend `TerminalSyncEvidence` with a bounded review summary that groups unresolved conflict/review examples by type, owner, and actionability.
+- Preserve the existing capped `unresolvedConflicts` examples for detail display, but add explicit scan metadata: `sampledCount`, `cap`, `hasMore`, and `targetResolutionIncomplete`.
+- Use named caps and index-scoped `take(cap + 1)` or pagination-style bounded reads. Do not collect broad store-wide sets and slice in memory.
+- For Operations/Open Work ownership, either add an indexed lookup field for POS sync local-event ownership with a migration/backfill/rollback plan, or weaken the public lane to "open work target when resolved" and set `targetResolutionIncomplete: true` when the bounded lookup may have missed an owner.
+- Keep all raw payloads, secrets, staff proof material, customer/payment details, and browser fingerprints out of the summary.
+- Do not compute exact all-time counts with unbounded `.collect()`. If exact counts are not available safely, expose bounded counts and sampling language.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts`
+- `convex/_generated/ai/guidelines.md`
+- `docs/solutions/logic-errors/athena-pos-sync-review-workspace-boundaries-2026-06-19.md`
+
+**Test scenarios:**
+- Happy path: inventory conflict with `reviewTarget` groups under Operations/Open Work.
+- Happy path: mapped register-session conflict groups under Cash Controls.
+- Edge case: more conflicts than the cap returns capped examples plus `hasMore`.
+- Edge case: Operations target lookup misses because of the cap, so `targetResolutionIncomplete` is true and copy avoids claiming definitive ownership.
+- Error path: unknown/business-fact conflicts become manual review or diagnostic evidence, not cloud repair.
+- Integration: no unbounded arrays are returned in public terminal health summaries.
+
+**Verification:**
+- The policy can explain a large conflict backlog from safe bounded evidence.
+
+- U3. **Add Operational Explanation Policy**
+
+**Goal:** Add `operationalExplanation` to `TerminalOperationalState` as the canonical explanation of lane, sale impact, next step, and support action.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R10, R11.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/terminalOperationalState/types.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.ts`
+- Test: `packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts`
+
+**Approach:**
+- Define a compact explanation model with status/lane, severity, headline, detail, next step, blocking domain, sale impact, support action, and bounded evidence references.
+- Derive the explanation from existing `attentionReasons`, `supportRecovery`, `salesReadiness`, `recoveryEvidence`, `runtimeEvidence`, and the new bounded sync summary.
+- Preserve existing priority for business review: manual business review before terminal actions before safe cloud repair, with diagnostic-only evidence separated from repair lanes.
+- Correct the current generic `local_review` ambiguity. `buildTerminalRecoveryManualReview` must stop treating generic local runtime review as manual business review, or introduce a separate non-business local-review bucket consumed consistently by `operationalExplanation`, `supportRecovery`, and `recoveryPreview`.
+- Make sale impact explicit so sale-ready review backlog is not described as a cashier-blocking terminal failure.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.ts`
+- `packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts`
+- `docs/product-copy-tone.md`
+
+**Test scenarios:**
+- Happy path: sale-ready plus review backlog yields `sale_ready_with_review_backlog`, review-owned next step, and sale impact `can_transact_now`.
+- Happy path: local review alone yields terminal sync retry or diagnostic ownership, not manual business review.
+- Edge case: manual review plus safe repair keeps `needs_manual_review` primary and safe repair secondary.
+- Edge case: terminal seed missing yields terminal command support action.
+- Edge case: stale runtime yields stale/diagnostic lane without cloud repair.
+- Error path: unsafe business-fact conflict never yields safe cloud repair.
+
+**Verification:**
+- `TerminalOperationalState` has one server-owned explanation that every UI surface can consume.
+
+- U4. **Project And Validate The Public Contract**
+
+**Goal:** Expose the explanation through terminal health queries with Convex return validators and frontend mirrored types.
+
+**Requirements:** R8, R9, R11, R12, R13.
+
+**Dependencies:** U3.
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/queries/terminals.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts`
+- Test: `packages/athena-webapp/convex/pos/application/queries/terminals.test.ts`
+- Test: `packages/athena-webapp/convex/pos/public/terminals.test.ts`
+
+**Approach:**
+- Add the exact `Operational Explanation Contract` shape to `TerminalHealthSummary` and the return validator.
+- Keep the field additive on list/detail aliases. It must not replace `attentionReasons`, `recoveryPreview`, `registerSessionLink`, `runtimeStatus`, or `syncEvidence`.
+- Keep roster/detail/recovery-preview parity by projecting from the same `TerminalOperationalState` instance.
+- Keep `previewTerminalRecovery` aligned with detail by asserting that its `recoveryPreview` agrees with the same fixture's list/detail `recoveryPreview`. Do not add `operationalExplanation` to `previewTerminalRecovery` in this plan.
+- Add return-validator coverage for every new enum and optional field.
+- Add access tests for required role/claim, store scoping, cross-store terminal id denial, denied actor cases, and sync-secret-only callers.
+
+**Patterns to follow:**
+- `docs/solutions/harness/convex-return-validator-contract-proof-2026-06-18.md`
+- `packages/athena-webapp/convex/pos/public/terminals.ts`
+
+**Test scenarios:**
+- Happy path: public query validator accepts a full explanation object.
+- Edge case: older/partial data returns valid explanation defaults without `undefined` values in Convex returns.
+- Edge case: no runtime, no sync events, and no conflicts returns a valid explanation with no `undefined` Convex return fields.
+- Integration: `listTerminalHealthSummaries`, `getTerminalHealthSummary`, `listTerminalHealth`, and `getTerminalHealthDetail` preserve old fields and agree on lane, sale impact, and action state for the same fixture; `previewTerminalRecovery` preserves its existing shape and agrees on `recoveryPreview` readiness/actions for that fixture.
+- Integration: a public return fixture validates through Convex return validators and then through `terminalHealthTypes.ts` presentation input.
+- Error path: users without terminal health access cannot read the new field through a bypass.
+- Error path: sync-secret-only terminal proof cannot read terminal health detail or recovery preview.
+- Error path: evidence references exposed through the public contract contain only display-safe identifiers/labels and exclude raw payloads, sync/auth material, payment/customer data, and staff proof/PIN material.
+
+**Verification:**
+- Public Convex contracts are validator-backed before UI code depends on the new field.
+
+- U5. **Update Roster And Detail Presentation**
+
+**Goal:** Render the server explanation consistently across terminal roster and detail without adding another disconnected list.
+
+**Requirements:** R1, R6, R8, R10, R11.
+
+**Dependencies:** U4.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx`
+- Test: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx`
+
+**Approach:**
+- Teach `terminalHealthPresentation.ts` to prefer server `operationalExplanation`, with fallbacks for legacy/partial payloads.
+- Use the same explanation for roster headline/detail and detail-page recovery context.
+- Keep conflict/review examples capped and use the explanation summary to avoid long repeated lists.
+- For `sale_ready_with_review_backlog`, roster and detail must both show review-owned state and compact sale-continuity copy such as "Review needed" plus "Sales can continue." This is required, not optional based on space.
+- Route actions through existing action targets and recovery actions. Do not add new hidden resolution authority to Terminal Health.
+- Suggested copy posture: sale-ready review backlog uses "Review needed. Sales can continue."; terminal-local action uses "Terminal action needed."; stale runtime uses "Waiting for check-in."; manual business review uses "Manager review needed."
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`
+- `docs/product-copy-tone.md`
+
+**Test scenarios:**
+- Happy path: roster and detail show the same lane label and next step for review backlog.
+- Edge case: sale-ready plus review backlog shows both review-owned state and sale-continuity copy on the roster and does not imply cashier blocking.
+- Edge case: local runtime review does not show Cash Controls inline resolver.
+- Edge case: safe cloud repair button appears only for safe repair lane or safe secondary action.
+- Error path: raw conflict ids, backend exception text, sync secrets, payment/customer payloads, and store-specific names are not rendered.
+
+**Verification:**
+- Operators see one coherent explanation while still being able to inspect supporting evidence.
+
+- U6. **Strengthen Regression Coverage And Documentation**
+
+**Goal:** Make the generalized behavior durable for future terminal health work.
+
+**Requirements:** R3, R4, R5, R7, R8, R10, R11.
+
+**Dependencies:** U5.
+
+**Files:**
+- Modify: `docs/solutions/architecture/athena-terminal-operational-state-aggregate-2026-06-27.md`
+- Modify or create: `docs/solutions/logic-errors/athena-terminal-health-reconciliation-lanes-2026-06-27.md`
+- Test: `packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.test.ts`
+
+**Approach:**
+- Document the distinction between sale readiness, terminal health, support recovery, and review ownership.
+- Add or extend cloud repair tests for unsafe skips, precondition mismatch, resolved conflicts, missing source events, and mixed manual-review states if current coverage is thin.
+- Include a short prevention note that future terminal health diagnostics and any separately approved self-heal work must extend the operational explanation rather than rejoining raw ledgers in the UI.
+
+**Patterns to follow:**
+- `docs/solutions/logic-errors/athena-pos-sync-review-workspace-boundaries-2026-06-19.md`
+- `docs/solutions/logic-errors/athena-pos-register-sync-repair-and-runtime-reconciliation-2026-06-26.md`
+
+**Test scenarios:**
+- Error path: safe repair skips conflicts containing business facts.
+- Error path: safe cloud repair appears as a secondary action alongside manual review and cannot change, suppress, or resolve manual-review facts.
+- Error path: precondition hash mismatch fails safely.
+- Integration: documentation examples match tested behavior.
+
+**Verification:**
+- The new lanes are covered by tests and documented as the extension point for future terminal health work.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Terminal health queries, public Convex validators, frontend terminal roster, terminal detail, support recovery actions, cloud repair policy, and local runtime check-in evidence all consume the same classification.
+- **Error propagation:** Unsafe or unknown evidence becomes manual-review or diagnostic copy, not an automatic repair. Public query validation failures should be caught by tests before deployment.
+- **State lifecycle risks:** Command acknowledgement remains distinct from verification. Current evidence wins over old command history when blockers clear.
+- **API surface parity:** `listTerminalHealthSummaries`, `getTerminalHealthSummary`, `listTerminalHealth`, `getTerminalHealthDetail`, and `previewTerminalRecovery` must preserve existing fields and remain aligned on explanation/recovery semantics.
+- **Integration coverage:** Query, public validator, and UI tests must cover cross-layer behavior because unit tests alone will not catch return-shape or presentation drift.
+- **Access boundaries:** Authorized staff/user roles remain the only public health-read credentials. Terminal sync-secret proof remains terminal-channel proof only.
+- **Unchanged invariants:** Sync secrets, staff proof/PIN material, raw payloads, payment/customer details, browser fingerprints, and backend exception text remain excluded from support-facing output and new logs.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| The explanation hides a true sale blocker behind review copy. | Keep sale impact derived separately from `salesReadiness` and test terminal-local blockers. |
+| The plan encourages unsafe cleanup of business facts. | Preserve manual-review priority and safe cloud repair allow-list tests. |
+| Bounded summaries undercount large backlogs. | Expose sampling/cap metadata and defer exact aggregate counters to follow-up if needed. |
+| Public validators drift from query return shape. | Land validator, frontend type, and public tests with the contract change. |
+| Roster and detail copy diverge. | Consume the same presentation helper and test both surfaces against the same fixture. |
+| Old command failures continue to foreground support work. | Policy should use current evidence for active blockers and treat old commands as diagnostic history. |
+| Operations ownership is missed by bounded work-item lookup. | Add an indexed ownership lookup or expose `targetResolutionIncomplete` and avoid definitive routing copy. |
+| A terminal sync secret becomes an accidental read credential. | Add access tests proving sync-secret-only callers cannot read public health summaries or recovery preview. |
+
+---
+
+## Documentation / Operational Notes
+
+- The implementation should update or add a `docs/solutions/` note after behavior lands because this boundary will guide future terminal health diagnostics and any separately approved self-heal work.
+- Operator-facing copy should follow `docs/product-copy-tone.md`: lead with state, name the next action, and avoid raw backend summaries.
+- Browser validation is intentionally left to the user for this thread. Implementation validation should focus on Convex, presentation, and component tests.
+
+---
+
+## Sources & References
+
+- Related plan: `docs/plans/2026-06-27-001-refactor-terminal-operational-state-plan.md`
+- Related plan: `docs/plans/2026-06-27-002-fix-pos-sync-contract-plan.md`
+- Related code: `packages/athena-webapp/convex/pos/application/terminalOperationalState/types.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/queries/terminals.ts`
+- Related code: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Related code: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`
+- Related code: `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx`
+- Related code: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx`
+- Institutional learning: `docs/solutions/logic-errors/athena-pos-sync-review-workspace-boundaries-2026-06-19.md`
+- Institutional learning: `docs/solutions/logic-errors/athena-pos-register-sync-repair-and-runtime-reconciliation-2026-06-26.md`
+- Product copy: `docs/product-copy-tone.md`

--- a/docs/solutions/architecture/athena-terminal-operational-state-aggregate-2026-06-27.md
+++ b/docs/solutions/architecture/athena-terminal-operational-state-aggregate-2026-06-27.md
@@ -43,11 +43,27 @@ Keep the output concepts separate:
 - `salesReadiness`: `healthy_idle`, `drawer_open`, or `able_to_transact_now`
 - `supportRecovery`: cloud repair, terminal action, or manual review when support work exists
 - `diagnosticEvidence`: non-actuating stale or conflicting evidence for support/debugging
+- `operationalExplanation`: the operator-facing lane, owner, sale impact, and next step derived from the same state
+
+These concepts answer different questions and should not be collapsed:
+
+- Sale readiness asks whether the cashier can sell now. A terminal can be `able_to_transact_now` while review work remains.
+- Terminal health asks whether Athena has current, coherent runtime and ledger evidence. It can still be `needs_attention` for review backlog.
+- Support recovery asks whether support has a safe action available, such as a terminal command or a narrow cloud repair.
+- Review ownership asks which business workflow owns unresolved evidence. Cash Controls, Operations/Open Work, terminal-local retry, safe cloud repair, and diagnostic-only states are separate lanes.
 
 Fresh runtime evidence can prove active local drawer evidence and sale authority, but cloud register lifecycle evidence remains the guardrail for sale-ready projection when it conflicts. Command acknowledgement is not verification; fresh runtime evidence is still required to verify recovery.
+
+## Operational Explanation Boundary
+
+Terminal Health should explain the relationship between current facts instead of exposing raw ledger joins to each UI surface. `operationalExplanation` is the extension point for that explanation. It can say "Review needed. Sales can continue." when sale readiness is intact but unresolved review evidence remains, or "Waiting for check-in." when runtime evidence is stale. It should also name the primary owner and the bounded evidence that led to the lane.
+
+Safe cloud repair is never the explanation for business facts. The only repairable cloud lane is stale duplicate register/drawer-open lifecycle evidence that passes the existing source-event, store/terminal, stale-age, projection-safety, and precondition checks. Sale, payment, inventory, closeout, variance, customer, staff proof, unknown payload, and unresolved manual-review facts remain review-owned or diagnostic-owned evidence.
 
 ## Prevention
 
 Future diagnostics or self-heal work should compare a redacted local terminal snapshot against this aggregate. It should not recreate raw joins from the ledgers, and it should route any action through the existing audited mutation paths.
 
 When Terminal Health return shapes change, keep public Convex validators and frontend types in the same slice. When readiness semantics change, add policy tests and query projection tests so roster, detail, and `previewTerminalRecovery` cannot drift.
+
+Any separately approved self-heal work should extend `operationalExplanation` and the existing recovery command/cloud-repair boundaries. It should not make the UI recompute terminal health from raw sync conflicts, nor should it let a support repair suppress or resolve manual-review facts as a side effect.

--- a/docs/solutions/logic-errors/athena-terminal-health-reconciliation-lanes-2026-06-27.md
+++ b/docs/solutions/logic-errors/athena-terminal-health-reconciliation-lanes-2026-06-27.md
@@ -1,0 +1,67 @@
+---
+title: Athena Terminal Health Reconciliation Lanes
+date: 2026-06-27
+category: logic-errors
+module: pos-terminal-health
+problem_type: boundary_confusion
+component: terminal-recovery
+resolution_type: regression_guard
+severity: medium
+tags:
+  - pos
+  - terminal-health
+  - terminal-recovery
+  - cloud-repair
+  - sync-review
+related:
+  - docs/solutions/architecture/athena-terminal-operational-state-aggregate-2026-06-27.md
+  - docs/solutions/logic-errors/athena-pos-sync-review-workspace-boundaries-2026-06-19.md
+  - docs/solutions/logic-errors/athena-pos-register-sync-repair-and-runtime-reconciliation-2026-06-26.md
+---
+
+# Athena Terminal Health Reconciliation Lanes
+
+## Problem
+
+Terminal Health can hold several true facts at once: the terminal may be online, the cashier may be able to sell, a safe duplicate drawer-open repair may be available, and a business review conflict may still require a human owner. Treating those facts as one generic "unhealthy terminal" state leads to two failures:
+
+- support copy can imply sales are blocked when sale readiness is intact
+- safe repair can appear to own business facts that must remain in Cash Controls or Operations review
+
+## Solution
+
+Keep reconciliation lane ownership explicit in the server-derived terminal state:
+
+- Sale readiness: whether the cashier can transact now.
+- Terminal health: whether runtime, sync, register, and recovery evidence need attention.
+- Support recovery: whether a terminal command or safe cloud repair is available.
+- Review ownership: who owns unresolved business or operational evidence.
+- Operational explanation: the display-safe summary that ties those facts together for roster and detail views.
+
+`operationalExplanation` is the boundary for operator-facing interpretation. UI surfaces should consume the lane, sale impact, support action, owner, and bounded evidence references from the server instead of rejoining raw sync ledgers or inferring owners from conflict strings.
+
+## Repair Safety Rules
+
+Safe cloud repair is narrow:
+
+- It can only resolve stale duplicate register/drawer-open lifecycle evidence that has a matching source event.
+- It must skip conflicts that are already resolved, missing source events, scoped to a different store or terminal, not stale, not duplicate register-open evidence, or not projection-safe.
+- It must skip any conflict or source payload containing sale, payment, inventory, closeout, variance, customer, staff-proof, or unknown business facts.
+- It must compare the current safe-conflict set with the expected precondition hash before mutating anything.
+- It must leave manual-review facts unresolved, even when a separate safe repair succeeds in the same terminal backlog.
+
+Manual review plus safe repair is therefore a mixed state, not a promotion of manual review into repair. The safe repair may be a secondary support action, but Cash Controls or Operations still owns the business review lane.
+
+## Prevention
+
+When adding terminal health diagnostics, extend the operational explanation model and its tests. Do not add UI-only ledger joins or broad repair buttons.
+
+Regression coverage should include:
+
+- unsafe business facts are skipped by cloud repair policy
+- missing source events do not mutate review facts
+- resolved conflicts do not become repair candidates
+- precondition mismatch fails before any patch
+- manual-review facts remain unresolved when safe repair handles a separate duplicate lifecycle conflict
+
+Use calm operational copy that names state and next action. Avoid exposing raw backend summaries, sync payloads, secrets, staff proof/PIN material, payment/customer data, browser fingerprints, or exception text.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8203 nodes · 9711 edges · 2072 communities detected
+- 8228 nodes · 9773 edges · 2071 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2081,7 +2081,6 @@
 - [[_COMMUNITY_Community 2068|Community 2068]]
 - [[_COMMUNITY_Community 2069|Community 2069]]
 - [[_COMMUNITY_Community 2070|Community 2070]]
-- [[_COMMUNITY_Community 2071|Community 2071]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2119,7 +2118,7 @@ Nodes (70): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelong
 
 ### Community 2 - "Community 2"
 Cohesion: 0.06
-Nodes (66): buildLegacyOperationalExplanation(), buildRecoveryBlockers(), buildRecoveryBlockersFromPreview(), buildRecoveryReadiness(), buildStaticOperationalExplanation(), buildTerminalAppUpdatePresentation(), buildTerminalOperationalExplanationPresentation(), buildTerminalRecoveryPresentation() (+58 more)
+Nodes (68): buildLegacyOperationalExplanation(), buildRecoveryBlockers(), buildRecoveryBlockersFromPreview(), buildRecoveryReadiness(), buildStaticOperationalExplanation(), buildTerminalAppUpdatePresentation(), buildTerminalOperationalExplanationPresentation(), buildTerminalRecoveryPresentation() (+60 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.06
@@ -2142,64 +2141,64 @@ Cohesion: 0.06
 Nodes (26): asRecord(), createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), getExpenseLocalSessionId(), getUploadSequenceScopeId(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeLocalEventPayload() (+18 more)
 
 ### Community 8 - "Community 8"
+Cohesion: 0.05
+Nodes (24): assertPosLocalStoreOk(), buildRuntimeAppUpdateInput(), clearAcceptedTerminalIntegrityState(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus() (+16 more)
+
+### Community 9 - "Community 9"
 Cohesion: 0.09
 Nodes (48): buildFinalTrustedQuantitiesByRowNumber(), buildProductPageFinalizationMetadata(), buildProductPageFinalizationPayloadHash(), buildProvisionalSkuPatch(), buildSaleEvidenceFingerprint(), buildSkuInsert(), buildSkuPatch(), buildTrustedSkuFingerprint() (+40 more)
 
-### Community 9 - "Community 9"
-Cohesion: 0.06
-Nodes (27): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatCompactTextList(), formatPaymentMethods(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp() (+19 more)
-
 ### Community 10 - "Community 10"
-Cohesion: 0.06
-Nodes (21): assertPosLocalStoreOk(), buildRuntimeAppUpdateInput(), clearAcceptedTerminalIntegrityState(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus() (+13 more)
-
-### Community 11 - "Community 11"
 Cohesion: 0.09
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
+
+### Community 11 - "Community 11"
+Cohesion: 0.12
+Nodes (39): completed(), executeCallbackCommand(), executeClearLocalReviewItems(), executeClearStaleDrawerAuthority(), executeCollectLocalReview(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand() (+31 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.06
 Nodes (22): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+14 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.07
-Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
+Cohesion: 0.09
+Nodes (28): buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalOperationalStateForSummary(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryPreview(), createTerminalCloudRepairQueryRepository(), formatRuntimeAppUpdateAssetSummary() (+20 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.07
-Nodes (10): arrayDetail(), buildCashControlsDashboardSnapshot(), buildReviewedSaleProjectionEvent(), getCompletedTransactionForRegisterMappingRepair(), normalizeReviewedNonCashOverpaymentPayload(), numberDetail(), recordDetail(), roundCurrencyAmount() (+2 more)
+Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
 ### Community 15 - "Community 15"
+Cohesion: 0.07
+Nodes (10): arrayDetail(), buildCashControlsDashboardSnapshot(), buildReviewedSaleProjectionEvent(), getCompletedTransactionForRegisterMappingRepair(), normalizeReviewedNonCashOverpaymentPayload(), numberDetail(), recordDetail(), roundCurrencyAmount() (+2 more)
+
+### Community 16 - "Community 16"
 Cohesion: 0.08
 Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
 
-### Community 16 - "Community 16"
+### Community 17 - "Community 17"
 Cohesion: 0.14
 Nodes (35): asRecord(), canUploadedRegisterOpenReplaceBlockedDrawer(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta() (+27 more)
 
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
 Cohesion: 0.11
 Nodes (33): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+25 more)
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.12
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
-### Community 19 - "Community 19"
-Cohesion: 0.16
-Nodes (31): completed(), executeCallbackCommand(), executeClearStaleDrawerAuthority(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand(), executeUpdateApp(), failed() (+23 more)
-
 ### Community 20 - "Community 20"
 Cohesion: 0.09
-Nodes (19): buildDisplaySafeConflictSummary(), buildTerminalSyncReviewSummary(), classifyTerminalSyncReviewConflict(), emptyTerminalSyncReviewSummary(), getLatestRuntimeStatusForTerminal(), getOpenWorkTargetsByLocalEventId(), getRegisterSessionReviewActionTarget(), getTerminalByFingerprint() (+11 more)
+Nodes (20): buildDisplaySafeConflictSummary(), buildTerminalSyncReviewSummary(), classifyTerminalSyncReviewConflict(), emptyTerminalSyncReviewSummary(), getLatestRuntimeStatusForTerminal(), getOpenWorkTargetsByLocalEventId(), getTerminalByFingerprint(), getTerminalSyncEvidence() (+12 more)
 
 ### Community 21 - "Community 21"
-Cohesion: 0.15
-Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
+Cohesion: 0.07
+Nodes (11): formatCompactTextList(), formatPaymentMethods(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary(), formatReviewTypeSummary(), formatTimestamp() (+3 more)
 
 ### Community 22 - "Community 22"
-Cohesion: 0.12
-Nodes (25): buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalOperationalStateForSummary(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryPreview(), createTerminalCloudRepairQueryRepository(), formatRuntimeAppUpdateAssetSummary() (+17 more)
+Cohesion: 0.15
+Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
 ### Community 23 - "Community 23"
 Cohesion: 0.11
@@ -2258,144 +2257,144 @@ Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
 ### Community 37 - "Community 37"
+Cohesion: 0.14
+Nodes (24): buildDiagnosticEvidence(), buildTerminalOperationalExplanation(), buildTerminalOperationalState(), buildTerminalRecoveryActions(), buildTerminalRecoveryManualReview(), classifySalesReadiness(), classifySupportRecovery(), classifyTerminalHealth() (+16 more)
+
+### Community 38 - "Community 38"
 Cohesion: 0.19
 Nodes (23): assertRegisterNumberIsAvailable(), buildRuntimeActiveRegisterSessionDirective(), buildRuntimeDrawerAuthorityDirective(), cleanActiveRegisterSession(), cleanAppSessionRecovery(), cleanAppShell(), cleanAppUpdate(), cleanBrowserInfo() (+15 more)
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
+Cohesion: 0.16
+Nodes (25): acknowledgeTerminalRecoveryCommand(), arraysEqualAsSets(), buildExecutionId(), claimTerminalRecoveryCommand(), containsSecretLikeField(), getRuntimeAppUpdateEvidence(), hasRuntimeLocalReviewDetails(), isActiveCommand() (+17 more)
+
+### Community 40 - "Community 40"
 Cohesion: 0.09
 Nodes (6): getConversionRequestId(), handleClick(), handleFinalize(), isSkuReserved(), normalizeCommandMessage(), shouldDisable()
 
-### Community 39 - "Community 39"
+### Community 41 - "Community 41"
 Cohesion: 0.1
 Nodes (15): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+7 more)
 
-### Community 40 - "Community 40"
+### Community 42 - "Community 42"
 Cohesion: 0.12
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
-### Community 41 - "Community 41"
+### Community 43 - "Community 43"
 Cohesion: 0.15
 Nodes (21): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+13 more)
 
-### Community 42 - "Community 42"
+### Community 44 - "Community 44"
 Cohesion: 0.16
 Nodes (19): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), pendingCheckoutItemMatchesLine(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding() (+11 more)
 
-### Community 43 - "Community 43"
-Cohesion: 0.16
-Nodes (21): buildDiagnosticEvidence(), buildTerminalOperationalExplanation(), buildTerminalOperationalState(), buildTerminalRecoveryActions(), buildTerminalRecoveryManualReview(), classifySalesReadiness(), classifySupportRecovery(), classifyTerminalHealth() (+13 more)
-
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.09
 Nodes (5): listCompletedTransactionsForDay(), listCompletedTransactionsForRange(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
+Cohesion: 0.16
+Nodes (20): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getRuntimeReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady() (+12 more)
+
+### Community 48 - "Community 48"
 Cohesion: 0.19
 Nodes (23): assertCompoundSolutionCheck(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSourceLineChanges(), countFileLines(), extractFrontmatter() (+15 more)
 
-### Community 47 - "Community 47"
+### Community 49 - "Community 49"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 48 - "Community 48"
+### Community 50 - "Community 50"
 Cohesion: 0.21
 Nodes (23): buildCartChange(), buildLegacyContextPayload(), buildLegacyProductId(), compactPayload(), compileLegacyStorefrontAnalyticsRow(), compileLegacyStorefrontAnalyticsRows(), compileLegacyStorefrontAnalyticsRowsWithReport(), containsSensitiveText() (+15 more)
 
-### Community 49 - "Community 49"
+### Community 51 - "Community 51"
 Cohesion: 0.19
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
-### Community 50 - "Community 50"
+### Community 52 - "Community 52"
 Cohesion: 0.18
 Nodes (23): buildEventMessage(), buildNextEvidence(), buildNextSaleEvidence(), buildReviewPriority(), buildWorkItemPriority(), createOrReusePendingCheckoutItem(), createProvisionalCatalogAnchors(), findMatchingPendingCheckoutItem() (+15 more)
 
-### Community 51 - "Community 51"
+### Community 53 - "Community 53"
 Cohesion: 0.09
 Nodes (3): buildPersistedRuntimeStatus(), buildRegisterSession(), buildRuntimeStatus()
 
-### Community 52 - "Community 52"
+### Community 54 - "Community 54"
 Cohesion: 0.12
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
 
-### Community 53 - "Community 53"
+### Community 55 - "Community 55"
 Cohesion: 0.17
 Nodes (21): buildHomepageSnapshotV1(), hydrateCategory(), hydrateFeaturedItem(), hydrateProduct(), hydrateSubcategory(), hydrateTargetProducts(), isCustomerVisibleProduct(), isCustomerVisibleSku() (+13 more)
 
-### Community 54 - "Community 54"
-Cohesion: 0.17
-Nodes (19): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady(), mapSyncStatus() (+11 more)
-
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.16
 Nodes (17): asRecord(), buildSnapshotHash(), buildStoreInsightsPromptFromContextBundle(), buildStoreInsightsPromptFromContextEvents(), buildUserInsightsPromptFromContextBundle(), buildUserInsightsPromptFromContextEvents(), compactContextEventsForPrompt(), compactEnvironmentForPrompt() (+9 more)
 
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.15
 Nodes (16): findLatestOpenOperatingDay(), getTodaySummary(), getTransactionById(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile() (+8 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
+Cohesion: 0.1
+Nodes (6): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onIssueTerminalRecoveryCommand(), onStartRemoteAssist(), submitUpdateApp()
+
+### Community 60 - "Community 60"
 Cohesion: 0.21
 Nodes (21): detectFormat(), extractJsonRows(), flattenJsonRows(), inferProductName(), isRecord(), looksLikeLabel(), normalizeKey(), normalizeLegacyRow() (+13 more)
 
-### Community 59 - "Community 59"
+### Community 61 - "Community 61"
 Cohesion: 0.25
 Nodes (21): asRecord(), errorFor(), getLocalExpenseSessionId(), getOrCreateSession(), isExpenseEvent(), itemSource(), itemSourceKey(), numberField() (+13 more)
 
-### Community 60 - "Community 60"
+### Community 62 - "Community 62"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 61 - "Community 61"
+### Community 63 - "Community 63"
 Cohesion: 0.18
 Nodes (18): assertValidEodLocalCompletionWindowMinutes(), assertValidEodThreshold(), assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getEodAutoCompletePolicyConfigWithCtx() (+10 more)
 
-### Community 62 - "Community 62"
+### Community 64 - "Community 64"
 Cohesion: 0.11
 Nodes (6): asBoolean(), asNumber(), asRecord(), buildRegisterCloseoutVarianceTimelineMessage(), formatCloseoutVarianceAmount(), getCashControlsConfig()
 
-### Community 63 - "Community 63"
+### Community 65 - "Community 65"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
-### Community 64 - "Community 64"
+### Community 66 - "Community 66"
 Cohesion: 0.21
 Nodes (18): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), formatRecoveryCode(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode() (+10 more)
 
-### Community 65 - "Community 65"
-Cohesion: 0.11
-Nodes (6): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onIssueTerminalRecoveryCommand(), onStartRemoteAssist(), submitUpdateApp()
-
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.13
 Nodes (9): asCloudOperableSession(), countPendingSyncableLocalEventsForStaff(), hasSyncedSaleLocalEventsForStaff(), hasUploadedLocalEventsForStaff(), isCloudOperableSession(), isEmptyLocalSaleShell(), selectPassiveCloseoutBlockedRegisterSession(), trimOptional() (+1 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.27
 Nodes (18): assertConformsToExportedReturns(), collectReturnValidatorIssues(), decodeSerializedFloat64(), decodeSerializedInt64(), decodeSerializedLiteralValue(), describeValue(), formatReturnValidatorIssues(), isConvexValue() (+10 more)
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.22
 Nodes (15): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), classifyRegisterSessionSyncReview(), findProjectedRegisterSessionIdForRepairableMissingMapping(), findTransactionIdForSyncEvent(), hasInventoryReviewWorkItemForProjectedSale(), isNonSaleMissingRegisterSessionMappingConflict() (+7 more)
-
-### Community 71 - "Community 71"
-Cohesion: 0.2
-Nodes (17): acknowledgeTerminalRecoveryCommand(), buildExecutionId(), claimTerminalRecoveryCommand(), containsSecretLikeField(), getRuntimeAppUpdateEvidence(), isActiveCommand(), isEquivalentCommand(), issueTerminalRecoveryCommand() (+9 more)
 
 ### Community 72 - "Community 72"
 Cohesion: 0.17
@@ -2758,128 +2757,128 @@ Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
 ### Community 162 - "Community 162"
-Cohesion: 0.29
-Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
+Cohesion: 0.31
+Nodes (6): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), getScopedRegisterSession(), isCurrentTerminalRecoveryConflict(), resolveMappedRegisterSession(), resolveRegisterSessionForConflict()
 
 ### Community 163 - "Community 163"
 Cohesion: 0.29
-Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
+Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
 ### Community 164 - "Community 164"
+Cohesion: 0.29
+Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
+
+### Community 165 - "Community 165"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.27
 Nodes (5): clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), runProcess(), writePrAthenaProviderEvidence()
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.25
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
-
-### Community 176 - "Community 176"
-Cohesion: 0.22
-Nodes (0):
 
 ### Community 177 - "Community 177"
 Cohesion: 0.22
 Nodes (0):
 
 ### Community 178 - "Community 178"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Cohesion: 0.22
+Nodes (0):
 
 ### Community 179 - "Community 179"
 Cohesion: 0.39
-Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 180 - "Community 180"
+Cohesion: 0.39
+Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
+
+### Community 181 - "Community 181"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.33
 Nodes (6): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), saveProduct(), updateVariantSku()
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.28
 Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.28
 Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.25
 Nodes (2): isValidMessageBlocker(), isValidPriority()
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.28
 Nodes (4): comparePendingEvents(), getPendingEventUploadSequence(), selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
-
-### Community 192 - "Community 192"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 193 - "Community 193"
 Cohesion: 0.42
@@ -2898,280 +2897,280 @@ Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 197 - "Community 197"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 198 - "Community 198"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 205 - "Community 205"
+### Community 206 - "Community 206"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 209 - "Community 209"
-Cohesion: 0.5
-Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
 ### Community 210 - "Community 210"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.5
+Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
 ### Community 211 - "Community 211"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 212 - "Community 212"
-Cohesion: 0.36
-Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 213 - "Community 213"
 Cohesion: 0.36
-Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
 
 ### Community 214 - "Community 214"
+Cohesion: 0.36
+Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+
+### Community 215 - "Community 215"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 215 - "Community 215"
+### Community 216 - "Community 216"
 Cohesion: 0.29
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 216 - "Community 216"
+### Community 217 - "Community 217"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.29
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 222 - "Community 222"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 223 - "Community 223"
 Cohesion: 0.39
-Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 224 - "Community 224"
+Cohesion: 0.39
+Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+
+### Community 225 - "Community 225"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.29
 Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.38
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.33
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 246 - "Community 246"
+### Community 247 - "Community 247"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
-
-### Community 252 - "Community 252"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 253 - "Community 253"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 254 - "Community 254"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 255 - "Community 255"
 Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 256 - "Community 256"
 Cohesion: 0.33
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 257 - "Community 257"
-Cohesion: 0.29
-Nodes (1): ResizeObserverStub
+Cohesion: 0.33
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 258 - "Community 258"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
 ### Community 259 - "Community 259"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 260 - "Community 260"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 262 - "Community 262"
-Cohesion: 0.52
-Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 263 - "Community 263"
 Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 264 - "Community 264"
-Cohesion: 0.33
-Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
 ### Community 265 - "Community 265"
-Cohesion: 0.29
-Nodes (0):
+Cohesion: 0.33
+Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
 ### Community 266 - "Community 266"
 Cohesion: 0.29
@@ -3182,56 +3181,56 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 268 - "Community 268"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 269 - "Community 269"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 270 - "Community 270"
+### Community 271 - "Community 271"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 271 - "Community 271"
+### Community 272 - "Community 272"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 272 - "Community 272"
+### Community 273 - "Community 273"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.47
 Nodes (3): canListRegisterSessionSyncConflicts(), listPendingCompletedSaleVoidApprovals(), listRegisterSessionCloseoutHolds()
-
-### Community 280 - "Community 280"
-Cohesion: 0.4
-Nodes (2): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository()
 
 ### Community 281 - "Community 281"
 Cohesion: 0.33
@@ -3350,8 +3349,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 310 - "Community 310"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 311 - "Community 311"
 Cohesion: 0.33
@@ -3366,8 +3365,8 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 314 - "Community 314"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.53
+Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
 ### Community 315 - "Community 315"
 Cohesion: 0.4
@@ -3378,200 +3377,200 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 317 - "Community 317"
+Cohesion: 0.53
+Nodes (5): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
+
+### Community 318 - "Community 318"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 321 - "Community 321"
+### Community 322 - "Community 322"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 322 - "Community 322"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 323 - "Community 323"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 324 - "Community 324"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 325 - "Community 325"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 326 - "Community 326"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 327 - "Community 327"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 328 - "Community 328"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 329 - "Community 329"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 330 - "Community 330"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 330 - "Community 330"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 331 - "Community 331"
-Cohesion: 0.53
-Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 332 - "Community 332"
 Cohesion: 0.47
-Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 333 - "Community 333"
 Cohesion: 0.53
-Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
 ### Community 334 - "Community 334"
+Cohesion: 0.47
+Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+
+### Community 335 - "Community 335"
+Cohesion: 0.53
+Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+
+### Community 336 - "Community 336"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 335 - "Community 335"
+### Community 337 - "Community 337"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 336 - "Community 336"
+### Community 338 - "Community 338"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 337 - "Community 337"
+### Community 339 - "Community 339"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 338 - "Community 338"
-Cohesion: 0.6
-Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 339 - "Community 339"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 340 - "Community 340"
 Cohesion: 0.6
-Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
+Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 341 - "Community 341"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 342 - "Community 342"
-Cohesion: 0.5
-Nodes (2): createMutationCtx(), seedTrustedConversionData()
+Cohesion: 0.6
+Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
 ### Community 343 - "Community 343"
-Cohesion: 0.5
-Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
-
-### Community 344 - "Community 344"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 344 - "Community 344"
+Cohesion: 0.5
+Nodes (2): createMutationCtx(), seedTrustedConversionData()
+
 ### Community 345 - "Community 345"
 Cohesion: 0.5
-Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
+Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
 ### Community 346 - "Community 346"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 347 - "Community 347"
+Cohesion: 0.5
+Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
+
+### Community 348 - "Community 348"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 349 - "Community 349"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 348 - "Community 348"
+### Community 350 - "Community 350"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 349 - "Community 349"
+### Community 351 - "Community 351"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 350 - "Community 350"
+### Community 352 - "Community 352"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 351 - "Community 351"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 352 - "Community 352"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 353 - "Community 353"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 354 - "Community 354"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 355 - "Community 355"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 354 - "Community 354"
+### Community 356 - "Community 356"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
 
-### Community 355 - "Community 355"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 356 - "Community 356"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 357 - "Community 357"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 358 - "Community 358"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 358 - "Community 358"
+### Community 359 - "Community 359"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 359 - "Community 359"
+### Community 360 - "Community 360"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 360 - "Community 360"
+### Community 361 - "Community 361"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 361 - "Community 361"
+### Community 362 - "Community 362"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 362 - "Community 362"
+### Community 363 - "Community 363"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 363 - "Community 363"
+### Community 364 - "Community 364"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 364 - "Community 364"
+### Community 365 - "Community 365"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
-
-### Community 365 - "Community 365"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 366 - "Community 366"
 Cohesion: 0.4
@@ -3582,12 +3581,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 368 - "Community 368"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 369 - "Community 369"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 369 - "Community 369"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 370 - "Community 370"
 Cohesion: 0.4
@@ -3602,20 +3601,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 373 - "Community 373"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 374 - "Community 374"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 375 - "Community 375"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 376 - "Community 376"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 377 - "Community 377"
 Cohesion: 0.4
@@ -3634,84 +3633,84 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 381 - "Community 381"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 382 - "Community 382"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 382 - "Community 382"
+### Community 383 - "Community 383"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 383 - "Community 383"
+### Community 384 - "Community 384"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 384 - "Community 384"
+### Community 385 - "Community 385"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 385 - "Community 385"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 386 - "Community 386"
 Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 387 - "Community 387"
 Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
 ### Community 388 - "Community 388"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 389 - "Community 389"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 389 - "Community 389"
+### Community 390 - "Community 390"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 390 - "Community 390"
+### Community 391 - "Community 391"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 391 - "Community 391"
+### Community 392 - "Community 392"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 392 - "Community 392"
+### Community 393 - "Community 393"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 393 - "Community 393"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 394 - "Community 394"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 395 - "Community 395"
 Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 396 - "Community 396"
 Cohesion: 0.6
-Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
 ### Community 397 - "Community 397"
-Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
-
-### Community 398 - "Community 398"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 399 - "Community 399"
+### Community 398 - "Community 398"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 400 - "Community 400"
+### Community 399 - "Community 399"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
+
+### Community 400 - "Community 400"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 401 - "Community 401"
 Cohesion: 0.4
@@ -3722,132 +3721,132 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 403 - "Community 403"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 404 - "Community 404"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 405 - "Community 405"
+### Community 404 - "Community 404"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 406 - "Community 406"
+### Community 405 - "Community 405"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 407 - "Community 407"
+### Community 406 - "Community 406"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 408 - "Community 408"
+### Community 407 - "Community 407"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 409 - "Community 409"
+### Community 408 - "Community 408"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
-### Community 410 - "Community 410"
+### Community 409 - "Community 409"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 411 - "Community 411"
+### Community 410 - "Community 410"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 412 - "Community 412"
+### Community 411 - "Community 411"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 413 - "Community 413"
+### Community 412 - "Community 412"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+
+### Community 413 - "Community 413"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 414 - "Community 414"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 415 - "Community 415"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 416 - "Community 416"
 Cohesion: 0.6
 Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
 
-### Community 417 - "Community 417"
+### Community 416 - "Community 416"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 418 - "Community 418"
+### Community 417 - "Community 417"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 419 - "Community 419"
+### Community 418 - "Community 418"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 420 - "Community 420"
+### Community 419 - "Community 419"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 421 - "Community 421"
+### Community 420 - "Community 420"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 422 - "Community 422"
+### Community 421 - "Community 421"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 423 - "Community 423"
+### Community 422 - "Community 422"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 424 - "Community 424"
+### Community 423 - "Community 423"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 425 - "Community 425"
+### Community 424 - "Community 424"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 426 - "Community 426"
+### Community 425 - "Community 425"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
+
+### Community 426 - "Community 426"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 427 - "Community 427"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 428 - "Community 428"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 429 - "Community 429"
 Cohesion: 0.67
 Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
+
+### Community 429 - "Community 429"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 430 - "Community 430"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 431 - "Community 431"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 432 - "Community 432"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 433 - "Community 433"
+### Community 432 - "Community 432"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 434 - "Community 434"
+### Community 433 - "Community 433"
 Cohesion: 0.67
 Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
+
+### Community 434 - "Community 434"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 435 - "Community 435"
 Cohesion: 0.5
@@ -3866,68 +3865,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 439 - "Community 439"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 440 - "Community 440"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 441 - "Community 441"
+### Community 440 - "Community 440"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 442 - "Community 442"
+### Community 441 - "Community 441"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 443 - "Community 443"
+### Community 442 - "Community 442"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 444 - "Community 444"
+### Community 443 - "Community 443"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 444 - "Community 444"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 445 - "Community 445"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 446 - "Community 446"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 447 - "Community 447"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 448 - "Community 448"
+### Community 447 - "Community 447"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 449 - "Community 449"
+### Community 448 - "Community 448"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 450 - "Community 450"
+### Community 449 - "Community 449"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 451 - "Community 451"
+### Community 450 - "Community 450"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 452 - "Community 452"
+### Community 451 - "Community 451"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 453 - "Community 453"
+### Community 452 - "Community 452"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 454 - "Community 454"
+### Community 453 - "Community 453"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+
+### Community 454 - "Community 454"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 455 - "Community 455"
 Cohesion: 0.5
@@ -3938,24 +3937,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 457 - "Community 457"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 458 - "Community 458"
 Cohesion: 0.67
 Nodes (2): buildCtx(), buildQueryCtx()
 
-### Community 459 - "Community 459"
+### Community 458 - "Community 458"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 460 - "Community 460"
+### Community 459 - "Community 459"
 Cohesion: 0.67
 Nodes (2): buildRepository(), buildSession()
 
-### Community 461 - "Community 461"
+### Community 460 - "Community 460"
 Cohesion: 0.67
 Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+
+### Community 461 - "Community 461"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 462 - "Community 462"
 Cohesion: 0.5
@@ -3970,36 +3969,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 465 - "Community 465"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 466 - "Community 466"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 467 - "Community 467"
+### Community 466 - "Community 466"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
+
+### Community 467 - "Community 467"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 468 - "Community 468"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 469 - "Community 469"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 470 - "Community 470"
 Cohesion: 0.83
 Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
-### Community 471 - "Community 471"
+### Community 470 - "Community 470"
 Cohesion: 0.83
 Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
-### Community 472 - "Community 472"
+### Community 471 - "Community 471"
 Cohesion: 0.83
 Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+
+### Community 472 - "Community 472"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 473 - "Community 473"
 Cohesion: 0.5
@@ -4010,32 +4009,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 475 - "Community 475"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 476 - "Community 476"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 477 - "Community 477"
+### Community 476 - "Community 476"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 478 - "Community 478"
+### Community 477 - "Community 477"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
-### Community 479 - "Community 479"
+### Community 478 - "Community 478"
 Cohesion: 0.67
 Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
-### Community 480 - "Community 480"
+### Community 479 - "Community 479"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
-### Community 481 - "Community 481"
+### Community 480 - "Community 480"
 Cohesion: 0.67
 Nodes (2): getPosRouteScope(), Login()
+
+### Community 481 - "Community 481"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 482 - "Community 482"
 Cohesion: 0.5
@@ -4066,12 +4065,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 489 - "Community 489"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 490 - "Community 490"
 Cohesion: 0.67
 Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+
+### Community 490 - "Community 490"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 491 - "Community 491"
 Cohesion: 0.5
@@ -4082,12 +4081,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 493 - "Community 493"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 494 - "Community 494"
 Cohesion: 1.0
 Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
+
+### Community 494 - "Community 494"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 495 - "Community 495"
 Cohesion: 0.5
@@ -4098,120 +4097,120 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 497 - "Community 497"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 498 - "Community 498"
 Cohesion: 0.67
 Nodes (2): applyCommandResult(), handleCreateCase()
+
+### Community 498 - "Community 498"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 499 - "Community 499"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 500 - "Community 500"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 501 - "Community 501"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 502 - "Community 502"
+### Community 501 - "Community 501"
 Cohesion: 0.67
 Nodes (2): useGetArchivedProducts(), useGetProducts()
 
-### Community 503 - "Community 503"
+### Community 502 - "Community 502"
 Cohesion: 0.67
 Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
-### Community 504 - "Community 504"
+### Community 503 - "Community 503"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 505 - "Community 505"
+### Community 504 - "Community 504"
 Cohesion: 0.67
 Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
-### Community 506 - "Community 506"
+### Community 505 - "Community 505"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 507 - "Community 507"
+### Community 506 - "Community 506"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 508 - "Community 508"
+### Community 507 - "Community 507"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 509 - "Community 509"
+### Community 508 - "Community 508"
 Cohesion: 0.67
 Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
-### Community 510 - "Community 510"
+### Community 509 - "Community 509"
 Cohesion: 0.67
 Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+
+### Community 510 - "Community 510"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 511 - "Community 511"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 512 - "Community 512"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 513 - "Community 513"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 514 - "Community 514"
+### Community 513 - "Community 513"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 515 - "Community 515"
+### Community 514 - "Community 514"
 Cohesion: 0.83
 Nodes (3): completedEvent(), event(), item()
 
-### Community 516 - "Community 516"
+### Community 515 - "Community 515"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 517 - "Community 517"
+### Community 516 - "Community 516"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 518 - "Community 518"
+### Community 517 - "Community 517"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+
+### Community 518 - "Community 518"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 519 - "Community 519"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 520 - "Community 520"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 521 - "Community 521"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 522 - "Community 522"
+### Community 521 - "Community 521"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 523 - "Community 523"
+### Community 522 - "Community 522"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 524 - "Community 524"
+### Community 523 - "Community 523"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 525 - "Community 525"
+### Community 524 - "Community 524"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+
+### Community 525 - "Community 525"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 526 - "Community 526"
 Cohesion: 0.5
@@ -4242,63 +4241,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 533 - "Community 533"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 534 - "Community 534"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 535 - "Community 535"
+### Community 534 - "Community 534"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 536 - "Community 536"
+### Community 535 - "Community 535"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 537 - "Community 537"
+### Community 536 - "Community 536"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 538 - "Community 538"
+### Community 537 - "Community 537"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 539 - "Community 539"
+### Community 538 - "Community 538"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 540 - "Community 540"
+### Community 539 - "Community 539"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 541 - "Community 541"
+### Community 540 - "Community 540"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 542 - "Community 542"
+### Community 541 - "Community 541"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 543 - "Community 543"
+### Community 542 - "Community 542"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 544 - "Community 544"
+### Community 543 - "Community 543"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 545 - "Community 545"
+### Community 544 - "Community 544"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
+
+### Community 545 - "Community 545"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 546 - "Community 546"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 547 - "Community 547"
-Cohesion: 0.5
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 548 - "Community 548"
@@ -4306,12 +4305,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 549 - "Community 549"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 550 - "Community 550"
 Cohesion: 1.0
 Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+
+### Community 550 - "Community 550"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 551 - "Community 551"
 Cohesion: 0.67
@@ -4370,32 +4369,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 565 - "Community 565"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 566 - "Community 566"
 Cohesion: 1.0
 Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
-### Community 567 - "Community 567"
+### Community 566 - "Community 566"
 Cohesion: 1.0
 Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
-### Community 568 - "Community 568"
+### Community 567 - "Community 567"
 Cohesion: 1.0
 Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
-### Community 569 - "Community 569"
+### Community 568 - "Community 568"
 Cohesion: 1.0
 Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
-### Community 570 - "Community 570"
+### Community 569 - "Community 569"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 571 - "Community 571"
+### Community 570 - "Community 570"
 Cohesion: 0.67
 Nodes (1): PosServerError
+
+### Community 571 - "Community 571"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 572 - "Community 572"
 Cohesion: 0.67
@@ -4410,12 +4409,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 575 - "Community 575"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 576 - "Community 576"
 Cohesion: 1.0
 Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+
+### Community 576 - "Community 576"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 577 - "Community 577"
 Cohesion: 0.67
@@ -4438,12 +4437,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 582 - "Community 582"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 583 - "Community 583"
 Cohesion: 1.0
 Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 583 - "Community 583"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 584 - "Community 584"
 Cohesion: 0.67
@@ -4458,16 +4457,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 587 - "Community 587"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 588 - "Community 588"
 Cohesion: 1.0
 Nodes (2): listBagItems(), loadBagWithItems()
 
-### Community 589 - "Community 589"
+### Community 588 - "Community 588"
 Cohesion: 1.0
 Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+
+### Community 589 - "Community 589"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 590 - "Community 590"
 Cohesion: 0.67
@@ -4478,28 +4477,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 592 - "Community 592"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 593 - "Community 593"
 Cohesion: 1.0
 Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
-### Community 594 - "Community 594"
+### Community 593 - "Community 593"
 Cohesion: 1.0
 Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
-### Community 595 - "Community 595"
+### Community 594 - "Community 594"
 Cohesion: 1.0
 Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
-### Community 596 - "Community 596"
+### Community 595 - "Community 595"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 597 - "Community 597"
+### Community 596 - "Community 596"
 Cohesion: 1.0
 Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
+
+### Community 597 - "Community 597"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 598 - "Community 598"
 Cohesion: 0.67
@@ -4507,11 +4506,11 @@ Nodes (0):
 
 ### Community 599 - "Community 599"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 600 - "Community 600"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 601 - "Community 601"
 Cohesion: 0.67
@@ -4526,12 +4525,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 604 - "Community 604"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 605 - "Community 605"
 Cohesion: 1.0
 Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+
+### Community 605 - "Community 605"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 606 - "Community 606"
 Cohesion: 0.67
@@ -4550,28 +4549,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 610 - "Community 610"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 611 - "Community 611"
 Cohesion: 1.0
 Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
-### Community 612 - "Community 612"
+### Community 611 - "Community 611"
 Cohesion: 0.67
 Nodes (1): FadeIn()
+
+### Community 612 - "Community 612"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 613 - "Community 613"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 614 - "Community 614"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 615 - "Community 615"
 Cohesion: 1.0
 Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
+
+### Community 615 - "Community 615"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 616 - "Community 616"
 Cohesion: 0.67
@@ -4579,15 +4578,15 @@ Nodes (0):
 
 ### Community 617 - "Community 617"
 Cohesion: 0.67
-Nodes (0):
-
-### Community 618 - "Community 618"
-Cohesion: 0.67
 Nodes (1): VideoPlayer()
 
-### Community 619 - "Community 619"
+### Community 618 - "Community 618"
 Cohesion: 1.0
 Nodes (2): handleRefundOrder(), toast()
+
+### Community 619 - "Community 619"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 620 - "Community 620"
 Cohesion: 0.67
@@ -4598,16 +4597,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 622 - "Community 622"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 623 - "Community 623"
 Cohesion: 1.0
 Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
-### Community 624 - "Community 624"
+### Community 623 - "Community 623"
 Cohesion: 1.0
 Nodes (2): buildTodaySummary(), renderStorePulse()
+
+### Community 624 - "Community 624"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 625 - "Community 625"
 Cohesion: 0.67
@@ -4642,12 +4641,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 633 - "Community 633"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 634 - "Community 634"
 Cohesion: 1.0
 Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
+
+### Community 634 - "Community 634"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 635 - "Community 635"
 Cohesion: 0.67
@@ -4667,79 +4666,79 @@ Nodes (0):
 
 ### Community 639 - "Community 639"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): SingleLineError()
 
 ### Community 640 - "Community 640"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (1): ErrorPage()
 
 ### Community 641 - "Community 641"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): AppSkeleton()
 
 ### Community 642 - "Community 642"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 643 - "Community 643"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 644 - "Community 644"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 645 - "Community 645"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
-
-### Community 646 - "Community 646"
-Cohesion: 0.67
 Nodes (1): NotFound()
 
-### Community 647 - "Community 647"
+### Community 646 - "Community 646"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 648 - "Community 648"
+### Community 647 - "Community 647"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 649 - "Community 649"
+### Community 648 - "Community 648"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 650 - "Community 650"
+### Community 649 - "Community 649"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 651 - "Community 651"
+### Community 650 - "Community 650"
 Cohesion: 0.67
 Nodes (1): LoadingButton()
 
-### Community 652 - "Community 652"
+### Community 651 - "Community 651"
 Cohesion: 0.67
 Nodes (1): onChange()
 
-### Community 653 - "Community 653"
+### Community 652 - "Community 652"
 Cohesion: 0.67
 Nodes (1): AlertModal()
 
-### Community 654 - "Community 654"
+### Community 653 - "Community 653"
 Cohesion: 0.67
 Nodes (1): OverlayModal()
 
-### Community 655 - "Community 655"
+### Community 654 - "Community 654"
 Cohesion: 0.67
 Nodes (1): Skeleton()
 
-### Community 656 - "Community 656"
+### Community 655 - "Community 655"
 Cohesion: 0.67
 Nodes (1): Toaster()
 
-### Community 657 - "Community 657"
+### Community 656 - "Community 656"
 Cohesion: 0.67
 Nodes (1): Spinner()
+
+### Community 657 - "Community 657"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 658 - "Community 658"
 Cohesion: 0.67
@@ -4771,11 +4770,11 @@ Nodes (0):
 
 ### Community 665 - "Community 665"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 666 - "Community 666"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 667 - "Community 667"
 Cohesion: 0.67
@@ -4802,44 +4801,44 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 673 - "Community 673"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 674 - "Community 674"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 675 - "Community 675"
+### Community 674 - "Community 674"
 Cohesion: 0.67
 Nodes (1): isInMaintenanceMode()
 
-### Community 676 - "Community 676"
+### Community 675 - "Community 675"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 677 - "Community 677"
+### Community 676 - "Community 676"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 678 - "Community 678"
+### Community 677 - "Community 677"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 679 - "Community 679"
+### Community 678 - "Community 678"
 Cohesion: 1.0
 Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+
+### Community 679 - "Community 679"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 680 - "Community 680"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 681 - "Community 681"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 682 - "Community 682"
 Cohesion: 1.0
 Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
+
+### Community 682 - "Community 682"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 683 - "Community 683"
 Cohesion: 0.67
@@ -4866,76 +4865,76 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 689 - "Community 689"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 690 - "Community 690"
 Cohesion: 1.0
 Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
-### Community 691 - "Community 691"
+### Community 690 - "Community 690"
 Cohesion: 1.0
 Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+
+### Community 691 - "Community 691"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 692 - "Community 692"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 693 - "Community 693"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 694 - "Community 694"
 Cohesion: 1.0
 Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
-### Community 695 - "Community 695"
+### Community 694 - "Community 694"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 696 - "Community 696"
+### Community 695 - "Community 695"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 697 - "Community 697"
+### Community 696 - "Community 696"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 698 - "Community 698"
+### Community 697 - "Community 697"
 Cohesion: 0.67
 Nodes (1): manualChunks()
+
+### Community 698 - "Community 698"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 699 - "Community 699"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 700 - "Community 700"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 701 - "Community 701"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 702 - "Community 702"
+### Community 701 - "Community 701"
 Cohesion: 1.0
 Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
-### Community 703 - "Community 703"
+### Community 702 - "Community 702"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 704 - "Community 704"
+### Community 703 - "Community 703"
 Cohesion: 1.0
 Nodes (2): getBaseUrl(), getLastViewedProduct()
 
-### Community 705 - "Community 705"
+### Community 704 - "Community 704"
 Cohesion: 1.0
 Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
-### Community 706 - "Community 706"
+### Community 705 - "Community 705"
 Cohesion: 1.0
 Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+
+### Community 706 - "Community 706"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 707 - "Community 707"
 Cohesion: 0.67
@@ -4950,12 +4949,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 710 - "Community 710"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 711 - "Community 711"
 Cohesion: 1.0
 Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+
+### Community 711 - "Community 711"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 712 - "Community 712"
 Cohesion: 0.67
@@ -4966,12 +4965,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 714 - "Community 714"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 715 - "Community 715"
 Cohesion: 1.0
 Nodes (2): getPromoAlertCopy(), PromoAlert()
+
+### Community 715 - "Community 715"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 716 - "Community 716"
 Cohesion: 0.67
@@ -5038,16 +5037,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 732 - "Community 732"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 733 - "Community 733"
 Cohesion: 1.0
 Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
-### Community 734 - "Community 734"
+### Community 733 - "Community 733"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 734 - "Community 734"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 735 - "Community 735"
 Cohesion: 1.0
@@ -5062,20 +5061,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 738 - "Community 738"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 739 - "Community 739"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 740 - "Community 740"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 741 - "Community 741"
 Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Nodes (0):
 
 ### Community 742 - "Community 742"
 Cohesion: 1.0
@@ -6203,11 +6202,11 @@ Nodes (0):
 
 ### Community 1023 - "Community 1023"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1024 - "Community 1024"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1025 - "Community 1025"
 Cohesion: 1.0
@@ -10393,376 +10392,372 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
-### Community 2071 - "Community 2071"
-Cohesion: 1.0
-Nodes (0):
-
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 742`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 741`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 742`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 743`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 744`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 745`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 746`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 747`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 748`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 749`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 750`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 751`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 752`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 753`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 754`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 755`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 756`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 757`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 758`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 759`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 760`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 761`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 762`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 763`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 764`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 765`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 766`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 767`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 768`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 769`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 770`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 771`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 772`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 773`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 774`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 775`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 776`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 777`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 778`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 779`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 780`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 781`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 782`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 783`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 784`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 785`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 786`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 787`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 788`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 789`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 790`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 791`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 792`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 793`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 794`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 795`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 796`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 797`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 798`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 799`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 800`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 801`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 802`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 803`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 804`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 805`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 806`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 807`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 808`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 809`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 810`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 811`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 812`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 813`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 814`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 815`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 816`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 817`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 818`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 819`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 820`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 821`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 822`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 823`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 824`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 825`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 826`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 827`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 828`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 829`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 830`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 831`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 832`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 833`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 834`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 835`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 836`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 837`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 838`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 839`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 840`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 841`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 842`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 843`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 844`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 845`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 846`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 847`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 848`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 849`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 850`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 851`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 852`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 853`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 854`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 855`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 856`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 857`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 858`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 859`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 860`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 861`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 862`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 863`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 864`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 865`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 866`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 867`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 868`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 869`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 870`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 871`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 872`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 873`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 874`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 875`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 876`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 877`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 878`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 879`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 880`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 881`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 882`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 883`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 884`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 885`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 886`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 887`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 888`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 889`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 890`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 891`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 892`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 893`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 894`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 895`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 896`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 897`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 898`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 899`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 900`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 901`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 902`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 903`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 904`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 905`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
+- **Thin community `Community 906`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 907`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 908`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 909`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 910`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 911`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 912`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 913`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 914`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 915`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 916`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 917`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 918`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 919`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 920`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
+- **Thin community `Community 921`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 922`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -10798,2301 +10793,2301 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 923`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 924`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 925`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 926`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 927`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 928`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 929`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 930`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 931`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 932`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
+- **Thin community `Community 933`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 934`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 935`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 936`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 937`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 938`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 939`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 940`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 941`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 942`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 943`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 944`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 945`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 946`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 947`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 948`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 949`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 950`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 951`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 952`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 953`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 954`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 955`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 956`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 957`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 958`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 959`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 960`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 961`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 962`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 963`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 964`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 965`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 966`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 967`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 968`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 969`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 970`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 971`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 972`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 973`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 974`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 975`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 976`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 977`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 978`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 979`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 980`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 981`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 982`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 983`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 984`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 985`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 986`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 987`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 988`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 989`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 990`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 991`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 992`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 993`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 994`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 995`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 996`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 997`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 998`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 999`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1000`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1001`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1002`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1003`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1004`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1005`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1006`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1007`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1008`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1009`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1010`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1011`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1012`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1013`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1014`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1015`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1016`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1017`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1018`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1019`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1020`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1021`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1022`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1023`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1024`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1025`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1026`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1027`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1028`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1029`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1030`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 1031`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1032`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1033`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1034`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1035`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1036`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1037`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1038`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1039`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1040`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1041`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1042`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
+- **Thin community `Community 1043`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1044`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1045`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1046`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1047`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
+- **Thin community `Community 1048`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1049`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1050`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1051`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1052`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1053`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1054`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1055`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1056`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1057`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1058`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1059`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1060`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `Index()`, `-index-route-view.tsx`
+- **Thin community `Community 1061`** (2 nodes): `Index()`, `-index-route-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1062`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1063`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1064`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1065`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1066`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1067`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1068`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1069`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1070`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
+- **Thin community `Community 1071`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1072`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1073`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1074`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1075`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1076`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1077`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1078`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1079`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1080`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1081`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1082`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1083`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1084`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1085`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1086`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1087`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1088`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1089`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1090`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1091`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1092`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1093`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1094`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1095`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1096`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1097`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1098`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1099`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1100`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1101`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1102`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1103`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1104`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1105`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1106`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1107`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1108`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1109`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1110`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1111`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1112`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1113`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1114`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1115`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1116`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1117`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1118`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1119`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1120`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1121`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1122`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1123`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1124`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1125`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1126`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1127`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1128`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1129`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1130`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1131`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1132`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1133`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1134`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1135`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1136`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1137`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1138`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1139`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1140`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1141`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1142`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1143`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1144`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1145`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1146`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1147`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1148`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1149`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1150`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1151`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1152`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1153`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1154`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1155`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1156`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1157`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1158`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1159`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1160`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1161`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1162`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1163`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1164`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1165`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1166`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1167`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1168`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1169`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1170`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1171`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1172`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1173`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1174`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1175`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1176`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1177`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1178`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1179`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1180`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1181`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1182`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1183`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1184`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1185`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1186`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1187`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1188`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1189`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1190`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1191`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1192`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1193`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1194`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1195`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1196`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1197`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1198`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1199`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1200`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1201`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1202`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1203`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1204`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1205`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1206`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1207`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1208`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1209`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1210`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1211`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1212`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1213`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1214`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `runGit()`, `pr-athena-delivery-run.test.ts`
+- **Thin community `Community 1215`** (2 nodes): `runGit()`, `pr-athena-delivery-run.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1216`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1217`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `api.js`
+- **Thin community `Community 1218`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1219`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1220`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `server.js`
+- **Thin community `Community 1221`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `app.ts`
+- **Thin community `Community 1222`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1223`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1224`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1225`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1226`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `auth.ts`
+- **Thin community `Community 1227`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1228`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1229`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1230`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `countries.ts`
+- **Thin community `Community 1231`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `email.ts`
+- **Thin community `Community 1232`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1233`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `payment.ts`
+- **Thin community `Community 1234`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `contextEvents.test.ts`
+- **Thin community `Community 1235`** (1 nodes): `contextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1236`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `types.ts`
+- **Thin community `Community 1237`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1238`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `crons.ts`
+- **Thin community `Community 1239`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1240`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `internal.ts`
+- **Thin community `Community 1241`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1242`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1243`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1244`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1245`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1246`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1247`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1248`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1249`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1250`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1251`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1252`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `env.ts`
+- **Thin community `Community 1253`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1254`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `auth.ts`
+- **Thin community `Community 1255`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1256`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `colors.ts`
+- **Thin community `Community 1257`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `index.ts`
+- **Thin community `Community 1258`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1259`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `products.ts`
+- **Thin community `Community 1260`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1261`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `stores.ts`
+- **Thin community `Community 1262`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1263`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `bag.ts`
+- **Thin community `Community 1264`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `guest.ts`
+- **Thin community `Community 1265`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1266`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `index.ts`
+- **Thin community `Community 1267`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `me.ts`
+- **Thin community `Community 1268`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `offers.ts`
+- **Thin community `Community 1269`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1270`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1271`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1272`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1273`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1274`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1275`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1276`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1277`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1278`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `user.ts`
+- **Thin community `Community 1279`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1280`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `index.ts`
+- **Thin community `Community 1281`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1282`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `http.ts`
+- **Thin community `Community 1283`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `access.ts`
+- **Thin community `Community 1284`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1285`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1286`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1287`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `index.ts`
+- **Thin community `Community 1288`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1289`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `types.ts`
+- **Thin community `Community 1290`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1291`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `categories.ts`
+- **Thin community `Community 1292`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `colors.ts`
+- **Thin community `Community 1293`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1294`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1295`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1296`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1297`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `pos.ts`
+- **Thin community `Community 1298`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1299`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1300`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1301`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1302`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1303`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1304`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1305`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1306`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1307`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1308`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1309`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1310`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1311`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1312`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1313`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1314`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1315`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `types.ts`
+- **Thin community `Community 1316`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1317`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1318`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1319`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1320`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1321`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1322`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `dto.ts`
+- **Thin community `Community 1323`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1324`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1325`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1326`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `types.ts`
+- **Thin community `Community 1327`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `facts.ts`
+- **Thin community `Community 1328`** (1 nodes): `facts.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1329`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1330`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `types.ts`
+- **Thin community `Community 1331`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1332`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `types.ts`
+- **Thin community `Community 1333`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1334`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1335`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `customers.ts`
+- **Thin community `Community 1336`** (1 nodes): `register.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `register.test.ts`
+- **Thin community `Community 1337`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `register.ts`
+- **Thin community `Community 1338`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `sync.ts`
+- **Thin community `Community 1339`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1340`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1341`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1342`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `schema.ts`
+- **Thin community `Community 1343`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `automation.ts`
+- **Thin community `Community 1344`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1345`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1346`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `index.ts`
+- **Thin community `Community 1347`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1348`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1349`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1350`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1351`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1352`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1353`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1354`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `category.ts`
+- **Thin community `Community 1355`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `color.ts`
+- **Thin community `Community 1356`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1357`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1358`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `index.ts`
+- **Thin community `Community 1359`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1360`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1361`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1362`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1363`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `organization.ts`
+- **Thin community `Community 1364`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1365`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `product.ts`
+- **Thin community `Community 1366`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1367`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1368`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1369`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `store.ts`
+- **Thin community `Community 1370`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1371`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1372`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `index.ts`
+- **Thin community `Community 1373`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1374`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1375`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1376`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1377`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1378`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1379`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1380`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `index.ts`
+- **Thin community `Community 1381`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1382`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1383`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1384`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1385`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1386`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1387`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1388`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1389`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1390`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1391`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1392`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `customer.ts`
+- **Thin community `Community 1393`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1394`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1395`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1396`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1397`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `index.ts`
+- **Thin community `Community 1398`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1399`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1400`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1401`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1402`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1403`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1404`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1405`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1406`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1407`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1408`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1409`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1410`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1411`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1412`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1413`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1414`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1415`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1416`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1417`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `index.ts`
+- **Thin community `Community 1418`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1419`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1420`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `index.ts`
+- **Thin community `Community 1421`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1422`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1423`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1424`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1425`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1426`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1427`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `index.ts`
+- **Thin community `Community 1428`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1429`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1430`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1431`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1432`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1433`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1434`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `bag.ts`
+- **Thin community `Community 1435`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1436`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1437`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1438`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `guest.ts`
+- **Thin community `Community 1439`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `index.ts`
+- **Thin community `Community 1440`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `offer.ts`
+- **Thin community `Community 1441`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1442`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1443`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `review.ts`
+- **Thin community `Community 1444`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1445`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1446`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1447`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1448`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1449`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1450`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1451`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1452`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1453`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `bag.ts`
+- **Thin community `Community 1454`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1455`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `customer.ts`
+- **Thin community `Community 1456`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `guest.ts`
+- **Thin community `Community 1457`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1458`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1459`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1460`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1461`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1462`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1463`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1464`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `users.ts`
+- **Thin community `Community 1465`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `payment.ts`
+- **Thin community `Community 1466`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1467`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1468`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1469`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1470`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1471`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1472`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1473`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `index.ts`
+- **Thin community `Community 1474`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1475`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1476`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1477`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1478`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `auth.ts`
+- **Thin community `Community 1479`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1480`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1481`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1482`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1483`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1484`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1485`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1486`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `index.ts`
+- **Thin community `Community 1487`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1488`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1489`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1490`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1491`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1492`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1493`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1494`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1495`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1496`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1497`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1498`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1499`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1500`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1501`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1502`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1503`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1504`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1505`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1506`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1507`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1508`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `constants.ts`
+- **Thin community `Community 1509`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1510`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1511`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1512`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `types.ts`
+- **Thin community `Community 1513`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1514`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1515`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1516`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1517`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1518`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1519`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1520`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1521`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1522`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1523`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1524`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1525`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1526`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1527`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1528`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1529`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1530`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1531`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1532`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1533`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `constants.ts`
+- **Thin community `Community 1534`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1535`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1536`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1537`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `data.ts`
+- **Thin community `Community 1538`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1539`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1540`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1541`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1542`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1543`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1544`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1545`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1546`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1547`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `constants.ts`
+- **Thin community `Community 1548`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1549`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1550`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1551`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `data.ts`
+- **Thin community `Community 1552`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1553`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1554`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1555`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1556`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1557`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1558`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1559`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1560`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1561`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1562`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1563`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1564`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `constants.ts`
+- **Thin community `Community 1565`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1566`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1567`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1568`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1569`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1570`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1571`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1572`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1573`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1574`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1575`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1576`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1577`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1578`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1579`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1580`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1581`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1582`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1583`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1584`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1585`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1586`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1587`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1588`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1589`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1590`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1591`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1592`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1593`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1594`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1595`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1596`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1597`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1598`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1599`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `constants.ts`
+- **Thin community `Community 1600`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1601`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1602`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1603`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `data.ts`
+- **Thin community `Community 1604`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1605`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1606`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `constants.ts`
+- **Thin community `Community 1607`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1608`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1609`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1610`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1611`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `data.ts`
+- **Thin community `Community 1612`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1613`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `constants.ts`
+- **Thin community `Community 1614`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1615`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1616`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1617`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1618`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `data.ts`
+- **Thin community `Community 1619`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1620`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1621`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1622`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1623`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1624`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1625`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1626`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1627`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1628`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1629`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1630`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1631`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1632`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1633`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1634`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1635`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1636`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1637`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1638`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1639`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1640`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1641`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1642`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1643`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1644`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1645`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1646`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1647`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `types.ts`
+- **Thin community `Community 1648`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1649`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1650`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1651`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1652`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1653`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1654`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1655`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1656`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 1657`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1658`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1659`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1660`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1661`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1662`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1663`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1664`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1665`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1666`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `data.ts`
+- **Thin community `Community 1667`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1668`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1669`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1670`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1671`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1672`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1673`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1674`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1675`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1676`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1677`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1678`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1679`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `constants.ts`
+- **Thin community `Community 1680`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1681`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1682`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1683`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `data.ts`
+- **Thin community `Community 1684`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `types.ts`
+- **Thin community `Community 1685`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1686`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1687`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1688`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1689`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1690`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `index.ts`
+- **Thin community `Community 1691`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1692`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1693`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1694`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1695`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `index.tsx`
+- **Thin community `Community 1696`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1697`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1698`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1699`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1700`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1701`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1702`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1703`** (1 nodes): `StoreHoursView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `StoreHoursView.test.tsx`
+- **Thin community `Community 1704`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1705`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 1706`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `index.tsx`
+- **Thin community `Community 1707`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1708`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1709`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1710`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `button.tsx`
+- **Thin community `Community 1711`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1712`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `card.tsx`
+- **Thin community `Community 1713`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1714`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1715`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `command.tsx`
+- **Thin community `Community 1716`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1717`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1718`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1719`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `form.tsx`
+- **Thin community `Community 1720`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1721`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1722`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `input.tsx`
+- **Thin community `Community 1723`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1724`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1725`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1726`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1727`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1728`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1729`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `select.tsx`
+- **Thin community `Community 1730`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1731`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1732`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1733`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1734`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `table.tsx`
+- **Thin community `Community 1735`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1736`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1737`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1738`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1739`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1740`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1741`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1742`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1743`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `constants.ts`
+- **Thin community `Community 1744`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1745`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1746`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1747`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `data.ts`
+- **Thin community `Community 1748`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1749`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1750`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1751`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1752`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1753`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1754`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1755`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1756`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1757`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1758`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `index.ts`
+- **Thin community `Community 1759`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1760`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1761`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1762`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 1763`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1764`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1765`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1766`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1767`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1768`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1769`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1770`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1771`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 1772`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 1773`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `index.ts`
+- **Thin community `Community 1774`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 1775`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `index.ts`
+- **Thin community `Community 1776`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 1777`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 1778`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `aws.ts`
+- **Thin community `Community 1779`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `constants.ts`
+- **Thin community `Community 1780`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `countries.ts`
+- **Thin community `Community 1781`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1782`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1783`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1784`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1785`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1786`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1787`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1788`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 1789`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `dto.ts`
+- **Thin community `Community 1790`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `ports.ts`
+- **Thin community `Community 1791`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `constants.ts`
+- **Thin community `Community 1792`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1793`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1794`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `index.ts`
+- **Thin community `Community 1795`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1796`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `types.ts`
+- **Thin community `Community 1797`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1798`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1799`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1800`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1801`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1802`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1803`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1804`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1805`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1806`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 1807`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 1808`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 1809`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 1810`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 1811`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1812`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1813`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1814`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1815`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `index.ts`
+- **Thin community `Community 1816`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1817`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `category.ts`
+- **Thin community `Community 1818`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `product.ts`
+- **Thin community `Community 1819`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `store.ts`
+- **Thin community `Community 1820`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1821`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `user.ts`
+- **Thin community `Community 1822`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1823`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1824`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1825`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1826`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1827`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `main.tsx`
+- **Thin community `Community 1828`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 1829`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1830`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1831`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1832`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1833`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1834`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1835`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1836`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `index.tsx`
+- **Thin community `Community 1837`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1838`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1839`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1840`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1841`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1842`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `index.tsx`
+- **Thin community `Community 1843`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1844`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1845`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1846`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `home.tsx`
+- **Thin community `Community 1847`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1848`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1849`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1850`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `index.tsx`
+- **Thin community `Community 1851`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `review.tsx`
+- **Thin community `Community 1852`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1853`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1854`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `index.tsx`
+- **Thin community `Community 1855`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1856`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1857`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1858`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `index.tsx`
+- **Thin community `Community 1859`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1860`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1861`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1862`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1863`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1864`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1865`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 1866`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `index.tsx`
+- **Thin community `Community 1867`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1868`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1869`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1870`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1871`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1872`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1873`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1874`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1875`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1876`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `index.tsx`
+- **Thin community `Community 1877`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1878`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `index.tsx`
+- **Thin community `Community 1879`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `new.tsx`
+- **Thin community `Community 1880`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `index.tsx`
+- **Thin community `Community 1881`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `new.tsx`
+- **Thin community `Community 1882`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1883`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1884`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `index.tsx`
+- **Thin community `Community 1885`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `new.tsx`
+- **Thin community `Community 1886`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `index.tsx`
+- **Thin community `Community 1887`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1888`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1889`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1890`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1891`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `index.tsx`
+- **Thin community `Community 1892`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1893`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1894`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1895`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `index.tsx`
+- **Thin community `Community 1896`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1897`** (1 nodes): `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `_authed.tsx`
+- **Thin community `Community 1898`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1899`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `index.tsx`
+- **Thin community `Community 1900`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1901`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1902`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1903`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 1904`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1905`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 1906`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1907`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 1908`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1909`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1910`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1911`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1912`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1913`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1914`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1915`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1916`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1917`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1918`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1919`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1920`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1921`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1922`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1923`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1924`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `setup.ts`
+- **Thin community `Community 1925`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1926`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `types.ts`
+- **Thin community `Community 1927`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1928`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1929`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1930`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1931`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1932`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1933`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1934`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `types.ts`
+- **Thin community `Community 1935`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1936`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1937`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1938`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1939`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1940`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1941`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1942`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1943`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `schema.ts`
+- **Thin community `Community 1944`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1945`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1946`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1947`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1948`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1949`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1950`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1951`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1952`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1953`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `types.ts`
+- **Thin community `Community 1954`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1955`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1956`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1957`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1958`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1959`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1960`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1961`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `constants.ts`
+- **Thin community `Community 1962`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1963`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `About.tsx`
+- **Thin community `Community 1964`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1965`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1966`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1967`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1968`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1969`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1970`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1971`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1972`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1973`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1974`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `types.ts`
+- **Thin community `Community 1975`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1976`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1977`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1978`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1979`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1980`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1981`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1982`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1983`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1984`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1985`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1986`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `button.tsx`
+- **Thin community `Community 1987`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `card.tsx`
+- **Thin community `Community 1988`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1989`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `command.tsx`
+- **Thin community `Community 1990`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1991`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1992`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1993`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `form.tsx`
+- **Thin community `Community 1994`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1995`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1996`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1997`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1998`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `input.tsx`
+- **Thin community `Community 1999`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `label.tsx`
+- **Thin community `Community 2000`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2001`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2002`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2003`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `index.ts`
+- **Thin community `Community 2004`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `types.ts`
+- **Thin community `Community 2005`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2006`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2007`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2008`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2009`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `select.tsx`
+- **Thin community `Community 2010`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2011`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2012`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `table.tsx`
+- **Thin community `Community 2013`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2014`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2015`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2016`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2017`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2018`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `config.ts`
+- **Thin community `Community 2019`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2020`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2021`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2022`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2023`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2024`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `constants.ts`
+- **Thin community `Community 2025`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `countries.ts`
+- **Thin community `Community 2026`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2027`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2028`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2029`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2030`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `index.ts`
+- **Thin community `Community 2031`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2032`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `store.ts`
+- **Thin community `Community 2033`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `bag.ts`
+- **Thin community `Community 2034`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2035`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `category.ts`
+- **Thin community `Community 2036`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `organization.ts`
+- **Thin community `Community 2037`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `product.ts`
+- **Thin community `Community 2038`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `store.ts`
+- **Thin community `Community 2039`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2040`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `user.ts`
+- **Thin community `Community 2041`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `states.ts`
+- **Thin community `Community 2042`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2043`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2044`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2045`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2046`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2047`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2048`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2049`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2050`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `index.tsx`
+- **Thin community `Community 2051`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2052`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `index.tsx`
+- **Thin community `Community 2053`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2054`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2055`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2056`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2056`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2057`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2057`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2058`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2058`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2059`** (1 nodes): `index.tsx`
+- **Thin community `Community 2059`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2060`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2060`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2061`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2061`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2062`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2062`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2063`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2063`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2064`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2064`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2065`** (1 nodes): `index.js`
+- **Thin community `Community 2065`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2066`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2066`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2067`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2067`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2068`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2068`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2069`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2069`** (1 nodes): `harness-behavior-scenarios.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2070`** (1 nodes): `harness-behavior-scenarios.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2071`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2070`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8149 nodes · 9600 edges · 2072 communities detected
+- 8203 nodes · 9711 edges · 2072 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2119,23 +2119,23 @@ Nodes (70): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelong
 
 ### Community 2 - "Community 2"
 Cohesion: 0.06
-Nodes (64): attentionSeverity(), automationRunClassification(), automationStatusBucketForRun(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildRegisterCloseoutTimelineMessage() (+56 more)
+Nodes (66): buildLegacyOperationalExplanation(), buildRecoveryBlockers(), buildRecoveryBlockersFromPreview(), buildRecoveryReadiness(), buildStaticOperationalExplanation(), buildTerminalAppUpdatePresentation(), buildTerminalOperationalExplanationPresentation(), buildTerminalRecoveryPresentation() (+58 more)
 
 ### Community 3 - "Community 3"
+Cohesion: 0.06
+Nodes (64): attentionSeverity(), automationRunClassification(), automationStatusBucketForRun(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildRegisterCloseoutTimelineMessage() (+56 more)
+
+### Community 4 - "Community 4"
 Cohesion: 0.04
 Nodes (34): buildDailyCloseExpenseSearch(), buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), getBucketCountClassName(), getCarryForwardWorkItemId(), getDailyCloseSalesMetricLabels(), getDailyCloseStatus() (+26 more)
 
-### Community 4 - "Community 4"
+### Community 5 - "Community 5"
 Cohesion: 0.09
 Nodes (61): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), capNonCashPaymentsToExpectedTotal(), collectExistingSaleMappings() (+53 more)
 
-### Community 5 - "Community 5"
+### Community 6 - "Community 6"
 Cohesion: 0.09
 Nodes (46): buildLocalSyncEventRecordInput(), canonicalize(), canonicalJson(), createLocalSyncIngestionService(), getLocalSyncCursorIdentity(), getLocalSyncScope(), ingestLocalEventsWithCtx(), isNonEmptyString() (+38 more)
-
-### Community 6 - "Community 6"
-Cohesion: 0.08
-Nodes (46): buildRecoveryBlockers(), buildRecoveryBlockersFromPreview(), buildRecoveryReadiness(), buildTerminalAppUpdatePresentation(), buildTerminalRecoveryPresentation(), buildUpdateAppAction(), classifyTerminalHealth(), defaultBlockerSummary() (+38 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.06
@@ -2147,119 +2147,119 @@ Nodes (48): buildFinalTrustedQuantitiesByRowNumber(), buildProductPageFinalizati
 
 ### Community 9 - "Community 9"
 Cohesion: 0.06
-Nodes (21): assertPosLocalStoreOk(), buildRuntimeAppUpdateInput(), clearAcceptedTerminalIntegrityState(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus() (+13 more)
+Nodes (27): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatCompactTextList(), formatPaymentMethods(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp() (+19 more)
 
 ### Community 10 - "Community 10"
+Cohesion: 0.06
+Nodes (21): assertPosLocalStoreOk(), buildRuntimeAppUpdateInput(), clearAcceptedTerminalIntegrityState(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus() (+13 more)
+
+### Community 11 - "Community 11"
 Cohesion: 0.09
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
 
-### Community 11 - "Community 11"
+### Community 12 - "Community 12"
 Cohesion: 0.06
 Nodes (22): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+14 more)
 
-### Community 12 - "Community 12"
+### Community 13 - "Community 13"
 Cohesion: 0.07
 Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
-### Community 13 - "Community 13"
+### Community 14 - "Community 14"
 Cohesion: 0.07
 Nodes (10): arrayDetail(), buildCashControlsDashboardSnapshot(), buildReviewedSaleProjectionEvent(), getCompletedTransactionForRegisterMappingRepair(), normalizeReviewedNonCashOverpaymentPayload(), numberDetail(), recordDetail(), roundCurrencyAmount() (+2 more)
 
-### Community 14 - "Community 14"
+### Community 15 - "Community 15"
 Cohesion: 0.08
 Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
 
-### Community 15 - "Community 15"
+### Community 16 - "Community 16"
 Cohesion: 0.14
 Nodes (35): asRecord(), canUploadedRegisterOpenReplaceBlockedDrawer(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta() (+27 more)
 
-### Community 16 - "Community 16"
+### Community 17 - "Community 17"
 Cohesion: 0.11
 Nodes (33): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+25 more)
 
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
 Cohesion: 0.12
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
-
-### Community 18 - "Community 18"
-Cohesion: 0.07
-Nodes (11): formatCompactTextList(), formatPaymentMethods(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary(), formatReviewTypeSummary(), formatTimestamp() (+3 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.16
 Nodes (31): completed(), executeCallbackCommand(), executeClearStaleDrawerAuthority(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand(), executeUpdateApp(), failed() (+23 more)
 
 ### Community 20 - "Community 20"
+Cohesion: 0.09
+Nodes (19): buildDisplaySafeConflictSummary(), buildTerminalSyncReviewSummary(), classifyTerminalSyncReviewConflict(), emptyTerminalSyncReviewSummary(), getLatestRuntimeStatusForTerminal(), getOpenWorkTargetsByLocalEventId(), getRegisterSessionReviewActionTarget(), getTerminalByFingerprint() (+11 more)
+
+### Community 21 - "Community 21"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
-### Community 21 - "Community 21"
-Cohesion: 0.12
-Nodes (25): annotateTerminalSyncEvidenceReviewTargets(), buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalOperationalStateForSummary(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryPreview(), createTerminalCloudRepairQueryRepository() (+17 more)
-
 ### Community 22 - "Community 22"
+Cohesion: 0.12
+Nodes (25): buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalOperationalStateForSummary(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryPreview(), createTerminalCloudRepairQueryRepository(), formatRuntimeAppUpdateAssetSummary() (+17 more)
+
+### Community 23 - "Community 23"
 Cohesion: 0.11
 Nodes (21): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), buildLocalAvailabilityEventIndex(), cartItemLineEventKey(), cartItemLineKey(), cartItemsFromLocalRegisterModel(), cartLineSourceKey(), formatLocalPendingCheckoutSku() (+13 more)
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.12
 Nodes (26): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildInventorySnapshotRowsForProductSkusWithCtx(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle() (+18 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.11
 Nodes (24): buildGitProcessEnv(), buildProviderSkip(), collectCommandsForChangedFiles(), commandDisplayName(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs() (+16 more)
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.16
 Nodes (26): addDays(), addField(), contextWindowsForDate(), dayOfWeek(), exceptionWindowsOverlap(), findNextWindow(), getFormatter(), getMissingStoreScheduleContext() (+18 more)
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.12
 Nodes (24): automationErrorMessage(), automationIdempotencyKey(), eodAutoCompleteDecision(), eodAutoCompletePolicyCronWindow(), eodAutoCompleteTiming(), eodDecision(), getLatestDailyOperationsAutomationStatusWithCtx(), getOpeningAutoStartPolicyForApi() (+16 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.14
 Nodes (24): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+16 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.13
 Nodes (24): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), expenseSessionItemHasTrustedAvailabilityHold(), expenseSessionItemSourceKey(), failure() (+16 more)
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.2
 Nodes (28): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftCreatedMessage(), buildCycleCountDraftSavedMessage(), buildCycleCountDraftSubmissionKey(), buildCycleCountDraftSubmittedMessage(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx() (+20 more)
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.13
 Nodes (21): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), formatPendingApprovalsLabel(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate() (+13 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.19
 Nodes (27): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), isExpenseLocalSyncEvent(), isSyncablePosLocalEvent() (+19 more)
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.14
 Nodes (23): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+15 more)
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.19
 Nodes (23): assertRegisterNumberIsAvailable(), buildRuntimeActiveRegisterSessionDirective(), buildRuntimeDrawerAuthorityDirective(), cleanActiveRegisterSession(), cleanAppSessionRecovery(), cleanAppShell(), cleanAppUpdate(), cleanBrowserInfo() (+15 more)
-
-### Community 37 - "Community 37"
-Cohesion: 0.1
-Nodes (12): getLatestRuntimeStatusForTerminal(), getTerminalByFingerprint(), getTerminalSyncEvidence(), isActionableRejectedSyncEvent(), isActionableTerminalReviewSyncEvent(), mapTerminalRecord(), mergeRuntimeStatusPatch(), omitUndefined() (+4 more)
 
 ### Community 38 - "Community 38"
 Cohesion: 0.09
@@ -2282,236 +2282,236 @@ Cohesion: 0.16
 Nodes (19): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), pendingCheckoutItemMatchesLine(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding() (+11 more)
 
 ### Community 43 - "Community 43"
+Cohesion: 0.16
+Nodes (21): buildDiagnosticEvidence(), buildTerminalOperationalExplanation(), buildTerminalOperationalState(), buildTerminalRecoveryActions(), buildTerminalRecoveryManualReview(), classifySalesReadiness(), classifySupportRecovery(), classifyTerminalHealth() (+13 more)
+
+### Community 44 - "Community 44"
 Cohesion: 0.09
 Nodes (5): listCompletedTransactionsForDay(), listCompletedTransactionsForRange(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.19
 Nodes (23): assertCompoundSolutionCheck(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSourceLineChanges(), countFileLines(), extractFrontmatter() (+15 more)
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
 Cohesion: 0.21
 Nodes (23): buildCartChange(), buildLegacyContextPayload(), buildLegacyProductId(), compactPayload(), compileLegacyStorefrontAnalyticsRow(), compileLegacyStorefrontAnalyticsRows(), compileLegacyStorefrontAnalyticsRowsWithReport(), containsSensitiveText() (+15 more)
 
-### Community 48 - "Community 48"
+### Community 49 - "Community 49"
 Cohesion: 0.19
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
-### Community 49 - "Community 49"
+### Community 50 - "Community 50"
 Cohesion: 0.18
 Nodes (23): buildEventMessage(), buildNextEvidence(), buildNextSaleEvidence(), buildReviewPriority(), buildWorkItemPriority(), createOrReusePendingCheckoutItem(), createProvisionalCatalogAnchors(), findMatchingPendingCheckoutItem() (+15 more)
 
-### Community 50 - "Community 50"
+### Community 51 - "Community 51"
 Cohesion: 0.09
 Nodes (3): buildPersistedRuntimeStatus(), buildRegisterSession(), buildRuntimeStatus()
 
-### Community 51 - "Community 51"
+### Community 52 - "Community 52"
 Cohesion: 0.12
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
 
-### Community 52 - "Community 52"
+### Community 53 - "Community 53"
 Cohesion: 0.17
 Nodes (21): buildHomepageSnapshotV1(), hydrateCategory(), hydrateFeaturedItem(), hydrateProduct(), hydrateSubcategory(), hydrateTargetProducts(), isCustomerVisibleProduct(), isCustomerVisibleSku() (+13 more)
 
-### Community 53 - "Community 53"
+### Community 54 - "Community 54"
 Cohesion: 0.17
 Nodes (19): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady(), mapSyncStatus() (+11 more)
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.16
 Nodes (17): asRecord(), buildSnapshotHash(), buildStoreInsightsPromptFromContextBundle(), buildStoreInsightsPromptFromContextEvents(), buildUserInsightsPromptFromContextBundle(), buildUserInsightsPromptFromContextEvents(), compactContextEventsForPrompt(), compactEnvironmentForPrompt() (+9 more)
 
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.15
 Nodes (16): findLatestOpenOperatingDay(), getTodaySummary(), getTransactionById(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile() (+8 more)
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.21
 Nodes (21): detectFormat(), extractJsonRows(), flattenJsonRows(), inferProductName(), isRecord(), looksLikeLabel(), normalizeKey(), normalizeLegacyRow() (+13 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.25
 Nodes (21): asRecord(), errorFor(), getLocalExpenseSessionId(), getOrCreateSession(), isExpenseEvent(), itemSource(), itemSourceKey(), numberField() (+13 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.18
 Nodes (18): assertValidEodLocalCompletionWindowMinutes(), assertValidEodThreshold(), assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getEodAutoCompletePolicyConfigWithCtx() (+10 more)
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.11
 Nodes (6): asBoolean(), asNumber(), asRecord(), buildRegisterCloseoutVarianceTimelineMessage(), formatCloseoutVarianceAmount(), getCashControlsConfig()
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.21
 Nodes (18): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), formatRecoveryCode(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode() (+10 more)
 
-### Community 64 - "Community 64"
-Cohesion: 0.1
-Nodes (4): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onStartRemoteAssist()
-
 ### Community 65 - "Community 65"
+Cohesion: 0.11
+Nodes (6): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onIssueTerminalRecoveryCommand(), onStartRemoteAssist(), submitUpdateApp()
+
+### Community 66 - "Community 66"
 Cohesion: 0.13
 Nodes (9): asCloudOperableSession(), countPendingSyncableLocalEventsForStaff(), hasSyncedSaleLocalEventsForStaff(), hasUploadedLocalEventsForStaff(), isCloudOperableSession(), isEmptyLocalSaleShell(), selectPassiveCloseoutBlockedRegisterSession(), trimOptional() (+1 more)
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.27
 Nodes (18): assertConformsToExportedReturns(), collectReturnValidatorIssues(), decodeSerializedFloat64(), decodeSerializedInt64(), decodeSerializedLiteralValue(), describeValue(), formatReturnValidatorIssues(), isConvexValue() (+10 more)
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.22
 Nodes (15): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), classifyRegisterSessionSyncReview(), findProjectedRegisterSessionIdForRepairableMissingMapping(), findTransactionIdForSyncEvent(), hasInventoryReviewWorkItemForProjectedSale(), isNonSaleMissingRegisterSessionMappingConflict() (+7 more)
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.2
 Nodes (17): acknowledgeTerminalRecoveryCommand(), buildExecutionId(), claimTerminalRecoveryCommand(), containsSecretLikeField(), getRuntimeAppUpdateEvidence(), isActiveCommand(), isEquivalentCommand(), issueTerminalRecoveryCommand() (+9 more)
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.22
 Nodes (18): assertPrAthenaProofReady(), classifySnapshotError(), collectFilesUnder(), collectProofSnapshot(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof() (+10 more)
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.17
 Nodes (13): buildProviderRegistry(), createIntelligenceRun(), defaultFakeOutput(), failedGenerationResult(), getStoreInsightsSnapshotFallback(), isActivityTrend(), isDeviceDistribution(), isInsightGenerationInProgressError() (+5 more)
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.16
 Nodes (10): buildProductSkuSearchProjection(), buildSearchText(), hydrateCanonicalProjection(), normalizeAttributes(), normalizeLookup(), projectionsEqual(), requireProductSkuSearchAccess(), requireProductSkuSearchAdmin() (+2 more)
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.25
 Nodes (17): getRegisterCatalogPrice(), isActiveProvisionalImportSkuForStore(), isDraftAllowedInTrustedRegisterCatalog(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailability(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogAvailabilitySkus() (+9 more)
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.22
 Nodes (15): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+7 more)
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.25
 Nodes (16): buildStorefrontContextEvent(), buildStorefrontIdempotencyKey(), compactScalarPayload(), createStorefrontContextTrackingEnvelope(), createStorefrontRouteViewedContextEvent(), getCartChange(), getCartContextEventInput(), getCheckoutBlocker() (+8 more)
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.22
 Nodes (14): assertActorMatchesStore(), buildCompiledContextBundle(), buildStoreInsightsContextBundleFromContextEvents(), buildUserInsightsContextBundleFromContextEvents(), compileContextEvent(), compileContextEventsWithReport(), getDataWindow(), getStoreFrontActorById() (+6 more)
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.13
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.15
 Nodes (5): buildMissingDraftResult(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.15
 Nodes (7): buildStoreSchedulePayload(), handleSave(), hasDuplicateExceptionDates(), normalizeWeeklyHours(), resetForm(), timeInputToMinute(), validate()
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.14
 Nodes (5): getBlockedPosTerminalShellCopy(), getPosHubRouteParams(), getRouteParamsForPattern(), getStoreWorkspaceRouteParams(), PosTerminalBlockedShell()
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.23
 Nodes (13): buildAbusePartitionKey(), buildServerContextTrackingEnvelope(), deriveBrowserFamily(), deriveContextEnvironment(), deriveOsFamily(), derivePrimarySubject(), isAcceptedSyntheticContext(), isRecord() (+5 more)
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.19
 Nodes (10): buildLatestRunDebugPayload(), getBoundedDebugRunsByCapability(), getLatestDebugRunByCapability(), getLatestDebugRunBySubject(), isActiveRunStale(), isActiveRunStatus(), selectLatestDebugRunFromCandidates(), shouldRecoverActiveRun() (+2 more)
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.13
 Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.24
 Nodes (15): buildGeneratedControlId(), captureRemoteAssistCoBrowseFrame(), collectSanitizedSurface(), collectSensitiveRegions(), collectVisibleText(), getControlId(), getControlPriority(), getElementLabel() (+7 more)
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.22
 Nodes (11): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), getInvalidationNodes(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline() (+3 more)
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.23
 Nodes (13): collectConvexReturnValidatorContractFindings(), escapeRegExp(), extractConvexPublicFunctionsWithReturns(), fileExists(), findMatchingDefinitionEnd(), hasConvexReturnContractProofForExport(), isConvexReturnContractSourcePath(), isRelevantConvexContractProofPath() (+5 more)
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.22
 Nodes (9): buildHistoricalContextEventAppendArgs(), buildHistoricalImportIdempotencyKey(), buildPrimarySubject(), buildStoppedReport(), countOmittedFields(), createEmptyReport(), increment(), planHistoricalStorefrontContextImport() (+1 more)
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.32
 Nodes (14): buildPosOperatorSnapshot(), buildRecentDayBuckets(), buildSummaryTrendBucket(), buildTransactionDateBuckets(), calculateDeltaPercent(), formatHourLabel(), formatPaymentMethodLabel(), formatShortDate() (+6 more)
-
-### Community 100 - "Community 100"
-Cohesion: 0.28
-Nodes (14): buildDiagnosticEvidence(), buildTerminalOperationalState(), buildTerminalRecoveryActions(), buildTerminalRecoveryManualReview(), classifySalesReadiness(), classifySupportRecovery(), classifyTerminalHealth(), dedupeTerminalActions() (+6 more)
 
 ### Community 101 - "Community 101"
 Cohesion: 0.17
@@ -2818,256 +2818,256 @@ Cohesion: 0.22
 Nodes (0):
 
 ### Community 177 - "Community 177"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Cohesion: 0.22
+Nodes (0):
 
 ### Community 178 - "Community 178"
 Cohesion: 0.39
-Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 179 - "Community 179"
+Cohesion: 0.39
+Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
+
+### Community 180 - "Community 180"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.33
 Nodes (6): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), saveProduct(), updateVariantSku()
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.28
 Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.28
 Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.25
 Nodes (2): isValidMessageBlocker(), isValidPriority()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.28
 Nodes (4): comparePendingEvents(), getPendingEventUploadSequence(), selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
-### Community 191 - "Community 191"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
 ### Community 192 - "Community 192"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
-### Community 193 - "Community 193"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 194 - "Community 194"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 195 - "Community 195"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
+### Community 193 - "Community 193"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
+
+### Community 194 - "Community 194"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
+### Community 195 - "Community 195"
+Cohesion: 0.22
+Nodes (0):
+
 ### Community 196 - "Community 196"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 197 - "Community 197"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 205 - "Community 205"
+### Community 206 - "Community 206"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 208 - "Community 208"
-Cohesion: 0.5
-Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
 ### Community 209 - "Community 209"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.5
+Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
 ### Community 210 - "Community 210"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 211 - "Community 211"
-Cohesion: 0.36
-Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 212 - "Community 212"
 Cohesion: 0.36
-Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
 
 ### Community 213 - "Community 213"
+Cohesion: 0.36
+Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+
+### Community 214 - "Community 214"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 214 - "Community 214"
+### Community 215 - "Community 215"
 Cohesion: 0.29
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 215 - "Community 215"
+### Community 216 - "Community 216"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 216 - "Community 216"
+### Community 217 - "Community 217"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.29
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 221 - "Community 221"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 222 - "Community 222"
 Cohesion: 0.39
-Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 223 - "Community 223"
+Cohesion: 0.39
+Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+
+### Community 224 - "Community 224"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.29
 Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.38
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 238 - "Community 238"
-Cohesion: 0.48
-Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
 ### Community 239 - "Community 239"
-Cohesion: 0.29
-Nodes (0):
+Cohesion: 0.48
+Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
 ### Community 240 - "Community 240"
 Cohesion: 0.33
@@ -3378,200 +3378,200 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 317 - "Community 317"
-Cohesion: 0.53
-Nodes (5): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
-
-### Community 318 - "Community 318"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 319 - "Community 319"
+### Community 318 - "Community 318"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 320 - "Community 320"
+### Community 319 - "Community 319"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 321 - "Community 321"
+### Community 320 - "Community 320"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 322 - "Community 322"
+### Community 321 - "Community 321"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 322 - "Community 322"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 323 - "Community 323"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 324 - "Community 324"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 325 - "Community 325"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 326 - "Community 326"
+### Community 325 - "Community 325"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 327 - "Community 327"
+### Community 326 - "Community 326"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 327 - "Community 327"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 328 - "Community 328"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 329 - "Community 329"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 330 - "Community 330"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 331 - "Community 331"
+### Community 330 - "Community 330"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 332 - "Community 332"
+### Community 331 - "Community 331"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 333 - "Community 333"
+### Community 332 - "Community 332"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 334 - "Community 334"
+### Community 333 - "Community 333"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 335 - "Community 335"
+### Community 334 - "Community 334"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 336 - "Community 336"
+### Community 335 - "Community 335"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 337 - "Community 337"
+### Community 336 - "Community 336"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 338 - "Community 338"
+### Community 337 - "Community 337"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 339 - "Community 339"
+### Community 338 - "Community 338"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
-### Community 340 - "Community 340"
+### Community 339 - "Community 339"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 341 - "Community 341"
+### Community 340 - "Community 340"
 Cohesion: 0.6
 Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
-### Community 342 - "Community 342"
+### Community 341 - "Community 341"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 343 - "Community 343"
+### Community 342 - "Community 342"
 Cohesion: 0.5
 Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
-### Community 344 - "Community 344"
+### Community 343 - "Community 343"
 Cohesion: 0.5
 Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
-### Community 345 - "Community 345"
+### Community 344 - "Community 344"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 346 - "Community 346"
+### Community 345 - "Community 345"
 Cohesion: 0.5
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 347 - "Community 347"
+### Community 346 - "Community 346"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 348 - "Community 348"
+### Community 347 - "Community 347"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 349 - "Community 349"
+### Community 348 - "Community 348"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 350 - "Community 350"
+### Community 349 - "Community 349"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 351 - "Community 351"
+### Community 350 - "Community 350"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
+
+### Community 351 - "Community 351"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 352 - "Community 352"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 353 - "Community 353"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 354 - "Community 354"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 355 - "Community 355"
+### Community 354 - "Community 354"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
+
+### Community 355 - "Community 355"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 356 - "Community 356"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 357 - "Community 357"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 358 - "Community 358"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 359 - "Community 359"
+### Community 358 - "Community 358"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 360 - "Community 360"
+### Community 359 - "Community 359"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 361 - "Community 361"
+### Community 360 - "Community 360"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 362 - "Community 362"
+### Community 361 - "Community 361"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 363 - "Community 363"
+### Community 362 - "Community 362"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 364 - "Community 364"
+### Community 363 - "Community 363"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 365 - "Community 365"
+### Community 364 - "Community 364"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
+
+### Community 365 - "Community 365"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 366 - "Community 366"
 Cohesion: 0.4
@@ -3582,12 +3582,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 368 - "Community 368"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 369 - "Community 369"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 369 - "Community 369"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 370 - "Community 370"
 Cohesion: 0.4
@@ -3602,20 +3602,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 373 - "Community 373"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 374 - "Community 374"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 375 - "Community 375"
+### Community 374 - "Community 374"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 376 - "Community 376"
+### Community 375 - "Community 375"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+
+### Community 376 - "Community 376"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 377 - "Community 377"
 Cohesion: 0.4
@@ -3634,72 +3634,72 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 381 - "Community 381"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 382 - "Community 382"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 383 - "Community 383"
+### Community 382 - "Community 382"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 384 - "Community 384"
+### Community 383 - "Community 383"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 385 - "Community 385"
+### Community 384 - "Community 384"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 386 - "Community 386"
+### Community 385 - "Community 385"
 Cohesion: 0.5
 Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
-### Community 387 - "Community 387"
+### Community 386 - "Community 386"
 Cohesion: 0.5
 Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
-### Community 388 - "Community 388"
+### Community 387 - "Community 387"
 Cohesion: 0.5
 Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
 
-### Community 389 - "Community 389"
+### Community 388 - "Community 388"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 390 - "Community 390"
+### Community 389 - "Community 389"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 391 - "Community 391"
+### Community 390 - "Community 390"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 392 - "Community 392"
+### Community 391 - "Community 391"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 393 - "Community 393"
+### Community 392 - "Community 392"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 394 - "Community 394"
+### Community 393 - "Community 393"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 395 - "Community 395"
+### Community 394 - "Community 394"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 396 - "Community 396"
+### Community 395 - "Community 395"
 Cohesion: 0.6
 Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
-### Community 397 - "Community 397"
+### Community 396 - "Community 396"
 Cohesion: 0.6
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
+
+### Community 397 - "Community 397"
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
 ### Community 398 - "Community 398"
 Cohesion: 0.4
@@ -13107,8 +13107,8 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**
-  _Cohesion score 0.04 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**
-  _Cohesion score 0.09 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.04 - nodes in this community are weakly interconnected._
 - **Should `Community 5` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,14 +8,14 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2144
-- Graph nodes: 8203
-- Graph edges: 9711
-- Communities: 2072
+- Graph nodes: 8228
+- Graph edges: 9773
+- Communities: 2071
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (85 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `dailyClose.ts` (83 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `terminalHealthPresentation.ts` (73 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
+- `terminalHealthPresentation.ts` (75 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (67 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `DailyCloseView.tsx` (66 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `projectLocalEvents.ts` (65 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,18 +8,18 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2144
-- Graph nodes: 8149
-- Graph edges: 9600
+- Graph nodes: 8203
+- Graph edges: 9711
 - Communities: 2072
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (85 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `dailyClose.ts` (83 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `dailyOperations.ts` (67 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `DailyCloseView.tsx` (66 edges, Community 3) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `projectLocalEvents.ts` (65 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
-- `terminalHealthPresentation.ts` (53 edges, Community 6) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
+- `terminalHealthPresentation.ts` (73 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
+- `dailyOperations.ts` (67 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `DailyCloseView.tsx` (66 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `projectLocalEvents.ts` (65 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `ingestLocalEvents.ts` (54 edges, Community 6) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 - `posLocalStore.ts` (50 edges, Community 7) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 
 ## Registered Packages

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -18,7 +18,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 
 ## Graph Hotspots
 - `dailyClose.ts` (83 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `terminalHealthPresentation.ts` (73 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
+- `terminalHealthPresentation.ts` (75 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (67 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `DailyCloseView.tsx` (66 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `projectLocalEvents.ts` (65 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -18,10 +18,10 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 
 ## Graph Hotspots
 - `dailyClose.ts` (83 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `dailyOperations.ts` (67 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `DailyCloseView.tsx` (66 edges, Community 3) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `projectLocalEvents.ts` (65 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `ingestLocalEvents.ts` (54 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
+- `terminalHealthPresentation.ts` (73 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
+- `dailyOperations.ts` (67 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `DailyCloseView.tsx` (66 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `projectLocalEvents.ts` (65 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -17,11 +17,11 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - [validation-map.json](../../../packages/storefront-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `storefrontJourneyEvents.ts` (45 edges, Community 10) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `createJourneyEvent()` (40 edges, Community 10) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 59) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `storefrontContextEvents.ts` (17 edges, Community 78) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
-- `checkoutSession.ts` (14 edges, Community 93) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `storefrontJourneyEvents.ts` (45 edges, Community 11) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 11) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `getStoreConfigV2()` (17 edges, Community 60) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storefrontContextEvents.ts` (17 edges, Community 79) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
+- `checkoutSession.ts` (14 edges, Community 94) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -17,9 +17,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - [validation-map.json](../../../packages/storefront-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `storefrontJourneyEvents.ts` (45 edges, Community 11) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `createJourneyEvent()` (40 edges, Community 11) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 60) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storefrontJourneyEvents.ts` (45 edges, Community 10) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 10) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `getStoreConfigV2()` (17 edges, Community 62) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `storefrontContextEvents.ts` (17 edges, Community 79) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
 - `checkoutSession.ts` (14 edges, Community 94) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (15 edges, Community 95) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 198) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 199) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 95) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (4 edges, Community 95) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (4 edges, Community 95) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (15 edges, Community 94) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 197) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 94) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossCluster()` (4 edges, Community 94) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossClusterWithPipeline()` (4 edges, Community 94) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (15 edges, Community 95) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.test.js` (6 edges, Community 198) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `createRedisClient()` (4 edges, Community 95) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossCluster()` (4 edges, Community 95) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossClusterWithPipeline()` (4 edges, Community 95) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
@@ -54,6 +54,67 @@ describe("terminal health queries", () => {
     expect(summary?.recoveryPreview?.terminalActions).toEqual([]);
   });
 
+  it("does not report settled closed-register conflicts as terminal health review debt", async () => {
+    const ctx = buildQueryCtx({
+      posLocalSyncConflict: [
+        buildConflict({
+          _id: "conflict-closed-register" as Id<"posLocalSyncConflict">,
+          conflictType: "permission",
+          localRegisterSessionId: "local-register-closed",
+          sequence: 4,
+        }),
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "mapping-closed-register" as Id<"posLocalSyncMapping">,
+          _creationTime: now - 5_000,
+          cloudId: "register-closed",
+          cloudTable: "registerSession",
+          createdAt: now - 5_000,
+          localEventId: "event-closed-register",
+          localId: "local-register-closed",
+          localIdKind: "registerSession",
+          localRegisterSessionId: "local-register-closed",
+          storeId,
+          terminalId,
+        } satisfies Doc<"posLocalSyncMapping">,
+      ],
+      posTerminal: [buildTerminal()],
+      posTerminalRuntimeStatus: [buildRuntimeStatus()],
+      registerSession: [
+        buildRegisterSession({
+          _id: "register-closed" as Id<"registerSession">,
+          closedAt: now - 1_000,
+          countedCash: 6_013,
+          expectedCash: 6_013,
+          status: "closed",
+          variance: 0,
+        }),
+      ],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.syncEvidence.unresolvedConflictCount).toBe(0);
+    expect(summary?.syncEvidence.reviewSummary).toEqual({
+      groups: [],
+      meta: {
+        cap: 50,
+        hasMore: false,
+        sampledCount: 0,
+        targetResolutionIncomplete: false,
+      },
+    });
+    expect(summary?.attentionReasons.map((reason) => reason.type)).not.toContain(
+      "cloud_conflict",
+    );
+    expect(summary?.recoveryPreview?.readiness).toBe("healthy_idle");
+  });
+
   it.each(["closing", "closeout_rejected"] as const)(
     "treats a %s cloud drawer authority as ready for replacement",
     async (status) => {

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.ts
@@ -632,9 +632,38 @@ async function buildTerminalRecoveryCommandStatus(
     commandType: latestCommand.commandType,
     label: getTerminalRecoveryCommandLabel(latestCommand.commandType),
     latestAcknowledgement: latestCommand.acknowledgement?.message,
+    localReviewEvents: stripLocalReviewEvents(
+      latestCommand.acknowledgement?.localReviewEvents,
+    ),
     status: getTerminalRecoveryCommandStatusForPreview(latestCommand, args.now),
     verificationStatus: latestCommand.verificationStatus,
   };
+}
+
+function stripLocalReviewEvents(
+  events:
+    | NonNullable<
+        Doc<"posTerminalRecoveryCommand">["acknowledgement"]
+      >["localReviewEvents"]
+    | undefined,
+) {
+  return events?.map((event) => ({
+    createdAt: event.createdAt,
+    localEventId: event.localEventId,
+    ...(event.localPosSessionId
+      ? { localPosSessionId: event.localPosSessionId }
+      : {}),
+    ...(event.localRegisterSessionId
+      ? { localRegisterSessionId: event.localRegisterSessionId }
+      : {}),
+    sequence: event.sequence,
+    status: event.status,
+    type: event.type,
+    ...(event.uploaded !== undefined ? { uploaded: event.uploaded } : {}),
+    ...(typeof event.uploadSequence === "number"
+      ? { uploadSequence: event.uploadSequence }
+      : {}),
+  }));
 }
 
 function getTerminalRecoveryCommandStatusForPreview(
@@ -657,6 +686,8 @@ function getTerminalRecoveryCommandLabel(
   switch (commandType) {
     case "update_app":
       return "Update app";
+    case "collect_local_review":
+      return "Collect local review items";
     case "repair_terminal_seed":
       return "Terminal setup repair";
     case "clear_stale_drawer_authority":
@@ -1044,5 +1075,33 @@ function stripRuntimeStatusIdentity(status: Doc<"posTerminalRuntimeStatus">) {
     terminalId: _terminalId,
     ...runtimeStatus
   } = status;
-  return runtimeStatus;
+  return {
+    ...runtimeStatus,
+    sync: {
+      ...runtimeStatus.sync,
+      reviewEvents: stripRuntimeReviewEvents(runtimeStatus.sync.reviewEvents),
+    },
+  };
+}
+
+function stripRuntimeReviewEvents(
+  events: Doc<"posTerminalRuntimeStatus">["sync"]["reviewEvents"],
+) {
+  return events?.map((event) => ({
+    createdAt: event.createdAt,
+    localEventId: event.localEventId,
+    ...(event.localPosSessionId
+      ? { localPosSessionId: event.localPosSessionId }
+      : {}),
+    ...(event.localRegisterSessionId
+      ? { localRegisterSessionId: event.localRegisterSessionId }
+      : {}),
+    sequence: event.sequence,
+    status: event.status,
+    type: event.type,
+    ...(event.uploaded !== undefined ? { uploaded: event.uploaded } : {}),
+    ...(typeof event.uploadSequence === "number"
+      ? { uploadSequence: event.uploadSequence }
+      : {}),
+  }));
 }

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.ts
@@ -38,6 +38,7 @@ import type {
   TerminalHealth,
   TerminalHealthAttentionActionTarget,
   TerminalHealthAttentionReason,
+  TerminalOperationalExplanation,
   TerminalOperationalState,
   TerminalRecoveryPreview,
 } from "../terminalOperationalState/types";
@@ -47,8 +48,21 @@ export type {
   TerminalAppUpdateStatus,
   TerminalHealthAttentionActionTarget,
   TerminalHealthAttentionReason,
+  TerminalOperationalExplanation,
   TerminalRecoveryPreview,
 } from "../terminalOperationalState/types";
+
+const EMPTY_TERMINAL_SYNC_REVIEW_SUMMARY: NonNullable<
+  TerminalSyncEvidence["reviewSummary"]
+> = {
+  groups: [],
+  meta: {
+    sampledCount: 0,
+    cap: 50,
+    hasMore: false,
+    targetResolutionIncomplete: false,
+  },
+};
 
 const EMPTY_TERMINAL_SYNC_EVIDENCE: TerminalSyncEvidence = {
   latestEvent: null,
@@ -64,6 +78,30 @@ const EMPTY_TERMINAL_SYNC_EVIDENCE: TerminalSyncEvidence = {
   conflictedCount: 0,
   heldCount: 0,
   rejectedCount: 0,
+  reviewSummary: EMPTY_TERMINAL_SYNC_REVIEW_SUMMARY,
+};
+
+const UNKNOWN_OPERATIONAL_EXPLANATION: TerminalOperationalExplanation = {
+  blockingDomain: "none",
+  detail: "Terminal health evidence has not been collected yet.",
+  evidenceReferences: [],
+  headline: "Health unknown",
+  lane: "unknown",
+  nextStep: "Wait for terminal health evidence.",
+  primaryOwner: "none",
+  saleImpact: "unknown",
+  secondaryActions: [],
+  severity: "info",
+  summaryMeta: {
+    hasSecondarySafeRepair: false,
+    reviewBacklogCount: 0,
+    targetResolutionIncomplete: false,
+  },
+  supportAction: "none",
+};
+
+type TerminalHealthSummarySyncEvidence = TerminalSyncEvidence & {
+  reviewSummary: NonNullable<TerminalSyncEvidence["reviewSummary"]>;
 };
 
 export type TerminalHealthSummary = {
@@ -83,12 +121,13 @@ export type TerminalHealthSummary = {
     "_id" | "_creationTime" | "storeId" | "terminalId"
   > | null;
   attentionReasons: TerminalHealthAttentionReason[];
+  operationalExplanation: TerminalOperationalExplanation;
   recoveryPreview: TerminalRecoveryPreview | null;
   registerSessionLink: {
     registerSessionId: Id<"registerSession">;
     status: ActiveRegisterSessionLinkStatus;
   } | null;
-  syncEvidence: TerminalSyncEvidence;
+  syncEvidence: TerminalHealthSummarySyncEvidence;
 };
 
 type ActiveRegisterSessionLinkStatus = Extract<
@@ -171,10 +210,9 @@ async function buildTerminalHealthSummary(
     terminal: args.terminal,
   });
   const { runtimeStatus, registerSessionLink } = facts;
-  const syncEvidence = await annotateTerminalSyncEvidenceReviewTargets(ctx, {
-    storeId: args.terminal.storeId,
-    syncEvidence: facts.rawSyncEvidence,
-  });
+  const syncEvidence = normalizeTerminalSyncEvidenceReviewSummary(
+    facts.rawSyncEvidence,
+  );
   const runtimeAgeMs = runtimeStatus
     ? Math.max(0, args.now - runtimeStatus.receivedAt)
     : null;
@@ -188,20 +226,11 @@ async function buildTerminalHealthSummary(
         runtimeStatus,
         registerNumber: args.terminal.registerNumber,
         storeId: args.terminal.storeId,
-        syncEvidence,
+        syncEvidence: facts.rawSyncEvidence,
         terminalId: args.terminal._id,
         terminalStatus: args.terminal.status,
       })
     : null;
-  const resolvedAttentionReasons = await resolveAttentionReasonActionTargets(
-    ctx,
-    {
-      attentionReasons: operationalState?.attentionReasons ?? [],
-      storeId: args.terminal.storeId,
-      syncEvidence,
-      terminalId: args.terminal._id,
-    },
-  );
   const recoveryPreview = operationalState?.recoveryPreview ?? null;
 
   return {
@@ -219,7 +248,9 @@ async function buildTerminalHealthSummary(
     runtimeStatus: operationalState?.runtimeEvidence.effectiveStatus
       ? stripRuntimeStatusIdentity(operationalState.runtimeEvidence.effectiveStatus)
       : null,
-    attentionReasons: resolvedAttentionReasons,
+    attentionReasons: operationalState?.attentionReasons ?? [],
+    operationalExplanation:
+      operationalState?.operationalExplanation ?? UNKNOWN_OPERATIONAL_EXPLANATION,
     recoveryPreview,
     registerSessionLink,
     syncEvidence,
@@ -236,6 +267,16 @@ export async function previewTerminalRecovery(
 ) {
   const summary = await getTerminalHealthSummary(ctx, args);
   return summary?.recoveryPreview ?? null;
+}
+
+function normalizeTerminalSyncEvidenceReviewSummary(
+  syncEvidence: TerminalSyncEvidence,
+): TerminalHealthSummarySyncEvidence {
+  return {
+    ...syncEvidence,
+    reviewSummary:
+      syncEvidence.reviewSummary ?? EMPTY_TERMINAL_SYNC_REVIEW_SUMMARY,
+  };
 }
 
 async function buildTerminalRecoveryPreview(
@@ -286,7 +327,7 @@ async function buildTerminalOperationalStateForSummary(
     storeId: args.storeId,
     terminalId: args.terminalId,
   });
-  const operationalState = buildTerminalOperationalState({
+  const policyInput = {
     appUpdate: buildTerminalAppUpdatePreview({
       commandStatus,
       now: args.now,
@@ -307,9 +348,22 @@ async function buildTerminalOperationalStateForSummary(
     syncEvidence: args.syncEvidence,
     terminalId: args.terminalId,
     terminalStatus: args.terminalStatus,
-  });
+  } satisfies Parameters<typeof buildTerminalOperationalState>[0];
+  const operationalState = buildTerminalOperationalState(policyInput);
+  const resolvedAttentionReasons = await resolveAttentionReasonActionTargets(
+    ctx,
+    {
+      attentionReasons: operationalState.attentionReasons,
+      storeId: args.storeId,
+      syncEvidence: args.syncEvidence,
+      terminalId: args.terminalId,
+    },
+  );
 
-  return operationalState;
+  return buildTerminalOperationalState({
+    ...policyInput,
+    attentionReasons: resolvedAttentionReasons,
+  });
 }
 
 function buildTerminalAppUpdatePreview(args: {
@@ -980,75 +1034,6 @@ function getAttentionReasonActionTarget(
     case "sync_unavailable":
       return { type: "pos_register" };
   }
-}
-
-async function annotateTerminalSyncEvidenceReviewTargets(
-  ctx: QueryCtx,
-  args: {
-    storeId: Id<"store">;
-    syncEvidence: TerminalSyncEvidence;
-  },
-): Promise<TerminalSyncEvidence> {
-  const unresolvedConflicts = args.syncEvidence.unresolvedConflicts ?? [];
-  const inventoryConflictLocalEventIds = new Set(
-    unresolvedConflicts
-      .filter((conflict) => conflict.conflictType === "inventory")
-      .map((conflict) => conflict.localEventId),
-  );
-  if (
-    inventoryConflictLocalEventIds.size === 0 ||
-    !ctx.db ||
-    typeof ctx.db.query !== "function"
-  ) {
-    return args.syncEvidence;
-  }
-
-  const workItems = await ctx.db
-    .query("operationalWorkItem")
-    .withIndex("by_storeId_type", (q) =>
-      q
-        .eq("storeId", args.storeId)
-        .eq("type", "synced_sale_inventory_review"),
-    )
-    .take(200);
-  const openWorkItemByLocalEventId = new Map<
-    string,
-    Doc<"operationalWorkItem">
-  >();
-  for (const workItem of workItems) {
-    if (workItem.status !== "open") {
-      continue;
-    }
-    const localEventId = workItem.metadata?.localEventId;
-    if (
-      typeof localEventId === "string" &&
-      inventoryConflictLocalEventIds.has(localEventId)
-    ) {
-      openWorkItemByLocalEventId.set(localEventId, workItem);
-    }
-  }
-
-  if (openWorkItemByLocalEventId.size === 0) {
-    return args.syncEvidence;
-  }
-
-  return {
-    ...args.syncEvidence,
-    unresolvedConflicts: unresolvedConflicts.map((conflict) => {
-      const workItem = openWorkItemByLocalEventId.get(conflict.localEventId);
-      if (!workItem || conflict.conflictType !== "inventory") {
-        return conflict;
-      }
-      return {
-        ...conflict,
-        reviewTarget: {
-          type: "open_work" as const,
-          workItemId: workItem._id,
-          workItemType: "synced_sale_inventory_review" as const,
-        },
-      };
-    }),
-  };
 }
 
 function stripRuntimeStatusIdentity(status: Doc<"posTerminalRuntimeStatus">) {

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { Doc, Id } from "../../../_generated/dataModel";
 import type { QueryCtx } from "../../../_generated/server";
+import { TERMINAL_SYNC_REVIEW_SUMMARY_CAP } from "../../infrastructure/repositories/terminalRepository";
 import { collectTerminalOperationalFacts } from "./collectTerminalOperationalFacts";
 
 const now = 2_000_000;
@@ -127,6 +128,22 @@ describe("collectTerminalOperationalFacts", () => {
     expect(facts.rawSyncEvidence.unresolvedConflicts?.[0]?._id).toBe(
       "conflict-1",
     );
+    expect(facts.rawSyncEvidence.reviewSummary).toEqual({
+      groups: [
+        expect.objectContaining({
+          actionability: "manual_review",
+          conflictType: "inventory",
+          count: 1,
+          owner: "manual_review",
+        }),
+      ],
+      meta: {
+        cap: TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
+        hasMore: false,
+        sampledCount: 1,
+        targetResolutionIncomplete: false,
+      },
+    });
   });
 });
 
@@ -296,6 +313,15 @@ function emptySyncEvidence() {
     rejectedCount: 0,
     unresolvedConflictCount: 0,
     unresolvedConflicts: [],
+    reviewSummary: {
+      groups: [],
+      meta: {
+        cap: TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
+        hasMore: false,
+        sampledCount: 0,
+        targetResolutionIncomplete: false,
+      },
+    },
   };
 }
 

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts
@@ -75,11 +75,10 @@ describe("terminal operational state policy", () => {
       cloudRepair: {
         preconditionHash: "hash",
         safeConflictIds: ["conflict-1" as Id<"posLocalSyncConflict">],
-        skippedConflictIds: [],
+        skippedConflictIds: ["conflict-unsafe" as Id<"posLocalSyncConflict">],
       },
       syncEvidence: {
         ...emptySyncEvidence(),
-        heldCount: 1,
         latestEvent: {
           eventType: "sale_completed",
           localEventId: "local-held",
@@ -89,6 +88,36 @@ describe("terminal operational state policy", () => {
           status: "held",
           submittedAt: 1_999_000,
         },
+        reviewSummary: {
+          groups: [
+            {
+              actionability: "manual_review",
+              conflictType: "payment",
+              count: 1,
+              latestCreatedAt: 1_999_000,
+              latestSequence: 12,
+              owner: "manual_review",
+            },
+          ],
+          meta: {
+            cap: 20,
+            hasMore: false,
+            sampledCount: 1,
+            targetResolutionIncomplete: false,
+          },
+        },
+        unresolvedConflictCount: 1,
+        unresolvedConflicts: [
+          {
+            _id: "conflict-held" as Id<"posLocalSyncConflict">,
+            conflictType: "payment",
+            createdAt: 1_999_000,
+            localEventId: "local-held",
+            localRegisterSessionId: "local-register-1",
+            sequence: 12,
+            summary: "A synced event was rejected by the server.",
+          },
+        ],
       },
       runtimeStatus: buildRuntimeStatus({
         sync: {
@@ -105,6 +134,145 @@ describe("terminal operational state policy", () => {
     expect(buildTerminalOperationalState(input).recoveryPreview.readiness).toBe(
       "needs_manual_review",
     );
+  });
+
+  it("explains sale-ready review backlog without implying cashier blocking", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        runtimeStatus: buildRuntimeStatus({
+          activeRegisterSession: {
+            localRegisterSessionId: "local-register-1",
+            observedAt: 1_999_000,
+            openedAt: 1_980_000,
+            status: "open",
+          },
+          saleAuthority: {
+            observedAt: 1_999_000,
+            status: "ready",
+            transactionMode: "products_and_services",
+          },
+        }),
+        syncEvidence: {
+          ...emptySyncEvidence(),
+          conflictedCount: 1,
+          unresolvedConflictCount: 1,
+          unresolvedConflicts: [
+            {
+              _id: "conflict-1" as Id<"posLocalSyncConflict">,
+              conflictType: "inventory",
+              createdAt: 1_999_000,
+              localEventId: "local-event-1",
+              localRegisterSessionId: "local-register-1",
+              reviewTarget: {
+                type: "open_work",
+                workItemId: "work-item-1" as Id<"operationalWorkItem">,
+                workItemType: "synced_sale_inventory_review",
+              },
+              sequence: 26,
+              summary: "Inventory needs manager review for a synced offline sale.",
+            },
+          ],
+          reviewSummary: {
+            groups: [
+              {
+                actionability: "open_work_review",
+                conflictType: "inventory",
+                count: 1,
+                latestCreatedAt: 1_999_000,
+                latestSequence: 26,
+                owner: "operations_open_work",
+                reviewTarget: {
+                  type: "open_work",
+                  workItemId: "work-item-1" as Id<"operationalWorkItem">,
+                  workItemType: "synced_sale_inventory_review",
+                },
+              },
+            ],
+            meta: {
+              cap: 20,
+              hasMore: false,
+              sampledCount: 1,
+              targetResolutionIncomplete: false,
+            },
+          },
+        },
+      }),
+    );
+
+    expect(state.salesReadiness).toBe("able_to_transact_now");
+    expect(state.operationalExplanation).toMatchObject({
+      headline: "Review needed. Sales can continue.",
+      lane: "sale_ready_with_review_backlog",
+      primaryOwner: "operations",
+      saleImpact: "can_transact_now",
+      supportAction: "manual_review",
+    });
+    expect(state.recoveryPreview.readiness).toBe("able_to_transact_now");
+  });
+
+  it("treats local runtime review as terminal sync retry instead of manual business review", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        runtimeStatus: buildRuntimeStatus({
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 0,
+            pendingEventCount: 1,
+            reviewEventCount: 1,
+            status: "needs_review",
+            uploadableEventCount: 1,
+          },
+        }),
+      }),
+    );
+
+    expect(state.recoveryEvidence.manualReview).toEqual([]);
+    expect(state.recoveryPreview.readiness).toBe("needs_terminal_action");
+    expect(state.operationalExplanation).toMatchObject({
+      lane: "needs_terminal_action",
+      primaryOwner: "terminal",
+      supportAction: "terminal_sync_retry",
+    });
+  });
+
+  it("keeps safe cloud repair secondary when manual review is primary", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        cloudRepair: {
+          preconditionHash: "hash",
+          safeConflictIds: ["safe-conflict" as Id<"posLocalSyncConflict">],
+          skippedConflictIds: ["unsafe-conflict" as Id<"posLocalSyncConflict">],
+        },
+      }),
+    );
+
+    expect(state.recoveryPreview.readiness).toBe("needs_manual_review");
+    expect(state.operationalExplanation).toMatchObject({
+      lane: "needs_manual_review",
+      supportAction: "manual_review",
+    });
+    expect(state.operationalExplanation.secondaryActions).toContainEqual({
+      label: "Safe cloud repair available",
+      primaryOwner: "support",
+      supportAction: "safe_cloud_repair",
+    });
+  });
+
+  it("explains stale runtime without creating a cloud repair lane", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        runtimeAgeMs: 16 * 60 * 1_000,
+        runtimeFresh: false,
+      }),
+    );
+
+    expect(state.terminalHealth).toBe("offline");
+    expect(state.supportRecovery).toBeNull();
+    expect(state.operationalExplanation).toMatchObject({
+      headline: "Waiting for check-in",
+      lane: "stale_runtime",
+      supportAction: "wait_for_check_in",
+    });
   });
 
   it("classifies safe cloud repair when no manual review or terminal action exists", () => {
@@ -201,12 +369,12 @@ describe("terminal operational state policy", () => {
     ).toBe("offline");
   });
 
-  it("derives attention reasons inside the aggregate policy", () => {
+  it("derives cloud attention from unresolved review summary instead of historical event status", () => {
     const state = buildTerminalOperationalState(
       baseInput({
         syncEvidence: {
           ...emptySyncEvidence(),
-          conflictedCount: 1,
+          conflictedCount: 2,
           latestEvent: {
             eventType: "sale_completed",
             localEventId: "local-conflicted",
@@ -215,6 +383,24 @@ describe("terminal operational state policy", () => {
             sequence: 7,
             status: "conflicted",
             submittedAt: 1_999_000,
+          },
+          reviewSummary: {
+            groups: [
+              {
+                actionability: "manual_review",
+                conflictType: "payment",
+                count: 1,
+                latestCreatedAt: 1_999_000,
+                latestSequence: 7,
+                owner: "manual_review",
+              },
+            ],
+            meta: {
+              cap: 20,
+              hasMore: false,
+              sampledCount: 1,
+              targetResolutionIncomplete: false,
+            },
           },
         },
       }),
@@ -229,6 +415,94 @@ describe("terminal operational state policy", () => {
       }),
     );
     expect(state.terminalHealth).toBe("needs_attention");
+  });
+
+  it("does not treat closed historical sync event statuses as current review backlog", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        syncEvidence: {
+          ...emptySyncEvidence(),
+          conflictedCount: 3,
+          heldCount: 1,
+          latestEvent: {
+            eventType: "sale_completed",
+            localEventId: "local-resolved",
+            localRegisterSessionId: "local-register-1",
+            occurredAt: 1_999_000,
+            sequence: 9,
+            status: "conflicted",
+            submittedAt: 1_999_000,
+          },
+          reviewSummary: {
+            groups: [],
+            meta: {
+              cap: 20,
+              hasMore: false,
+              sampledCount: 0,
+              targetResolutionIncomplete: false,
+            },
+          },
+          unresolvedConflictCount: 0,
+          unresolvedConflicts: [],
+        },
+      }),
+    );
+
+    expect(state.attentionReasons).toEqual([]);
+    expect(state.recoveryEvidence.manualReview).toEqual([]);
+    expect(state.terminalHealth).toBe("online");
+  });
+
+  it("explains current review backlog even when the terminal is not sale-ready", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        runtimeStatus: buildRuntimeStatus({
+          activeRegisterSession: undefined,
+          saleAuthority: undefined,
+        }),
+        syncEvidence: {
+          ...emptySyncEvidence(),
+          reviewSummary: {
+            groups: [
+              {
+                actionability: "manual_review",
+                conflictType: "permission",
+                count: 1,
+                latestCreatedAt: 1_999_000,
+                latestSequence: 14,
+                owner: "manual_review",
+              },
+            ],
+            meta: {
+              cap: 20,
+              hasMore: false,
+              sampledCount: 1,
+              targetResolutionIncomplete: false,
+            },
+          },
+          unresolvedConflictCount: 1,
+          unresolvedConflicts: [
+            {
+              _id: "conflict-review" as Id<"posLocalSyncConflict">,
+              conflictType: "permission",
+              createdAt: 1_999_000,
+              localEventId: "event-review",
+              localRegisterSessionId: "local-register-1",
+              sequence: 14,
+              summary: "A synced register event needs permission review.",
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(state.salesReadiness).toBe("healthy_idle");
+    expect(state.operationalExplanation).toMatchObject({
+      headline: "Review needed",
+      lane: "needs_manual_review",
+      saleImpact: "not_ready",
+      supportAction: "manual_review",
+    });
   });
 
   it("clears cleanly closed drawer authority inside the aggregate policy", () => {

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts
@@ -11,6 +11,7 @@ import type { TerminalOperationalPolicyInput } from "./types";
 
 const storeId = "store-1" as Id<"store">;
 const terminalId = "terminal-1" as Id<"posTerminal">;
+const now = 2_000_000;
 
 describe("terminal operational state policy", () => {
   it("keeps sales readiness distinct from support recovery", () => {
@@ -210,7 +211,7 @@ describe("terminal operational state policy", () => {
     expect(state.recoveryPreview.readiness).toBe("able_to_transact_now");
   });
 
-  it("treats local runtime review as terminal sync retry instead of manual business review", () => {
+  it("treats local runtime review as terminal-local evidence collection instead of manual business review", () => {
     const state = buildTerminalOperationalState(
       baseInput({
         runtimeStatus: buildRuntimeStatus({
@@ -229,9 +230,350 @@ describe("terminal operational state policy", () => {
     expect(state.recoveryEvidence.manualReview).toEqual([]);
     expect(state.recoveryPreview.readiness).toBe("needs_terminal_action");
     expect(state.operationalExplanation).toMatchObject({
+      headline: "Local review collection needed",
       lane: "needs_terminal_action",
       primaryOwner: "terminal",
-      supportAction: "terminal_sync_retry",
+      supportAction: "terminal_command",
+    });
+    expect(state.recoveryPreview.terminalActions[0]).toMatchObject({
+      commandType: "collect_local_review",
+      expectedEvidence: { localReviewDetailsCollected: true },
+    });
+  });
+
+  it("keeps local runtime collection available when verified collection did not clear latest runtime review", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        commandStatus: {
+          commandId: "command-collect-review" as Id<"posTerminalRecoveryCommand">,
+          commandType: "collect_local_review",
+          label: "Collect local review items",
+          status: "completed",
+          verificationStatus: "verified",
+        },
+        runtimeStatus: buildRuntimeStatus({
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 0,
+            pendingEventCount: 1,
+            reviewEventCount: 84,
+            status: "needs_review",
+            uploadableEventCount: 1,
+          },
+        }),
+      }),
+    );
+
+    expect(state.recoveryEvidence.terminalActions[0]).toMatchObject({
+      commandType: "collect_local_review",
+      expectedEvidence: { localReviewDetailsCollected: true },
+    });
+    expect(state.recoveryPreview.terminalActions[0]).toMatchObject({
+      commandType: "collect_local_review",
+      expectedEvidence: { localReviewDetailsCollected: true },
+    });
+    expect(state.recoveryPreview.commandStatus).toMatchObject({
+      commandType: "collect_local_review",
+      verificationStatus: "verified",
+    });
+  });
+
+  it("offers local review cleanup from matching collected terminal evidence", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        commandStatus: {
+          commandId: "command-collect-review" as Id<"posTerminalRecoveryCommand">,
+          commandType: "collect_local_review",
+          label: "Collect local review items",
+          localReviewEvents: [
+            {
+              createdAt: now - 1_000,
+              localEventId: "event-review-1",
+              sequence: 12,
+              status: "needs_review",
+              type: "transaction.completed",
+              uploaded: true,
+              uploadSequence: 12,
+            },
+            {
+              createdAt: now - 500,
+              localEventId: "event-review-2",
+              sequence: 13,
+              status: "needs_review",
+              type: "register.closeout_started",
+              uploaded: true,
+              uploadSequence: 13,
+            },
+          ],
+          status: "completed",
+          verificationStatus: "verified",
+        },
+        runtimeStatus: buildRuntimeStatus({
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 2,
+            reviewEvents: [
+              {
+                createdAt: now - 1_000,
+                localEventId: "event-review-1",
+                sequence: 12,
+                status: "needs_review",
+                type: "transaction.completed",
+                uploaded: true,
+                uploadSequence: 12,
+              },
+              {
+                createdAt: now - 500,
+                localEventId: "event-review-2",
+                sequence: 13,
+                status: "needs_review",
+                type: "register.closeout_started",
+                uploaded: true,
+                uploadSequence: 13,
+              },
+            ],
+            status: "needs_review",
+            uploadableEventCount: 0,
+          },
+        }),
+      }),
+    );
+
+    expect(state.recoveryEvidence.terminalActions[0]).toMatchObject({
+      commandContext: {
+        expectedBlockerType: "local_review",
+        localReviewEventIds: ["event-review-1", "event-review-2"],
+      },
+      commandType: "clear_local_review_items",
+      expectedEvidence: {
+        localReviewClearedEventIds: ["event-review-1", "event-review-2"],
+        localReviewEventCount: 0,
+      },
+    });
+  });
+
+  it("requires fresh runtime ids before clearing collected local review evidence", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        commandStatus: {
+          commandId: "command-collect-review" as Id<"posTerminalRecoveryCommand">,
+          commandType: "collect_local_review",
+          label: "Collect local review items",
+          localReviewEvents: [
+            {
+              createdAt: now - 1_000,
+              localEventId: "event-review-1",
+              sequence: 12,
+              status: "needs_review",
+              type: "transaction.completed",
+              uploaded: true,
+              uploadSequence: 12,
+            },
+          ],
+          status: "completed",
+          verificationStatus: "verified",
+        },
+        runtimeStatus: buildRuntimeStatus({
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 1,
+            reviewEvents: [],
+            status: "needs_review",
+            uploadableEventCount: 0,
+          },
+        }),
+      }),
+    );
+
+    expect(state.recoveryEvidence.terminalActions[0]).toMatchObject({
+      commandType: "collect_local_review",
+      expectedEvidence: { localReviewDetailsCollected: true },
+    });
+  });
+
+  it("does not use stale collected local review evidence when runtime ids differ", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        commandStatus: {
+          commandId: "command-collect-review" as Id<"posTerminalRecoveryCommand">,
+          commandType: "collect_local_review",
+          label: "Collect local review items",
+          localReviewEvents: [
+            {
+              createdAt: now - 1_000,
+              localEventId: "stale-review-1",
+              sequence: 12,
+              status: "needs_review",
+              type: "transaction.completed",
+              uploaded: true,
+              uploadSequence: 12,
+            },
+          ],
+          status: "completed",
+          verificationStatus: "verified",
+        },
+        runtimeStatus: buildRuntimeStatus({
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 1,
+            reviewEvents: [
+              {
+                createdAt: now - 500,
+                localEventId: "current-review-1",
+                sequence: 13,
+                status: "needs_review",
+                type: "register.closeout_started",
+                uploaded: true,
+                uploadSequence: 13,
+              },
+            ],
+            status: "needs_review",
+            uploadableEventCount: 0,
+          },
+        }),
+      }),
+    );
+
+    expect(state.recoveryEvidence.terminalActions[0]).toMatchObject({
+      commandContext: {
+        localReviewEventIds: ["current-review-1"],
+      },
+      commandType: "clear_local_review_items",
+      expectedEvidence: {
+        localReviewClearedEventIds: ["current-review-1"],
+        localReviewEventCount: 0,
+      },
+    });
+  });
+
+  it("offers local review cleanup when all local review items were uploaded and reported", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        runtimeStatus: buildRuntimeStatus({
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 2,
+            reviewEvents: [
+              {
+                createdAt: now - 1_000,
+                localEventId: "event-review-1",
+                sequence: 12,
+                status: "needs_review",
+                type: "transaction.completed",
+                uploaded: true,
+                uploadSequence: 12,
+              },
+              {
+                createdAt: now - 500,
+                localEventId: "event-review-2",
+                sequence: 13,
+                status: "needs_review",
+                type: "register.closeout_started",
+                uploaded: true,
+                uploadSequence: 13,
+              },
+            ],
+            status: "needs_review",
+            uploadableEventCount: 0,
+          },
+        }),
+      }),
+    );
+
+    expect(state.recoveryEvidence.terminalActions[0]).toMatchObject({
+      commandContext: {
+        expectedBlockerType: "local_review",
+        localReviewEventIds: ["event-review-1", "event-review-2"],
+      },
+      commandType: "clear_local_review_items",
+      expectedEvidence: {
+        localReviewClearedEventIds: ["event-review-1", "event-review-2"],
+        localReviewEventCount: 0,
+      },
+    });
+    expect(state.recoveryPreview.terminalActions[0]).toMatchObject({
+      commandType: "clear_local_review_items",
+    });
+  });
+
+  it("offers a 100-item local review cleanup batch for over-cap review backlogs", () => {
+    const reviewEvents = Array.from({ length: 100 }, (_, index) => ({
+      createdAt: now - index,
+      localEventId: `event-review-${index + 1}`,
+      sequence: index + 1,
+      status: "needs_review" as const,
+      type: "transaction.completed",
+      uploaded: true,
+      uploadSequence: index + 1,
+    }));
+
+    const state = buildTerminalOperationalState(
+      baseInput({
+        runtimeStatus: buildRuntimeStatus({
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 101,
+            reviewEvents,
+            status: "needs_review",
+            uploadableEventCount: 0,
+          },
+        }),
+      }),
+    );
+
+    expect(state.recoveryEvidence.terminalActions[0]).toMatchObject({
+      commandContext: {
+        localReviewEventIds: reviewEvents.map((event) => event.localEventId),
+      },
+      commandType: "clear_local_review_items",
+      expectedEvidence: {
+        localReviewClearedEventIds: reviewEvents.map(
+          (event) => event.localEventId,
+        ),
+        localReviewEventCount: 1,
+      },
+    });
+  });
+
+  it("keeps collecting local review evidence when any reported local review item was not uploaded", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        runtimeStatus: buildRuntimeStatus({
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 1,
+            reviewEvents: [
+              {
+                createdAt: now - 1_000,
+                localEventId: "event-review-1",
+                sequence: 12,
+                status: "needs_review",
+                type: "transaction.completed",
+                uploadSequence: 12,
+              },
+            ],
+            status: "needs_review",
+            uploadableEventCount: 0,
+          },
+        }),
+      }),
+    );
+
+    expect(state.recoveryEvidence.terminalActions[0]).toMatchObject({
+      commandType: "collect_local_review",
+      expectedEvidence: { localReviewDetailsCollected: true },
     });
   });
 

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.ts
@@ -2,8 +2,10 @@ import {
   isRegisterSessionReplacementBlocking,
   isRegisterSessionSaleUsable,
 } from "../../../../shared/registerSessionLifecyclePolicy";
+import type { TerminalSyncReviewSummaryGroup } from "../../domain/terminalSyncEvidence";
 import type {
   TerminalHealthAttentionReason,
+  TerminalOperationalExplanation,
   TerminalOperationalPolicyInput,
   TerminalOperationalState,
   TerminalSalesReadiness,
@@ -33,10 +35,12 @@ export function buildTerminalOperationalState(
   const cloudRegisterSessionSaleUsable = input.latestRegisterSession
     ? isRegisterSessionSaleUsable(input.latestRegisterSession)
     : undefined;
-  const attentionReasons = deriveTerminalHealthAttentionReasons({
-    ...input,
-    runtimeStatus: effectiveRuntimeStatus,
-  });
+  const attentionReasons =
+    input.attentionReasons ??
+    deriveTerminalHealthAttentionReasons({
+      ...input,
+      runtimeStatus: effectiveRuntimeStatus,
+    });
   const terminalActions = buildTerminalRecoveryActions({
     runtimeStatus: effectiveRuntimeStatus,
   });
@@ -75,11 +79,28 @@ export function buildTerminalOperationalState(
     runtimeStatus: effectiveRuntimeStatus,
     terminalStatus: input.terminalStatus,
   });
+  const operationalExplanation = buildTerminalOperationalExplanation({
+    attentionReasons,
+    cloudRepair: input.cloudRepair,
+    diagnosticEvidence,
+    recoveryEvidence: {
+      cloudRepair: input.cloudRepair,
+      manualReview,
+      terminalActions,
+    },
+    runtimeFresh: input.runtimeFresh,
+    runtimeStatus: effectiveRuntimeStatus,
+    salesReadiness,
+    supportRecovery,
+    syncEvidence: input.syncEvidence,
+    terminalHealth,
+  });
 
   return {
     appUpdateEvidence: input.appUpdate,
     attentionReasons,
     diagnosticEvidence,
+    operationalExplanation,
     recoveryEvidence: {
       cloudRepair: input.cloudRepair,
       commandStatus: input.commandStatus,
@@ -243,34 +264,45 @@ export function deriveTerminalHealthAttentionReasons(
     });
   }
 
-  const inventoryReviewCount =
-    input.syncEvidence.unresolvedConflicts?.filter(
-      (conflict) =>
-        conflict.conflictType === "inventory" &&
-        conflict.reviewTarget?.workItemType ===
-          "synced_sale_inventory_review",
-    ).length ?? 0;
+  const currentReviewGroups = getCurrentReviewGroups(input.syncEvidence);
+  const inventoryReviewGroups = currentReviewGroups.filter(
+    (group) => isInventoryReviewGroup(group, !!input.syncEvidence.reviewSummary),
+  );
+  const inventoryReviewCount = sumReviewGroupCounts(inventoryReviewGroups);
 
   if (inventoryReviewCount > 0) {
-    reasons.push({
+    const inventoryReviewTarget = inventoryReviewGroups.find(
+      (group) => group.reviewTarget,
+    )?.reviewTarget;
+    const latestInventoryReviewSequence =
+      latestReviewGroupSequence(inventoryReviewGroups) ?? latestEvent?.sequence;
+    const reason: TerminalHealthAttentionReason = {
       count: inventoryReviewCount,
-      latestEventSequence: latestEvent?.sequence,
+      latestEventSequence: latestInventoryReviewSequence,
       latestEventStatus: latestEvent?.status,
       source: "cloud_sync",
       summary: `${inventoryReviewCount} inventory review item${inventoryReviewCount === 1 ? " needs" : "s need"} attention.`,
       type: "synced_sale_inventory_review",
-    });
+    };
+    if (inventoryReviewTarget) {
+      reason.actionTarget = {
+        label: "Inventory review",
+        type: "open_work",
+      };
+    }
+    reasons.push(reason);
   }
 
-  const conflictedCount = Math.max(
-    0,
-    input.syncEvidence.conflictedCount - inventoryReviewCount,
+  const cloudReviewGroups = currentReviewGroups.filter(
+    (group) => !isInventoryReviewGroup(group, !!input.syncEvidence.reviewSummary),
   );
+  const conflictedCount = sumReviewGroupCounts(cloudReviewGroups);
 
   if (conflictedCount > 0) {
     reasons.push({
       count: conflictedCount,
-      latestEventSequence: latestEvent?.sequence,
+      latestEventSequence:
+        latestReviewGroupSequence(cloudReviewGroups) ?? latestEvent?.sequence,
       latestEventStatus: latestEvent?.status,
       source: "cloud_sync",
       summary: `${conflictedCount} cloud sync conflict${conflictedCount === 1 ? " needs" : "s need"} review.`,
@@ -278,29 +310,95 @@ export function deriveTerminalHealthAttentionReasons(
     });
   }
 
-  if (input.syncEvidence.heldCount > 0) {
-    reasons.push({
-      count: input.syncEvidence.heldCount,
-      latestEventSequence: latestEvent?.sequence,
-      latestEventStatus: latestEvent?.status,
-      source: "cloud_sync",
-      summary: `${input.syncEvidence.heldCount} synced item${input.syncEvidence.heldCount === 1 ? " is" : "s are"} held before projection.`,
-      type: "cloud_held",
-    });
-  }
-
-  if (input.syncEvidence.rejectedCount > 0) {
-    reasons.push({
-      count: input.syncEvidence.rejectedCount,
-      latestEventSequence: latestEvent?.sequence,
-      latestEventStatus: latestEvent?.status,
-      source: "cloud_sync",
-      summary: `${input.syncEvidence.rejectedCount} synced item${input.syncEvidence.rejectedCount === 1 ? " was" : "s were"} rejected by the server.`,
-      type: "cloud_rejected",
-    });
+  if (!input.syncEvidence.reviewSummary && currentReviewGroups.length === 0) {
+    if (input.syncEvidence.conflictedCount > 0) {
+      reasons.push({
+        count: input.syncEvidence.conflictedCount,
+        latestEventSequence: latestEvent?.sequence,
+        latestEventStatus: latestEvent?.status,
+        source: "cloud_sync",
+        summary: `${input.syncEvidence.conflictedCount} cloud sync conflict${input.syncEvidence.conflictedCount === 1 ? " needs" : "s need"} review.`,
+        type: "cloud_conflict",
+      });
+    }
+    if (input.syncEvidence.heldCount > 0) {
+      reasons.push({
+        count: input.syncEvidence.heldCount,
+        latestEventSequence: latestEvent?.sequence,
+        latestEventStatus: latestEvent?.status,
+        source: "cloud_sync",
+        summary: `${input.syncEvidence.heldCount} synced item${input.syncEvidence.heldCount === 1 ? " is" : "s are"} held before projection.`,
+        type: "cloud_held",
+      });
+    }
+    if (input.syncEvidence.rejectedCount > 0) {
+      reasons.push({
+        count: input.syncEvidence.rejectedCount,
+        latestEventSequence: latestEvent?.sequence,
+        latestEventStatus: latestEvent?.status,
+        source: "cloud_sync",
+        summary: `${input.syncEvidence.rejectedCount} synced item${input.syncEvidence.rejectedCount === 1 ? " was" : "s were"} rejected by the server.`,
+        type: "cloud_rejected",
+      });
+    }
   }
 
   return reasons;
+}
+
+function getCurrentReviewGroups(
+  syncEvidence: TerminalOperationalPolicyInput["syncEvidence"],
+): TerminalSyncReviewSummaryGroup[] {
+  if (syncEvidence.reviewSummary) {
+    return syncEvidence.reviewSummary.groups;
+  }
+
+  return (syncEvidence.unresolvedConflicts ?? []).map((conflict) => ({
+    ...(conflict.reviewTarget
+      ? {
+          actionability: "open_work_review" as const,
+          owner: "operations_open_work" as const,
+          reviewTarget: conflict.reviewTarget,
+        }
+      : {
+          actionability: "manual_review" as const,
+          owner: "manual_review" as const,
+        }),
+    conflictType: conflict.conflictType,
+    count: 1,
+    latestCreatedAt: conflict.createdAt,
+    latestSequence: conflict.sequence,
+  }));
+}
+
+function sumReviewGroupCounts(groups: TerminalSyncReviewSummaryGroup[]) {
+  return groups.reduce((total, group) => total + group.count, 0);
+}
+
+function latestReviewGroupSequence(groups: TerminalSyncReviewSummaryGroup[]) {
+  return groups.reduce<number | undefined>(
+    (latest, group) =>
+      latest === undefined
+        ? group.latestSequence
+        : Math.max(latest, group.latestSequence),
+    undefined,
+  );
+}
+
+function isInventoryReviewGroup(
+  group: TerminalSyncReviewSummaryGroup,
+  hasRepositoryReviewSummary: boolean,
+) {
+  if (group.conflictType !== "inventory") {
+    return false;
+  }
+  if (!hasRepositoryReviewSummary) {
+    return true;
+  }
+  return (
+    group.actionability === "open_work_review" ||
+    group.actionability === "diagnostic_only"
+  );
 }
 
 export function classifySupportRecovery(
@@ -362,7 +460,6 @@ export function classifySalesReadiness(
   input: TerminalSalesReadinessInput,
 ): TerminalSalesReadiness {
   if (
-    input.healthyIdle &&
     input.activeRegisterSession &&
     input.saleAuthorityReady &&
     input.cloudRegisterSessionSaleUsable !== false
@@ -518,8 +615,7 @@ function buildTerminalRecoveryManualReview(args: {
     args.attentionReasons
       .filter((reason) =>
         reason.type === "cloud_held" ||
-        reason.type === "cloud_rejected" ||
-        reason.type === "local_review",
+        reason.type === "cloud_rejected",
       )
       .map((reason) => ({
         reason: reason.summary,
@@ -535,6 +631,316 @@ function buildTerminalRecoveryManualReview(args: {
     });
   }
   return manual;
+}
+
+function buildTerminalOperationalExplanation(args: {
+  attentionReasons: TerminalHealthAttentionReason[];
+  cloudRepair: TerminalOperationalPolicyInput["cloudRepair"];
+  diagnosticEvidence: TerminalOperationalState["diagnosticEvidence"];
+  recoveryEvidence: Pick<
+    TerminalOperationalState["recoveryEvidence"],
+    "cloudRepair" | "manualReview" | "terminalActions"
+  >;
+  runtimeFresh: boolean;
+  runtimeStatus: TerminalOperationalPolicyInput["runtimeStatus"];
+  salesReadiness: TerminalSalesReadiness;
+  supportRecovery: TerminalSupportRecovery;
+  syncEvidence: TerminalOperationalPolicyInput["syncEvidence"];
+  terminalHealth: TerminalOperationalState["terminalHealth"];
+}): TerminalOperationalExplanation {
+  const reviewBacklogReasons = args.attentionReasons.filter(isReviewBacklogReason);
+  const reviewBacklogCount = reviewBacklogReasons.reduce(
+    (total, reason) => total + (reason.count ?? 1),
+    0,
+  );
+  const targetResolutionIncomplete =
+    args.syncEvidence.reviewSummary?.meta.targetResolutionIncomplete ?? false;
+  const evidenceReferences = [
+    ...args.attentionReasons.map((reason) =>
+      buildExplanationEvidenceReference({
+        count: reason.count,
+        source: reason.source,
+        summary: reason.summary,
+        type: reason.type,
+      }),
+    ),
+    ...args.diagnosticEvidence.map((diagnostic) => ({
+      source: diagnostic.source,
+      summary: diagnostic.summary,
+      type: "diagnostic" as const,
+    })),
+  ];
+  const safeRepairSecondaryAction =
+    args.cloudRepair.safeConflictIds.length > 0 &&
+    args.supportRecovery?.status !== "needs_cloud_repair"
+      ? {
+          label: "Safe cloud repair available",
+          primaryOwner: "support" as const,
+          supportAction: "safe_cloud_repair" as const,
+        }
+      : null;
+  const secondaryActions = safeRepairSecondaryAction
+    ? [safeRepairSecondaryAction]
+    : [];
+
+  if (
+    reviewBacklogReasons.length > 0 &&
+    !args.supportRecovery
+  ) {
+    const saleReady = args.salesReadiness === "able_to_transact_now";
+    return {
+      blockingDomain: "sync_review",
+      detail:
+        targetResolutionIncomplete
+          ? "Review-owned sync work needs attention, but the exact owner was capped while this terminal remains sale-ready."
+          : saleReady
+            ? "Review-owned sync work needs attention, but this terminal has fresh sale authority."
+            : "Review-owned sync work needs attention before terminal health is clear.",
+      evidenceReferences,
+      headline: saleReady
+        ? "Review needed. Sales can continue."
+        : "Review needed",
+      lane: saleReady ? "sale_ready_with_review_backlog" : "needs_manual_review",
+      nextStep: targetResolutionIncomplete
+        ? "Use Operations or Cash Controls review workspaces to locate the backlog."
+        : "Use the linked review workspace to clear the backlog.",
+      primaryOwner: resolveReviewBacklogOwner(
+        reviewBacklogReasons,
+        targetResolutionIncomplete,
+      ),
+      saleImpact: saleImpactForReadiness(args.salesReadiness),
+      secondaryActions,
+      severity: saleReady ? "warning" : "critical",
+      summaryMeta: {
+        hasSecondarySafeRepair: !!safeRepairSecondaryAction,
+        reviewBacklogCount,
+        targetResolutionIncomplete,
+      },
+      supportAction: "manual_review",
+    };
+  }
+
+  if (args.supportRecovery?.status === "needs_manual_review") {
+    return {
+      blockingDomain: "manual_review",
+      detail:
+        "Manual review must finish before support repairs this terminal.",
+      evidenceReferences,
+      headline: "Manager review needed",
+      lane: "needs_manual_review",
+      nextStep: "Use the linked review workspace before running support repair.",
+      primaryOwner: "manager",
+      saleImpact: saleImpactForReadiness(args.salesReadiness),
+      secondaryActions,
+      severity: "critical",
+      summaryMeta: {
+        hasSecondarySafeRepair: !!safeRepairSecondaryAction,
+        reviewBacklogCount,
+        targetResolutionIncomplete,
+      },
+      supportAction: "manual_review",
+    };
+  }
+
+  if (args.supportRecovery?.status === "needs_terminal_action") {
+    const retryOnly = args.recoveryEvidence.terminalActions.every(
+      (action) => action.commandType === "retry_sync",
+    );
+    return {
+      blockingDomain: "terminal_runtime",
+      detail: retryOnly
+        ? "The terminal needs to retry local sync before evidence is current."
+        : "The terminal needs a local repair command before support can continue.",
+      evidenceReferences,
+      headline: retryOnly ? "Terminal sync retry needed" : "Terminal action needed",
+      lane: "needs_terminal_action",
+      nextStep: retryOnly
+        ? "Send a terminal sync retry and wait for a fresh check-in."
+        : "Send the available terminal repair command.",
+      primaryOwner: "terminal",
+      saleImpact: saleImpactForReadiness(args.salesReadiness),
+      secondaryActions,
+      severity: "warning",
+      summaryMeta: {
+        hasSecondarySafeRepair: !!safeRepairSecondaryAction,
+        reviewBacklogCount,
+        targetResolutionIncomplete,
+      },
+      supportAction: retryOnly ? "terminal_sync_retry" : "terminal_command",
+    };
+  }
+
+  if (args.supportRecovery?.status === "needs_cloud_repair") {
+    return {
+      blockingDomain: "cloud_repair",
+      detail: "Support can run the safe cloud repair for the listed sync evidence.",
+      evidenceReferences: [
+        ...evidenceReferences,
+        {
+          count: args.cloudRepair.safeConflictIds.length,
+          source: "cloud_repair",
+          summary: "Safe cloud repair conflicts are available.",
+          type: "safe_cloud_conflict",
+        },
+      ],
+      headline: "Cloud repair available",
+      lane: "needs_cloud_repair",
+      nextStep: "Run the safe cloud repair action.",
+      primaryOwner: "support",
+      saleImpact: saleImpactForReadiness(args.salesReadiness),
+      secondaryActions,
+      severity: "warning",
+      summaryMeta: {
+        hasSecondarySafeRepair: false,
+        reviewBacklogCount,
+        targetResolutionIncomplete,
+      },
+      supportAction: "safe_cloud_repair",
+    };
+  }
+
+  if (
+    !args.runtimeFresh ||
+    !args.runtimeStatus ||
+    args.terminalHealth === "stale" ||
+    args.terminalHealth === "offline"
+  ) {
+    return {
+      blockingDomain: "terminal_runtime",
+      detail: "Terminal runtime evidence is stale or unavailable.",
+      evidenceReferences,
+      headline: "Waiting for check-in",
+      lane: args.runtimeStatus ? "stale_runtime" : "unknown",
+      nextStep: "Wait for a fresh terminal check-in or send terminal sync retry.",
+      primaryOwner: "terminal",
+      saleImpact: args.salesReadiness === "able_to_transact_now"
+        ? "can_transact_now"
+        : "unknown",
+      secondaryActions,
+      severity: "warning",
+      summaryMeta: {
+        hasSecondarySafeRepair: !!safeRepairSecondaryAction,
+        reviewBacklogCount,
+        targetResolutionIncomplete,
+      },
+      supportAction: "wait_for_check_in",
+    };
+  }
+
+  if (args.salesReadiness === "able_to_transact_now") {
+    return {
+      blockingDomain: "none",
+      detail: "Fresh runtime evidence reports an active drawer with sale authority.",
+      evidenceReferences,
+      headline: "Ready for sales",
+      lane: "able_to_transact_now",
+      nextStep: "No support action needed.",
+      primaryOwner: "none",
+      saleImpact: "can_transact_now",
+      secondaryActions,
+      severity: "info",
+      summaryMeta: {
+        hasSecondarySafeRepair: !!safeRepairSecondaryAction,
+        reviewBacklogCount,
+        targetResolutionIncomplete,
+      },
+      supportAction: "none",
+    };
+  }
+
+  if (args.salesReadiness === "drawer_open") {
+    return {
+      blockingDomain: "none",
+      detail: "A drawer is open for this terminal.",
+      evidenceReferences,
+      headline: "Drawer open",
+      lane: "drawer_open",
+      nextStep: "No support action needed.",
+      primaryOwner: "none",
+      saleImpact: "unknown",
+      secondaryActions,
+      severity: "info",
+      summaryMeta: {
+        hasSecondarySafeRepair: !!safeRepairSecondaryAction,
+        reviewBacklogCount,
+        targetResolutionIncomplete,
+      },
+      supportAction: "none",
+    };
+  }
+
+  return {
+    blockingDomain: "none",
+    detail: "No terminal health blockers are reported.",
+    evidenceReferences,
+    headline: "Healthy idle",
+    lane: "healthy_idle",
+    nextStep: "No support action needed.",
+    primaryOwner: "none",
+    saleImpact: "unknown",
+    secondaryActions,
+    severity: "info",
+    summaryMeta: {
+      hasSecondarySafeRepair: !!safeRepairSecondaryAction,
+      reviewBacklogCount,
+      targetResolutionIncomplete,
+    },
+    supportAction: "none",
+  };
+}
+
+function isReviewBacklogReason(reason: TerminalHealthAttentionReason) {
+  return (
+    reason.type === "synced_sale_inventory_review" ||
+    reason.type === "cloud_conflict" ||
+    reason.type === "cloud_held" ||
+    reason.type === "cloud_rejected"
+  );
+}
+
+function buildExplanationEvidenceReference(args: {
+  count?: number;
+  source: TerminalOperationalExplanation["evidenceReferences"][number]["source"];
+  summary: string;
+  type: TerminalOperationalExplanation["evidenceReferences"][number]["type"];
+}): TerminalOperationalExplanation["evidenceReferences"][number] {
+  const reference: TerminalOperationalExplanation["evidenceReferences"][number] = {
+    source: args.source,
+    summary: args.summary,
+    type: args.type,
+  };
+  if (args.count !== undefined) {
+    reference.count = args.count;
+  }
+  return reference;
+}
+
+function resolveReviewBacklogOwner(
+  reasons: TerminalHealthAttentionReason[],
+  targetResolutionIncomplete = false,
+): TerminalOperationalExplanation["primaryOwner"] {
+  if (targetResolutionIncomplete) {
+    return "operations";
+  }
+  if (reasons.some((reason) => reason.actionTarget?.type === "open_work")) {
+    return "operations";
+  }
+  if (
+    reasons.some(
+      (reason) => reason.actionTarget?.type === "cash_control_register_session",
+    )
+  ) {
+    return "cash_controls";
+  }
+  return "manager";
+}
+
+function saleImpactForReadiness(
+  readiness: TerminalSalesReadiness,
+): TerminalOperationalExplanation["saleImpact"] {
+  return readiness === "able_to_transact_now"
+    ? "can_transact_now"
+    : "not_ready";
 }
 
 function hasHealthyIdleEvidence(args: {
@@ -562,12 +968,26 @@ function hasHealthyIdleEvidence(args: {
     (!status.terminalIntegrity || status.terminalIntegrity.status === "healthy") &&
     (!status.drawerAuthority || status.drawerAuthority.status === "healthy") &&
     (args.syncEvidence.unresolvedConflictCount ?? 0) === 0 &&
-    args.syncEvidence.conflictedCount === 0 &&
-    args.syncEvidence.heldCount === 0 &&
-    args.syncEvidence.rejectedCount === 0 &&
+    !hasCurrentSyncReviewBacklog(args.syncEvidence) &&
     args.terminalActions.length === 0 &&
     args.manualReview.length === 0 &&
     args.cloudRepair.safeConflictIds.length === 0
+  );
+}
+
+function hasCurrentSyncReviewBacklog(
+  syncEvidence: TerminalOperationalPolicyInput["syncEvidence"],
+) {
+  if (getCurrentReviewGroups(syncEvidence).length > 0) {
+    return true;
+  }
+  if (syncEvidence.reviewSummary) {
+    return false;
+  }
+  return (
+    syncEvidence.conflictedCount > 0 ||
+    syncEvidence.heldCount > 0 ||
+    syncEvidence.rejectedCount > 0
   );
 }
 

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.ts
@@ -24,6 +24,8 @@ type TerminalSalesReadinessInput = {
   saleAuthorityReady: boolean;
 };
 
+const LOCAL_REVIEW_CLEAR_COMMAND_EVENT_LIMIT = 100;
+
 export function buildTerminalOperationalState(
   input: TerminalOperationalPolicyInput,
 ): TerminalOperationalState {
@@ -41,9 +43,10 @@ export function buildTerminalOperationalState(
       ...input,
       runtimeStatus: effectiveRuntimeStatus,
     });
-  const terminalActions = buildTerminalRecoveryActions({
-    runtimeStatus: effectiveRuntimeStatus,
-  });
+  const terminalActions = buildTerminalRecoveryActions(
+    effectiveRuntimeStatus,
+    input.commandStatus,
+  );
   const manualReview = buildTerminalRecoveryManualReview({
     attentionReasons,
     skippedConflictIds: input.cloudRepair.skippedConflictIds,
@@ -526,9 +529,9 @@ function buildDiagnosticEvidence(input: TerminalOperationalPolicyInput) {
 }
 
 function buildTerminalRecoveryActions(
-  input: Pick<TerminalOperationalPolicyInput, "runtimeStatus">,
+  status: TerminalOperationalPolicyInput["runtimeStatus"],
+  commandStatus: TerminalOperationalPolicyInput["commandStatus"],
 ): TerminalOperationalState["recoveryEvidence"]["terminalActions"] {
-  const status = input.runtimeStatus;
   if (!status) {
     return [];
   }
@@ -591,20 +594,100 @@ function buildTerminalRecoveryActions(
       reason: "Local sync needs a terminal retry.",
     });
   }
-  if (status.sync.status === "needs_review" || status.sync.reviewEventCount > 0) {
+  const clearableReviewEvents =
+    getClearableRuntimeLocalReviewEvents(status.sync) ??
+    getClearableCollectedLocalReviewEvents(status.sync, commandStatus);
+  if (clearableReviewEvents) {
+    const localReviewEventIds = clearableReviewEvents.map(
+      (event) => event.localEventId,
+    );
     actions.push({
-      commandType: "retry_sync",
+      commandType: "clear_local_review_items",
       expectedEvidence: {
-        syncStatus: "idle",
+        localReviewClearedEventIds: localReviewEventIds,
+        localReviewEventCount: Math.max(
+          status.sync.reviewEventCount - clearableReviewEvents.length,
+          0,
+        ),
       },
       commandContext: {
         expectedBlockerType: "local_review",
-        reason: "Local review items need a terminal sync retry.",
+        localReviewEventIds,
+        reason: "Uploaded local review items can be cleared from this terminal.",
       },
-      reason: "Local review items need a terminal sync retry.",
+      reason: "Uploaded local review items can be cleared from this terminal.",
+    });
+  } else if (status.sync.status === "needs_review" || status.sync.reviewEventCount > 0) {
+    actions.push({
+      commandType: "collect_local_review",
+      expectedEvidence: {
+        localReviewDetailsCollected: true,
+      },
+      commandContext: {
+        expectedBlockerType: "local_review",
+        reason: "Local review items need terminal-local evidence collection.",
+      },
+      reason: "Local review items need terminal-local evidence collection.",
     });
   }
   return dedupeTerminalActions(actions);
+}
+
+function getClearableRuntimeLocalReviewEvents(
+  sync: NonNullable<
+    TerminalOperationalPolicyInput["runtimeStatus"]
+  >["sync"],
+) {
+  if (sync.reviewEventCount <= 0) {
+    return null;
+  }
+  const reviewEvents = sync.reviewEvents ?? [];
+  return reviewEvents.length > 0 &&
+    reviewEvents.length <= sync.reviewEventCount &&
+    reviewEvents.every((event) => event.uploaded === true)
+    ? reviewEvents.slice(0, LOCAL_REVIEW_CLEAR_COMMAND_EVENT_LIMIT)
+    : null;
+}
+
+function getClearableCollectedLocalReviewEvents(
+  sync: NonNullable<
+    TerminalOperationalPolicyInput["runtimeStatus"]
+  >["sync"],
+  commandStatus: TerminalOperationalPolicyInput["commandStatus"],
+) {
+  if (
+    sync.reviewEventCount <= 0 ||
+    commandStatus?.commandType !== "collect_local_review" ||
+    commandStatus.verificationStatus !== "verified"
+  ) {
+    return null;
+  }
+
+  const reviewEvents = commandStatus.localReviewEvents ?? [];
+  const runtimeReviewEvents = sync.reviewEvents ?? [];
+  if (runtimeReviewEvents.length === 0) {
+    return null;
+  }
+  if (!sameLocalReviewEventIds(reviewEvents, runtimeReviewEvents)) {
+    return null;
+  }
+
+  return reviewEvents.length > 0 &&
+    reviewEvents.length <= sync.reviewEventCount &&
+    reviewEvents.every((event) => event.uploaded === true)
+    ? reviewEvents.slice(0, LOCAL_REVIEW_CLEAR_COMMAND_EVENT_LIMIT)
+    : null;
+}
+
+function sameLocalReviewEventIds(
+  left: Array<{ localEventId: string }>,
+  right: Array<{ localEventId: string }>,
+) {
+  if (left.length !== right.length) {
+    return false;
+  }
+  const rightIds = new Set(right.map((event) => event.localEventId));
+  return left.every((event) => rightIds.has(event.localEventId));
 }
 
 function buildTerminalRecoveryManualReview(args: {
@@ -746,15 +829,28 @@ function buildTerminalOperationalExplanation(args: {
     const retryOnly = args.recoveryEvidence.terminalActions.every(
       (action) => action.commandType === "retry_sync",
     );
+    const localReviewCollectionOnly =
+      args.recoveryEvidence.terminalActions.length > 0 &&
+      args.recoveryEvidence.terminalActions.every(
+        (action) => action.commandType === "collect_local_review",
+      );
     return {
       blockingDomain: "terminal_runtime",
-      detail: retryOnly
+      detail: localReviewCollectionOnly
+        ? "The terminal needs to publish local review item evidence before support can continue."
+        : retryOnly
         ? "The terminal needs to retry local sync before evidence is current."
         : "The terminal needs a local repair command before support can continue.",
       evidenceReferences,
-      headline: retryOnly ? "Terminal sync retry needed" : "Terminal action needed",
+      headline: localReviewCollectionOnly
+        ? "Local review collection needed"
+        : retryOnly
+          ? "Terminal sync retry needed"
+          : "Terminal action needed",
       lane: "needs_terminal_action",
-      nextStep: retryOnly
+      nextStep: localReviewCollectionOnly
+        ? "Collect local review items and wait for a fresh check-in."
+        : retryOnly
         ? "Send a terminal sync retry and wait for a fresh check-in."
         : "Send the available terminal repair command.",
       primaryOwner: "terminal",

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/types.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/types.ts
@@ -4,6 +4,7 @@ import type {
   TerminalRecoveryCommandPayload,
   TerminalRecoveryCommandType,
   TerminalRecoveryExpectedEvidence,
+  TerminalRecoveryLocalReviewEventEvidence,
   TerminalRecoveryReadiness,
 } from "../terminalRecovery/types";
 
@@ -152,6 +153,7 @@ export type TerminalRecoveryPreview = {
     commandType: TerminalRecoveryCommandType;
     label: string;
     latestAcknowledgement?: string;
+    localReviewEvents?: TerminalRecoveryLocalReviewEventEvidence[];
     status: Doc<"posTerminalRecoveryCommand">["status"];
     verificationStatus: Doc<"posTerminalRecoveryCommand">["verificationStatus"];
   } | null;

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/types.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/types.ts
@@ -19,6 +19,70 @@ export type TerminalSupportRecovery =
     }
   | null;
 
+export type TerminalOperationalExplanation = {
+  blockingDomain:
+    | "cloud_repair"
+    | "manual_review"
+    | "none"
+    | "sync_review"
+    | "terminal_runtime";
+  detail: string;
+  evidenceReferences: Array<{
+    count?: number;
+    source:
+      | "cloud_repair"
+      | TerminalHealthAttentionReason["source"]
+      | TerminalDiagnosticEvidence[number]["source"];
+    summary: string;
+    type: "diagnostic" | "safe_cloud_conflict" | TerminalHealthAttentionReason["type"];
+  }>;
+  headline: string;
+  lane:
+    | TerminalSalesReadiness
+    | "needs_cloud_repair"
+    | "needs_manual_review"
+    | "needs_terminal_action"
+    | "sale_ready_with_review_backlog"
+    | "stale_runtime"
+    | "unknown";
+  nextStep: string;
+  primaryOwner:
+    | "cash_controls"
+    | "manager"
+    | "none"
+    | "operations"
+    | "support"
+    | "terminal";
+  saleImpact: "can_transact_now" | "not_ready" | "unknown";
+  secondaryActions: Array<{
+    label: string;
+    primaryOwner:
+      | "cash_controls"
+      | "manager"
+      | "operations"
+      | "support"
+      | "terminal";
+    supportAction:
+      | "manual_review"
+      | "safe_cloud_repair"
+      | "terminal_command"
+      | "terminal_sync_retry";
+  }>;
+  severity: "critical" | "info" | "warning";
+  summaryMeta: {
+    hasSecondarySafeRepair: boolean;
+    reviewBacklogCount: number;
+    targetResolutionIncomplete: boolean;
+  };
+  supportAction:
+    | "manual_review"
+    | "none"
+    | "safe_cloud_repair"
+    | "terminal_command"
+    | "terminal_sync_retry"
+    | "wait_for_check_in";
+};
+
 export type TerminalDiagnosticEvidence = Array<{
   severity: "info" | "warning";
   source:
@@ -135,6 +199,7 @@ export type TerminalOperationalState = {
   appUpdateEvidence: TerminalRecoveryPreview["appUpdate"];
   attentionReasons: TerminalHealthAttentionReason[];
   diagnosticEvidence: TerminalDiagnosticEvidence;
+  operationalExplanation: TerminalOperationalExplanation;
   recoveryEvidence: {
     cloudRepair: TerminalRecoveryPreview["cloudRepair"];
     commandStatus: TerminalRecoveryPreview["commandStatus"];
@@ -166,6 +231,7 @@ export type TerminalOperationalState = {
 export type TerminalOperationalPolicyInput = {
   appUpdate: TerminalRecoveryPreview["appUpdate"];
   activeRegisterSession?: Doc<"registerSession"> | null;
+  attentionReasons?: TerminalHealthAttentionReason[];
   cloudRepair: TerminalRecoveryPreview["cloudRepair"];
   commandStatus: TerminalRecoveryPreview["commandStatus"];
   drawerAuthorityRegisterSession?: Doc<"registerSession"> | null;

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts
@@ -89,6 +89,65 @@ describe("terminal cloud repair policy", () => {
     });
   });
 
+  it("skips source events that carry unsafe business facts", () => {
+    const conflict = buildConflict();
+
+    expect(
+      classifyTerminalCloudRepairConflict({
+        conflict,
+        now,
+        sourceEvent: buildEvent({
+          payload: {
+            openingFloat: 100,
+            registerNumber: "A1",
+            sale: {
+              saleId: "sale-1",
+              total: 25,
+            },
+          },
+        }),
+        storeId,
+        terminalId,
+      }),
+    ).toMatchObject({
+      conflictId: conflict._id,
+      kind: "skipped",
+      reason: "contains_business_facts",
+    });
+  });
+
+  it("skips missing source events and already-resolved conflicts", () => {
+    expect(
+      classifyTerminalCloudRepairConflict({
+        conflict: buildConflict(),
+        now,
+        sourceEvent: null,
+        storeId,
+        terminalId,
+      }),
+    ).toMatchObject({
+      kind: "skipped",
+      reason: "missing_source_event",
+    });
+
+    expect(
+      classifyTerminalCloudRepairConflict({
+        conflict: buildConflict({
+          _id: "resolved-conflict" as Id<"posLocalSyncConflict">,
+          status: "resolved",
+        }),
+        now,
+        sourceEvent: buildEvent({ eventType: "register_opened" }),
+        storeId,
+        terminalId,
+      }),
+    ).toMatchObject({
+      conflictId: "resolved-conflict",
+      kind: "skipped",
+      reason: "not_needs_review",
+    });
+  });
+
   it("requires preview preconditions to match before repair runs", () => {
     const safeConflict = buildConflict();
     const preview = buildTerminalCloudRepairPreview({

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.test.ts
@@ -161,6 +161,13 @@ describe("resolveTerminalCloudRepair", () => {
         status: "needs_review",
       }),
     );
+    expect(ctx.db.patch).not.toHaveBeenCalledWith(
+      "posLocalSyncConflict",
+      closeoutVarianceConflict._id,
+      expect.objectContaining({
+        status: "resolved",
+      }),
+    );
   });
 
   it("repairs only the latest safe duplicate register-open conflict", async () => {
@@ -371,6 +378,49 @@ describe("resolveTerminalCloudRepair", () => {
       },
       kind: "user_error",
     });
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it("reports missing source events as skipped without mutating review facts", async () => {
+    const conflict = buildConflict({
+      _id: "missing-source-conflict" as Id<"posLocalSyncConflict">,
+      localEventId: "missing-event",
+    });
+    const ctx = buildCtx({
+      posLocalSyncConflict: [conflict],
+      posLocalSyncEvent: [],
+    });
+
+    const result = await resolveTerminalCloudRepair(ctx as never, {
+      expectedPreconditionHash: buildTerminalCloudRepairPreconditionHash({
+        safeConflictIds: [],
+        storeId,
+        terminalId,
+      }),
+      now,
+      resolvedByUserId: "user-1" as Id<"athenaUser">,
+      storeId,
+      terminalId,
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: {
+        preconditionHash: buildTerminalCloudRepairPreconditionHash({
+          safeConflictIds: [],
+          storeId,
+          terminalId,
+        }),
+        resolvedConflictIds: [],
+        skippedConflictIds: [conflict._id],
+      },
+    });
+    expect(ctx.tables.posLocalSyncConflict).toContainEqual(
+      expect.objectContaining({
+        _id: conflict._id,
+        status: "needs_review",
+      }),
+    );
     expect(ctx.db.patch).not.toHaveBeenCalled();
   });
 });

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts
@@ -103,6 +103,98 @@ describe("terminal command service", () => {
     expect(repository.insertCommand).not.toHaveBeenCalled();
   });
 
+  it("rejects local review cleanup commands without bounded explicit ids", async () => {
+    const repository = buildRepository();
+
+    await expect(
+      issueTerminalRecoveryCommand(repository, {
+        commandType: "clear_local_review_items",
+        expectedEvidence: { localReviewEventCount: 0 },
+        issuedAt: now,
+        issuedByUserId: "user-1" as Id<"athenaUser">,
+        commandContext: {
+          localReviewClearAll: true,
+          reason: "Clear all local review items.",
+        },
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toMatchObject({
+      error: { code: "validation_failed" },
+      kind: "user_error",
+    });
+
+    await expect(
+      issueTerminalRecoveryCommand(repository, {
+        commandType: "clear_local_review_items",
+        expectedEvidence: { localReviewEventCount: 0 },
+        issuedAt: now,
+        issuedByUserId: "user-1" as Id<"athenaUser">,
+        commandContext: {
+          localReviewEventIds: Array.from(
+            { length: 101 },
+            (_, index) => `event-review-${index}`,
+          ),
+          reason: "Clear reviewed local review items.",
+        },
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toMatchObject({
+      error: { code: "validation_failed" },
+      kind: "user_error",
+    });
+
+    await expect(
+      issueTerminalRecoveryCommand(repository, {
+        commandType: "clear_local_review_items",
+        expectedEvidence: {},
+        issuedAt: now,
+        issuedByUserId: "user-1" as Id<"athenaUser">,
+        commandContext: {
+          localReviewEventIds: ["event-review-1"],
+          reason: "Clear reviewed local review items.",
+        },
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toMatchObject({
+      error: { code: "validation_failed" },
+      kind: "user_error",
+    });
+
+    expect(repository.insertCommand).not.toHaveBeenCalled();
+  });
+
+  it("rejects local review cleanup commands with duplicate explicit ids", async () => {
+    const repository = buildRepository();
+
+    await expect(
+      issueTerminalRecoveryCommand(repository, {
+        commandType: "clear_local_review_items",
+        expectedEvidence: {
+          localReviewClearedEventIds: ["event-review-1", "event-review-1"],
+          localReviewEventCount: 0,
+        },
+        issuedAt: now,
+        issuedByUserId: "user-1" as Id<"athenaUser">,
+        commandContext: {
+          expectedBlockerType: "local_review",
+          localReviewEventIds: ["event-review-1", "event-review-1"],
+          reason: "Clear uploaded review item.",
+        },
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toMatchObject({
+      error: {
+        code: "validation_failed",
+      },
+      kind: "user_error",
+    });
+    expect(repository.insertCommand).not.toHaveBeenCalled();
+  });
+
   it("issues update_app with command-correlated expected evidence", async () => {
     const repository = buildRepository();
 
@@ -755,6 +847,94 @@ describe("terminal command service", () => {
     });
   });
 
+  it("stores sanitized local review evidence on command acknowledgement", async () => {
+    const repository = buildRepository({
+      commands: [
+        buildCommand({
+          executionId: "command-1:2000100",
+          status: "claimed",
+        }),
+      ],
+    });
+
+    await expect(
+      acknowledgeTerminalRecoveryCommand(repository, {
+        acknowledgedAt: now + 300,
+        commandId: "command-1" as Id<"posTerminalRecoveryCommand">,
+        executionId: "command-1:2000100",
+        localReviewEvents: [
+          {
+            createdAt: now - 1_000,
+            localEventId: "event-review-1",
+            localRegisterSessionId: "register-local-1",
+            localTransactionId: "transaction-local-1",
+            sequence: 12,
+            staffProfileId: "staff-1",
+            status: "needs_review",
+            type: "transaction.completed",
+            uploaded: true,
+            uploadSequence: 3,
+          } as never,
+          {
+            createdAt: now - 500,
+            localEventId: "event-review-2",
+            localRegisterSessionId: "register-local-1",
+            sequence: 13,
+            status: "needs_review",
+            type: "register.closeout_started",
+            uploaded: true,
+            uploadSequence: 4,
+          },
+          {
+            createdAt: now - 100,
+            localEventId: "event-review-1",
+            localRegisterSessionId: "register-local-stale",
+            sequence: 99,
+            status: "needs_review",
+            type: "stale.duplicate",
+            uploaded: true,
+            uploadSequence: 99,
+          },
+        ],
+        message: "Collected review payload token=raw-secret",
+        result: "completed",
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toMatchObject({
+      kind: "ok",
+      data: {
+        acknowledgement: {
+          localReviewEvents: [
+            expect.objectContaining({
+              localEventId: "event-review-1",
+              localRegisterSessionId: "register-local-1",
+              sequence: 12,
+              status: "needs_review",
+              type: "transaction.completed",
+              uploaded: true,
+              uploadSequence: 3,
+            }),
+            expect.objectContaining({
+              localEventId: "event-review-2",
+              sequence: 13,
+              type: "register.closeout_started",
+            }),
+          ],
+          message: "Collected review payload [redacted]",
+        },
+        status: "completed",
+      },
+    });
+    expect(JSON.stringify(repository.patchCommand.mock.calls)).not.toMatch(
+      /raw-secret|payment|customer|proof-token|transaction-local-1|staff-1/i,
+    );
+    const storedCommand = await repository.getCommand(
+      "command-1" as Id<"posTerminalRecoveryCommand">,
+    );
+    expect(storedCommand?.acknowledgement?.localReviewEvents).toHaveLength(2);
+  });
+
   it("does not let another terminal claim or acknowledge a command", async () => {
     const repository = buildRepository({
       commands: [buildCommand()],
@@ -827,6 +1007,310 @@ describe("terminal command service", () => {
       verifiedAt: now,
     });
     expect(fresh.verifiedCommandIds).toEqual(["command-1"]);
+  });
+
+  it("verifies local review collection only after item-level details are present", async () => {
+    const repository = buildRepository({
+      commands: [
+        buildCommand({
+          commandType: "collect_local_review",
+          expectedEvidence: {
+            localReviewDetailsCollected: true,
+          },
+          status: "completed",
+          verificationStatus: "runtime_verification_ready",
+        }),
+      ],
+    });
+
+    const countOnly = await verifyTerminalRecoveryCommandsFromRuntime(
+      repository,
+      {
+        runtimeStatus: buildRuntimeStatus({
+          receivedAt: now,
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 84,
+            reviewEvents: [],
+            status: "needs_review",
+            uploadableEventCount: 0,
+          },
+        }),
+        storeId,
+        terminalId,
+        verifiedAt: now,
+      },
+    );
+    expect(countOnly.verifiedCommandIds).toEqual([]);
+
+    const withDetails = await verifyTerminalRecoveryCommandsFromRuntime(
+      repository,
+      {
+        runtimeStatus: buildRuntimeStatus({
+          receivedAt: now,
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 84,
+            reviewEvents: [
+              {
+                createdAt: now - 1_000,
+                localEventId: "event-review-1",
+                sequence: 10,
+                status: "needs_review",
+                type: "transaction.completed",
+                uploaded: true,
+              },
+            ],
+            status: "needs_review",
+            uploadableEventCount: 0,
+          },
+        }),
+        storeId,
+        terminalId,
+        verifiedAt: now,
+      },
+    );
+
+    expect(withDetails.verifiedCommandIds).toEqual(["command-1"]);
+  });
+
+  it("verifies local review cleanup only after review count reaches expected count", async () => {
+    const repository = buildRepository({
+      commands: [
+        buildCommand({
+          commandType: "clear_local_review_items",
+          commandContext: {
+            expectedBlockerType: "local_review",
+            localReviewEventIds: ["event-review-1", "event-review-2"],
+          },
+          expectedEvidence: {
+            localReviewClearedEventIds: ["event-review-1", "event-review-2"],
+            localReviewEventCount: 0,
+          },
+          acknowledgement: {
+            acknowledgedAt: now - 100,
+            clearedLocalReviewEventIds: ["event-review-1", "event-review-2"],
+            result: "completed",
+          },
+          status: "completed",
+          verificationStatus: "runtime_verification_ready",
+        }),
+      ],
+    });
+
+    const stillBlocked = await verifyTerminalRecoveryCommandsFromRuntime(
+      repository,
+      {
+        runtimeStatus: buildRuntimeStatus({
+          receivedAt: now,
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 2,
+            reviewEvents: [],
+            status: "needs_review",
+            uploadableEventCount: 0,
+          },
+        }),
+        storeId,
+        terminalId,
+        verifiedAt: now,
+      },
+    );
+    expect(stillBlocked.verifiedCommandIds).toEqual([]);
+
+    const cleared = await verifyTerminalRecoveryCommandsFromRuntime(
+      repository,
+      {
+        runtimeStatus: buildRuntimeStatus({
+          receivedAt: now,
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 0,
+            reviewEvents: [],
+            status: "idle",
+            uploadableEventCount: 0,
+          },
+        }),
+        storeId,
+        terminalId,
+        verifiedAt: now,
+      },
+    );
+
+    expect(cleared.verifiedCommandIds).toEqual(["command-1"]);
+  });
+
+  it("does not verify local review cleanup when cleared ids are incomplete", async () => {
+    const repository = buildRepository({
+      commands: [
+        buildCommand({
+          acknowledgement: {
+            acknowledgedAt: now - 100,
+            clearedLocalReviewEventIds: ["event-review-1"],
+            result: "completed",
+          },
+          commandType: "clear_local_review_items",
+          commandContext: {
+            expectedBlockerType: "local_review",
+            localReviewEventIds: ["event-review-1", "event-review-2"],
+          },
+          expectedEvidence: {
+            localReviewClearedEventIds: ["event-review-1", "event-review-2"],
+            localReviewEventCount: 0,
+          },
+          status: "completed",
+          verificationStatus: "runtime_verification_ready",
+        }),
+      ],
+    });
+
+    const result = await verifyTerminalRecoveryCommandsFromRuntime(repository, {
+      runtimeStatus: buildRuntimeStatus({
+        receivedAt: now,
+        sync: {
+          failedEventCount: 0,
+          localOnlyEventCount: 0,
+          pendingEventCount: 0,
+          reviewEventCount: 0,
+          reviewEvents: [],
+          status: "idle",
+          uploadableEventCount: 0,
+        },
+      }),
+      storeId,
+      terminalId,
+      verifiedAt: now,
+    });
+
+    expect(result.verifiedCommandIds).toEqual([]);
+  });
+
+  it("does not verify local review cleanup when a cleared id remains in runtime evidence", async () => {
+    const repository = buildRepository({
+      commands: [
+        buildCommand({
+          acknowledgement: {
+            acknowledgedAt: now - 100,
+            clearedLocalReviewEventIds: ["event-review-1", "event-review-2"],
+            result: "completed",
+          },
+          commandType: "clear_local_review_items",
+          commandContext: {
+            expectedBlockerType: "local_review",
+            localReviewEventIds: ["event-review-1", "event-review-2"],
+          },
+          expectedEvidence: {
+            localReviewClearedEventIds: ["event-review-1", "event-review-2"],
+            localReviewEventCount: 1,
+          },
+          status: "completed",
+          verificationStatus: "runtime_verification_ready",
+        }),
+      ],
+    });
+
+    const result = await verifyTerminalRecoveryCommandsFromRuntime(repository, {
+      runtimeStatus: buildRuntimeStatus({
+        receivedAt: now,
+        sync: {
+          failedEventCount: 0,
+          localOnlyEventCount: 0,
+          pendingEventCount: 0,
+          reviewEventCount: 1,
+          reviewEvents: [
+            {
+              createdAt: now - 1_000,
+              localEventId: "event-review-1",
+              sequence: 12,
+              status: "needs_review",
+              type: "transaction.completed",
+              uploaded: true,
+              uploadSequence: 12,
+            },
+          ],
+          status: "needs_review",
+          uploadableEventCount: 0,
+        },
+      }),
+      storeId,
+      terminalId,
+      verifiedAt: now,
+    });
+
+    expect(result.verifiedCommandIds).toEqual([]);
+  });
+
+  it("does not verify completed commands with runtime evidence captured before acknowledgement", async () => {
+    const repository = buildRepository({
+      commands: [
+        buildCommand({
+          acknowledgement: {
+            acknowledgedAt: now + 1_000,
+            result: "completed",
+          },
+          commandType: "clear_local_review_items",
+          commandContext: {
+            expectedBlockerType: "local_review",
+            localReviewEventIds: ["event-review-1"],
+          },
+          expectedEvidence: {
+            localReviewEventCount: 0,
+          },
+          status: "completed",
+          verificationStatus: "runtime_verification_ready",
+        }),
+      ],
+    });
+
+    const preCommandRuntime = await verifyTerminalRecoveryCommandsFromRuntime(
+      repository,
+      {
+        runtimeStatus: buildRuntimeStatus({
+          receivedAt: now,
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 0,
+            status: "idle",
+            uploadableEventCount: 0,
+          },
+        }),
+        storeId,
+        terminalId,
+        verifiedAt: now + 1_500,
+      },
+    );
+    expect(preCommandRuntime.verifiedCommandIds).toEqual([]);
+
+    const postCommandRuntime = await verifyTerminalRecoveryCommandsFromRuntime(
+      repository,
+      {
+        runtimeStatus: buildRuntimeStatus({
+          receivedAt: now + 1_500,
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 0,
+            status: "idle",
+            uploadableEventCount: 0,
+          },
+        }),
+        storeId,
+        terminalId,
+        verifiedAt: now + 1_500,
+      },
+    );
+    expect(postCommandRuntime.verifiedCommandIds).toEqual(["command-1"]);
   });
 
   it("treats omitted optional terminal health sections as healthy during verification", async () => {

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts
@@ -7,6 +7,7 @@ import {
 import {
   TERMINAL_RECOVERY_COMMAND_TYPES,
   type TerminalRecoveryCommandAckResult,
+  type TerminalRecoveryLocalReviewEventEvidence,
   type TerminalRecoveryCommandPayload,
   type TerminalRecoveryCommandType,
   type TerminalRecoveryExpectedEvidence,
@@ -15,6 +16,8 @@ import {
 const COMMAND_TTL_MS = 15 * 60 * 1000;
 const RUNTIME_VERIFICATION_FRESHNESS_MS = 2 * 60 * 1000;
 const ACKNOWLEDGEMENT_MESSAGE_MAX_LENGTH = 240;
+const LOCAL_REVIEW_CLEAR_COMMAND_EVENT_LIMIT = 100;
+const LOCAL_REVIEW_ACK_EVENT_LIMIT = 100;
 const SECRET_LIKE_KEYS = [
   "secret",
   "token",
@@ -84,6 +87,17 @@ export async function issueTerminalRecoveryCommand(
 
   const commandContext = pruneUndefined(args.commandContext);
   const expectedEvidence = pruneUndefined(args.expectedEvidence);
+  const shapeValidation = validateTerminalRecoveryCommandShape({
+    commandContext,
+    commandType: args.commandType,
+    expectedEvidence,
+  });
+  if (shapeValidation) {
+    return userError({
+      code: "validation_failed",
+      message: shapeValidation,
+    });
+  }
   const existingCommands = await repository.listCommandsForTerminal({
     expiresAfter: args.issuedAt,
     storeId: args.storeId,
@@ -236,8 +250,10 @@ export async function acknowledgeTerminalRecoveryCommand(
   repository: TerminalRecoveryCommandRepository,
   args: {
     acknowledgedAt: number;
+    clearedLocalReviewEventIds?: string[];
     commandId: Id<"posTerminalRecoveryCommand">;
     executionId?: string;
+    localReviewEvents?: TerminalRecoveryLocalReviewEventEvidence[];
     message?: string;
     result: TerminalRecoveryCommandAckResult;
     storeId: Id<"store">;
@@ -266,9 +282,17 @@ export async function acknowledgeTerminalRecoveryCommand(
     args.result === "completed"
       ? "runtime_verification_ready"
       : "verification_failed";
+  const localReviewEvents = sanitizeLocalReviewEvents(args.localReviewEvents);
+  const clearedLocalReviewEventIds = uniqueStrings(
+    args.clearedLocalReviewEventIds,
+  );
   const patch = {
     acknowledgement: pruneUndefined({
       acknowledgedAt: args.acknowledgedAt,
+      ...(clearedLocalReviewEventIds.length > 0
+        ? { clearedLocalReviewEventIds }
+        : {}),
+      ...(localReviewEvents.length > 0 ? { localReviewEvents } : {}),
       message: sanitizeAcknowledgementMessage(args.message),
       result: args.result,
     }),
@@ -306,6 +330,69 @@ function sanitizeAcknowledgementMessage(message: string | undefined) {
     : `${redacted.slice(0, ACKNOWLEDGEMENT_MESSAGE_MAX_LENGTH - 3)}...`;
 }
 
+function sanitizeLocalReviewEvents(
+  events?: TerminalRecoveryLocalReviewEventEvidence[],
+): TerminalRecoveryLocalReviewEventEvidence[] {
+  if (!Array.isArray(events)) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const safeEvents: TerminalRecoveryLocalReviewEventEvidence[] = [];
+  for (const event of events) {
+    if (safeEvents.length >= LOCAL_REVIEW_ACK_EVENT_LIMIT) break;
+    const localEventId = safeString(event.localEventId);
+    const type = safeString(event.type);
+    const status = safeString(event.status);
+    if (!localEventId || !type || !status) continue;
+    if (seen.has(localEventId)) continue;
+    if (!Number.isFinite(event.createdAt) || !Number.isFinite(event.sequence)) {
+      continue;
+    }
+    seen.add(localEventId);
+    safeEvents.push(
+      pruneUndefined({
+        createdAt: event.createdAt,
+        localEventId,
+        localPosSessionId: safeString(event.localPosSessionId),
+        localRegisterSessionId: safeString(event.localRegisterSessionId),
+        sequence: event.sequence,
+        status,
+        type,
+        uploaded:
+          typeof event.uploaded === "boolean" ? event.uploaded : undefined,
+        uploadSequence: Number.isFinite(event.uploadSequence)
+          ? event.uploadSequence
+          : undefined,
+      }),
+    );
+  }
+
+  return safeEvents;
+}
+
+function safeString(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function uniqueStrings(values: unknown[] | undefined) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const safeValue = safeString(value);
+    if (!safeValue || seen.has(safeValue)) continue;
+    seen.add(safeValue);
+    result.push(safeValue);
+  }
+  return result;
+}
+
 export async function verifyTerminalRecoveryCommandsFromRuntime(
   repository: TerminalRecoveryCommandRepository,
   args: {
@@ -330,7 +417,13 @@ export async function verifyTerminalRecoveryCommandsFromRuntime(
     if (command.verificationStatus !== "runtime_verification_ready") {
       continue;
     }
-    if (runtimeMatchesExpectedEvidence(args.runtimeStatus, command.expectedEvidence)) {
+    if (
+      command.acknowledgement?.acknowledgedAt !== undefined &&
+      args.runtimeStatus.receivedAt < command.acknowledgement.acknowledgedAt
+    ) {
+      continue;
+    }
+    if (runtimeMatchesExpectedEvidence(args.runtimeStatus, command)) {
       await repository.patchCommand(command._id, {
         verificationStatus: "verified",
         verifiedAt: args.verifiedAt,
@@ -344,8 +437,9 @@ export async function verifyTerminalRecoveryCommandsFromRuntime(
 
 function runtimeMatchesExpectedEvidence(
   runtimeStatus: Doc<"posTerminalRuntimeStatus">,
-  expectedEvidence: TerminalRecoveryExpectedEvidence,
+  command: Doc<"posTerminalRecoveryCommand">,
 ) {
+  const expectedEvidence = command.expectedEvidence;
   const appUpdateEvidence = getRuntimeAppUpdateEvidence(runtimeStatus);
   if (
     expectedEvidence.appUpdateStatus !== undefined &&
@@ -376,6 +470,25 @@ function runtimeMatchesExpectedEvidence(
   if (
     expectedEvidence.syncStatus !== undefined &&
     runtimeStatus.sync.status !== expectedEvidence.syncStatus
+  ) {
+    return false;
+  }
+  if (
+    expectedEvidence.localReviewDetailsCollected !== undefined &&
+    hasRuntimeLocalReviewDetails(runtimeStatus) !==
+      expectedEvidence.localReviewDetailsCollected
+  ) {
+    return false;
+  }
+  if (
+    expectedEvidence.localReviewEventCount !== undefined &&
+    runtimeStatus.sync.reviewEventCount !== expectedEvidence.localReviewEventCount
+  ) {
+    return false;
+  }
+  if (
+    expectedEvidence.localReviewClearedEventIds !== undefined &&
+    !localReviewClearEvidenceMatchesRuntime(command, runtimeStatus)
   ) {
     return false;
   }
@@ -416,8 +529,103 @@ function runtimeMatchesExpectedEvidence(
   return true;
 }
 
+function validateTerminalRecoveryCommandShape(input: {
+  commandContext: TerminalRecoveryCommandPayload;
+  commandType: TerminalRecoveryCommandType;
+  expectedEvidence: TerminalRecoveryExpectedEvidence;
+}) {
+  if (input.commandType !== "clear_local_review_items") {
+    return null;
+  }
+
+  const eventIds = input.commandContext.localReviewEventIds ?? [];
+  if (eventIds.length === 0) {
+    return "Local review cleanup commands require explicit local review item ids.";
+  }
+  if (eventIds.length > LOCAL_REVIEW_CLEAR_COMMAND_EVENT_LIMIT) {
+    return `Local review cleanup commands can include at most ${LOCAL_REVIEW_CLEAR_COMMAND_EVENT_LIMIT} item ids.`;
+  }
+  if (uniqueStrings(eventIds).length !== eventIds.length) {
+    return "Local review cleanup commands require unique local review item ids.";
+  }
+  if (
+    input.commandContext.localReviewClearAll === true ||
+    input.commandContext.localReviewClearLimit !== undefined
+  ) {
+    return "Local review cleanup commands must target explicit reviewed item ids.";
+  }
+  if (input.expectedEvidence.localReviewEventCount === undefined) {
+    return "Local review cleanup commands require expected local review count evidence.";
+  }
+  const expectedClearedIds = input.expectedEvidence.localReviewClearedEventIds ?? [];
+  if (uniqueStrings(expectedClearedIds).length !== expectedClearedIds.length) {
+    return "Local review cleanup commands require unique cleared item evidence.";
+  }
+  if (
+    !arraysEqualAsSets(
+      eventIds,
+      expectedClearedIds,
+    )
+  ) {
+    return "Local review cleanup commands require matching cleared item evidence.";
+  }
+
+  return null;
+}
+
+function localReviewClearedIdsMatchAcknowledgement(
+  command: Doc<"posTerminalRecoveryCommand">,
+) {
+  const expectedIds = command.expectedEvidence.localReviewClearedEventIds ?? [];
+  const clearedIds = command.acknowledgement?.clearedLocalReviewEventIds ?? [];
+  if (!arraysEqualAsSets(expectedIds, clearedIds)) {
+    return false;
+  }
+
+  return true;
+}
+
+function localReviewClearEvidenceMatchesRuntime(
+  command: Doc<"posTerminalRecoveryCommand">,
+  runtimeStatus: Doc<"posTerminalRuntimeStatus">,
+) {
+  if (!localReviewClearedIdsMatchAcknowledgement(command)) {
+    return false;
+  }
+
+  const expectedIds = command.expectedEvidence.localReviewClearedEventIds ?? [];
+  const currentReviewEvents = runtimeStatus.sync.reviewEvents ?? [];
+  if (currentReviewEvents.length === 0) {
+    return runtimeStatus.sync.reviewEventCount === 0;
+  }
+
+  const currentReviewIds = new Set(
+    currentReviewEvents.map((event) => event.localEventId),
+  );
+  return expectedIds.every((id) => !currentReviewIds.has(id));
+}
+
+function arraysEqualAsSets(left: string[], right: string[]) {
+  const leftIds = uniqueStrings(left);
+  const rightIds = uniqueStrings(right);
+  if (leftIds.length !== rightIds.length) {
+    return false;
+  }
+  const rightSet = new Set(rightIds);
+  return leftIds.every((id) => rightSet.has(id));
+}
+
 function normalizeOptionalHealthyStatus(status: string | undefined) {
   return status ?? "healthy";
+}
+
+function hasRuntimeLocalReviewDetails(
+  runtimeStatus: Doc<"posTerminalRuntimeStatus">,
+) {
+  return (
+    runtimeStatus.sync.reviewEventCount === 0 ||
+    (runtimeStatus.sync.reviewEvents?.length ?? 0) > 0
+  );
 }
 
 function getRuntimeAppUpdateEvidence(

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/types.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/types.ts
@@ -2,6 +2,8 @@ import type { Doc, Id } from "../../../_generated/dataModel";
 
 export const TERMINAL_RECOVERY_COMMAND_TYPES = [
   "retry_sync",
+  "collect_local_review",
+  "clear_local_review_items",
   "repair_terminal_seed",
   "clear_stale_drawer_authority",
   "refresh_staff_authority",
@@ -41,6 +43,9 @@ export type TerminalRecoveryCommandPayload = {
   expectedBlockerType?: string;
   expectedConflictIds?: Array<Id<"posLocalSyncConflict">>;
   expectedTerminalSeedIdentity?: string;
+  localReviewClearAll?: boolean;
+  localReviewClearLimit?: number;
+  localReviewEventIds?: string[];
   localRegisterSessionId?: string;
   reason?: string;
 };
@@ -58,6 +63,9 @@ export type TerminalRecoveryExpectedEvidence = {
   drawerAuthorityStatus?: "healthy" | "blocked";
   localRegisterSessionId?: string;
   localStoreAvailable?: boolean;
+  localReviewDetailsCollected?: boolean;
+  localReviewEventCount?: number;
+  localReviewClearedEventIds?: string[];
   saleAuthorityStatus?: "ready" | "missing" | "blocked" | "unknown";
   staffAuthorityStatus?: "ready" | "missing" | "expired" | "unknown";
   syncStatus?: Doc<"posTerminalRuntimeStatus">["sync"]["status"];
@@ -71,3 +79,15 @@ export type TerminalRecoveryCommandAckResult =
   | "completed"
   | "failed"
   | "precondition_failed";
+
+export type TerminalRecoveryLocalReviewEventEvidence = {
+  createdAt: number;
+  localEventId: string;
+  localPosSessionId?: string;
+  localRegisterSessionId?: string;
+  sequence: number;
+  status: string;
+  type: string;
+  uploaded?: boolean;
+  uploadSequence?: number;
+};

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -1204,9 +1204,9 @@ describe("terminal health summaries", () => {
         commandContext: expect.objectContaining({
           expectedBlockerType: "local_review",
         }),
-        commandType: "retry_sync",
-        expectedEvidence: { syncStatus: "idle" },
-        reason: "Local review items need a terminal sync retry.",
+        commandType: "collect_local_review",
+        expectedEvidence: { localReviewDetailsCollected: true },
+        reason: "Local review items need terminal-local evidence collection.",
       }),
     ]);
   });

--- a/packages/athena-webapp/convex/pos/domain/terminalSyncEvidence.ts
+++ b/packages/athena-webapp/convex/pos/domain/terminalSyncEvidence.ts
@@ -1,11 +1,51 @@
 import type { Doc, Id } from "../../_generated/dataModel";
 
+export type TerminalSyncReviewTarget = {
+  type: "open_work";
+  workItemId: Id<"operationalWorkItem">;
+  workItemType: "synced_sale_inventory_review";
+};
+
+export type TerminalSyncReviewActionTarget = {
+  type: "register_session";
+  registerSessionId: Id<"registerSession">;
+};
+
 export type TerminalSyncReviewEvent = {
   localEventId: string;
   localRegisterSessionId: string;
   sequence: number;
   eventType: Doc<"posLocalSyncEvent">["eventType"];
   status: Doc<"posLocalSyncEvent">["status"];
+};
+
+export type TerminalSyncReviewSummaryGroup = {
+  actionTarget?: TerminalSyncReviewActionTarget;
+  actionability:
+    | "cash_controls_review"
+    | "diagnostic_only"
+    | "manual_review"
+    | "open_work_review";
+  conflictType: Doc<"posLocalSyncConflict">["conflictType"];
+  count: number;
+  latestCreatedAt: number;
+  latestSequence: number;
+  owner:
+    | "cash_controls"
+    | "diagnostic"
+    | "manual_review"
+    | "operations_open_work";
+  reviewTarget?: TerminalSyncReviewTarget;
+};
+
+export type TerminalSyncReviewSummary = {
+  groups: TerminalSyncReviewSummaryGroup[];
+  meta: {
+    sampledCount: number;
+    cap: number;
+    hasMore: boolean;
+    targetResolutionIncomplete: boolean;
+  };
 };
 
 export type TerminalSyncEvidence = {
@@ -39,14 +79,11 @@ export type TerminalSyncEvidence = {
     createdAt: number;
     localEventId: string;
     localRegisterSessionId: string;
-    reviewTarget?: {
-      type: "open_work";
-      workItemId: Id<"operationalWorkItem">;
-      workItemType: "synced_sale_inventory_review";
-    };
+    reviewTarget?: TerminalSyncReviewTarget;
     sequence: number;
     summary: string;
   }>;
+  reviewSummary?: TerminalSyncReviewSummary;
   acceptedThroughSequence?: number;
   cursorUpdatedAt?: number;
 };

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts
@@ -1,5 +1,6 @@
 import type { Doc, Id } from "../../../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../../../_generated/server";
+import { isRegisterSessionConflictBlockingStatus } from "../../../../shared/registerSessionStatus";
 import type {
   TerminalRecoveryCommandReadRepository,
   TerminalRecoveryCommandRepository,
@@ -81,7 +82,7 @@ export async function listTerminalRecoveryConflictsForRepair(
     terminalId: Id<"posTerminal">;
   },
 ) {
-  return ctx.db
+  const conflicts = await ctx.db
     .query("posLocalSyncConflict")
     .withIndex("by_store_terminal_status", (q) =>
       q
@@ -90,6 +91,134 @@ export async function listTerminalRecoveryConflictsForRepair(
         .eq("status", "needs_review"),
     )
     .take(100);
+
+  const currentConflicts = await Promise.all(
+    conflicts.map(async (conflict) =>
+      (await isCurrentTerminalRecoveryConflict(ctx, conflict, args))
+        ? conflict
+        : null,
+    ),
+  );
+  return currentConflicts.filter(
+    (conflict): conflict is Doc<"posLocalSyncConflict"> => conflict !== null,
+  );
+}
+
+async function isCurrentTerminalRecoveryConflict(
+  ctx: QueryCtx | MutationCtx,
+  conflict: Doc<"posLocalSyncConflict">,
+  args: {
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+) {
+  if (
+    conflict.conflictType !== "duplicate_local_id" &&
+    conflict.conflictType !== "permission"
+  ) {
+    return true;
+  }
+
+  const registerSession = await resolveRegisterSessionForConflict(ctx, {
+    localRegisterSessionId: conflict.localRegisterSessionId,
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+  });
+  if (!registerSession) {
+    return true;
+  }
+
+  return isRegisterSessionConflictBlockingStatus(registerSession.status);
+}
+
+async function resolveRegisterSessionForConflict(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    localRegisterSessionId?: string | null;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+): Promise<Doc<"registerSession"> | null> {
+  if (!args.localRegisterSessionId) {
+    return null;
+  }
+  const localRegisterSessionId = args.localRegisterSessionId;
+
+  const mappedSession = await resolveMappedRegisterSession(ctx, {
+    localRegisterSessionId,
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+  });
+  if (mappedSession) {
+    return mappedSession;
+  }
+
+  const normalizeId = (
+    ctx.db as unknown as {
+      normalizeId?: (
+        tableName: string,
+        value: string,
+      ) => Id<"registerSession"> | null;
+    }
+  ).normalizeId;
+  const registerSessionId =
+    normalizeId?.call(ctx.db, "registerSession", localRegisterSessionId) ??
+    null;
+  return registerSessionId
+    ? getScopedRegisterSession(ctx, {
+        registerSessionId,
+        storeId: args.storeId,
+        terminalId: args.terminalId,
+      })
+    : null;
+}
+
+async function resolveMappedRegisterSession(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    localRegisterSessionId: string;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+) {
+  const registerSessionMapping = await ctx.db
+    .query("posLocalSyncMapping")
+    .withIndex("by_store_terminal_local", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("terminalId", args.terminalId)
+        .eq("localRegisterSessionId", args.localRegisterSessionId)
+        .eq("localIdKind", "registerSession")
+        .eq("localId", args.localRegisterSessionId),
+    )
+    .unique();
+  if (registerSessionMapping?.cloudTable !== "registerSession") {
+    return null;
+  }
+
+  return getScopedRegisterSession(ctx, {
+    registerSessionId: registerSessionMapping.cloudId as Id<"registerSession">,
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+  });
+}
+
+async function getScopedRegisterSession(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    registerSessionId: Id<"registerSession">;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+) {
+  const registerSession = await ctx.db.get(
+    "registerSession",
+    args.registerSessionId,
+  );
+  return registerSession?.storeId === args.storeId &&
+    registerSession.terminalId === args.terminalId
+    ? registerSession
+    : null;
 }
 
 export async function getTerminalRecoverySourceEvent(

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
@@ -467,6 +467,52 @@ describe("terminalRepository sync evidence", () => {
     ]);
   });
 
+  it("omits mapped conflicts for settled register sessions from current review evidence", async () => {
+    const ctx = buildCtx({
+      posLocalSyncConflict: [
+        buildSyncConflict({
+          _id: "conflict-closed-register" as Id<"posLocalSyncConflict">,
+          conflictType: "permission",
+          localRegisterSessionId: "local-register-closed",
+          sequence: 8,
+        }),
+      ],
+      posLocalSyncMapping: [
+        buildSyncMapping({
+          cloudId: "register-session-closed",
+          localId: "local-register-closed",
+          localRegisterSessionId: "local-register-closed",
+        }),
+      ],
+      registerSession: [
+        buildRegisterSession({
+          _id: "register-session-closed" as Id<"registerSession">,
+          closedAt: 900,
+          countedCash: 100,
+          status: "closed",
+          variance: 0,
+        }),
+      ],
+    });
+
+    const result = await getTerminalSyncEvidence(ctx as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+    });
+
+    expect(result.unresolvedConflictCount).toBe(0);
+    expect(result.unresolvedConflicts).toEqual([]);
+    expect(result.reviewSummary).toEqual({
+      groups: [],
+      meta: {
+        cap: TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
+        hasMore: false,
+        sampledCount: 0,
+        targetResolutionIncomplete: false,
+      },
+    });
+  });
+
   it("caps review summary samples and reports when more conflicts exist", async () => {
     const conflicts = Array.from(
       { length: TERMINAL_SYNC_REVIEW_SUMMARY_CAP + 1 },
@@ -825,7 +871,7 @@ describe("terminalRepository register-session action targets", () => {
           openedByStaffProfileId: "staff-1" as Id<"staffProfile">,
           openingFloat: 100,
           registerNumber: "1",
-          status: "closed",
+          status: "open",
           storeId: "store-1" as Id<"store">,
           terminalId: "terminal-1" as Id<"posTerminal">,
         },

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
@@ -5,6 +5,8 @@ import {
   getTerminalSyncEvidence,
   hasActiveRegisterSessionForTerminal,
   resolveTerminalRegisterSessionActionTarget,
+  TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
+  TERMINAL_SYNC_REVIEW_TARGET_LOOKUP_CAP,
   upsertLatestRuntimeStatus,
 } from "./terminalRepository";
 
@@ -145,7 +147,10 @@ describe("terminalRepository runtime status", () => {
     const result = await upsertLatestRuntimeStatus(ctx as never, input);
 
     expect(result).toBe("runtime-status-new");
-    expect(ctx.db.insert).toHaveBeenCalledWith("posTerminalRuntimeStatus", input);
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      "posTerminalRuntimeStatus",
+      input,
+    );
     expect(ctx.db.patch).not.toHaveBeenCalled();
   });
 
@@ -202,6 +207,15 @@ describe("terminalRepository sync evidence", () => {
       rejectedCount: 0,
       unresolvedConflictCount: 0,
       unresolvedConflicts: [],
+      reviewSummary: {
+        groups: [],
+        meta: {
+          cap: TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
+          hasMore: false,
+          sampledCount: 0,
+          targetResolutionIncomplete: false,
+        },
+      },
       acceptedThroughSequence: 12,
       cursorUpdatedAt: 300,
     });
@@ -221,11 +235,31 @@ describe("terminalRepository sync evidence", () => {
         },
       ],
       posLocalSyncEvent: [
-        buildSyncEvent({ localEventId: "event-accepted", sequence: 1, status: "accepted" }),
-        buildSyncEvent({ localEventId: "event-projected", sequence: 2, status: "projected" }),
-        buildSyncEvent({ localEventId: "event-conflicted", sequence: 3, status: "conflicted" }),
-        buildSyncEvent({ localEventId: "event-held", sequence: 4, status: "held" }),
-        buildSyncEvent({ localEventId: "event-rejected", sequence: 5, status: "rejected" }),
+        buildSyncEvent({
+          localEventId: "event-accepted",
+          sequence: 1,
+          status: "accepted",
+        }),
+        buildSyncEvent({
+          localEventId: "event-projected",
+          sequence: 2,
+          status: "projected",
+        }),
+        buildSyncEvent({
+          localEventId: "event-conflicted",
+          sequence: 3,
+          status: "conflicted",
+        }),
+        buildSyncEvent({
+          localEventId: "event-held",
+          sequence: 4,
+          status: "held",
+        }),
+        buildSyncEvent({
+          localEventId: "event-rejected",
+          sequence: 5,
+          status: "rejected",
+        }),
       ],
       posLocalSyncConflict: [
         buildSyncConflict({
@@ -302,18 +336,304 @@ describe("terminalRepository sync evidence", () => {
           _id: "conflict-latest",
           localEventId: "event-rejected",
           sequence: 5,
-          summary: "A register session is already open for this terminal.",
+          summary: "A synced register event needs permission review.",
         }),
         expect.objectContaining({
           _id: "conflict-older",
           localEventId: "event-conflicted",
           sequence: 3,
-          summary: "Older conflict.",
+          summary: "A synced register event needs permission review.",
         }),
       ],
       acceptedThroughSequence: 7,
       cursorUpdatedAt: 400,
+      reviewSummary: {
+        groups: [
+          expect.objectContaining({
+            actionability: "manual_review",
+            conflictType: "permission",
+            count: 2,
+            owner: "manual_review",
+          }),
+        ],
+        meta: {
+          cap: TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
+          hasMore: false,
+          sampledCount: 2,
+          targetResolutionIncomplete: false,
+        },
+      },
     });
+  });
+
+  it("groups inventory conflicts with open work targets under operations", async () => {
+    const ctx = buildCtx({
+      operationalWorkItem: [
+        buildOperationalWorkItem({
+          _id: "work-item-1" as Id<"operationalWorkItem">,
+          metadata: {
+            localEventId: "event-inventory",
+          },
+          status: "open",
+          type: "synced_sale_inventory_review",
+        }),
+      ],
+      posLocalSyncConflict: [
+        buildSyncConflict({
+          _id: "conflict-inventory" as Id<"posLocalSyncConflict">,
+          conflictType: "inventory",
+          localEventId: "event-inventory",
+          sequence: 9,
+        }),
+      ],
+    });
+
+    const result = await getTerminalSyncEvidence(ctx as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+    });
+
+    expect(result.unresolvedConflicts?.[0]).toMatchObject({
+      _id: "conflict-inventory",
+      reviewTarget: {
+        type: "open_work",
+        workItemId: "work-item-1",
+        workItemType: "synced_sale_inventory_review",
+      },
+    });
+    expect(result.reviewSummary).toEqual({
+      groups: [
+        expect.objectContaining({
+          actionability: "open_work_review",
+          conflictType: "inventory",
+          count: 1,
+          owner: "operations_open_work",
+          reviewTarget: {
+            type: "open_work",
+            workItemId: "work-item-1",
+            workItemType: "synced_sale_inventory_review",
+          },
+        }),
+      ],
+      meta: {
+        cap: TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
+        hasMore: false,
+        sampledCount: 1,
+        targetResolutionIncomplete: false,
+      },
+    });
+  });
+
+  it("groups mapped register-session conflicts under cash controls", async () => {
+    const ctx = buildCtx({
+      posLocalSyncConflict: [
+        buildSyncConflict({
+          _id: "conflict-register" as Id<"posLocalSyncConflict">,
+          conflictType: "permission",
+          localRegisterSessionId: "local-register-1",
+          sequence: 8,
+        }),
+      ],
+      posLocalSyncMapping: [
+        buildSyncMapping({
+          cloudId: "register-session-1",
+          localId: "local-register-1",
+          localRegisterSessionId: "local-register-1",
+        }),
+      ],
+      registerSession: [
+        buildRegisterSession({
+          _id: "register-session-1" as Id<"registerSession">,
+        }),
+      ],
+    });
+
+    const result = await getTerminalSyncEvidence(ctx as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+    });
+
+    expect(result.reviewSummary?.groups).toEqual([
+      expect.objectContaining({
+        actionTarget: {
+          registerSessionId: "register-session-1",
+          type: "register_session",
+        },
+        actionability: "cash_controls_review",
+        conflictType: "permission",
+        count: 1,
+        owner: "cash_controls",
+      }),
+    ]);
+  });
+
+  it("caps review summary samples and reports when more conflicts exist", async () => {
+    const conflicts = Array.from(
+      { length: TERMINAL_SYNC_REVIEW_SUMMARY_CAP + 1 },
+      (_, index) =>
+        buildSyncConflict({
+          _id: `conflict-${index}` as Id<"posLocalSyncConflict">,
+          localEventId: `event-${index}`,
+          sequence: index + 1,
+        }),
+    );
+    const ctx = buildCtx({
+      posLocalSyncConflict: conflicts,
+    });
+
+    const result = await getTerminalSyncEvidence(ctx as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+    });
+
+    expect(result.unresolvedConflicts).toHaveLength(20);
+    expect(result.reviewSummary?.meta).toEqual({
+      cap: TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
+      hasMore: true,
+      sampledCount: TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
+      targetResolutionIncomplete: true,
+    });
+    expect(result.reviewSummary?.groups).toEqual([
+      expect.objectContaining({
+        count: TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
+      }),
+    ]);
+  });
+
+  it("marks target resolution incomplete when open work lookup is capped before a match", async () => {
+    const workItems = Array.from(
+      { length: TERMINAL_SYNC_REVIEW_TARGET_LOOKUP_CAP + 1 },
+      (_, index) =>
+        buildOperationalWorkItem({
+          _id: `work-item-${index}` as Id<"operationalWorkItem">,
+          metadata: {
+            localEventId:
+              index === TERMINAL_SYNC_REVIEW_TARGET_LOOKUP_CAP
+                ? "event-inventory"
+                : `other-event-${index}`,
+          },
+          status: "open",
+          type: "synced_sale_inventory_review",
+        }),
+    );
+    const ctx = buildCtx({
+      operationalWorkItem: workItems,
+      posLocalSyncConflict: [
+        buildSyncConflict({
+          _id: "conflict-inventory" as Id<"posLocalSyncConflict">,
+          conflictType: "inventory",
+          localEventId: "event-inventory",
+        }),
+      ],
+    });
+
+    const result = await getTerminalSyncEvidence(ctx as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+    });
+
+    expect(result.unresolvedConflicts?.[0]?.reviewTarget).toBeUndefined();
+    expect(result.reviewSummary?.meta).toEqual({
+      cap: TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
+      hasMore: false,
+      sampledCount: 1,
+      targetResolutionIncomplete: true,
+    });
+    expect(result.reviewSummary?.groups).toEqual([
+      expect.objectContaining({
+        actionability: "diagnostic_only",
+        conflictType: "inventory",
+        owner: "diagnostic",
+      }),
+    ]);
+  });
+
+  it("finds matching open work targets after closed inventory review history", async () => {
+    const closedWorkItems = Array.from({ length: 8 }, (_, index) =>
+      buildOperationalWorkItem({
+        _id: `closed-work-item-${index}` as Id<"operationalWorkItem">,
+        metadata: {
+          localEventId: `closed-event-${index}`,
+        },
+        status: "completed",
+        type: "synced_sale_inventory_review",
+      }),
+    );
+    const ctx = buildCtx({
+      operationalWorkItem: [
+        ...closedWorkItems,
+        buildOperationalWorkItem({
+          _id: "work-item-current" as Id<"operationalWorkItem">,
+          metadata: {
+            localEventId: "event-inventory",
+          },
+          status: "open",
+          type: "synced_sale_inventory_review",
+        }),
+      ],
+      posLocalSyncConflict: [
+        buildSyncConflict({
+          _id: "conflict-inventory" as Id<"posLocalSyncConflict">,
+          conflictType: "inventory",
+          localEventId: "event-inventory",
+        }),
+      ],
+    });
+
+    const result = await getTerminalSyncEvidence(ctx as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+    });
+
+    expect(result.unresolvedConflicts?.[0]?.reviewTarget).toEqual({
+      type: "open_work",
+      workItemId: "work-item-current",
+      workItemType: "synced_sale_inventory_review",
+    });
+    expect(result.reviewSummary?.meta.targetResolutionIncomplete).toBe(false);
+  });
+
+  it("keeps business-fact conflicts in manual review without exposing raw details", async () => {
+    const ctx = buildCtx({
+      posLocalSyncConflict: [
+        buildSyncConflict({
+          _id: "conflict-payment" as Id<"posLocalSyncConflict">,
+          conflictType: "payment",
+          details: {
+            accountNumber: "4111111111111111",
+            customerName: "Sensitive Customer",
+            staffProofToken: "staff-proof-secret",
+          },
+          summary: "Payment projection requires manager review.",
+        }),
+      ],
+    });
+
+    const result = await getTerminalSyncEvidence(ctx as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+    });
+
+    expect(result.reviewSummary?.groups).toEqual([
+      expect.objectContaining({
+        actionability: "manual_review",
+        conflictType: "payment",
+        count: 1,
+        owner: "manual_review",
+      }),
+    ]);
+    expect(JSON.stringify(result.reviewSummary)).not.toContain(
+      "4111111111111111",
+    );
+    expect(JSON.stringify(result.reviewSummary)).not.toContain(
+      "Sensitive Customer",
+    );
+    expect(JSON.stringify(result.reviewSummary)).not.toContain(
+      "staff-proof-secret",
+    );
+    expect(result.unresolvedConflicts?.[0]?.summary).toBe(
+      "A synced register event needs review.",
+    );
   });
 
   it("excludes manager-rejected sync reviews from actionable terminal evidence", async () => {
@@ -564,14 +884,17 @@ describe("terminalRepository register-session action targets", () => {
   });
 });
 
-function buildCtx(seed: {
-  posLocalSyncCursor?: Array<Doc<"posLocalSyncCursor">>;
-  posLocalSyncConflict?: Array<Doc<"posLocalSyncConflict">>;
-  posLocalSyncEvent?: Array<Doc<"posLocalSyncEvent">>;
-  posLocalSyncMapping?: Array<Doc<"posLocalSyncMapping">>;
-  posTerminalRuntimeStatus?: Array<Doc<"posTerminalRuntimeStatus">>;
-  registerSession?: Array<Doc<"registerSession">>;
-} = {}) {
+function buildCtx(
+  seed: {
+    operationalWorkItem?: Array<Doc<"operationalWorkItem">>;
+    posLocalSyncCursor?: Array<Doc<"posLocalSyncCursor">>;
+    posLocalSyncConflict?: Array<Doc<"posLocalSyncConflict">>;
+    posLocalSyncEvent?: Array<Doc<"posLocalSyncEvent">>;
+    posLocalSyncMapping?: Array<Doc<"posLocalSyncMapping">>;
+    posTerminalRuntimeStatus?: Array<Doc<"posTerminalRuntimeStatus">>;
+    registerSession?: Array<Doc<"registerSession">>;
+  } = {},
+) {
   return {
     db: {
       get: vi.fn(async (tableName: keyof typeof seed, id: string) => {
@@ -598,37 +921,42 @@ function buildQuery<T extends { _creationTime?: number; sequence?: number }>(
 ) {
   let currentRows = [...rows];
   return {
-    withIndex: vi.fn((_indexName: string, build: (q: {
-      eq: (field: string, value: unknown) => unknown;
-    }) => unknown) => {
-      const q = {
-        eq: vi.fn((field: string, value: unknown) => {
-          currentRows = currentRows.filter(
-            (row) => (row as Record<string, unknown>)[field] === value,
-          );
-          return q;
-        }),
-      };
-      build(q);
+    withIndex: vi.fn(
+      (
+        _indexName: string,
+        build: (q: {
+          eq: (field: string, value: unknown) => unknown;
+        }) => unknown,
+      ) => {
+        const q = {
+          eq: vi.fn((field: string, value: unknown) => {
+            currentRows = currentRows.filter(
+              (row) => (row as Record<string, unknown>)[field] === value,
+            );
+            return q;
+          }),
+        };
+        build(q);
 
-      return {
-        order: vi.fn((direction: "asc" | "desc") => {
-          currentRows = [...currentRows].sort((left, right) => {
-            const leftOrder = left.sequence ?? left._creationTime ?? 0;
-            const rightOrder = right.sequence ?? right._creationTime ?? 0;
-            return direction === "desc"
-              ? rightOrder - leftOrder
-              : leftOrder - rightOrder;
-          });
-          return {
-            first: vi.fn(async () => currentRows[0] ?? null),
-            take: vi.fn(async (count: number) => currentRows.slice(0, count)),
-          };
-        }),
-        take: vi.fn(async (count: number) => currentRows.slice(0, count)),
-        unique: vi.fn(async () => currentRows[0] ?? null),
-      };
-    }),
+        return {
+          order: vi.fn((direction: "asc" | "desc") => {
+            currentRows = [...currentRows].sort((left, right) => {
+              const leftOrder = left.sequence ?? left._creationTime ?? 0;
+              const rightOrder = right.sequence ?? right._creationTime ?? 0;
+              return direction === "desc"
+                ? rightOrder - leftOrder
+                : leftOrder - rightOrder;
+            });
+            return {
+              first: vi.fn(async () => currentRows[0] ?? null),
+              take: vi.fn(async (count: number) => currentRows.slice(0, count)),
+            };
+          }),
+          take: vi.fn(async (count: number) => currentRows.slice(0, count)),
+          unique: vi.fn(async () => currentRows[0] ?? null),
+        };
+      },
+    ),
   };
 }
 
@@ -700,6 +1028,25 @@ function buildSyncEvent(
   } as Doc<"posLocalSyncEvent">;
 }
 
+function buildSyncMapping(
+  overrides: Partial<Doc<"posLocalSyncMapping">> = {},
+): Doc<"posLocalSyncMapping"> {
+  return {
+    _id: "mapping-1" as Id<"posLocalSyncMapping">,
+    _creationTime: 1,
+    cloudId: "register-session-1",
+    cloudTable: "registerSession",
+    createdAt: 1,
+    localEventId: "event-1",
+    localId: "local-register-1",
+    localIdKind: "registerSession",
+    localRegisterSessionId: "local-register-1",
+    storeId: "store-1" as Id<"store">,
+    terminalId: "terminal-1" as Id<"posTerminal">,
+    ...overrides,
+  } as Doc<"posLocalSyncMapping">;
+}
+
 function buildSyncConflict(
   overrides: Partial<Doc<"posLocalSyncConflict">> = {},
 ): Doc<"posLocalSyncConflict"> {
@@ -718,4 +1065,23 @@ function buildSyncConflict(
     createdAt: 120,
     ...overrides,
   } as Doc<"posLocalSyncConflict">;
+}
+
+function buildOperationalWorkItem(
+  overrides: Partial<Doc<"operationalWorkItem">> = {},
+): Doc<"operationalWorkItem"> {
+  return {
+    _id: "work-item-1" as Id<"operationalWorkItem">,
+    _creationTime: 1,
+    approvalState: "not_required",
+    createdAt: 1,
+    metadata: {},
+    organizationId: "organization-1" as Id<"organization">,
+    priority: "normal",
+    status: "open",
+    storeId: "store-1" as Id<"store">,
+    title: "Review synced sale inventory",
+    type: "synced_sale_inventory_review",
+    ...overrides,
+  } as Doc<"operationalWorkItem">;
 }

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
@@ -5,13 +5,23 @@ import type { PosLocalSyncEventStatus } from "../../../../shared/posLocalSyncCon
 import { isPosUsableRegisterSessionStatus } from "../../../../shared/registerSessionStatus";
 import type {
   TerminalSyncEvidence,
+  TerminalSyncReviewActionTarget,
   TerminalSyncReviewEvent,
+  TerminalSyncReviewSummary,
+  TerminalSyncReviewSummaryGroup,
+  TerminalSyncReviewTarget,
 } from "../../domain/terminalSyncEvidence";
 import type { PosTerminalSummary } from "../../domain/types";
 
 const MANAGER_REJECTED_SYNC_REVIEW_CODE = "manager_rejected";
+export const TERMINAL_SYNC_REVIEW_SUMMARY_CAP = 50;
+export const TERMINAL_SYNC_REVIEW_TARGET_LOOKUP_CAP = 200;
+const TERMINAL_SYNC_UNRESOLVED_CONFLICT_EXAMPLE_CAP = 20;
 
 type PosTerminalReadCtx = QueryCtx | MutationCtx;
+type TerminalSyncConflictWithReviewTarget = Doc<"posLocalSyncConflict"> & {
+  reviewTarget?: TerminalSyncReviewTarget;
+};
 
 export function mapTerminalRecord(
   terminal: Doc<"posTerminal">,
@@ -153,6 +163,15 @@ const EMPTY_TERMINAL_SYNC_EVIDENCE: TerminalSyncEvidence = {
   rejectedCount: 0,
   unresolvedConflictCount: 0,
   unresolvedConflicts: [],
+  reviewSummary: {
+    groups: [],
+    meta: {
+      sampledCount: 0,
+      cap: TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
+      hasMore: false,
+      targetResolutionIncomplete: false,
+    },
+  },
 };
 
 export async function getTerminalSyncEvidence(
@@ -185,20 +204,21 @@ export async function getTerminalSyncEvidence(
           .eq("terminalId", args.terminalId)
           .eq("status", "needs_review"),
       )
-      .take(100),
+      .order("desc")
+      .take(TERMINAL_SYNC_REVIEW_SUMMARY_CAP + 1),
   ]);
-  const terminalConflicts = conflicts
-    .sort((left, right) => right.sequence - left.sequence)
-    .slice(0, 20);
-  const unresolvedConflicts = terminalConflicts.map((conflict) => ({
-    _id: conflict._id,
-    conflictType: conflict.conflictType,
-    createdAt: conflict.createdAt,
-    localEventId: conflict.localEventId,
-    localRegisterSessionId: conflict.localRegisterSessionId,
-    sequence: conflict.sequence,
-    summary: conflict.summary,
-  }));
+  const conflictSample = conflicts
+    .slice(0, TERMINAL_SYNC_REVIEW_SUMMARY_CAP)
+    .sort((left, right) => right.sequence - left.sequence);
+  const conflictSummary = await buildTerminalSyncReviewSummary(ctx, {
+    conflicts: conflictSample,
+    hasMore: conflicts.length > TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+  });
+  const unresolvedConflicts = conflictSummary.conflicts
+    .slice(0, TERMINAL_SYNC_UNRESOLVED_CONFLICT_EXAMPLE_CAP)
+    .map(toTerminalSyncConflictExample);
 
   const latestCursor = cursors.reduce<Doc<"posLocalSyncCursor"> | null>(
     (latest, cursor) =>
@@ -211,8 +231,9 @@ export async function getTerminalSyncEvidence(
       ...EMPTY_TERMINAL_SYNC_EVIDENCE,
       acceptedThroughSequence: latestCursor?.acceptedThroughSequence,
       cursorUpdatedAt: latestCursor?.updatedAt,
-      unresolvedConflictCount: unresolvedConflicts.length,
+      unresolvedConflictCount: conflictSummary.reviewSummary.meta.sampledCount,
       unresolvedConflicts,
+      reviewSummary: conflictSummary.reviewSummary,
     };
   }
 
@@ -257,11 +278,280 @@ export async function getTerminalSyncEvidence(
     conflictedCount: count("conflicted"),
     heldCount: count("held"),
     rejectedCount: count("rejected"),
-    unresolvedConflictCount: unresolvedConflicts.length,
+    unresolvedConflictCount: conflictSummary.reviewSummary.meta.sampledCount,
     unresolvedConflicts,
+    reviewSummary: conflictSummary.reviewSummary,
     acceptedThroughSequence: latestCursor?.acceptedThroughSequence,
     cursorUpdatedAt: latestCursor?.updatedAt,
   };
+}
+
+function emptyTerminalSyncReviewSummary(): TerminalSyncReviewSummary {
+  return {
+    groups: [],
+    meta: {
+      sampledCount: 0,
+      cap: TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
+      hasMore: false,
+      targetResolutionIncomplete: false,
+    },
+  };
+}
+
+async function buildTerminalSyncReviewSummary(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    conflicts: Array<Doc<"posLocalSyncConflict">>;
+    hasMore: boolean;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+): Promise<{
+  conflicts: TerminalSyncConflictWithReviewTarget[];
+  reviewSummary: TerminalSyncReviewSummary;
+}> {
+  if (args.conflicts.length === 0) {
+    const empty = emptyTerminalSyncReviewSummary();
+    return {
+      conflicts: [],
+      reviewSummary: {
+        ...empty,
+        meta: {
+          ...empty.meta,
+          hasMore: args.hasMore,
+          targetResolutionIncomplete: args.hasMore,
+        },
+      },
+    };
+  }
+
+  const openWorkTargets = await getOpenWorkTargetsByLocalEventId(ctx, {
+    conflicts: args.conflicts,
+    storeId: args.storeId,
+  });
+  const annotatedConflicts = args.conflicts.map((conflict) => {
+    const reviewTarget =
+      conflict.conflictType === "inventory"
+        ? openWorkTargets.targetByLocalEventId.get(conflict.localEventId)
+        : undefined;
+    return reviewTarget ? { ...conflict, reviewTarget } : conflict;
+  });
+  const groupByKey = new Map<string, TerminalSyncReviewSummaryGroup>();
+
+  for (const conflict of annotatedConflicts) {
+    const groupInput = await classifyTerminalSyncReviewConflict(ctx, {
+      conflict,
+      storeId: args.storeId,
+      targetResolutionIncomplete:
+        openWorkTargets.targetResolutionIncomplete,
+      terminalId: args.terminalId,
+    });
+    const key = [
+      groupInput.owner,
+      groupInput.actionability,
+      groupInput.conflictType,
+      groupInput.reviewTarget?.workItemId ?? "",
+      groupInput.actionTarget?.registerSessionId ?? "",
+    ].join(":");
+    const existing = groupByKey.get(key);
+    if (existing) {
+      existing.count += 1;
+      if (groupInput.latestSequence > existing.latestSequence) {
+        existing.latestCreatedAt = groupInput.latestCreatedAt;
+        existing.latestSequence = groupInput.latestSequence;
+      }
+      continue;
+    }
+    groupByKey.set(key, groupInput);
+  }
+
+  return {
+    conflicts: annotatedConflicts,
+    reviewSummary: {
+      groups: Array.from(groupByKey.values()).sort(
+        (left, right) => right.latestSequence - left.latestSequence,
+      ),
+      meta: {
+        sampledCount: annotatedConflicts.length,
+        cap: TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
+        hasMore: args.hasMore,
+        targetResolutionIncomplete:
+          args.hasMore || openWorkTargets.targetResolutionIncomplete,
+      },
+    },
+  };
+}
+
+async function getOpenWorkTargetsByLocalEventId(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    conflicts: Array<Doc<"posLocalSyncConflict">>;
+    storeId: Id<"store">;
+  },
+): Promise<{
+  targetByLocalEventId: Map<string, TerminalSyncReviewTarget>;
+  targetResolutionIncomplete: boolean;
+}> {
+  const inventoryConflictLocalEventIds = new Set(
+    args.conflicts
+      .filter((conflict) => conflict.conflictType === "inventory")
+      .map((conflict) => conflict.localEventId),
+  );
+  if (inventoryConflictLocalEventIds.size === 0) {
+    return {
+      targetByLocalEventId: new Map(),
+      targetResolutionIncomplete: false,
+    };
+  }
+
+  const workItems = await ctx.db
+    .query("operationalWorkItem")
+    .withIndex("by_storeId_type_status", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("type", "synced_sale_inventory_review")
+        .eq("status", "open"),
+    )
+    .take(TERMINAL_SYNC_REVIEW_TARGET_LOOKUP_CAP + 1);
+  const targetByLocalEventId = new Map<string, TerminalSyncReviewTarget>();
+  for (const workItem of workItems.slice(
+    0,
+    TERMINAL_SYNC_REVIEW_TARGET_LOOKUP_CAP,
+  )) {
+    const localEventId = workItem.metadata?.localEventId;
+    if (
+      typeof localEventId === "string" &&
+      inventoryConflictLocalEventIds.has(localEventId)
+    ) {
+      targetByLocalEventId.set(localEventId, {
+        type: "open_work",
+        workItemId: workItem._id,
+        workItemType: "synced_sale_inventory_review",
+      });
+    }
+  }
+
+  return {
+    targetByLocalEventId,
+    targetResolutionIncomplete:
+      workItems.length > TERMINAL_SYNC_REVIEW_TARGET_LOOKUP_CAP,
+  };
+}
+
+async function classifyTerminalSyncReviewConflict(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    conflict: TerminalSyncConflictWithReviewTarget;
+    storeId: Id<"store">;
+    targetResolutionIncomplete: boolean;
+    terminalId: Id<"posTerminal">;
+  },
+): Promise<TerminalSyncReviewSummaryGroup> {
+  if (args.conflict.reviewTarget) {
+    return {
+      actionability: "open_work_review",
+      conflictType: args.conflict.conflictType,
+      count: 1,
+      latestCreatedAt: args.conflict.createdAt,
+      latestSequence: args.conflict.sequence,
+      owner: "operations_open_work",
+      reviewTarget: args.conflict.reviewTarget,
+    };
+  }
+
+  const actionTarget = await getRegisterSessionReviewActionTarget(ctx, args);
+  if (actionTarget) {
+    return {
+      actionTarget,
+      actionability: "cash_controls_review",
+      conflictType: args.conflict.conflictType,
+      count: 1,
+      latestCreatedAt: args.conflict.createdAt,
+      latestSequence: args.conflict.sequence,
+      owner: "cash_controls",
+    };
+  }
+
+  if (args.conflict.conflictType === "inventory" && args.targetResolutionIncomplete) {
+    return {
+      actionability: "diagnostic_only",
+      conflictType: args.conflict.conflictType,
+      count: 1,
+      latestCreatedAt: args.conflict.createdAt,
+      latestSequence: args.conflict.sequence,
+      owner: "diagnostic",
+    };
+  }
+
+  return {
+    actionability: "manual_review",
+    conflictType: args.conflict.conflictType,
+    count: 1,
+    latestCreatedAt: args.conflict.createdAt,
+    latestSequence: args.conflict.sequence,
+    owner: "manual_review",
+  };
+}
+
+async function getRegisterSessionReviewActionTarget(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    conflict: Doc<"posLocalSyncConflict">;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+): Promise<TerminalSyncReviewActionTarget | null> {
+  if (
+    args.conflict.conflictType !== "duplicate_local_id" &&
+    args.conflict.conflictType !== "permission"
+  ) {
+    return null;
+  }
+
+  const registerSessionId = await resolveTerminalRegisterSessionActionTarget(
+    ctx,
+    {
+      localRegisterSessionId: args.conflict.localRegisterSessionId,
+      storeId: args.storeId,
+      terminalId: args.terminalId,
+    },
+  );
+  return registerSessionId
+    ? {
+        type: "register_session",
+        registerSessionId,
+      }
+    : null;
+}
+
+function toTerminalSyncConflictExample(
+  conflict: TerminalSyncConflictWithReviewTarget,
+): NonNullable<TerminalSyncEvidence["unresolvedConflicts"]>[number] {
+  return {
+    _id: conflict._id,
+    conflictType: conflict.conflictType,
+    createdAt: conflict.createdAt,
+    localEventId: conflict.localEventId,
+    localRegisterSessionId: conflict.localRegisterSessionId,
+    ...(conflict.reviewTarget ? { reviewTarget: conflict.reviewTarget } : {}),
+    sequence: conflict.sequence,
+    summary: buildDisplaySafeConflictSummary(conflict),
+  };
+}
+
+function buildDisplaySafeConflictSummary(
+  conflict: Pick<Doc<"posLocalSyncConflict">, "conflictType">,
+) {
+  switch (conflict.conflictType) {
+    case "inventory":
+      return "Inventory needs manager review for a synced offline sale.";
+    case "duplicate_local_id":
+      return "A synced register event needs duplicate review.";
+    case "permission":
+      return "A synced register event needs permission review.";
+    default:
+      return "A synced register event needs review.";
+  }
 }
 
 export async function hasActiveRegisterSessionForTerminal(
@@ -413,7 +703,10 @@ export async function getDrawerAuthorityRegisterSession(
     return null;
   }
 
-  const registerSession = await ctx.db.get("registerSession", registerSessionId);
+  const registerSession = await ctx.db.get(
+    "registerSession",
+    registerSessionId,
+  );
   if (
     registerSession?.storeId === args.storeId &&
     registerSession.terminalId === args.terminalId
@@ -516,7 +809,8 @@ export async function resolveTerminalRegisterSessionActionTarget(
     .unique();
   if (registerSessionMapping?.cloudTable === "registerSession") {
     return resolveRegisterSessionActionTarget(ctx, {
-      registerSessionId: registerSessionMapping.cloudId as Id<"registerSession">,
+      registerSessionId:
+        registerSessionMapping.cloudId as Id<"registerSession">,
       storeId: args.storeId,
       terminalId: args.terminalId,
     });
@@ -552,7 +846,10 @@ async function resolveRegisterSessionActionTarget(
     terminalId: Id<"posTerminal">;
   },
 ) {
-  const registerSession = await ctx.db.get("registerSession", args.registerSessionId);
+  const registerSession = await ctx.db.get(
+    "registerSession",
+    args.registerSessionId,
+  );
   if (
     registerSession?.storeId === args.storeId &&
     registerSession.terminalId === args.terminalId

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
@@ -2,7 +2,10 @@ import type { Doc, Id } from "../../../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../../../_generated/server";
 
 import type { PosLocalSyncEventStatus } from "../../../../shared/posLocalSyncContract";
-import { isPosUsableRegisterSessionStatus } from "../../../../shared/registerSessionStatus";
+import {
+  isPosUsableRegisterSessionStatus,
+  isRegisterSessionConflictBlockingStatus,
+} from "../../../../shared/registerSessionStatus";
 import type {
   TerminalSyncEvidence,
   TerminalSyncReviewActionTarget,
@@ -22,6 +25,14 @@ type PosTerminalReadCtx = QueryCtx | MutationCtx;
 type TerminalSyncConflictWithReviewTarget = Doc<"posLocalSyncConflict"> & {
   reviewTarget?: TerminalSyncReviewTarget;
 };
+type RegisterSessionReviewTargetResolution =
+  | {
+      actionTarget: TerminalSyncReviewActionTarget;
+      status: "actionable";
+    }
+  | {
+      status: "not_register_conflict" | "settled" | "unresolved";
+    };
 
 export function mapTerminalRecord(
   terminal: Doc<"posTerminal">,
@@ -337,6 +348,7 @@ async function buildTerminalSyncReviewSummary(
     return reviewTarget ? { ...conflict, reviewTarget } : conflict;
   });
   const groupByKey = new Map<string, TerminalSyncReviewSummaryGroup>();
+  const currentConflicts: TerminalSyncConflictWithReviewTarget[] = [];
 
   for (const conflict of annotatedConflicts) {
     const groupInput = await classifyTerminalSyncReviewConflict(ctx, {
@@ -346,6 +358,10 @@ async function buildTerminalSyncReviewSummary(
         openWorkTargets.targetResolutionIncomplete,
       terminalId: args.terminalId,
     });
+    if (!groupInput) {
+      continue;
+    }
+    currentConflicts.push(conflict);
     const key = [
       groupInput.owner,
       groupInput.actionability,
@@ -366,13 +382,13 @@ async function buildTerminalSyncReviewSummary(
   }
 
   return {
-    conflicts: annotatedConflicts,
+    conflicts: currentConflicts,
     reviewSummary: {
       groups: Array.from(groupByKey.values()).sort(
         (left, right) => right.latestSequence - left.latestSequence,
       ),
       meta: {
-        sampledCount: annotatedConflicts.length,
+        sampledCount: currentConflicts.length,
         cap: TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
         hasMore: args.hasMore,
         targetResolutionIncomplete:
@@ -446,7 +462,7 @@ async function classifyTerminalSyncReviewConflict(
     targetResolutionIncomplete: boolean;
     terminalId: Id<"posTerminal">;
   },
-): Promise<TerminalSyncReviewSummaryGroup> {
+): Promise<TerminalSyncReviewSummaryGroup | null> {
   if (args.conflict.reviewTarget) {
     return {
       actionability: "open_work_review",
@@ -459,10 +475,14 @@ async function classifyTerminalSyncReviewConflict(
     };
   }
 
-  const actionTarget = await getRegisterSessionReviewActionTarget(ctx, args);
-  if (actionTarget) {
+  const registerSessionResolution =
+    await resolveRegisterSessionReviewTargetForConflict(ctx, args);
+  if (registerSessionResolution.status === "settled") {
+    return null;
+  }
+  if (registerSessionResolution.status === "actionable") {
     return {
-      actionTarget,
+      actionTarget: registerSessionResolution.actionTarget,
       actionability: "cash_controls_review",
       conflictType: args.conflict.conflictType,
       count: 1,
@@ -493,35 +513,26 @@ async function classifyTerminalSyncReviewConflict(
   };
 }
 
-async function getRegisterSessionReviewActionTarget(
+async function resolveRegisterSessionReviewTargetForConflict(
   ctx: QueryCtx | MutationCtx,
   args: {
     conflict: Doc<"posLocalSyncConflict">;
     storeId: Id<"store">;
     terminalId: Id<"posTerminal">;
   },
-): Promise<TerminalSyncReviewActionTarget | null> {
+): Promise<RegisterSessionReviewTargetResolution> {
   if (
     args.conflict.conflictType !== "duplicate_local_id" &&
     args.conflict.conflictType !== "permission"
   ) {
-    return null;
+    return { status: "not_register_conflict" };
   }
 
-  const registerSessionId = await resolveTerminalRegisterSessionActionTarget(
-    ctx,
-    {
-      localRegisterSessionId: args.conflict.localRegisterSessionId,
-      storeId: args.storeId,
-      terminalId: args.terminalId,
-    },
-  );
-  return registerSessionId
-    ? {
-        type: "register_session",
-        registerSessionId,
-      }
-    : null;
+  return resolveTerminalRegisterSessionReviewTarget(ctx, {
+    localRegisterSessionId: args.conflict.localRegisterSessionId,
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+  });
 }
 
 function toTerminalSyncConflictExample(
@@ -794,6 +805,23 @@ export async function resolveTerminalRegisterSessionActionTarget(
   if (!args.localRegisterSessionId) {
     return null;
   }
+  const resolution = await resolveTerminalRegisterSessionReviewTarget(ctx, args);
+  return resolution.status === "actionable"
+    ? resolution.actionTarget.registerSessionId
+    : null;
+}
+
+async function resolveTerminalRegisterSessionReviewTarget(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    localRegisterSessionId?: string | null;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+): Promise<RegisterSessionReviewTargetResolution> {
+  if (!args.localRegisterSessionId) {
+    return { status: "unresolved" };
+  }
   const localRegisterSessionId = args.localRegisterSessionId;
 
   const registerSessionMapping = await ctx.db
@@ -808,7 +836,7 @@ export async function resolveTerminalRegisterSessionActionTarget(
     )
     .unique();
   if (registerSessionMapping?.cloudTable === "registerSession") {
-    return resolveRegisterSessionActionTarget(ctx, {
+    return resolveRegisterSessionReviewTarget(ctx, {
       registerSessionId:
         registerSessionMapping.cloudId as Id<"registerSession">,
       storeId: args.storeId,
@@ -828,24 +856,24 @@ export async function resolveTerminalRegisterSessionActionTarget(
     normalizeId?.call(ctx.db, "registerSession", localRegisterSessionId) ??
     null;
   if (!cloudRegisterSessionId) {
-    return null;
+    return { status: "unresolved" };
   }
 
-  return resolveRegisterSessionActionTarget(ctx, {
+  return resolveRegisterSessionReviewTarget(ctx, {
     registerSessionId: cloudRegisterSessionId,
     storeId: args.storeId,
     terminalId: args.terminalId,
   });
 }
 
-async function resolveRegisterSessionActionTarget(
+async function resolveRegisterSessionReviewTarget(
   ctx: QueryCtx | MutationCtx,
   args: {
     registerSessionId: Id<"registerSession">;
     storeId: Id<"store">;
     terminalId: Id<"posTerminal">;
   },
-) {
+): Promise<RegisterSessionReviewTargetResolution> {
   const registerSession = await ctx.db.get(
     "registerSession",
     args.registerSessionId,
@@ -854,10 +882,19 @@ async function resolveRegisterSessionActionTarget(
     registerSession?.storeId === args.storeId &&
     registerSession.terminalId === args.terminalId
   ) {
-    return args.registerSessionId;
+    if (!isRegisterSessionConflictBlockingStatus(registerSession.status)) {
+      return { status: "settled" };
+    }
+    return {
+      actionTarget: {
+        type: "register_session",
+        registerSessionId: args.registerSessionId,
+      },
+      status: "actionable",
+    };
   }
 
-  return null;
+  return { status: "unresolved" };
 }
 
 export async function getTerminalByFingerprint(

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -133,6 +133,37 @@ function buildTerminalHealthSummaryResult() {
         },
       },
     ],
+    operationalExplanation: {
+      blockingDomain: "terminal_runtime",
+      detail: "The terminal needs a local repair command before support can continue.",
+      evidenceReferences: [
+        {
+          count: 1,
+          source: "terminal_runtime",
+          summary: "Terminal setup data needs repair.",
+          type: "terminal_seed_missing",
+        },
+      ],
+      headline: "Terminal action needed",
+      lane: "needs_terminal_action",
+      nextStep: "Send the available terminal repair command.",
+      primaryOwner: "terminal",
+      saleImpact: "not_ready",
+      secondaryActions: [
+        {
+          label: "Safe cloud repair available",
+          primaryOwner: "support",
+          supportAction: "safe_cloud_repair",
+        },
+      ],
+      severity: "warning",
+      summaryMeta: {
+        hasSecondarySafeRepair: true,
+        reviewBacklogCount: 0,
+        targetResolutionIncomplete: false,
+      },
+      supportAction: "terminal_command",
+    },
     recoveryPreview: {
       readiness: "needs_terminal_action",
       runtimeFresh: true,
@@ -237,6 +268,24 @@ function buildTerminalHealthSummaryResult() {
           summary: "Duplicate local event id.",
         },
       ],
+      reviewSummary: {
+        groups: [
+          {
+            actionability: "manual_review",
+            conflictType: "duplicate_local_id",
+            count: 1,
+            latestCreatedAt: 100,
+            latestSequence: 8,
+            owner: "manual_review",
+          },
+        ],
+        meta: {
+          sampledCount: 1,
+          cap: 50,
+          hasMore: false,
+          targetResolutionIncomplete: false,
+        },
+      },
       acceptedThroughSequence: 7,
       cursorUpdatedAt: 110,
     },
@@ -1374,6 +1423,44 @@ describe("POS terminal public mutations", () => {
         terminalId: "terminal-1",
       }),
     );
+  });
+
+  it("does not allow sync-secret-only terminal proof to read terminal health", async () => {
+    mocks.requireAuthenticatedAthenaUserWithCtx.mockRejectedValue(
+      new Error("not signed in"),
+    );
+    const ctx = buildCtx({
+      terminal: {
+        _id: "terminal-1",
+        storeId: "store-1",
+        status: "active",
+        registeredByUserId: "athena-user-2",
+        syncSecretHash: SYNC_SECRET_HASH,
+      },
+    });
+
+    await expect(
+      getHandler(listTerminalHealthSummaries)(ctx as never, {
+        storeId: "store-1",
+      }),
+    ).rejects.toThrow("not signed in");
+    await expect(
+      getHandler(getTerminalHealthSummary)(ctx as never, {
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).rejects.toThrow("not signed in");
+    await expect(
+      getHandler(previewTerminalRecovery)(ctx as never, {
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).rejects.toThrow("not signed in");
+
+    expect(mocks.requireOrganizationMemberRoleWithCtx).not.toHaveBeenCalled();
+    expect(mocks.listTerminalHealthSummariesQuery).not.toHaveBeenCalled();
+    expect(mocks.getTerminalHealthSummaryQuery).not.toHaveBeenCalled();
+    expect(mocks.previewTerminalRecoveryQuery).not.toHaveBeenCalled();
   });
 
   it("requires full admin membership and actor attribution before cloud repair", async () => {

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -377,6 +377,38 @@ describe("POS terminal public mutations", () => {
     mocks.listTerminalHealthSummariesQuery.mockResolvedValue([]);
     mocks.getTerminalHealthSummaryQuery.mockResolvedValue(null);
     mocks.getLatestRuntimeStatusForTerminal.mockResolvedValue(null);
+    mocks.previewTerminalRecoveryQuery.mockResolvedValue({
+      appUpdate: {
+        description: "Current",
+        status: "current",
+      },
+      readiness: "needs_terminal_action",
+      runtimeFresh: true,
+      evidence: {
+        activeRegisterSession: false,
+        freshRuntimeRequiredForAbleToTransactNow: true,
+      },
+      cloudRepair: {
+        preconditionHash: "hash",
+        safeConflictIds: [],
+        skippedConflictIds: [],
+      },
+      commandStatus: null,
+      terminalActions: [
+        {
+          commandType: "repair_terminal_seed",
+          commandContext: {
+            expectedBlockerType: "terminal_seed",
+            reason: "Terminal setup data needs repair.",
+          },
+          expectedEvidence: {
+            terminalIntegrityStatus: "healthy",
+          },
+          reason: "Terminal setup data needs repair.",
+        },
+      ],
+      manualReview: [],
+    });
     mocks.createTerminalRecoveryCommandReadRepository.mockReturnValue({
       repository: "read",
     });
@@ -680,7 +712,9 @@ describe("POS terminal public mutations", () => {
               createdAt: 101,
               localEventId: "event-review-1",
               localRegisterSessionId: "local-register-1",
+              localTransactionId: "transaction-local-1",
               sequence: 9,
+              staffProfileId: "staff-1",
               status: "needs_review",
               type: "transaction.completed",
               uploaded: true,
@@ -747,6 +781,11 @@ describe("POS terminal public mutations", () => {
         verifierMetadata: expect.anything(),
         rawLocalEvents: expect.anything(),
       }),
+    );
+    const forwardedStatus =
+      mocks.submitTerminalRuntimeStatusCommand.mock.calls[0]?.[1].status;
+    expect(JSON.stringify(forwardedStatus.sync.reviewEvents)).not.toMatch(
+      /transaction-local-1|staff-1/,
     );
   });
 
@@ -1334,7 +1373,25 @@ describe("POS terminal public mutations", () => {
       ...terminal,
       syncSecretHash: "sync-secret-hash",
     };
-    const recoveryCommand = buildRecoveryCommand();
+    const recoveryCommand = buildRecoveryCommand({
+      acknowledgement: {
+        acknowledgedAt: 2,
+        clearedLocalReviewEventIds: ["event-review-1"],
+        localReviewEvents: [
+          {
+            createdAt: 1,
+            localEventId: "event-review-1",
+            localRegisterSessionId: "register-local-1",
+            sequence: 1,
+            status: "needs_review",
+            type: "transaction.completed",
+            uploaded: true,
+            uploadSequence: 1,
+          },
+        ],
+        result: "completed",
+      },
+    });
     const commandResult = { kind: "ok" as const, data: recoveryCommand };
 
     assertConformsToExportedReturns(listTerminals as never, [terminal]);
@@ -1493,6 +1550,23 @@ describe("POS terminal public mutations", () => {
 
   it("requires full admin membership before issuing terminal recovery commands", async () => {
     const ctx = buildCtx();
+    mocks.previewTerminalRecoveryQuery.mockResolvedValue({
+      appUpdate: null,
+      readiness: "healthy_idle",
+      runtimeFresh: true,
+      evidence: {
+        activeRegisterSession: false,
+        freshRuntimeRequiredForAbleToTransactNow: false,
+      },
+      cloudRepair: {
+        preconditionHash: "hash",
+        safeConflictIds: [],
+        skippedConflictIds: [],
+      },
+      commandStatus: null,
+      terminalActions: [],
+      manualReview: [],
+    });
 
     const result = await getHandler(issueTerminalRecoveryCommand)(ctx as never, {
       storeId: "store-1",
@@ -1525,6 +1599,124 @@ describe("POS terminal public mutations", () => {
       }),
     );
     expect(result.kind).toBe("ok");
+  });
+
+  it("issues preview-matched local review cleanup commands", async () => {
+    const ctx = buildCtx();
+    const clearAction = {
+      commandType: "clear_local_review_items",
+      commandContext: {
+        expectedBlockerType: "local_review",
+        localReviewEventIds: ["event-review-1"],
+        reason: "Uploaded local review items can be cleared from this terminal.",
+      },
+      expectedEvidence: {
+        localReviewClearedEventIds: ["event-review-1"],
+        localReviewEventCount: 0,
+      },
+      reason: "Uploaded local review items can be cleared from this terminal.",
+    };
+    mocks.previewTerminalRecoveryQuery.mockResolvedValue({
+      appUpdate: {
+        description: "Current",
+        status: "current",
+      },
+      readiness: "needs_terminal_action",
+      runtimeFresh: true,
+      evidence: {
+        activeRegisterSession: false,
+        freshRuntimeRequiredForAbleToTransactNow: true,
+      },
+      cloudRepair: {
+        preconditionHash: "hash",
+        safeConflictIds: [],
+        skippedConflictIds: [],
+      },
+      commandStatus: null,
+      terminalActions: [clearAction],
+      manualReview: [],
+    });
+
+    const result = await getHandler(issueTerminalRecoveryCommand)(ctx as never, {
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      commandType: "clear_local_review_items",
+      commandContext: clearAction.commandContext,
+      expectedEvidence: clearAction.expectedEvidence,
+    });
+
+    expect(mocks.issueTerminalRecoveryCommandService).toHaveBeenCalledWith(
+      { repository: "write" },
+      expect.objectContaining({
+        commandContext: clearAction.commandContext,
+        commandType: "clear_local_review_items",
+        expectedEvidence: clearAction.expectedEvidence,
+        issuedByUserId: "athena-user-1",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    );
+    expect(result.kind).toBe("ok");
+  });
+
+  it("rejects terminal recovery commands that are not in the current server preview", async () => {
+    const ctx = buildCtx();
+    mocks.previewTerminalRecoveryQuery.mockResolvedValue({
+      appUpdate: {
+        description: "Current",
+        status: "current",
+      },
+      readiness: "needs_terminal_action",
+      runtimeFresh: true,
+      evidence: {
+        activeRegisterSession: false,
+        freshRuntimeRequiredForAbleToTransactNow: true,
+      },
+      cloudRepair: {
+        preconditionHash: "hash",
+        safeConflictIds: [],
+        skippedConflictIds: [],
+      },
+      commandStatus: null,
+      terminalActions: [
+        {
+          commandType: "clear_local_review_items",
+          commandContext: {
+            expectedBlockerType: "local_review",
+            localReviewEventIds: ["event-review-1"],
+            reason: "Uploaded local review items can be cleared from this terminal.",
+          },
+          expectedEvidence: {
+            localReviewClearedEventIds: ["event-review-1"],
+            localReviewEventCount: 0,
+          },
+          reason: "Uploaded local review items can be cleared from this terminal.",
+        },
+      ],
+      manualReview: [],
+    });
+
+    const result = await getHandler(issueTerminalRecoveryCommand)(ctx as never, {
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      commandType: "clear_local_review_items",
+      commandContext: {
+        expectedBlockerType: "local_review",
+        localReviewClearAll: true,
+        reason: "Clear everything.",
+      },
+      expectedEvidence: {
+        localReviewEventCount: 0,
+      },
+    });
+
+    expect(result).toMatchObject({
+      error: {
+        code: "precondition_failed",
+      },
+      kind: "user_error",
+    });
+    expect(mocks.issueTerminalRecoveryCommandService).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -1699,6 +1891,62 @@ describe("POS terminal public mutations", () => {
       expect.objectContaining({
         commandId: "command-1",
         executionId: "command-1:2000100",
+        result: "completed",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    );
+    expect(result.kind).toBe("ok");
+  });
+
+  it("forwards local review acknowledgement evidence from terminal runtime proof", async () => {
+    mocks.requireAuthenticatedAthenaUserWithCtx.mockRejectedValue(
+      new Error("not signed in"),
+    );
+    const ctx = buildCtx({
+      terminal: {
+        _id: "terminal-1",
+        storeId: "store-1",
+        status: "active",
+        registeredByUserId: "athena-user-2",
+        syncSecretHash: SYNC_SECRET_HASH,
+      },
+    });
+    const localReviewEvents = [
+      {
+        createdAt: 1,
+        localEventId: "event-review-1",
+        localRegisterSessionId: "register-local-1",
+        sequence: 1,
+        status: "needs_review",
+        type: "transaction.completed",
+        uploaded: true,
+        uploadSequence: 1,
+      },
+    ];
+
+    const result = await getHandler(acknowledgeTerminalRecoveryCommand)(
+      ctx as never,
+      {
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        syncSecretHash: "sync-secret-1",
+        commandId: "command-1",
+        result: "completed",
+        message: "Local review evidence collected.",
+        executionId: "command-1:2000100",
+        clearedLocalReviewEventIds: ["event-review-1"],
+        localReviewEvents,
+      },
+    );
+
+    expect(mocks.acknowledgeTerminalRecoveryCommandService).toHaveBeenCalledWith(
+      { repository: "write" },
+      expect.objectContaining({
+        clearedLocalReviewEventIds: ["event-review-1"],
+        commandId: "command-1",
+        executionId: "command-1:2000100",
+        localReviewEvents,
         result: "completed",
         storeId: "store-1",
         terminalId: "terminal-1",

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -193,6 +193,48 @@ const runtimeStatusSnapshotReturnValidator = v.object({
   receivedAt: v.number(),
 });
 
+const terminalSyncReviewTargetReturnValidator = v.object({
+  type: v.literal("open_work"),
+  workItemId: v.id("operationalWorkItem"),
+  workItemType: v.literal("synced_sale_inventory_review"),
+});
+
+const terminalSyncReviewSummaryReturnValidator = v.object({
+  groups: v.array(
+    v.object({
+      actionTarget: v.optional(
+        v.object({
+          type: v.literal("register_session"),
+          registerSessionId: v.id("registerSession"),
+        }),
+      ),
+      actionability: v.union(
+        v.literal("cash_controls_review"),
+        v.literal("diagnostic_only"),
+        v.literal("manual_review"),
+        v.literal("open_work_review"),
+      ),
+      conflictType: v.string(),
+      count: v.number(),
+      latestCreatedAt: v.number(),
+      latestSequence: v.number(),
+      owner: v.union(
+        v.literal("cash_controls"),
+        v.literal("diagnostic"),
+        v.literal("manual_review"),
+        v.literal("operations_open_work"),
+      ),
+      reviewTarget: v.optional(terminalSyncReviewTargetReturnValidator),
+    }),
+  ),
+  meta: v.object({
+    sampledCount: v.number(),
+    cap: v.number(),
+    hasMore: v.boolean(),
+    targetResolutionIncomplete: v.boolean(),
+  }),
+});
+
 const terminalSyncEvidenceReturnValidator = v.object({
   latestEvent: v.union(
     v.object({
@@ -263,14 +305,11 @@ const terminalSyncEvidenceReturnValidator = v.object({
     createdAt: v.number(),
     localEventId: v.string(),
     localRegisterSessionId: v.string(),
-    reviewTarget: v.optional(v.object({
-      type: v.literal("open_work"),
-      workItemId: v.id("operationalWorkItem"),
-      workItemType: v.literal("synced_sale_inventory_review"),
-    })),
+    reviewTarget: v.optional(terminalSyncReviewTargetReturnValidator),
     sequence: v.number(),
     summary: v.string(),
   }))),
+  reviewSummary: terminalSyncReviewSummaryReturnValidator,
   acceptedThroughSequence: v.optional(v.number()),
   cursorUpdatedAt: v.optional(v.number()),
 });
@@ -329,6 +368,95 @@ const terminalHealthAttentionReasonReturnValidator = v.object({
   ),
 });
 
+const terminalOperationalExplanationReturnValidator = v.object({
+  blockingDomain: v.union(
+    v.literal("cloud_repair"),
+    v.literal("manual_review"),
+    v.literal("none"),
+    v.literal("sync_review"),
+    v.literal("terminal_runtime"),
+  ),
+  detail: v.string(),
+  evidenceReferences: v.array(
+    v.object({
+      count: v.optional(v.number()),
+      source: v.union(
+        v.literal("cloud_repair"),
+        v.literal("cloud_register_lifecycle"),
+        v.literal("local_runtime"),
+        v.literal("recovery_command"),
+        v.literal("sync_evidence"),
+        v.literal("cloud_sync"),
+        v.literal("terminal_runtime"),
+      ),
+      summary: v.string(),
+      type: v.string(),
+    }),
+  ),
+  headline: v.string(),
+  lane: v.union(
+    v.literal("able_to_transact_now"),
+    v.literal("drawer_open"),
+    v.literal("healthy_idle"),
+    v.literal("needs_cloud_repair"),
+    v.literal("needs_manual_review"),
+    v.literal("needs_terminal_action"),
+    v.literal("sale_ready_with_review_backlog"),
+    v.literal("stale_runtime"),
+    v.literal("unknown"),
+  ),
+  nextStep: v.string(),
+  primaryOwner: v.union(
+    v.literal("cash_controls"),
+    v.literal("manager"),
+    v.literal("none"),
+    v.literal("operations"),
+    v.literal("support"),
+    v.literal("terminal"),
+  ),
+  saleImpact: v.union(
+    v.literal("can_transact_now"),
+    v.literal("not_ready"),
+    v.literal("unknown"),
+  ),
+  secondaryActions: v.array(
+    v.object({
+      label: v.string(),
+      primaryOwner: v.union(
+        v.literal("cash_controls"),
+        v.literal("manager"),
+        v.literal("operations"),
+        v.literal("support"),
+        v.literal("terminal"),
+      ),
+      supportAction: v.union(
+        v.literal("manual_review"),
+        v.literal("safe_cloud_repair"),
+        v.literal("terminal_command"),
+        v.literal("terminal_sync_retry"),
+      ),
+    }),
+  ),
+  severity: v.union(
+    v.literal("critical"),
+    v.literal("info"),
+    v.literal("warning"),
+  ),
+  summaryMeta: v.object({
+    hasSecondarySafeRepair: v.boolean(),
+    reviewBacklogCount: v.number(),
+    targetResolutionIncomplete: v.boolean(),
+  }),
+  supportAction: v.union(
+    v.literal("manual_review"),
+    v.literal("none"),
+    v.literal("safe_cloud_repair"),
+    v.literal("terminal_command"),
+    v.literal("terminal_sync_retry"),
+    v.literal("wait_for_check_in"),
+  ),
+});
+
 const terminalAppUpdatePreviewReturnValidator = v.object({
   commandCorrelated: v.optional(v.boolean()),
   currentBuildId: v.optional(v.string()),
@@ -371,6 +499,7 @@ const terminalHealthSummaryReturnValidator = v.object({
   runtimeAgeMs: v.union(v.number(), v.null()),
   runtimeStatus: v.union(runtimeStatusSnapshotReturnValidator, v.null()),
   attentionReasons: v.array(terminalHealthAttentionReasonReturnValidator),
+  operationalExplanation: terminalOperationalExplanationReturnValidator,
   recoveryPreview: v.union(
     v.object({
       readiness: v.union(

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -30,6 +30,7 @@ import {
   issueTerminalRecoveryCommand as issueTerminalRecoveryCommandService,
   listClaimableTerminalRecoveryCommands,
 } from "../application/terminalRecovery/terminalCommandService";
+import type { TerminalRecoveryPreview } from "../application/terminalOperationalState/types";
 import { runAcceptedRuntimeStatusSideEffects } from "../application/terminalRuntime/postRuntimeStatusSideEffects";
 import {
   createTerminalRecoveryCommandReadRepository,
@@ -45,6 +46,7 @@ import {
   posTerminalRecoveryCommandStatusValidator,
   posTerminalRecoveryCommandTypeValidator,
   posTerminalRecoveryExpectedEvidenceValidator,
+  posTerminalRecoveryLocalReviewEventValidator,
   posTerminalRecoveryVerificationStatusValidator,
 } from "../../schemas/pos/posTerminalRecovery";
 import {
@@ -528,6 +530,9 @@ const terminalHealthSummaryReturnValidator = v.object({
           commandType: posTerminalRecoveryCommandTypeValidator,
           label: v.string(),
           latestAcknowledgement: v.optional(v.string()),
+          localReviewEvents: v.optional(
+            v.array(posTerminalRecoveryLocalReviewEventValidator),
+          ),
           status: posTerminalRecoveryCommandStatusValidator,
           verificationStatus: posTerminalRecoveryVerificationStatusValidator,
         }),
@@ -587,6 +592,10 @@ const terminalRecoveryCommandReturnValidator = v.object({
   acknowledgement: v.optional(
     v.object({
       acknowledgedAt: v.number(),
+      clearedLocalReviewEventIds: v.optional(v.array(v.string())),
+      localReviewEvents: v.optional(
+        v.array(posTerminalRecoveryLocalReviewEventValidator),
+      ),
       message: v.optional(v.string()),
       result: v.union(
         v.literal("completed"),
@@ -676,7 +685,7 @@ function stripRuntimeStatusInput(
       failedEventCount: status.sync.failedEventCount,
       reviewEventCount: status.sync.reviewEventCount,
       localOnlyEventCount: status.sync.localOnlyEventCount,
-      reviewEvents: status.sync.reviewEvents,
+      reviewEvents: stripRuntimeReviewEvents(status.sync.reviewEvents),
       oldestPendingEventAt: status.sync.oldestPendingEventAt,
       nextPendingUploadSequence: status.sync.nextPendingUploadSequence,
       lastSyncedSequence: status.sync.lastSyncedSequence,
@@ -733,6 +742,28 @@ function stripRuntimeStatusInput(
       registerReadModelAgeMs: status.snapshots.registerReadModelAgeMs,
     },
   };
+}
+
+function stripRuntimeReviewEvents(
+  reviewEvents: TerminalRuntimeStatusInput["sync"]["reviewEvents"],
+) {
+  return reviewEvents?.map((event) => ({
+    createdAt: event.createdAt,
+    localEventId: event.localEventId,
+    ...(event.localPosSessionId
+      ? { localPosSessionId: event.localPosSessionId }
+      : {}),
+    ...(event.localRegisterSessionId
+      ? { localRegisterSessionId: event.localRegisterSessionId }
+      : {}),
+    sequence: event.sequence,
+    status: event.status,
+    type: event.type,
+    ...(event.uploaded !== undefined ? { uploaded: event.uploaded } : {}),
+    ...(typeof event.uploadSequence === "number"
+      ? { uploadSequence: event.uploadSequence }
+      : {}),
+  }));
 }
 
 async function requireTerminalStoreAccess(
@@ -1160,14 +1191,38 @@ export const issueTerminalRecoveryCommand = mutation({
           message: "This terminal is not active for this store.",
         });
       }
+      const recoveryPreview = await previewTerminalRecoveryQuery(ctx, {
+        now: Date.now(),
+        storeId: args.storeId,
+        terminalId: args.terminalId,
+      });
+      const matchingAction =
+        args.commandType === "clear_local_review_items" && recoveryPreview
+          ? findMatchingTerminalRecoveryAction(recoveryPreview.terminalActions, {
+              commandContext: args.commandContext,
+              commandType: args.commandType,
+              expectedEvidence: args.expectedEvidence,
+            })
+          : null;
+      if (args.commandType === "clear_local_review_items" && !matchingAction) {
+        return userError({
+          code: "precondition_failed",
+          message: "This terminal recovery command is no longer available.",
+        });
+      }
+      const commandAction = matchingAction ?? {
+        commandContext: args.commandContext,
+        commandType: args.commandType,
+        expectedEvidence: args.expectedEvidence,
+      };
       return issueTerminalRecoveryCommandService(
         createTerminalRecoveryCommandRepository(ctx),
         {
-          commandType: args.commandType,
-          expectedEvidence: args.expectedEvidence,
+          commandType: commandAction.commandType,
+          expectedEvidence: commandAction.expectedEvidence,
           issuedAt: Date.now(),
           issuedByUserId: athenaUser._id,
-          commandContext: args.commandContext,
+          commandContext: commandAction.commandContext,
           storeId: args.storeId,
           terminalId: args.terminalId,
         },
@@ -1181,6 +1236,38 @@ export const issueTerminalRecoveryCommand = mutation({
     }
   },
 });
+
+function findMatchingTerminalRecoveryAction(
+  actions: TerminalRecoveryPreview["terminalActions"],
+  target: {
+    commandContext: unknown;
+    commandType: string;
+    expectedEvidence: unknown;
+  },
+) {
+  return actions.find(
+    (action) =>
+      action.commandType === target.commandType &&
+      stableStringify(action.commandContext) ===
+        stableStringify(target.commandContext) &&
+      stableStringify(action.expectedEvidence) ===
+        stableStringify(target.expectedEvidence),
+  );
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter((entry) => entry[1] !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
 
 export const listTerminalRecoveryCommands = query({
   args: {
@@ -1265,6 +1352,10 @@ export const acknowledgeTerminalRecoveryCommand = mutation({
       v.literal("precondition_failed"),
     ),
     message: v.optional(v.string()),
+    clearedLocalReviewEventIds: v.optional(v.array(v.string())),
+    localReviewEvents: v.optional(
+      v.array(posTerminalRecoveryLocalReviewEventValidator),
+    ),
     executionId: v.optional(v.string()),
   },
   returns: commandResultValidator(terminalRecoveryCommandReturnValidator),
@@ -1282,8 +1373,10 @@ export const acknowledgeTerminalRecoveryCommand = mutation({
       createTerminalRecoveryCommandRepository(ctx),
       {
         acknowledgedAt: Date.now(),
+        clearedLocalReviewEventIds: args.clearedLocalReviewEventIds,
         commandId: args.commandId,
         executionId: args.executionId,
+        localReviewEvents: args.localReviewEvents,
         message: args.message,
         result: args.result,
         storeId: args.storeId,

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -855,6 +855,7 @@ const schema = defineSchema({
     .index("by_storeId", ["storeId"])
     .index("by_storeId_status", ["storeId", "status"])
     .index("by_storeId_type", ["storeId", "type"])
+    .index("by_storeId_type_status", ["storeId", "type", "status"])
     .index("by_storeId_assignedTo", ["storeId", "assignedToStaffProfileId"])
     .index("by_customerProfileId", ["customerProfileId"])
     .index("by_approvalState", ["approvalState"]),

--- a/packages/athena-webapp/convex/schemas/pos/posTerminalRecovery.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posTerminalRecovery.ts
@@ -2,6 +2,8 @@ import { v } from "convex/values";
 
 export const posTerminalRecoveryCommandTypeValidator = v.union(
   v.literal("retry_sync"),
+  v.literal("collect_local_review"),
+  v.literal("clear_local_review_items"),
   v.literal("repair_terminal_seed"),
   v.literal("clear_stale_drawer_authority"),
   v.literal("refresh_staff_authority"),
@@ -32,6 +34,9 @@ export const posTerminalRecoveryCommandPayloadValidator = v.object({
   expectedBlockerType: v.optional(v.string()),
   expectedConflictIds: v.optional(v.array(v.id("posLocalSyncConflict"))),
   expectedTerminalSeedIdentity: v.optional(v.string()),
+  localReviewClearAll: v.optional(v.boolean()),
+  localReviewClearLimit: v.optional(v.number()),
+  localReviewEventIds: v.optional(v.array(v.string())),
   localRegisterSessionId: v.optional(v.string()),
   reason: v.optional(v.string()),
 });
@@ -52,6 +57,9 @@ export const posTerminalRecoveryExpectedEvidenceValidator = v.object({
   drawerAuthorityStatus: v.optional(v.union(v.literal("healthy"), v.literal("blocked"))),
   localRegisterSessionId: v.optional(v.string()),
   localStoreAvailable: v.optional(v.boolean()),
+  localReviewDetailsCollected: v.optional(v.boolean()),
+  localReviewEventCount: v.optional(v.number()),
+  localReviewClearedEventIds: v.optional(v.array(v.string())),
   saleAuthorityStatus: v.optional(
     v.union(
       v.literal("ready"),
@@ -90,8 +98,40 @@ export const posTerminalRecoveryExpectedEvidenceValidator = v.object({
   terminalSeedReady: v.optional(v.boolean()),
 });
 
+export const posTerminalRecoveryLocalReviewEventValidator = v.object({
+  createdAt: v.number(),
+  localEventId: v.string(),
+  localPosSessionId: v.optional(v.string()),
+  localRegisterSessionId: v.optional(v.string()),
+  sequence: v.number(),
+  status: v.string(),
+  type: v.string(),
+  uploaded: v.optional(v.boolean()),
+  uploadSequence: v.optional(v.number()),
+});
+
+const posTerminalRecoveryStoredLocalReviewEventValidator = v.object({
+  createdAt: v.number(),
+  localEventId: v.string(),
+  localPosSessionId: v.optional(v.string()),
+  localRegisterSessionId: v.optional(v.string()),
+  // Legacy fields are accepted for existing audit rows but are no longer written
+  // or returned by public/runtime evidence paths.
+  localTransactionId: v.optional(v.string()),
+  sequence: v.number(),
+  staffProfileId: v.optional(v.string()),
+  status: v.string(),
+  type: v.string(),
+  uploaded: v.optional(v.boolean()),
+  uploadSequence: v.optional(v.number()),
+});
+
 export const posTerminalRecoveryCommandAckValidator = v.object({
   acknowledgedAt: v.number(),
+  clearedLocalReviewEventIds: v.optional(v.array(v.string())),
+  localReviewEvents: v.optional(
+    v.array(posTerminalRecoveryStoredLocalReviewEventValidator),
+  ),
   message: v.optional(v.string()),
   result: v.union(
     v.literal("completed"),

--- a/packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts
@@ -134,6 +134,8 @@ export const posTerminalRuntimeSyncValidator = v.object({
     localEventId: v.string(),
     localPosSessionId: v.optional(v.string()),
     localRegisterSessionId: v.optional(v.string()),
+    // Legacy fields are accepted for existing runtime rows but are stripped
+    // before new check-ins are persisted or terminal health reads are returned.
     localTransactionId: v.optional(v.string()),
     sequence: v.number(),
     staffProfileId: v.optional(v.string()),

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -809,6 +809,7 @@ describe("POSRegisterView", () => {
 
     expect(screen.getByText("Support sync diagnostics")).toBeInTheDocument();
     expect(screen.getAllByText("Offline")).not.toHaveLength(0);
+    await userEvent.click(screen.getByRole("tab", { name: "Register" }));
     expect(screen.getAllByText("Local")).not.toHaveLength(0);
     expect(screen.getByText("Open")).toBeInTheDocument();
   });
@@ -824,6 +825,41 @@ describe("POSRegisterView", () => {
         localEntryStatus: "ready",
         online: true,
         runtimeState: {
+          events: [
+            {
+              createdAt: Date.UTC(2026, 4, 15, 12, 33, 0),
+              localEventId: "local-event-open",
+              localRegisterSessionId: "cloud-register-1",
+              sequence: 1,
+              status: "synced",
+              type: "register.opened",
+              uploaded: true,
+              uploadSequence: 1,
+            },
+            {
+              createdAt: Date.UTC(2026, 4, 15, 12, 34, 0),
+              localEventId: "local-event-sale",
+              localPosSessionId: "sale-1",
+              localRegisterSessionId: "cloud-register-1",
+              localTransactionId: "transaction-1",
+              sequence: 4,
+              staffProfileId: "staff-1",
+              status: "needs_review",
+              type: "transaction.completed",
+              uploadSequence: 2,
+            },
+            {
+              createdAt: Date.UTC(2026, 4, 15, 12, 33, 30),
+              localEventId: "local-event-review-extra",
+              localRegisterSessionId: "cloud-register-1",
+              sequence: 3,
+              staffProfileId: "staff-1",
+              status: "needs_review",
+              syncUploadable: true,
+              type: "register.closeout_started",
+              uploadSequence: 2,
+            },
+          ],
           heartbeat: {
             activeRegisterSession: {
               cloudRegisterSessionId: "cloud-register-1",
@@ -857,6 +893,30 @@ describe("POSRegisterView", () => {
               failedEventCount: 0,
               pendingEventCount: 1,
               reviewEventCount: 2,
+              reviewEvents: [
+                {
+                  createdAt: Date.UTC(2026, 4, 15, 12, 34, 0),
+                  localEventId: "local-event-sale",
+                  localPosSessionId: "sale-1",
+                  localRegisterSessionId: "cloud-register-1",
+                  localTransactionId: "transaction-1",
+                  sequence: 4,
+                  staffProfileId: "staff-1",
+                  status: "needs_review",
+                  type: "transaction.completed",
+                  uploadSequence: 2,
+                },
+                {
+                  createdAt: Date.UTC(2026, 4, 15, 12, 33, 30),
+                  localEventId: "local-event-review-extra",
+                  localRegisterSessionId: "cloud-register-1",
+                  sequence: 3,
+                  staffProfileId: "staff-1",
+                  status: "needs_review",
+                  type: "register.closeout_started",
+                  uploadSequence: 2,
+                },
+              ],
               status: "pending_sync",
               uploadableEventCount: 1,
             },
@@ -972,8 +1032,10 @@ describe("POSRegisterView", () => {
     pressDebugPanelShortcut();
 
     expect(screen.getByText("Support sync diagnostics")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("tab", { name: "Register" }));
     expect(screen.getByText("Online")).toBeInTheDocument();
     expect(screen.getAllByText("Live")).not.toHaveLength(0);
+    await userEvent.click(screen.getByRole("tab", { name: "Runtime" }));
     expect(screen.getAllByText("Local review")).not.toHaveLength(0);
     expect(screen.getByText("Local review item")).toBeInTheDocument();
     expect(screen.getByText("Manual retry")).toBeInTheDocument();
@@ -1033,6 +1095,57 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("repair directive drawer")).toBeInTheDocument();
     expect(screen.getByText("repair directive expected")).toBeInTheDocument();
     expect(screen.getByText("13000")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("tab", { name: "Events" }));
+    const eventsPanel = screen
+      .getByText("Local IndexedDB events")
+      .closest("section");
+    expect(eventsPanel).not.toBeNull();
+    const eventsScope = within(eventsPanel!);
+    expect(eventsScope.getByRole("button", { name: "All 3" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(
+      eventsScope.getByRole("button", { name: "Review 2" }),
+    ).toBeInTheDocument();
+    expect(
+      eventsScope.getByRole("button", { name: "Uploadable 1" }),
+    ).toBeInTheDocument();
+    expect(
+      eventsScope.getByRole("button", { name: "Pending 0" }),
+    ).toBeInTheDocument();
+    expect(
+      eventsScope.getByRole("button", { name: "Failed 0" }),
+    ).toBeInTheDocument();
+    expect(
+      eventsScope.getByRole("button", { name: "Synced 1" }),
+    ).toBeInTheDocument();
+    expect(eventsScope.getByText("#4")).toBeInTheDocument();
+    expect(eventsScope.getByText("Transaction.Completed")).toBeInTheDocument();
+    expect(eventsScope.getAllByText("Needs Review")).toHaveLength(2);
+    expect(eventsScope.getByText("sale sale-1")).toBeInTheDocument();
+    expect(
+      eventsScope.getByText(
+        (_content, element) =>
+          element?.textContent === "transaction tran...tion-1",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      eventsScope.queryByText(/proof-token|payments|customer/i),
+    ).not.toBeInTheDocument();
+    await userEvent.click(eventsScope.getByRole("button", { name: "Review 2" }));
+    expect(eventsScope.getByText("#4")).toBeInTheDocument();
+    expect(eventsScope.getByText("#3")).toBeInTheDocument();
+    expect(eventsScope.queryByText("#1")).not.toBeInTheDocument();
+    await userEvent.click(
+      eventsScope.getByRole("button", { name: "Uploadable 1" }),
+    );
+    expect(eventsScope.getByText("#3")).toBeInTheDocument();
+    expect(eventsScope.queryByText("#4")).not.toBeInTheDocument();
+    expect(eventsScope.queryByText("#1")).not.toBeInTheDocument();
+    await userEvent.click(eventsScope.getByRole("button", { name: "Synced 1" }));
+    expect(eventsScope.getByText("#1")).toBeInTheDocument();
+    expect(eventsScope.queryByText("#4")).not.toBeInTheDocument();
 
     pressDebugPanelShortcut();
     expect(
@@ -1364,6 +1477,7 @@ describe("POSRegisterView", () => {
 
     await userEvent.keyboard("{Meta>}/{/Meta}");
 
+    await userEvent.click(screen.getByRole("tab", { name: "Register" }));
     expect(screen.getByText("cashier presence")).toBeInTheDocument();
     expect(screen.getByText("Restored")).toBeInTheDocument();
     expect(
@@ -1442,6 +1556,7 @@ describe("POSRegisterView", () => {
 
     pressDebugPanelShortcut();
 
+    await userEvent.click(screen.getByRole("tab", { name: "Register" }));
     expect(screen.getByText("app session")).toBeInTheDocument();
     expect(screen.getByText("Local sale continuation")).toBeInTheDocument();
     expect(screen.getByText("reconciliation posture")).toBeInTheDocument();

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -12,6 +12,7 @@ import {
 import type { Product } from "@/components/pos/types";
 import { SidebarProvider, useSidebar } from "@/components/ui/sidebar";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import View from "@/components/View";
 import {
   calculatePosRemainingDue,
@@ -680,7 +681,13 @@ function POSLocalDebugStrip({
 }) {
   if (!debug || !isVisible) return null;
 
-  const rows = [
+  const runtimeState = debug.runtimeState;
+  const heartbeat = runtimeState?.heartbeat;
+  const localEvents = runtimeState?.events ?? [];
+  const localReviewEvents = heartbeat?.sync.reviewEvents ?? [];
+  const localReadModel = runtimeState?.localReadModel;
+  const repair = runtimeState?.repair;
+  const registerRows: DebugPanelRow[] = [
     ["connection", debug.online ? "Online" : "Offline"],
     ["register activity", formatDebugStatus(debug.localEntryStatus)],
     ["staff access", formatDebugStatus(debug.localStaffAuthorityStatus)],
@@ -698,6 +705,28 @@ function POSLocalDebugStrip({
       debug.syncFlow.staffProof === "present" ? "Ready" : "Needed",
     ],
     ["sign-in panel", debug.authDialogOpen ? "Open" : "Closed"],
+    [
+      "local drawer",
+      formatDebugRegisterSession(localReadModel?.activeRegisterSession),
+    ],
+    [
+      "local block reason",
+      localReadModel?.saleBlockReason
+        ? formatDebugStatus(localReadModel.saleBlockReason)
+        : "none",
+    ],
+    [
+      "local read sequence",
+      localReadModel
+        ? [
+            `local ${localReadModel.syncStatus.lastLocalSequence}`,
+            `synced ${localReadModel.syncStatus.lastSyncedSequence ?? "n/a"}`,
+            `next ${localReadModel.syncStatus.nextPendingSequence ?? "n/a"}`,
+          ].join(" ")
+        : "none",
+    ],
+  ];
+  const syncRows: DebugPanelRow[] = [
     ["sync status", formatDebugStatus(debug.syncFlow.status)],
     ["sync hold-up", getDebugSyncHoldUp(debug)],
     ["next sync step", getDebugSyncNextStep(debug)],
@@ -807,11 +836,7 @@ function POSLocalDebugStrip({
       ].join(" "),
     ],
   ];
-  const runtimeState = debug.runtimeState;
-  const heartbeat = runtimeState?.heartbeat;
-  const localReadModel = runtimeState?.localReadModel;
-  const repair = runtimeState?.repair;
-  const runtimeRows = runtimeState
+  const heartbeatRows: DebugPanelRow[] = runtimeState
     ? [
         [
           "heartbeat source",
@@ -910,26 +935,6 @@ function POSLocalDebugStrip({
             : "none",
         ],
         [
-          "local drawer",
-          formatDebugRegisterSession(localReadModel?.activeRegisterSession),
-        ],
-        [
-          "local block reason",
-          localReadModel?.saleBlockReason
-            ? formatDebugStatus(localReadModel.saleBlockReason)
-            : "none",
-        ],
-        [
-          "local read sequence",
-          localReadModel
-            ? [
-                `local ${localReadModel.syncStatus.lastLocalSequence}`,
-                `synced ${localReadModel.syncStatus.lastSyncedSequence ?? "n/a"}`,
-                `next ${localReadModel.syncStatus.nextPendingSequence ?? "n/a"}`,
-              ].join(" ")
-            : "none",
-        ],
-        [
           "repair seed result",
           repair ? formatDebugStatus(repair.seedResult) : "not observed",
         ],
@@ -950,6 +955,7 @@ function POSLocalDebugStrip({
         ],
       ]
     : [];
+  const runtimeRows = [...heartbeatRows, ...syncRows];
   const flow = [
     {
       label: debug.online ? "Connected" : "Offline",
@@ -1025,33 +1031,38 @@ function POSLocalDebugStrip({
       >
         Support sync diagnostics
       </summary>
-      <div className="mt-3 flex flex-wrap items-center gap-2">
-        {flow.map((step, index) => (
-          <div key={step.label} className="flex items-center gap-2">
-            <span
-              className={cn(
-                "inline-flex h-7 items-center gap-1.5 rounded-full border px-2.5 font-medium",
-                step.state === "ready"
-                  ? "border-success/25 bg-success/10 text-success"
-                  : step.state === "blocked"
-                    ? "border-warning/30 bg-warning/15 text-warning"
-                    : step.state === "active"
-                      ? "border-primary/25 bg-primary/10 text-primary"
-                      : "border-border bg-background text-muted-foreground",
-              )}
-            >
-              <Circle className="h-2 w-2 fill-current" />
-              {step.label}
-            </span>
-            {index < flow.length - 1 ? (
-              <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
-            ) : null}
-          </div>
-        ))}
-      </div>
-      {debug.terminalId ? (
-        <div className="mt-3 flex flex-wrap items-center gap-2">
-          <Button asChild size="sm" variant="utility">
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          {flow.map((step, index) => (
+            <div key={step.label} className="flex items-center gap-2">
+              <span
+                className={cn(
+                  "inline-flex h-7 items-center gap-1.5 rounded-full border px-2.5 font-medium",
+                  step.state === "ready"
+                    ? "border-success/25 bg-success/10 text-success"
+                    : step.state === "blocked"
+                      ? "border-warning/30 bg-warning/15 text-warning"
+                      : step.state === "active"
+                        ? "border-primary/25 bg-primary/10 text-primary"
+                        : "border-border bg-background text-muted-foreground",
+                )}
+              >
+                <Circle className="h-2 w-2 fill-current" />
+                {step.label}
+              </span>
+              {index < flow.length - 1 ? (
+                <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
+              ) : null}
+            </div>
+          ))}
+        </div>
+        {debug.terminalId ? (
+          <Button
+            asChild
+            className="ml-auto h-8 px-2.5 text-xs"
+            size="sm"
+            variant="ghost"
+          >
             <Link
               params={(params) => ({
                 ...params,
@@ -1066,63 +1077,382 @@ function POSLocalDebugStrip({
               <ArrowRight aria-hidden className="h-3.5 w-3.5" />
             </Link>
           </Button>
+        ) : null}
+      </div>
+      <Tabs defaultValue="runtime" className="mt-4">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <TabsList
+            aria-label="Support sync diagnostic sections"
+            className="bg-background/60"
+            size="sm"
+          >
+            <TabsTrigger size="sm" value="runtime">
+              Runtime
+            </TabsTrigger>
+            <TabsTrigger size="sm" value="register">
+              Register
+            </TabsTrigger>
+            <TabsTrigger size="sm" value="events">
+              Events
+            </TabsTrigger>
+          </TabsList>
+          <p className="text-xs text-muted-foreground">
+            Runtime covers heartbeat and sync worker state. Register covers the
+            cashier and drawer context. Events shows the local IndexedDB log.
+          </p>
         </div>
-      ) : null}
-      {runtimeRows.length > 0 ? (
-        <section className="mt-4 rounded-md border border-border bg-background/70 p-3">
-          <div className="flex flex-wrap items-center gap-2">
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Runtime state
-            </p>
+        <TabsContent className="mt-3" value="runtime">
+          <DebugPanelSection
+            badges={[
+              {
+                label: localReadModel?.canSell
+                  ? "local sale ready"
+                  : "local gate active",
+                tone: localReadModel?.canSell ? "ready" : "warning",
+              },
+              {
+                label: `repair ${
+                  repair ? formatDebugStatus(repair.seedResult) : "not observed"
+                }`,
+                tone:
+                  repair?.seedResult === "seeded"
+                    ? "ready"
+                    : repair?.seedResult === "gateway_rejected" ||
+                        repair?.seedResult === "missing_staff_identity"
+                      ? "warning"
+                      : "neutral",
+              },
+            ]}
+            description="Heartbeat, local read-model, repair, and upload-worker signals."
+            rows={runtimeRows}
+            title="Runtime state"
+          />
+        </TabsContent>
+        <TabsContent className="mt-3" value="register">
+          <DebugPanelSection
+            badges={[
+              {
+                label: debug.staffSignedIn ? "staff signed in" : "no staff",
+                tone: debug.staffSignedIn ? "ready" : "warning",
+              },
+              {
+                label: debug.authDialogOpen ? "sign-in open" : "sign-in closed",
+                tone: debug.authDialogOpen ? "warning" : "neutral",
+              },
+            ]}
+            description="Register record, cashier presence, app session, and drawer context."
+            rows={registerRows}
+            title="Register state"
+          />
+        </TabsContent>
+        <TabsContent className="mt-3" value="events">
+          <DebugEventsSection
+            events={localEvents}
+            reviewEvents={localReviewEvents}
+          />
+        </TabsContent>
+      </Tabs>
+    </details>
+  );
+}
+
+type DebugPanelRow = [label: string, value: string];
+
+type DebugRuntimeState = NonNullable<
+  NonNullable<RegisterViewModel["debug"]>["runtimeState"]
+>;
+type DebugEventRecord = NonNullable<DebugRuntimeState["events"]>[number];
+type DebugEventFilter =
+  | "all"
+  | "review"
+  | "uploadable"
+  | "pending"
+  | "failed"
+  | "synced";
+
+const DEBUG_EVENT_FILTERS: Array<{
+  label: string;
+  value: DebugEventFilter;
+}> = [
+  { label: "All", value: "all" },
+  { label: "Review", value: "review" },
+  { label: "Uploadable", value: "uploadable" },
+  { label: "Pending", value: "pending" },
+  { label: "Failed", value: "failed" },
+  { label: "Synced", value: "synced" },
+];
+
+function isDebugEventReview(event: DebugEventRecord) {
+  return event.status === "needs_review";
+}
+
+function isDebugEventFailed(event: DebugEventRecord) {
+  return event.status === "failed";
+}
+
+function isDebugEventSynced(event: DebugEventRecord) {
+  return (
+    !isDebugEventReview(event) &&
+    !isDebugEventFailed(event) &&
+    (event.uploaded === true ||
+      event.status === "synced" ||
+      event.status === "locally_resolved")
+  );
+}
+
+function isDebugEventUploadable(event: DebugEventRecord) {
+  if (event.syncUploadable !== undefined) {
+    return event.syncUploadable;
+  }
+
+  return (
+    !isDebugEventReview(event) &&
+    !isDebugEventFailed(event) &&
+    !isDebugEventSynced(event) &&
+    event.uploaded !== true &&
+    typeof event.uploadSequence === "number"
+  );
+}
+
+function isDebugEventPending(event: DebugEventRecord) {
+  return (
+    !isDebugEventReview(event) &&
+    !isDebugEventFailed(event) &&
+    !isDebugEventSynced(event) &&
+    !isDebugEventUploadable(event)
+  );
+}
+
+function debugEventMatchesFilter(
+  event: DebugEventRecord,
+  filter: DebugEventFilter,
+) {
+  switch (filter) {
+    case "review":
+      return isDebugEventReview(event);
+    case "uploadable":
+      return isDebugEventUploadable(event);
+    case "pending":
+      return isDebugEventPending(event);
+    case "failed":
+      return isDebugEventFailed(event);
+    case "synced":
+      return isDebugEventSynced(event);
+    case "all":
+    default:
+      return true;
+  }
+}
+
+function DebugPanelSection({
+  badges,
+  description,
+  rows,
+  title,
+}: {
+  badges: Array<{ label: string; tone: "neutral" | "ready" | "warning" }>;
+  description: string;
+  rows: DebugPanelRow[];
+  title: string;
+}) {
+  return (
+    <section className="rounded-md border border-border bg-background/70 p-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {title}
+          </p>
+          <p className="max-w-2xl text-xs leading-5 text-muted-foreground">
+            {description}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {badges.map((badge) => (
             <span
               className={cn(
                 "inline-flex h-6 items-center rounded-full border px-2 font-medium",
-                localReadModel?.canSell
+                badge.tone === "ready"
                   ? "border-success/25 bg-success/10 text-success"
-                  : "border-warning/30 bg-warning/15 text-warning",
-              )}
-            >
-              {localReadModel?.canSell ? "local sale ready" : "local gate active"}
-            </span>
-            <span
-              className={cn(
-                "inline-flex h-6 items-center rounded-full border px-2 font-medium",
-                repair?.seedResult === "seeded"
-                  ? "border-success/25 bg-success/10 text-success"
-                  : repair?.seedResult === "gateway_rejected" ||
-                      repair?.seedResult === "missing_staff_identity"
+                  : badge.tone === "warning"
                     ? "border-warning/30 bg-warning/15 text-warning"
                     : "border-border bg-muted/30 text-muted-foreground",
               )}
+              key={badge.label}
             >
-              repair {repair ? formatDebugStatus(repair.seedResult) : "not observed"}
+              {badge.label}
             </span>
-          </div>
-          <dl className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-            {runtimeRows.map(([label, value]) => (
-              <div key={label} className="min-w-0">
-                <dt className="uppercase tracking-wide text-muted-foreground">
-                  {label}
-                </dt>
-                <dd className="break-words font-mono text-foreground">
-                  {value}
-                </dd>
-              </div>
-            ))}
-          </dl>
-        </section>
-      ) : null}
-      <dl className="mt-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          ))}
+        </div>
+      </div>
+      <dl className="mt-3 grid gap-x-5 gap-y-3 sm:grid-cols-2 xl:grid-cols-3">
         {rows.map(([label, value]) => (
-          <div key={label} className="min-w-0">
-            <dt className="uppercase tracking-wide text-muted-foreground">
+          <div key={label} className="min-w-0 border-t border-border/60 pt-2">
+            <dt className="text-[0.68rem] font-medium uppercase tracking-wide text-muted-foreground">
               {label}
             </dt>
-            <dd className="break-words font-mono text-foreground">{value}</dd>
+            <dd className="mt-0.5 break-words font-mono text-[0.72rem] leading-5 text-foreground">
+              {value}
+            </dd>
           </div>
         ))}
       </dl>
-    </details>
+    </section>
+  );
+}
+
+function DebugEventsSection({
+  events,
+  reviewEvents,
+}: {
+  events: DebugRuntimeState["events"];
+  reviewEvents?: NonNullable<DebugRuntimeState["heartbeat"]>["sync"]["reviewEvents"];
+}) {
+  const [eventFilter, setEventFilter] = useState<DebugEventFilter>("all");
+  const mergedEventsById = new Map<string, DebugEventRecord>();
+  for (const event of reviewEvents ?? []) {
+    mergedEventsById.set(event.localEventId, event);
+  }
+  for (const event of events ?? []) {
+    mergedEventsById.set(event.localEventId, event);
+  }
+  const orderedEvents = [...mergedEventsById.values()].sort(
+    (left, right) => right.sequence - left.sequence,
+  );
+  const filteredEvents = orderedEvents.filter((event) =>
+    debugEventMatchesFilter(event, eventFilter),
+  );
+  const eventFilterCounts = DEBUG_EVENT_FILTERS.reduce<
+    Record<DebugEventFilter, number>
+  >((counts, filter) => {
+    counts[filter.value] =
+      filter.value === "all"
+        ? orderedEvents.length
+        : orderedEvents.filter((event) =>
+            debugEventMatchesFilter(event, filter.value),
+          ).length;
+    return counts;
+  }, {} as Record<DebugEventFilter, number>);
+
+  return (
+    <section className="rounded-md border border-border bg-background/70 p-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Local IndexedDB events
+          </p>
+          <p className="max-w-2xl text-xs leading-5 text-muted-foreground">
+            Local event records reported by this terminal. Payload and proof
+            fields are omitted.
+          </p>
+        </div>
+        <div aria-label="Local event filters" className="flex flex-wrap gap-2">
+          {DEBUG_EVENT_FILTERS.map((filter) => {
+            const isActive = eventFilter === filter.value;
+            return (
+              <button
+                aria-pressed={isActive}
+                className={cn(
+                  "inline-flex h-6 items-center rounded-full border px-2 font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  isActive
+                    ? "border-foreground/20 bg-foreground text-background"
+                    : filter.value === "synced"
+                      ? "border-success/25 bg-success/10 text-success"
+                      : filter.value === "review" || filter.value === "failed"
+                        ? "border-warning/30 bg-warning/15 text-warning"
+                        : "border-border bg-muted/30 text-muted-foreground hover:bg-muted",
+                )}
+                key={filter.value}
+                type="button"
+                onClick={() => setEventFilter(filter.value)}
+              >
+                {filter.label} {eventFilterCounts[filter.value]}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      {filteredEvents.length > 0 ? (
+        <div className="mt-3 max-h-[32rem] overflow-auto rounded-md border border-border/70">
+          <div className="min-w-[46rem]">
+            <div className="sticky top-0 z-10 grid grid-cols-[5rem_minmax(12rem,1fr)_8rem_8rem_minmax(10rem,1fr)] gap-3 border-b border-border bg-muted px-3 py-2 text-[0.68rem] font-medium uppercase tracking-wide text-muted-foreground">
+              <span>Sequence</span>
+              <span>Event</span>
+              <span>Status</span>
+              <span>Upload</span>
+              <span>Scope</span>
+            </div>
+            <div className="divide-y divide-border/70">
+              {filteredEvents.map((event) => (
+                <div
+                  className="grid grid-cols-[5rem_minmax(12rem,1fr)_8rem_8rem_minmax(10rem,1fr)] gap-3 px-3 py-2 text-xs"
+                  key={event.localEventId}
+                >
+                  <div className="font-mono text-muted-foreground">
+                    #{event.sequence}
+                  </div>
+                  <div className="min-w-0">
+                    <p className="truncate font-medium text-foreground">
+                      {formatDebugStatus(event.type)}
+                    </p>
+                    <p className="mt-0.5 truncate font-mono text-[0.68rem] text-muted-foreground">
+                      {event.localEventId}
+                    </p>
+                    <p className="mt-0.5 font-mono text-[0.68rem] text-muted-foreground">
+                      {formatDebugTimestamp(event.createdAt)}
+                    </p>
+                  </div>
+                  <div className="font-mono text-foreground">
+                    {formatDebugStatus(event.status)}
+                  </div>
+                  <div className="font-mono text-muted-foreground">
+                    {typeof event.uploadSequence === "number"
+                      ? `#${event.uploadSequence}`
+                      : "n/a"}
+                    {event.uploaded === true ? " uploaded" : ""}
+                  </div>
+                  <div className="min-w-0 space-y-0.5 font-mono text-[0.68rem] text-muted-foreground">
+                    {event.localRegisterSessionId ? (
+                      <p className="truncate">
+                        register{" "}
+                        {formatDebugIdentifier(event.localRegisterSessionId)}
+                      </p>
+                    ) : null}
+                    {event.localPosSessionId ? (
+                      <p className="truncate">
+                        sale {formatDebugIdentifier(event.localPosSessionId)}
+                      </p>
+                    ) : null}
+                    {event.localTransactionId ? (
+                      <p className="truncate">
+                        transaction{" "}
+                        {formatDebugIdentifier(event.localTransactionId)}
+                      </p>
+                    ) : null}
+                    {event.staffProfileId ? (
+                      <p className="truncate">
+                        staff {formatDebugIdentifier(event.staffProfileId)}
+                      </p>
+                    ) : null}
+                    {!event.localRegisterSessionId &&
+                    !event.localPosSessionId &&
+                    !event.localTransactionId &&
+                    !event.staffProfileId ? (
+                      <p>none</p>
+                    ) : null}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-3 rounded-md border border-dashed border-border px-3 py-4 text-xs text-muted-foreground">
+          {orderedEvents.length > 0
+            ? "No local events match this filter."
+            : "No local events were reported by this terminal."}
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -1078,6 +1084,79 @@ describe("POSTerminalDetailViewContent", () => {
     expect(mocks.toastSuccess).toHaveBeenCalledWith("Terminal command queued.");
   });
 
+  it("lets operators collect local review items from a local runtime review row", async () => {
+    const onIssueTerminalRecoveryCommand = vi.fn(async () => ({
+      data: { _id: "command-retry" },
+      kind: "ok" as const,
+    }));
+
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [
+            {
+              actionTarget: { type: "pos_register" },
+              count: 84,
+              nextPendingUploadSequence: 1,
+              source: "local_runtime",
+              summary: "84 local review items are still on this terminal.",
+              type: "local_review",
+            },
+          ],
+          recovery: {
+            readiness: "needs_terminal_action",
+            terminalActions: [
+              {
+                commandContext: {
+                  expectedBlockerType: "local_review",
+                  reason: "Local review items need terminal-local evidence collection.",
+                },
+                commandType: "collect_local_review",
+                expectedEvidence: {
+                  localReviewDetailsCollected: true,
+                },
+                reason: "Local review items need terminal-local evidence collection.",
+              },
+            ],
+          },
+        }}
+        isLoading={false}
+        onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+        orgUrlSlug="wigclub"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    const attentionSection = screen
+      .getByRole("heading", { name: /why this terminal needs attention/i })
+      .closest("section");
+    expect(attentionSection).not.toBeNull();
+
+    fireEvent.click(
+      within(attentionSection as HTMLElement).getByRole("button", {
+        name: /collect local review items/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onIssueTerminalRecoveryCommand).toHaveBeenCalledWith({
+        action: expect.objectContaining({
+          commandContext: expect.objectContaining({
+            expectedBlockerType: "local_review",
+          }),
+          commandType: "collect_local_review",
+          expectedEvidence: {
+            localReviewDetailsCollected: true,
+          },
+          kind: "terminal_command",
+        }),
+        terminalId: "terminal-1",
+      });
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Terminal command queued.");
+  });
+
   it("issues Update app from active terminals even when update readiness is unknown", async () => {
     const onIssueTerminalRecoveryCommand = vi.fn(async () => ({
       data: { _id: "command-update" },
@@ -1230,13 +1309,13 @@ describe("POSTerminalDetailViewContent", () => {
               {
                 commandContext: {
                   expectedBlockerType: "local_review",
-                  reason: "Local review items need a terminal sync retry.",
+                  reason: "Local review items need terminal-local evidence collection.",
                 },
-                commandType: "retry_sync",
+                commandType: "collect_local_review",
                 expectedEvidence: {
-                  syncStatus: "idle",
+                  localReviewDetailsCollected: true,
                 },
-                reason: "Local review items need a terminal sync retry.",
+                reason: "Local review items need terminal-local evidence collection.",
               },
             ],
           },
@@ -1254,7 +1333,7 @@ describe("POSTerminalDetailViewContent", () => {
     expect(screen.getByText("1 safe action")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "retry terminal sync, then use the next check-in to decide whether drawer repair still needs to run.",
+        "collect local review items from this checkout station, then use the next check-in to review the terminal-local evidence.",
       ),
     ).toBeInTheDocument();
     expect(
@@ -1264,12 +1343,13 @@ describe("POSTerminalDetailViewContent", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Command did not complete. Retry terminal sync before sending drawer repair again.",
+        "Command did not complete. Use the available terminal action before sending drawer repair again.",
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /retry terminal sync/i }),
-    ).toBeInTheDocument();
+      screen.getAllByRole("button", { name: /collect local review items/i })
+        .length,
+    ).toBeGreaterThan(0);
   });
 
   it("does not foreground old failed recovery commands when no support work remains", () => {
@@ -1793,7 +1873,12 @@ describe("POSTerminalDetailViewContent", () => {
     ).toBeInTheDocument();
   });
 
-  it("explains when local review counts arrive without item details", () => {
+  it("offers local review collection when local review counts arrive without item details", async () => {
+    const onIssueTerminalRecoveryCommand = vi.fn(async () => ({
+      data: { _id: "command-retry" },
+      kind: "ok" as const,
+    }));
+
     render(
       <POSTerminalDetailViewContent
         detail={{
@@ -1807,6 +1892,22 @@ describe("POSTerminalDetailViewContent", () => {
               status: "needs_review",
             },
           },
+          recovery: {
+            readiness: "needs_terminal_action",
+            terminalActions: [
+              {
+                commandContext: {
+                  expectedBlockerType: "local_review",
+                  reason: "Local review items need terminal-local evidence collection.",
+                },
+                commandType: "collect_local_review",
+                expectedEvidence: {
+                  localReviewDetailsCollected: true,
+                },
+                reason: "Local review items need terminal-local evidence collection.",
+              },
+            ],
+          },
           syncEvidence: {
             ...detail.syncEvidence,
             unresolvedConflicts: [],
@@ -1814,17 +1915,231 @@ describe("POSTerminalDetailViewContent", () => {
           },
         }}
         isLoading={false}
+        onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
       />,
     );
 
     expect(
-      screen.getByText("33 local review items were reported by this terminal."),
+      screen.getByText("33 local review items need local collection."),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "The latest runtime check-in did not include item-level local review details.",
+        "Details are missing from the latest check-in. Collect local review items from this checkout station.",
       ),
     ).toBeInTheDocument();
+
+    const conflictSection = screen
+      .getByRole("heading", { name: /conflicts and review/i })
+      .closest("section");
+    expect(conflictSection).not.toBeNull();
+    fireEvent.click(
+      within(conflictSection as HTMLElement).getByRole("button", {
+        name: /collect local review items/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onIssueTerminalRecoveryCommand).toHaveBeenCalledWith({
+        action: expect.objectContaining({
+          commandContext: expect.objectContaining({
+            expectedBlockerType: "local_review",
+          }),
+          commandType: "collect_local_review",
+          expectedEvidence: {
+            localReviewDetailsCollected: true,
+          },
+          kind: "terminal_command",
+        }),
+        terminalId: "terminal-1",
+      });
+    });
+  });
+
+  it("keeps local review collection available when verified collection did not clear the latest check-in", async () => {
+    const onIssueTerminalRecoveryCommand = vi.fn(async () => ({
+      data: { _id: "command-retry" },
+      kind: "ok" as const,
+    }));
+
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          runtimeStatus: {
+            ...detail.runtimeStatus!,
+            sync: {
+              ...detail.runtimeStatus!.sync,
+              reviewEventCount: 33,
+              reviewEvents: [],
+              status: "needs_review",
+            },
+          },
+          recovery: {
+            commandStatus: {
+              commandType: "collect_local_review",
+              label: "Collect local review items",
+              status: "completed",
+              verificationStatus: "verified",
+            },
+            readiness: "needs_terminal_action",
+            terminalActions: [
+              {
+                commandContext: {
+                  expectedBlockerType: "local_review",
+                  reason: "Local review items need terminal-local evidence collection.",
+                },
+                commandType: "collect_local_review",
+                expectedEvidence: {
+                  localReviewDetailsCollected: true,
+                },
+                reason: "Local review items need terminal-local evidence collection.",
+              },
+            ],
+          },
+          syncEvidence: {
+            ...detail.syncEvidence,
+            unresolvedConflicts: [],
+            unresolvedConflictCount: 0,
+          },
+        }}
+        isLoading={false}
+        onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+      />,
+    );
+
+    const conflictSection = screen
+      .getByRole("heading", { name: /conflicts and review/i })
+      .closest("section");
+    expect(conflictSection).not.toBeNull();
+    fireEvent.click(
+      within(conflictSection as HTMLElement).getByRole("button", {
+        name: /collect local review items/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onIssueTerminalRecoveryCommand).toHaveBeenCalledWith({
+        action: expect.objectContaining({
+          commandContext: expect.objectContaining({
+            expectedBlockerType: "local_review",
+          }),
+          commandType: "collect_local_review",
+          expectedEvidence: {
+            localReviewDetailsCollected: true,
+          },
+          kind: "terminal_command",
+        }),
+        terminalId: "terminal-1",
+      });
+    });
+  });
+
+  it("shows collected local review evidence and clear action when collection matches the latest count", async () => {
+    const onIssueTerminalRecoveryCommand = vi.fn(async () => ({
+      data: { _id: "command-clear" },
+      kind: "ok" as const,
+    }));
+
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          runtimeStatus: {
+            ...detail.runtimeStatus!,
+            sync: {
+              ...detail.runtimeStatus!.sync,
+              reviewEventCount: 2,
+              reviewEvents: [],
+              status: "needs_review",
+            },
+          },
+          recovery: {
+            commandStatus: {
+              commandType: "collect_local_review",
+              label: "Collect local review items",
+              localReviewEvents: [
+                {
+                  createdAt: Date.now() - 1_000,
+                  localEventId: "event-review-1",
+                  sequence: 12,
+                  status: "needs_review",
+                  type: "transaction.completed",
+                  uploaded: true,
+                  uploadSequence: 3,
+                },
+                {
+                  createdAt: Date.now() - 500,
+                  localEventId: "event-review-2",
+                  sequence: 13,
+                  status: "needs_review",
+                  type: "register.closeout_started",
+                  uploaded: true,
+                  uploadSequence: 4,
+                },
+              ],
+              status: "completed",
+              verificationStatus: "verified",
+            },
+            readiness: "needs_terminal_action",
+            terminalActions: [
+              {
+                commandContext: {
+                  expectedBlockerType: "local_review",
+                  localReviewEventIds: ["event-review-1", "event-review-2"],
+                  reason:
+                    "Uploaded local review items can be cleared from this terminal.",
+                },
+                commandType: "clear_local_review_items",
+                expectedEvidence: {
+                  localReviewEventCount: 0,
+                },
+                reason:
+                  "Uploaded local review items can be cleared from this terminal.",
+              },
+            ],
+          },
+          syncEvidence: {
+            ...detail.syncEvidence,
+            unresolvedConflicts: [],
+            unresolvedConflictCount: 0,
+          },
+        }}
+        isLoading={false}
+        onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+      />,
+    );
+
+    expect(screen.getByText("transaction.completed")).toBeInTheDocument();
+    expect(screen.getByText("register.closeout_started")).toBeInTheDocument();
+    expect(
+      screen.queryByText("2 local review items need local collection."),
+    ).not.toBeInTheDocument();
+
+    const conflictSection = screen
+      .getByRole("heading", { name: /conflicts and review/i })
+      .closest("section");
+    expect(conflictSection).not.toBeNull();
+    fireEvent.click(
+      within(conflictSection as HTMLElement).getByRole("button", {
+        name: /clear local review items/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onIssueTerminalRecoveryCommand).toHaveBeenCalledWith({
+        action: expect.objectContaining({
+          commandContext: expect.objectContaining({
+            localReviewEventIds: ["event-review-1", "event-review-2"],
+          }),
+          commandType: "clear_local_review_items",
+          expectedEvidence: {
+            localReviewEventCount: 0,
+          },
+          kind: "terminal_command",
+        }),
+        terminalId: "terminal-1",
+      });
+    });
   });
 
   it("renders no-data and query unavailable states", () => {

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -438,9 +438,7 @@ describe("POSTerminalDetailViewContent", () => {
     const staffAuthorityLabel = screen.getByText("Staff authority");
     expect(staffAuthorityLabel).toBeInTheDocument();
     expect(screen.getAllByText("Ready").length).toBeGreaterThanOrEqual(2);
-    expect(
-      screen.queryByText("Staff authority ready"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Staff authority ready")).not.toBeInTheDocument();
   });
 
   it("renders expired staff authority as a compact warning state", () => {
@@ -812,6 +810,163 @@ describe("POSTerminalDetailViewContent", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders server operational explanation with bounded evidence and hides raw review payloads", () => {
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [],
+          operationalExplanation: {
+            blockingDomain: "sync_review",
+            detail:
+              "M Supplies conflict-raw-001 includes payment payload and customer payload details.",
+            evidenceReferences: [
+              {
+                count: 17,
+                source: "cloud_sync",
+                summary: "M Supplies conflict-raw-001 payment payload",
+                type: "synced_sale_inventory_review",
+              },
+            ],
+            headline: "M Supplies review needed",
+            lane: "sale_ready_with_review_backlog",
+            nextStep:
+              "Review the open work queue before support repairs anything.",
+            primaryOwner: "operations",
+            saleImpact: "can_transact_now",
+            secondaryActions: [
+              {
+                label: "Safe cloud repair available",
+                primaryOwner: "support",
+                supportAction: "safe_cloud_repair",
+              },
+            ],
+            severity: "warning",
+            summaryMeta: {
+              hasSecondarySafeRepair: true,
+              reviewBacklogCount: 17,
+              targetResolutionIncomplete: false,
+            },
+            supportAction: "manual_review",
+          },
+          recovery: {
+            readiness: {
+              status: "able_to_transact_now",
+              summary:
+                "Able to transact now. Drawer, cashier, and sale authority are active.",
+            },
+          },
+          syncEvidence: {
+            ...detail.syncEvidence,
+            unresolvedConflicts: [
+              {
+                _id: "conflict-raw-001",
+                conflictType: "payment",
+                createdAt: Date.now() - 3 * 60_000,
+                localEventId: "local-secret-payment",
+                localRegisterSessionId: "local-session-secret",
+                sequence: 44,
+                summary: "A synced payment event needs manager review.",
+              },
+            ],
+          },
+        }}
+        isLoading={false}
+        orgUrlSlug="wigclub"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    expect(screen.getAllByText("Review needed").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Sales can continue.").length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getAllByText("Sales can continue").length).toBeGreaterThan(0);
+    expect(screen.getByText("Operations")).toBeInTheDocument();
+    expect(screen.getByText("Manual review")).toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        "Review the open work queue before support repairs anything.",
+      ).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("Review evidence")).toBeInTheDocument();
+    expect(screen.getByText("17")).toBeInTheDocument();
+    expect(screen.getByText("Synced Sale Inventory Review")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: /resolve safe cloud repair/i,
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        /M Supplies|conflict-raw-001|payment payload|customer payload|sync secret|backend exception/i,
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps detailed conflict and local review rows visible with an operational explanation", () => {
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          operationalExplanation: {
+            blockingDomain: "sync_review",
+            detail:
+              "Review-owned sync work needs attention, but this terminal has fresh sale authority.",
+            evidenceReferences: [
+              {
+                count: 1,
+                source: "cloud_sync",
+                summary: "1 cloud sync conflict needs review.",
+                type: "cloud_conflict",
+              },
+            ],
+            headline: "Review needed. Sales can continue.",
+            lane: "sale_ready_with_review_backlog",
+            nextStep: "Use the linked review workspace to clear the backlog.",
+            primaryOwner: "cash_controls",
+            saleImpact: "can_transact_now",
+            secondaryActions: [],
+            severity: "warning",
+            summaryMeta: {
+              hasSecondarySafeRepair: false,
+              reviewBacklogCount: 1,
+              targetResolutionIncomplete: false,
+            },
+            supportAction: "manual_review",
+          },
+          syncEvidence: {
+            ...detail.syncEvidence,
+            unresolvedConflicts: [
+              {
+                _id: "conflict-visible",
+                conflictType: "permission",
+                createdAt: Date.now() - 3 * 60_000,
+                localEventId: "local-visible",
+                localRegisterSessionId: "local-session-visible",
+                sequence: 44,
+                summary: "A synced register event needs permission review.",
+              },
+            ],
+          },
+        }}
+        isLoading={false}
+        orgUrlSlug="wigclub"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    expect(screen.getAllByText("Review needed").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Sales can continue.").length).toBeGreaterThan(
+      0,
+    );
+    expect(
+      screen.getByText("A synced register event needs permission review."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("register.opened")).toBeInTheDocument();
+    expect(screen.getByText("cart.item_added")).toBeInTheDocument();
+  });
+
   it("issues cloud and terminal recovery actions from displayed metadata", async () => {
     const onResolveTerminalCloudRepair = vi.fn(async () => ({
       data: { resolvedCount: 1 },
@@ -966,7 +1121,9 @@ describe("POSTerminalDetailViewContent", () => {
         terminalId: "terminal-1",
       });
     });
-    expect(mocks.toastSuccess).toHaveBeenCalledWith("Update app command queued.");
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "Update app command queued.",
+    );
   });
 
   it("disables duplicate Update app actions while an equivalent command is active", () => {
@@ -1255,7 +1412,9 @@ describe("POSTerminalDetailViewContent", () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText("Verification")).not.toBeInTheDocument();
     expect(
-      screen.queryByText("Recovery was verified by the latest terminal check-in."),
+      screen.queryByText(
+        "Recovery was verified by the latest terminal check-in.",
+      ),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByText(
@@ -1277,7 +1436,8 @@ describe("POSTerminalDetailViewContent", () => {
   it("shows normalized recovery action failures", async () => {
     const onResolveTerminalCloudRepair = vi.fn(async () => ({
       error: {
-        message: "Terminal recovery evidence changed. Preview the repair again.",
+        message:
+          "Terminal recovery evidence changed. Preview the repair again.",
       },
       kind: "user_error" as const,
     }));
@@ -1395,7 +1555,9 @@ describe("POSTerminalDetailViewContent", () => {
     );
 
     expect(screen.getByText("Manual review summary 5")).toBeInTheDocument();
-    expect(screen.queryByText("Manual review summary 6")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Manual review summary 6"),
+    ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Show 3 more" }));
 
@@ -1403,7 +1565,9 @@ describe("POSTerminalDetailViewContent", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Show fewer" }));
 
-    expect(screen.queryByText("Manual review summary 6")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Manual review summary 6"),
+    ).not.toBeInTheDocument();
   });
 
   it("routes attention reasons to the available action surfaces", () => {

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
@@ -1057,10 +1057,14 @@ function SyncEvidenceSection({
 }
 
 function ConflictSection({
+  detail,
+  onIssueTerminalRecoveryCommand,
   operationalExplanation,
   runtimeStatus,
   syncEvidence,
 }: {
+  detail?: TerminalHealthDetail;
+  onIssueTerminalRecoveryCommand?: POSTerminalDetailViewContentProps["onIssueTerminalRecoveryCommand"];
   operationalExplanation?: ReturnType<
     typeof buildTerminalOperationalExplanationPresentation
   >;
@@ -1070,7 +1074,18 @@ function ConflictSection({
   const [isConflictListExpanded, setIsConflictListExpanded] = useState(false);
   const [isLocalReviewListExpanded, setIsLocalReviewListExpanded] =
     useState(false);
-  const localReviewEvents = runtimeStatus?.sync.reviewEvents ?? [];
+  const runtimeLocalReviewEvents = runtimeStatus?.sync.reviewEvents ?? [];
+  const recoveryPreview = detail?.recovery ?? detail?.recoveryPreview;
+  const collectedLocalReviewEvents =
+    recoveryPreview?.commandStatus?.commandType ===
+      "collect_local_review" &&
+    recoveryPreview.commandStatus.verificationStatus === "verified"
+      ? (recoveryPreview.commandStatus.localReviewEvents ?? [])
+      : [];
+  const localReviewEvents =
+    runtimeLocalReviewEvents.length > 0
+      ? runtimeLocalReviewEvents
+      : collectedLocalReviewEvents;
   const runtimeReviewCount = runtimeStatus?.sync.reviewEventCount ?? 0;
   const missingRuntimeReviewDetails =
     runtimeReviewCount > 0 && localReviewEvents.length === 0;
@@ -1090,6 +1105,16 @@ function ConflictSection({
     0,
   );
   const reviewCount = getReviewEvidenceCount(syncEvidence);
+  const localReviewActionReason = {
+    actionTarget: { type: "pos_register" },
+    count: runtimeReviewCount,
+    source: "local_runtime",
+    summary: `${runtimeReviewCount} local review item${runtimeReviewCount === 1 ? " is" : "s are"} still on this terminal.`,
+    type: "local_review",
+  } satisfies TerminalHealthAttentionReason;
+  const hasLocalReviewTableAction = Boolean(
+    getAttentionReasonRecoveryAction(localReviewActionReason, detail),
+  );
 
   return (
     <DetailPanel
@@ -1141,73 +1166,97 @@ function ConflictSection({
         )}
 
         {localReviewEvents.length > 0 ? (
-          <div className="overflow-hidden rounded-md border border-border/80 bg-surface">
-            <div className="grid gap-layout-sm border-b border-border/80 bg-surface-muted/40 px-layout-md py-layout-xs text-xs font-medium uppercase text-muted-foreground md:grid-cols-[5rem_minmax(0,1fr)_8rem_7rem]">
-              <span>Sequence</span>
-              <span>Local review item</span>
-              <span>Upload</span>
-              <span>Status</span>
-            </div>
-            <div className="divide-y divide-border/80">
-              {visibleLocalReviewEvents.map((event) => (
-                <div
-                  className="grid gap-layout-sm px-layout-md py-layout-sm text-sm md:grid-cols-[5rem_minmax(0,1fr)_8rem_7rem] md:items-center"
-                  key={event.localEventId}
-                >
-                  <span className="font-numeric tabular-nums text-muted-foreground">
-                    #{event.sequence}
-                  </span>
-                  <span className="min-w-0 truncate font-medium text-foreground">
-                    {event.type}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {event.uploaded
-                      ? "Uploaded"
-                      : event.uploadSequence == null
-                        ? "Local only"
-                        : `Upload #${event.uploadSequence}`}
-                  </span>
-                  <span
-                    className={cn(
-                      "inline-flex w-fit items-center rounded-md border px-layout-xs py-1 text-xs font-medium",
-                      getSyncEventStatusClassName(event.status),
-                    )}
+          <div className="space-y-layout-sm">
+            <div className="overflow-hidden rounded-md border border-border/80 bg-surface">
+              <div className="grid gap-layout-sm border-b border-border/80 bg-surface-muted/40 px-layout-md py-layout-xs text-xs font-medium uppercase text-muted-foreground md:grid-cols-[5rem_minmax(0,1fr)_8rem_7rem]">
+                <span>Sequence</span>
+                <span>Local review item</span>
+                <span>Upload</span>
+                <span>Status</span>
+              </div>
+              <div className="divide-y divide-border/80">
+                {visibleLocalReviewEvents.map((event) => (
+                  <div
+                    className="grid gap-layout-sm px-layout-md py-layout-sm text-sm md:grid-cols-[5rem_minmax(0,1fr)_8rem_7rem] md:items-center"
+                    key={event.localEventId}
                   >
-                    {formatStatusLabel(event.status)}
-                  </span>
-                </div>
-              ))}
-              {hiddenLocalReviewCount > 0 ? (
-                <div className="px-layout-md py-layout-sm">
-                  <Button
-                    className="h-8 px-layout-sm text-xs"
-                    onClick={() =>
-                      setIsLocalReviewListExpanded((current) => !current)
-                    }
-                    type="button"
-                    variant="outline"
-                  >
-                    {isLocalReviewListExpanded
-                      ? "Show fewer"
-                      : `Show ${hiddenLocalReviewCount} more`}
-                  </Button>
-                </div>
-              ) : null}
+                    <span className="font-numeric tabular-nums text-muted-foreground">
+                      #{event.sequence}
+                    </span>
+                    <span className="min-w-0 truncate font-medium text-foreground">
+                      {event.type}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {event.uploaded
+                        ? "Uploaded"
+                        : event.uploadSequence == null
+                          ? "Local only"
+                          : `Upload #${event.uploadSequence}`}
+                    </span>
+                    <span
+                      className={cn(
+                        "inline-flex w-fit items-center rounded-md border px-layout-xs py-1 text-xs font-medium",
+                        getSyncEventStatusClassName(event.status),
+                      )}
+                    >
+                      {formatStatusLabel(event.status)}
+                    </span>
+                  </div>
+                ))}
+                {hiddenLocalReviewCount > 0 ? (
+                  <div className="px-layout-md py-layout-sm">
+                    <Button
+                      className="h-8 px-layout-sm text-xs"
+                      onClick={() =>
+                        setIsLocalReviewListExpanded((current) => !current)
+                      }
+                      type="button"
+                      variant="outline"
+                    >
+                      {isLocalReviewListExpanded
+                        ? "Show fewer"
+                        : `Show ${hiddenLocalReviewCount} more`}
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
             </div>
+            {hasLocalReviewTableAction ? (
+              <div className="flex justify-end">
+                <AttentionReasonAction
+                  detail={detail}
+                  onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+                  reason={localReviewActionReason}
+                />
+              </div>
+            ) : null}
           </div>
         ) : null}
 
         {missingRuntimeReviewDetails ? (
-          <div className="rounded-md border border-warning/30 bg-warning/10 px-layout-md py-layout-sm">
-            <p className="text-sm font-medium text-foreground">
-              {runtimeReviewCount} local review{" "}
-              {runtimeReviewCount === 1 ? "item was" : "items were"} reported by
-              this terminal.
-            </p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              The latest runtime check-in did not include item-level local
-              review details.
-            </p>
+          <div className="grid gap-layout-sm rounded-md border border-warning/30 bg-warning/10 px-layout-md py-layout-sm md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-foreground">
+                {runtimeReviewCount} local review{" "}
+                {runtimeReviewCount === 1 ? "item needs" : "items need"} local
+                collection.
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Details are missing from the latest check-in. Collect local
+                review items from this checkout station.
+              </p>
+            </div>
+            <AttentionReasonAction
+              detail={detail}
+              onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+              reason={{
+                actionTarget: { type: "pos_register" },
+                count: runtimeReviewCount,
+                source: "local_runtime",
+                summary: `${runtimeReviewCount} local review item${runtimeReviewCount === 1 ? " is" : "s are"} still on this terminal.`,
+                type: "local_review",
+              }}
+            />
           </div>
         ) : null}
       </div>
@@ -1239,7 +1288,7 @@ function OperationalExplanationReviewSummary({
 
       {operationalExplanation.evidenceReferences.length > 0 ? (
         <div className="overflow-hidden rounded-md border border-border/80 bg-surface">
-          <div className="grid gap-layout-sm border-b border-border/80 bg-surface-muted/40 px-layout-md py-layout-xs text-xs font-medium uppercase text-muted-foreground md:grid-cols-[minmax(0,1fr)_7rem_8rem]">
+          <div className="grid gap-layout-sm border-b border-border/80 bg-surface-muted/40 px-layout-md py-layout-xs text-xs font-medium uppercase text-muted-foreground md:grid-cols-[minmax(0,1fr)_4rem_minmax(14rem,max-content)]">
             <span>Evidence</span>
             <span>Count</span>
             <span>Type</span>
@@ -1248,7 +1297,7 @@ function OperationalExplanationReviewSummary({
             {operationalExplanation.evidenceReferences.map(
               (reference, index) => (
                 <div
-                  className="grid gap-layout-sm px-layout-md py-layout-sm text-sm md:grid-cols-[minmax(0,1fr)_7rem_8rem] md:items-center"
+                  className="grid gap-layout-sm px-layout-md py-layout-sm text-sm md:grid-cols-[minmax(0,1fr)_4rem_minmax(14rem,max-content)] md:items-center"
                   key={`${reference.source}-${reference.type}-${index}`}
                 >
                   <span className="min-w-0 font-medium text-foreground">
@@ -1257,7 +1306,7 @@ function OperationalExplanationReviewSummary({
                   <span className="font-numeric tabular-nums text-muted-foreground">
                     {reference.count ?? "-"}
                   </span>
-                  <span className="truncate text-muted-foreground">
+                  <span className="min-w-0 text-muted-foreground">
                     {formatStatusLabel(reference.type)}
                   </span>
                 </div>
@@ -1276,11 +1325,13 @@ function OperationalExplanationReviewSummary({
 
 function AttentionReasonsSection({
   detail,
+  onIssueTerminalRecoveryCommand,
   onResolveRegisterSessionReview,
   orgUrlSlug,
   storeUrlSlug,
 }: {
   detail: TerminalHealthDetail;
+  onIssueTerminalRecoveryCommand?: POSTerminalDetailViewContentProps["onIssueTerminalRecoveryCommand"];
   onResolveRegisterSessionReview?: POSTerminalDetailViewContentProps["onResolveRegisterSessionReview"];
   orgUrlSlug?: string;
   storeUrlSlug?: string;
@@ -1323,6 +1374,7 @@ function AttentionReasonsSection({
               </div>
               <AttentionReasonAction
                 detail={detail}
+                onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
                 onResolveRegisterSessionReview={onResolveRegisterSessionReview}
                 orgUrlSlug={orgUrlSlug}
                 reason={reason}
@@ -1338,12 +1390,14 @@ function AttentionReasonsSection({
 
 function AttentionReasonAction({
   detail,
+  onIssueTerminalRecoveryCommand,
   onResolveRegisterSessionReview,
   orgUrlSlug,
   reason,
   storeUrlSlug,
 }: {
   detail?: TerminalHealthDetail;
+  onIssueTerminalRecoveryCommand?: POSTerminalDetailViewContentProps["onIssueTerminalRecoveryCommand"];
   onResolveRegisterSessionReview?: POSTerminalDetailViewContentProps["onResolveRegisterSessionReview"];
   orgUrlSlug?: string;
   reason: TerminalHealthAttentionReason;
@@ -1351,13 +1405,17 @@ function AttentionReasonAction({
 }) {
   const target = reason.actionTarget;
   const [isResolving, setIsResolving] = useState(false);
+  const [isIssuingCommand, setIsIssuingCommand] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
 
-  if (!orgUrlSlug || !storeUrlSlug || !target) {
+  if (!target) {
     return null;
   }
 
   if (target.type === "cash_control_register_session") {
+    if (!orgUrlSlug || !storeUrlSlug) {
+      return null;
+    }
     const registerSessionId = target.registerSessionId;
     const resolveRegisterSessionReview = onResolveRegisterSessionReview;
 
@@ -1422,6 +1480,9 @@ function AttentionReasonAction({
   }
 
   if (target.type === "open_work") {
+    if (!orgUrlSlug || !storeUrlSlug) {
+      return null;
+    }
     return (
       <Button asChild size="sm" variant="utility">
         <Link
@@ -1446,6 +1507,63 @@ function AttentionReasonAction({
   }
 
   if (target.type === "pos_register") {
+    const action = getAttentionReasonRecoveryAction(reason, detail);
+    const canIssue = action ? isRecoveryActionIssuable(action) : false;
+
+    if (action) {
+      const issueRecoveryCommand = async () => {
+        if (
+          !canIssue ||
+          !onIssueTerminalRecoveryCommand ||
+          !detail ||
+          isIssuingCommand
+        ) {
+          return;
+        }
+
+        setIsIssuingCommand(true);
+        setErrorMessage("");
+        const result = await onIssueTerminalRecoveryCommand({
+          action,
+          terminalId: detail.terminal._id,
+        });
+        setIsIssuingCommand(false);
+
+        if (result.kind === "ok") {
+          toast.success("Terminal command queued.");
+          return;
+        }
+
+        const message = normalizeRecoveryActionError(result.error.message);
+        setErrorMessage(message);
+        toast.error(message);
+      };
+
+      return (
+        <div className="grid justify-items-start gap-layout-xs">
+          <Button
+            disabled={!canIssue || !onIssueTerminalRecoveryCommand || isIssuingCommand}
+            onClick={() => {
+              void issueRecoveryCommand();
+            }}
+            size="sm"
+            variant="utility"
+          >
+            <Send aria-hidden="true" />
+            {isIssuingCommand ? "Sending..." : action.label}
+          </Button>
+          {action.status && action.status !== "available" ? (
+            <p className="max-w-sm text-xs text-muted-foreground">
+              {getRecoveryActionStatusCopy(action)}
+            </p>
+          ) : null}
+          {errorMessage ? (
+            <p className="max-w-sm text-xs text-danger">{errorMessage}</p>
+          ) : null}
+        </div>
+      );
+    }
+
     return (
       <p className="max-w-sm text-xs text-muted-foreground">
         {getTerminalCommandAttentionCopy(reason, detail) ??
@@ -1474,10 +1592,7 @@ function getTerminalCommandAttentionCopy(
     return null;
   }
 
-  const commandName =
-    expectedCommandType === "clear_stale_drawer_authority"
-      ? "Drawer repair command"
-      : "Terminal setup repair command";
+  const commandName = getTerminalCommandStatusCopyName(expectedCommandType);
 
   if (commandStatus.verificationStatus === "verified") {
     return `${commandName} was completed and verified by terminal check-in. This row will clear when the terminal list receives the next check-in.`;
@@ -1532,10 +1647,7 @@ function getTerminalCommandAttentionTitle(
     return null;
   }
 
-  const commandName =
-    expectedCommandType === "clear_stale_drawer_authority"
-      ? "Drawer repair command"
-      : "Terminal setup repair command";
+  const commandName = getTerminalCommandStatusCopyName(expectedCommandType);
 
   if (commandStatus.verificationStatus === "verified") {
     return `${commandName} verified; waiting for the next terminal check-in.`;
@@ -1566,7 +1678,59 @@ function getAttentionReasonCommandType(reason: TerminalHealthAttentionReason) {
   ) {
     return "repair_terminal_seed";
   }
+  if (
+    reason.type === "sync_failed" ||
+    reason.type === "sync_unavailable"
+  ) {
+    return "retry_sync";
+  }
   return null;
+}
+
+function getTerminalCommandStatusCopyName(
+  commandType: NonNullable<ReturnType<typeof getAttentionReasonCommandType>>,
+) {
+  if (commandType === "clear_stale_drawer_authority") {
+    return "Drawer repair command";
+  }
+  if (commandType === "retry_sync") {
+    return "Terminal sync retry";
+  }
+  return "Terminal setup repair command";
+}
+
+function getAttentionReasonRecoveryAction(
+  reason: TerminalHealthAttentionReason,
+  detail?: TerminalHealthDetail,
+) {
+  if (reason.type === "local_review" && detail) {
+    return (
+      buildTerminalRecoveryPresentation(detail).safeActions.find(
+        isLocalReviewTerminalAction,
+      ) ?? null
+    );
+  }
+
+  const commandType = getAttentionReasonCommandType(reason);
+  if (!commandType || !detail) {
+    return null;
+  }
+
+  return (
+    buildTerminalRecoveryPresentation(detail).safeActions.find(
+      (action) =>
+        action.kind === "terminal_command" &&
+        action.commandType === commandType,
+    ) ?? null
+  );
+}
+
+function isLocalReviewTerminalAction(action: TerminalRecoveryAction) {
+  return (
+    action.kind === "terminal_command" &&
+    (action.commandType === "clear_local_review_items" ||
+      action.commandType === "collect_local_review")
+  );
 }
 
 function RecoveryMetric({
@@ -1623,6 +1787,12 @@ function shouldShowRecoveryNextStep(
 function getRecoveryNextStepCopy(action: TerminalRecoveryAction) {
   if (action.commandType === "retry_sync") {
     return "retry terminal sync, then use the next check-in to decide whether drawer repair still needs to run.";
+  }
+  if (action.commandType === "collect_local_review") {
+    return "collect local review items from this checkout station, then use the next check-in to review the terminal-local evidence.";
+  }
+  if (action.commandType === "clear_local_review_items") {
+    return "clear reviewed local items from this checkout station, then use the next check-in to confirm the local review count is zero.";
   }
   if (action.commandType === "clear_stale_drawer_authority") {
     return "send drawer authority repair from this checkout station.";
@@ -1935,7 +2105,7 @@ function getRecoveryActionStatusCopy(action: TerminalRecoveryAction) {
       return "Command expired. Refresh terminal health before sending another command.";
     case "failed":
       if (action.commandType === "clear_stale_drawer_authority") {
-        return "Command did not complete. Retry terminal sync before sending drawer repair again.";
+        return "Command did not complete. Use the available terminal action before sending drawer repair again.";
       }
       return "Command did not complete. Run the next safe action before retrying.";
     case "blocked":
@@ -2687,12 +2857,15 @@ export function POSTerminalDetailViewContent({
               />
               <AttentionReasonsSection
                 detail={detail}
+                onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
                 onResolveRegisterSessionReview={onResolveRegisterSessionReview}
                 orgUrlSlug={orgUrlSlug}
                 storeUrlSlug={storeUrlSlug}
               />
               <SyncEvidenceSection syncEvidence={detail.syncEvidence} />
               <ConflictSection
+                detail={detail}
+                onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
                 operationalExplanation={
                   detail.operationalExplanation
                     ? buildTerminalOperationalExplanationPresentation(detail)

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
@@ -46,6 +46,7 @@ import type { ApprovalRequirement } from "~/shared/approvalPolicy";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
 import {
+  buildTerminalOperationalExplanationPresentation,
   buildTerminalRecoveryPresentation,
   classifyTerminalHealth,
   formatAge,
@@ -275,9 +276,7 @@ function getStaffAuthorityTone(
   }
 }
 
-function getDrawerAuthorityTone(
-  runtimeStatus?: TerminalRuntimeStatus | null,
-) {
+function getDrawerAuthorityTone(runtimeStatus?: TerminalRuntimeStatus | null) {
   if (!runtimeStatus) {
     return "neutral";
   }
@@ -444,7 +443,9 @@ function RuntimeReportGroup({
   runtimeStatus: TerminalRuntimeStatus | null;
 }) {
   const syncTone = getRuntimeSyncTone(runtimeStatus?.sync.status);
-  const appUpdateTone = getRuntimeAppUpdateTone(runtimeStatus?.appUpdate?.status);
+  const appUpdateTone = getRuntimeAppUpdateTone(
+    runtimeStatus?.appUpdate?.status,
+  );
   const activeRegisterSession = runtimeStatus?.activeRegisterSession;
 
   return (
@@ -475,7 +476,9 @@ function RuntimeReportGroup({
           label="Sync"
           tone={syncTone}
           value={
-            runtimeStatus ? formatStatusLabel(runtimeStatus.sync.status) : "No report"
+            runtimeStatus
+              ? formatStatusLabel(runtimeStatus.sync.status)
+              : "No report"
           }
         />
         <RailSignalRow
@@ -484,7 +487,11 @@ function RuntimeReportGroup({
         />
         <RailSignalRow
           label="Local review"
-          tone={(runtimeStatus?.sync.reviewEventCount ?? 0) > 0 ? "warning" : "neutral"}
+          tone={
+            (runtimeStatus?.sync.reviewEventCount ?? 0) > 0
+              ? "warning"
+              : "neutral"
+          }
           value={formatLocalReviewCount(runtimeStatus)}
         />
         <RailSignalRow
@@ -835,7 +842,8 @@ function compareRuntimeBuildMetadata(
     terminalBuildMetadata.buildSha &&
     latestBuildMetadata.buildSha
   ) {
-    return terminalBuildMetadata.appVersion === latestBuildMetadata.appVersion &&
+    return terminalBuildMetadata.appVersion ===
+      latestBuildMetadata.appVersion &&
       terminalBuildMetadata.buildSha === latestBuildMetadata.buildSha
       ? "latest"
       : "stale";
@@ -859,7 +867,9 @@ function compareRuntimeBuildMetadata(
 function getTerminalBuildMetadata(
   runtimeStatus: TerminalRuntimeStatus | null,
 ): AthenaWebappRuntimeBuildMetadata {
-  const appVersion = normalizeOptionalRuntimeMetadata(runtimeStatus?.appVersion);
+  const appVersion = normalizeOptionalRuntimeMetadata(
+    runtimeStatus?.appVersion,
+  );
   const buildSha = normalizeOptionalRuntimeMetadata(runtimeStatus?.buildSha);
 
   return {
@@ -1047,9 +1057,13 @@ function SyncEvidenceSection({
 }
 
 function ConflictSection({
+  operationalExplanation,
   runtimeStatus,
   syncEvidence,
 }: {
+  operationalExplanation?: ReturnType<
+    typeof buildTerminalOperationalExplanationPresentation
+  >;
   runtimeStatus: TerminalRuntimeStatus | null;
   syncEvidence: TerminalSyncEvidence;
 }) {
@@ -1083,6 +1097,12 @@ function ConflictSection({
       title="Conflicts and review"
     >
       <div className="space-y-layout-sm">
+        {operationalExplanation ? (
+          <OperationalExplanationReviewSummary
+            operationalExplanation={operationalExplanation}
+          />
+        ) : null}
+
         {unresolvedConflicts.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             {reviewCount > 0
@@ -1181,8 +1201,8 @@ function ConflictSection({
           <div className="rounded-md border border-warning/30 bg-warning/10 px-layout-md py-layout-sm">
             <p className="text-sm font-medium text-foreground">
               {runtimeReviewCount} local review{" "}
-              {runtimeReviewCount === 1 ? "item was" : "items were"} reported
-              by this terminal.
+              {runtimeReviewCount === 1 ? "item was" : "items were"} reported by
+              this terminal.
             </p>
             <p className="mt-1 text-xs text-muted-foreground">
               The latest runtime check-in did not include item-level local
@@ -1192,6 +1212,65 @@ function ConflictSection({
         ) : null}
       </div>
     </DetailPanel>
+  );
+}
+
+function OperationalExplanationReviewSummary({
+  operationalExplanation,
+}: {
+  operationalExplanation: ReturnType<
+    typeof buildTerminalOperationalExplanationPresentation
+  >;
+}) {
+  return (
+    <>
+      <div className="rounded-md border border-border/80 bg-surface px-layout-md py-layout-md">
+        <p className="text-sm font-medium text-foreground">
+          {operationalExplanation.headline}
+        </p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {operationalExplanation.detail}
+        </p>
+        <p className="mt-layout-xs text-sm text-foreground">
+          <span className="font-medium">Next step:</span>{" "}
+          {operationalExplanation.nextStep}
+        </p>
+      </div>
+
+      {operationalExplanation.evidenceReferences.length > 0 ? (
+        <div className="overflow-hidden rounded-md border border-border/80 bg-surface">
+          <div className="grid gap-layout-sm border-b border-border/80 bg-surface-muted/40 px-layout-md py-layout-xs text-xs font-medium uppercase text-muted-foreground md:grid-cols-[minmax(0,1fr)_7rem_8rem]">
+            <span>Evidence</span>
+            <span>Count</span>
+            <span>Type</span>
+          </div>
+          <div className="divide-y divide-border/80">
+            {operationalExplanation.evidenceReferences.map(
+              (reference, index) => (
+                <div
+                  className="grid gap-layout-sm px-layout-md py-layout-sm text-sm md:grid-cols-[minmax(0,1fr)_7rem_8rem] md:items-center"
+                  key={`${reference.source}-${reference.type}-${index}`}
+                >
+                  <span className="min-w-0 font-medium text-foreground">
+                    {reference.label}
+                  </span>
+                  <span className="font-numeric tabular-nums text-muted-foreground">
+                    {reference.count ?? "-"}
+                  </span>
+                  <span className="truncate text-muted-foreground">
+                    {formatStatusLabel(reference.type)}
+                  </span>
+                </div>
+              ),
+            )}
+          </div>
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          No display-safe review samples were returned with this explanation.
+        </p>
+      )}
+    </>
   );
 }
 
@@ -1429,10 +1508,10 @@ function isVerifiedTerminalCommandAttention(
 
   return Boolean(
     expectedCommandType &&
-      commandStatus?.verificationStatus === "verified" &&
-      recovery?.terminalActions?.some(
-        (action) => action.commandType === expectedCommandType,
-      ),
+    commandStatus?.verificationStatus === "verified" &&
+    recovery?.terminalActions?.some(
+      (action) => action.commandType === expectedCommandType,
+    ),
   );
 }
 
@@ -1511,7 +1590,9 @@ function RecoveryNextStep({
   commandStatus,
   safeActions,
 }: {
-  commandStatus: ReturnType<typeof buildTerminalRecoveryPresentation>["commandStatus"];
+  commandStatus: ReturnType<
+    typeof buildTerminalRecoveryPresentation
+  >["commandStatus"];
   safeActions: TerminalRecoveryAction[];
 }) {
   const nextAction = safeActions[0];
@@ -1528,7 +1609,9 @@ function RecoveryNextStep({
 }
 
 function shouldShowRecoveryNextStep(
-  commandStatus: ReturnType<typeof buildTerminalRecoveryPresentation>["commandStatus"],
+  commandStatus: ReturnType<
+    typeof buildTerminalRecoveryPresentation
+  >["commandStatus"],
 ) {
   return (
     commandStatus.status === "Failed" ||
@@ -1557,7 +1640,9 @@ function RecoveryCommandFailureReason({
   commandStatus,
   safeActions,
 }: {
-  commandStatus: ReturnType<typeof buildTerminalRecoveryPresentation>["commandStatus"];
+  commandStatus: ReturnType<
+    typeof buildTerminalRecoveryPresentation
+  >["commandStatus"];
   safeActions: TerminalRecoveryAction[];
 }) {
   const reason = getRecoveryCommandFailureReason(commandStatus, safeActions);
@@ -1571,7 +1656,9 @@ function RecoveryCommandFailureReason({
 }
 
 function getRecoveryCommandFailureReason(
-  commandStatus: ReturnType<typeof buildTerminalRecoveryPresentation>["commandStatus"],
+  commandStatus: ReturnType<
+    typeof buildTerminalRecoveryPresentation
+  >["commandStatus"],
   safeActions: TerminalRecoveryAction[],
 ) {
   if (!shouldShowRecoveryNextStep(commandStatus)) {
@@ -1638,7 +1725,9 @@ function RecoveryBlockerGroup({
   const [isExpanded, setIsExpanded] = useState(false);
   const visibleLimit = 5;
   const hiddenCount = Math.max(blockers.length - visibleLimit, 0);
-  const visibleBlockers = isExpanded ? blockers : blockers.slice(0, visibleLimit);
+  const visibleBlockers = isExpanded
+    ? blockers
+    : blockers.slice(0, visibleLimit);
 
   return (
     <div className="rounded-md border border-border/80 bg-surface">
@@ -1674,9 +1763,13 @@ function RecoveryBlockerGroup({
                 </div>
                 <RecoveryBlockerAction
                   blocker={blocker}
-                  onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+                  onIssueTerminalRecoveryCommand={
+                    onIssueTerminalRecoveryCommand
+                  }
                   onResolveTerminalCloudRepair={onResolveTerminalCloudRepair}
-                  onResolveRegisterSessionReview={onResolveRegisterSessionReview}
+                  onResolveRegisterSessionReview={
+                    onResolveRegisterSessionReview
+                  }
                   orgUrlSlug={orgUrlSlug}
                   storeUrlSlug={storeUrlSlug}
                   terminalId={terminalId}
@@ -1691,9 +1784,7 @@ function RecoveryBlockerGroup({
                   type="button"
                   variant="outline"
                 >
-                  {isExpanded
-                    ? "Show fewer"
-                    : `Show ${hiddenCount} more`}
+                  {isExpanded ? "Show fewer" : `Show ${hiddenCount} more`}
                 </Button>
               </div>
             ) : null}
@@ -1882,7 +1973,12 @@ function AppUpdateActionPanel({
   const [errorMessage, setErrorMessage] = useState("");
 
   const submitUpdateApp = async () => {
-    if (!action || !canIssue || !onIssueTerminalRecoveryCommand || isSubmitting) {
+    if (
+      !action ||
+      !canIssue ||
+      !onIssueTerminalRecoveryCommand ||
+      isSubmitting
+    ) {
       return;
     }
 
@@ -1920,7 +2016,10 @@ function AppUpdateActionPanel({
             {appUpdate.description}
           </p>
           {action?.status && action.status !== "available" ? (
-            <p className="mt-layout-xs text-xs text-muted-foreground" role="status">
+            <p
+              className="mt-layout-xs text-xs text-muted-foreground"
+              role="status"
+            >
               {getRecoveryActionStatusCopy(action)}
             </p>
           ) : null}
@@ -1929,7 +2028,12 @@ function AppUpdateActionPanel({
           ) : null}
         </div>
         <Button
-          disabled={!action || !canIssue || !onIssueTerminalRecoveryCommand || isSubmitting}
+          disabled={
+            !action ||
+            !canIssue ||
+            !onIssueTerminalRecoveryCommand ||
+            isSubmitting
+          }
           onClick={() => {
             void submitUpdateApp();
           }}
@@ -1960,6 +2064,11 @@ function RecoveryPanel({
   storeUrlSlug?: string;
 }) {
   const recovery = buildTerminalRecoveryPresentation(detail);
+  const operationalExplanation =
+    buildTerminalOperationalExplanationPresentation(detail);
+  const hasServerOperationalExplanation = Boolean(
+    detail.operationalExplanation,
+  );
   const hasCurrentRecoveryWork = hasCurrentSupportRecoveryWork(recovery);
   const supportReadiness = hasCurrentRecoveryWork
     ? recovery.readiness
@@ -1978,17 +2087,54 @@ function RecoveryPanel({
         <div className="flex flex-col gap-layout-sm md:flex-row md:items-start md:justify-between">
           <div className="min-w-0">
             <p className="text-xs font-medium uppercase text-muted-foreground">
-              Readiness
+              {hasServerOperationalExplanation
+                ? "Operational explanation"
+                : "Readiness"}
             </p>
             <p className="mt-1 text-base font-medium text-foreground">
-              {supportReadiness.label}
+              {hasServerOperationalExplanation
+                ? operationalExplanation.headline
+                : supportReadiness.label}
             </p>
             <p className="mt-1 text-sm text-muted-foreground">
-              {supportReadiness.description}
+              {hasServerOperationalExplanation
+                ? operationalExplanation.detail
+                : supportReadiness.description}
             </p>
+            {hasServerOperationalExplanation ? (
+              <p className="mt-layout-xs text-sm text-foreground">
+                <span className="font-medium">Next step:</span>{" "}
+                {operationalExplanation.nextStep}
+              </p>
+            ) : null}
           </div>
+          {hasServerOperationalExplanation ? (
+            <Badge
+              className={operationalExplanation.toneClassName}
+              variant="outline"
+            >
+              {operationalExplanation.saleImpactLabel}
+            </Badge>
+          ) : null}
         </div>
       </div>
+
+      {hasServerOperationalExplanation ? (
+        <div className="mt-layout-md grid gap-layout-sm md:grid-cols-3">
+          <RecoveryMetric
+            label="Owner"
+            value={operationalExplanation.ownerLabel}
+          />
+          <RecoveryMetric
+            label="Support action"
+            value={operationalExplanation.supportActionLabel}
+          />
+          <RecoveryMetric
+            label="Recovery readiness"
+            value={supportReadiness.label}
+          />
+        </div>
+      ) : null}
 
       <AppUpdateActionPanel
         appUpdate={recovery.appUpdate}
@@ -2547,6 +2693,11 @@ export function POSTerminalDetailViewContent({
               />
               <SyncEvidenceSection syncEvidence={detail.syncEvidence} />
               <ConflictSection
+                operationalExplanation={
+                  detail.operationalExplanation
+                    ? buildTerminalOperationalExplanationPresentation(detail)
+                    : undefined
+                }
                 runtimeStatus={detail.runtimeStatus}
                 syncEvidence={detail.syncEvidence}
               />

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx
@@ -85,7 +85,9 @@ vi.mock("@/lib/pos/infrastructure/local/localPosEntryContext", () => ({
 }));
 
 vi.mock("@/components/View", () => ({
-  default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  default: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
 }));
 
 vi.mock("@/components/common/FadeIn", () => ({
@@ -93,11 +95,7 @@ vi.mock("@/components/common/FadeIn", () => ({
 }));
 
 vi.mock("@/components/common/PageLevelHeader", () => ({
-  PageLevelHeader: ({
-    title,
-  }: {
-    title: string;
-  }) => <h1>{title}</h1>,
+  PageLevelHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
   PageWorkspace: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   ),
@@ -302,7 +300,9 @@ describe("POSTerminalHealthViewContent", () => {
       screen.getByText("1 synced item is held before projection."),
     ).toBeInTheDocument();
     expect(screen.getByText("Review kiosk")).toBeInTheDocument();
-    expect(screen.getAllByText("Staff authority ready").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Staff authority ready").length).toBeGreaterThan(
+      0,
+    );
     expect(
       screen.getAllByText("Active in cash controls").length,
     ).toBeGreaterThan(0);
@@ -317,15 +317,14 @@ describe("POSTerminalHealthViewContent", () => {
     expect(screen.getByText("Update ready")).toBeInTheDocument();
     expect(screen.getAllByText("Products and stock").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Register details").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Offline diagnostics need attention").length).toBeGreaterThan(0);
     expect(
-      screen.getAllByText("Ready signals").length,
+      screen.getAllByText("Offline diagnostics need attention").length,
     ).toBeGreaterThan(0);
+    expect(screen.getAllByText("Ready signals").length).toBeGreaterThan(0);
     expect(screen.getAllByText("App shell").length).toBeGreaterThan(0);
-    expect(screen.getByRole("link", { name: /Front counter/i })).toHaveAttribute(
-      "href",
-      "/acme/store/osu/pos/terminals/terminal-1",
-    );
+    expect(
+      screen.getByRole("link", { name: /Front counter/i }),
+    ).toHaveAttribute("href", "/acme/store/osu/pos/terminals/terminal-1");
   });
 
   it("renders operational empty and query unavailable states", () => {
@@ -382,8 +381,12 @@ describe("POSTerminalHealthViewContent", () => {
     );
 
     expect(screen.getByText("This browser")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Front counter/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Back counter/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Front counter/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Back counter/i }),
+    ).toBeInTheDocument();
   });
 
   it("orders the terminal attached to the current browser first", () => {
@@ -413,11 +416,13 @@ describe("POSTerminalHealthViewContent", () => {
     );
 
     const backCounterLink = screen.getByRole("link", { name: "Back counter" });
-    const frontCounterLink = screen.getByRole("link", { name: "Front counter" });
+    const frontCounterLink = screen.getByRole("link", {
+      name: "Front counter",
+    });
     expect(
       Boolean(
         backCounterLink.compareDocumentPosition(frontCounterLink) &
-          Node.DOCUMENT_POSITION_FOLLOWING,
+        Node.DOCUMENT_POSITION_FOLLOWING,
       ),
     ).toBe(true);
   });
@@ -438,7 +443,9 @@ describe("POSTerminalHealthViewContent", () => {
     expect(screen.getByText("Needs review")).toBeInTheDocument();
     expect(screen.getByText("Stale or missing")).toBeInTheDocument();
     expect(screen.getAllByText("-")).toHaveLength(5);
-    expect(screen.queryByText("No POS terminals registered")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("No POS terminals registered"),
+    ).not.toBeInTheDocument();
   });
 
   it("shows redacted app-session reconciliation posture without marking cashier continuation as review", () => {
@@ -532,6 +539,69 @@ describe("POSTerminalHealthViewContent", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows sale-ready review backlog as review-owned without raw operational payloads", () => {
+    render(
+      <POSTerminalHealthViewContent
+        healthSummaries={[
+          {
+            ...baseSummary,
+            health: "needs_attention",
+            operationalExplanation: {
+              blockingDomain: "sync_review",
+              detail:
+                "M Supplies conflict-raw-001 has payment payload data pending review.",
+              evidenceReferences: [
+                {
+                  count: 9,
+                  source: "cloud_sync",
+                  summary: "M Supplies conflict-raw-001 payment payload",
+                  type: "synced_sale_inventory_review",
+                },
+              ],
+              headline: "M Supplies review needed",
+              lane: "sale_ready_with_review_backlog",
+              nextStep:
+                "Review the open work queue before support repairs anything.",
+              primaryOwner: "operations",
+              saleImpact: "can_transact_now",
+              secondaryActions: [],
+              severity: "warning",
+              summaryMeta: {
+                hasSecondarySafeRepair: false,
+                reviewBacklogCount: 9,
+                targetResolutionIncomplete: false,
+              },
+              supportAction: "manual_review",
+            },
+            recovery: {
+              readiness: {
+                status: "able_to_transact_now",
+                summary:
+                  "Able to transact now. Drawer, cashier, and sale authority are active.",
+              },
+            },
+          },
+        ]}
+        isLoading={false}
+        orgUrlSlug="acme"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    expect(screen.getAllByText("Review needed").length).toBeGreaterThan(0);
+    expect(screen.getByText("Sales can continue.")).toBeInTheDocument();
+    expect(screen.getByText("Sales can continue")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Review the open work queue before support repairs anything.",
+      ),
+    ).toBeInTheDocument();
+    expect(metricCard("Needs review")).toHaveTextContent("1");
+    expect(
+      screen.queryByText(/M Supplies|conflict-raw-001|payment payload/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not show stale setup notes when recovery cleared the terminal blocker", () => {
     render(
       <POSTerminalHealthViewContent
@@ -587,9 +657,9 @@ describe("POSTerminalHealthViewContent", () => {
 });
 
 function metricCard(label: string) {
-  const metricLabel = screen.getAllByText(label).find(
-    (element) => element.tagName.toLowerCase() === "p",
-  );
+  const metricLabel = screen
+    .getAllByText(label)
+    .find((element) => element.tagName.toLowerCase() === "p");
   if (!metricLabel) {
     throw new Error(`Metric ${label} was not rendered.`);
   }

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx
@@ -36,6 +36,7 @@ import {
   type PosOfflineReadinessSummary,
 } from "@/offline/posOfflineReadiness";
 import {
+  buildTerminalOperationalExplanationPresentation,
   buildTerminalRecoveryPresentation,
   classifyTerminalHealth,
   formatAge,
@@ -412,6 +413,8 @@ export function POSTerminalHealthViewContent({
         summary,
         currentBrowserTerminalIdSet,
       ),
+      operationalExplanation:
+        buildTerminalOperationalExplanationPresentation(summary),
       originalIndex: index,
       summary,
     }))
@@ -422,7 +425,10 @@ export function POSTerminalHealthViewContent({
       return left.originalIndex - right.originalIndex;
     });
   const reviewCount = healthRows.filter(
-    (row) => row.classification.label === "Needs review",
+    (row) =>
+      row.classification.label === "Needs review" ||
+      row.operationalExplanation.lane === "sale_ready_with_review_backlog" ||
+      row.operationalExplanation.lane === "needs_manual_review",
   ).length;
   const healthyCount = healthRows.filter(
     (row) => row.classification.label === "Healthy",
@@ -492,158 +498,195 @@ export function POSTerminalHealthViewContent({
               ) : (
                 <section className="space-y-layout-sm">
                   {healthRows.map(
-                    ({ classification, isCurrentBrowserTerminal, summary }) => {
-                    const runtimeStatus = summary.runtimeStatus;
-                    const primaryReason =
-                      getPrimaryTerminalAttentionReason(summary);
-                    const offlineReadiness =
-                      buildTerminalOfflineReadiness(summary);
-                    const recovery = buildTerminalRecoveryPresentation(summary);
-                    const syncReviewCount =
-                      (runtimeStatus?.sync.reviewEventCount ?? 0) +
-                      getReviewEvidenceCount(summary.syncEvidence);
-                    const syncSummary = runtimeStatus
-                      ? `${runtimeStatus.sync.pendingEventCount} pending / ${syncReviewCount} review`
-                      : "No runtime sync check-in";
-                    const cloudCursorSummary =
-                      summary.syncEvidence.acceptedThroughSequence == null
-                        ? "No accepted sequence"
-                        : `Accepted through ${summary.syncEvidence.acceptedThroughSequence}`;
-                    const operationalNote =
-                      classification.label === "Healthy"
-                        ? null
-                        : (primaryReason?.summary ??
-                          classification.description);
-                    return (
-                      <article
-                        className={cn(
-                          "rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface",
-                          isCurrentBrowserTerminal
-                            ? "bg-action-workflow-soft/10"
-                            : null,
-                        )}
-                        key={summary.terminal._id}
-                      >
-                        <div className="flex flex-wrap items-start justify-between gap-layout-md">
-                          <div className="min-w-0 space-y-layout-xs">
-                            <div className="flex flex-wrap items-center gap-layout-xs">
-                              <Link
-                                className="min-w-0 text-xl font-medium text-foreground underline-offset-4 hover:underline"
-                                params={{
-                                  orgUrlSlug,
-                                  storeUrlSlug,
-                                  terminalId: String(summary.terminal._id),
-                                }}
-                                to="/$orgUrlSlug/store/$storeUrlSlug/pos/terminals/$terminalId"
-                                search={{ o: getOrigin() }}
-                              >
-                                {summary.terminal.displayName}
-                              </Link>
-                              {isCurrentBrowserTerminal ? (
-                                <Badge
-                                  className="inline-flex shrink-0 items-center gap-layout-xs border-action-workflow-border text-action-workflow"
-                                  variant="outline"
+                    ({
+                      classification,
+                      isCurrentBrowserTerminal,
+                      operationalExplanation,
+                      summary,
+                    }) => {
+                      const runtimeStatus = summary.runtimeStatus;
+                      const primaryReason =
+                        getPrimaryTerminalAttentionReason(summary);
+                      const offlineReadiness =
+                        buildTerminalOfflineReadiness(summary);
+                      const recovery =
+                        buildTerminalRecoveryPresentation(summary);
+                      const syncReviewCount =
+                        (runtimeStatus?.sync.reviewEventCount ?? 0) +
+                        getReviewEvidenceCount(summary.syncEvidence);
+                      const syncSummary = runtimeStatus
+                        ? `${runtimeStatus.sync.pendingEventCount} pending / ${syncReviewCount} review`
+                        : "No runtime sync check-in";
+                      const cloudCursorSummary =
+                        summary.syncEvidence.acceptedThroughSequence == null
+                          ? "No accepted sequence"
+                          : `Accepted through ${summary.syncEvidence.acceptedThroughSequence}`;
+                      const operationalNote =
+                        classification.label === "Healthy"
+                          ? null
+                          : (primaryReason?.summary ??
+                            classification.description);
+                      return (
+                        <article
+                          className={cn(
+                            "rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface",
+                            isCurrentBrowserTerminal
+                              ? "bg-action-workflow-soft/10"
+                              : null,
+                          )}
+                          key={summary.terminal._id}
+                        >
+                          <div className="flex flex-wrap items-start justify-between gap-layout-md">
+                            <div className="min-w-0 space-y-layout-xs">
+                              <div className="flex flex-wrap items-center gap-layout-xs">
+                                <Link
+                                  className="min-w-0 text-xl font-medium text-foreground underline-offset-4 hover:underline"
+                                  params={{
+                                    orgUrlSlug,
+                                    storeUrlSlug,
+                                    terminalId: String(summary.terminal._id),
+                                  }}
+                                  to="/$orgUrlSlug/store/$storeUrlSlug/pos/terminals/$terminalId"
+                                  search={{ o: getOrigin() }}
                                 >
-                                  <MonitorCheck
-                                    aria-hidden="true"
-                                    className="h-3.5 w-3.5"
-                                  />
-                                  This browser
-                                </Badge>
-                              ) : null}
-                            </div>
-                            <div className="flex flex-wrap gap-layout-xs text-sm text-muted-foreground">
-                              <span>
-                                {formatRegisterNumber(
-                                  summary.terminal.registerNumber,
-                                )}
-                              </span>
-                              <span>
-                                {getStaffAuthorityLabel(
-                                  runtimeStatus?.staffAuthority,
-                                )}
-                              </span>
-                            </div>
-                          </div>
-                          <Badge
-                            className={classification.toneClassName}
-                            variant="outline"
-                          >
-                            {classification.label}
-                          </Badge>
-                        </div>
-
-                        <div className="mt-layout-md grid gap-layout-md border-t border-border pt-layout-md lg:grid-cols-[minmax(0,1.2fr)_minmax(26rem,0.8fr)]">
-                          <div>
-                            <p className="text-xs font-medium uppercase text-muted-foreground">
-                              Sales readiness
-                            </p>
-                            <p className="mt-1 text-base font-medium text-foreground">
-                              {recovery.readiness.label}
-                            </p>
-                            <p className="mt-layout-2xs text-sm text-muted-foreground">
-                              {recovery.readiness.description}
-                            </p>
-                            {operationalNote ? (
-                              <p className="mt-layout-sm text-sm text-foreground">
-                                {operationalNote}
-                              </p>
-                            ) : null}
-                          </div>
-
-                          <dl className="grid gap-x-layout-lg gap-y-layout-sm sm:grid-cols-2">
-                            <TerminalFact
-                              label="Last check-in"
-                              value={
-                                <span className="inline-flex items-center gap-layout-xs">
-                                  <Clock3
-                                    aria-hidden="true"
-                                    className="h-3.5 w-3.5 text-muted-foreground"
-                                  />
-                                  {formatTerminalTimestamp(
-                                    runtimeStatus?.receivedAt,
+                                  {summary.terminal.displayName}
+                                </Link>
+                                {isCurrentBrowserTerminal ? (
+                                  <Badge
+                                    className="inline-flex shrink-0 items-center gap-layout-xs border-action-workflow-border text-action-workflow"
+                                    variant="outline"
+                                  >
+                                    <MonitorCheck
+                                      aria-hidden="true"
+                                      className="h-3.5 w-3.5"
+                                    />
+                                    This browser
+                                  </Badge>
+                                ) : null}
+                              </div>
+                              <div className="flex flex-wrap gap-layout-xs text-sm text-muted-foreground">
+                                <span>
+                                  {formatRegisterNumber(
+                                    summary.terminal.registerNumber,
                                   )}
                                 </span>
+                                <span>
+                                  {getStaffAuthorityLabel(
+                                    runtimeStatus?.staffAuthority,
+                                  )}
+                                </span>
+                              </div>
+                            </div>
+                            <Badge
+                              className={
+                                summary.operationalExplanation
+                                  ? operationalExplanation.toneClassName
+                                  : classification.toneClassName
                               }
-                            />
-                            <TerminalFact label="Sync" value={syncSummary} />
-                            <TerminalFact
-                              label="Offline checkout"
-                              value={
-                                <LocalDataFreshness
-                                  snapshots={runtimeStatus?.snapshots}
-                                />
-                              }
-                            />
-                            <TerminalFact
-                              label="Register session"
-                              value={
-                                <RegisterSessionFactValue
-                                  orgUrlSlug={orgUrlSlug}
-                                  registerSessionLink={
-                                    summary.registerSessionLink
-                                  }
-                                  runtimeStatus={runtimeStatus}
-                                  storeUrlSlug={storeUrlSlug}
-                                />
-                              }
-                            />
-                            <TerminalFact
-                              label="App update"
-                              value={recovery.appUpdate.label}
-                            />
-                            <TerminalFact
-                              label="Cloud cursor"
-                              value={cloudCursorSummary}
-                            />
-                          </dl>
-                        </div>
+                              variant="outline"
+                            >
+                              {summary.operationalExplanation
+                                ? operationalExplanation.label
+                                : classification.label}
+                            </Badge>
+                          </div>
 
-                        <OfflineReadinessDiagnostic
-                          readiness={offlineReadiness}
-                        />
-                      </article>
-                    );
+                          <div className="mt-layout-md grid gap-layout-md border-t border-border pt-layout-md lg:grid-cols-[minmax(0,1.2fr)_minmax(26rem,0.8fr)]">
+                            <div>
+                              <p className="text-xs font-medium uppercase text-muted-foreground">
+                                Sales readiness
+                              </p>
+                              {summary.operationalExplanation ? (
+                                <>
+                                  <p className="mt-1 text-base font-medium text-foreground">
+                                    {operationalExplanation.headline}
+                                  </p>
+                                  <p className="mt-layout-2xs text-sm text-muted-foreground">
+                                    {operationalExplanation.detail}
+                                  </p>
+                                  <p className="mt-layout-sm text-sm text-foreground">
+                                    {operationalExplanation.saleImpactLabel}
+                                  </p>
+                                  {operationalExplanation.supportAction !==
+                                  "none" ? (
+                                    <p className="mt-layout-sm text-sm text-foreground">
+                                      <span className="font-medium">
+                                        Next step:
+                                      </span>{" "}
+                                      {operationalExplanation.nextStep}
+                                    </p>
+                                  ) : null}
+                                </>
+                              ) : (
+                                <>
+                                  <p className="mt-1 text-base font-medium text-foreground">
+                                    {recovery.readiness.label}
+                                  </p>
+                                  <p className="mt-layout-2xs text-sm text-muted-foreground">
+                                    {recovery.readiness.description}
+                                  </p>
+                                  {operationalNote ? (
+                                    <p className="mt-layout-sm text-sm text-foreground">
+                                      {operationalNote}
+                                    </p>
+                                  ) : null}
+                                </>
+                              )}
+                            </div>
+
+                            <dl className="grid gap-x-layout-lg gap-y-layout-sm sm:grid-cols-2">
+                              <TerminalFact
+                                label="Last check-in"
+                                value={
+                                  <span className="inline-flex items-center gap-layout-xs">
+                                    <Clock3
+                                      aria-hidden="true"
+                                      className="h-3.5 w-3.5 text-muted-foreground"
+                                    />
+                                    {formatTerminalTimestamp(
+                                      runtimeStatus?.receivedAt,
+                                    )}
+                                  </span>
+                                }
+                              />
+                              <TerminalFact label="Sync" value={syncSummary} />
+                              <TerminalFact
+                                label="Offline checkout"
+                                value={
+                                  <LocalDataFreshness
+                                    snapshots={runtimeStatus?.snapshots}
+                                  />
+                                }
+                              />
+                              <TerminalFact
+                                label="Register session"
+                                value={
+                                  <RegisterSessionFactValue
+                                    orgUrlSlug={orgUrlSlug}
+                                    registerSessionLink={
+                                      summary.registerSessionLink
+                                    }
+                                    runtimeStatus={runtimeStatus}
+                                    storeUrlSlug={storeUrlSlug}
+                                  />
+                                }
+                              />
+                              <TerminalFact
+                                label="App update"
+                                value={recovery.appUpdate.label}
+                              />
+                              <TerminalFact
+                                label="Cloud cursor"
+                                value={cloudCursorSummary}
+                              />
+                            </dl>
+                          </div>
+
+                          <OfflineReadinessDiagnostic
+                            readiness={offlineReadiness}
+                          />
+                        </article>
+                      );
                     },
                   )}
                 </section>

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  buildTerminalOperationalExplanationPresentation,
   buildTerminalRecoveryPresentation,
   classifyTerminalHealth,
   formatAge,
@@ -11,6 +12,202 @@ import {
 } from "./terminalHealthPresentation";
 
 describe("terminal health presentation", () => {
+  it("prefers server operational explanations and makes sale-ready review backlog explicit", () => {
+    const presentation = buildTerminalOperationalExplanationPresentation({
+      health: "needs_attention",
+      operationalExplanation: {
+        blockingDomain: "sync_review",
+        detail:
+          "A bounded sync review backlog is still open. Store conflict-raw-001 contains payment payload data.",
+        evidenceReferences: [
+          {
+            count: 12,
+            source: "cloud_sync",
+            summary: "Review backlog sample for Store conflict-raw-001",
+            type: "synced_sale_inventory_review",
+          },
+        ],
+        headline: "Back office review needed",
+        lane: "sale_ready_with_review_backlog",
+        nextStep: "Review the open work queue before support repairs anything.",
+        primaryOwner: "operations",
+        saleImpact: "can_transact_now",
+        secondaryActions: [
+          {
+            label: "Safe cloud repair available",
+            primaryOwner: "support",
+            supportAction: "safe_cloud_repair",
+          },
+        ],
+        severity: "warning",
+        summaryMeta: {
+          hasSecondarySafeRepair: true,
+          reviewBacklogCount: 12,
+          targetResolutionIncomplete: false,
+        },
+        supportAction: "manual_review",
+      },
+      recovery: {
+        readiness: {
+          status: "able_to_transact_now",
+          summary:
+            "Able to transact now. Drawer, cashier, and sale authority are active.",
+        },
+      },
+      runtimeStatus: null,
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    const renderedCopy = JSON.stringify(presentation);
+
+    expect(presentation).toEqual(
+      expect.objectContaining({
+        detail: "Sales can continue.",
+        headline: "Review needed",
+        label: "Review needed",
+        lane: "sale_ready_with_review_backlog",
+        nextStep: "Review the open work queue before support repairs anything.",
+        ownerLabel: "Operations",
+        saleImpactLabel: "Sales can continue",
+        supportActionLabel: "Manual review",
+      }),
+    );
+    expect(presentation.evidenceReferences).toEqual([
+      expect.objectContaining({
+        count: 12,
+        label: "Review evidence",
+        source: "cloud_sync",
+        type: "synced_sale_inventory_review",
+      }),
+    ]);
+    expect(renderedCopy).not.toMatch(
+      /conflict-raw-001|payment payload/i,
+    );
+  });
+
+  it("recognizes healthy server lanes and critical severity from the public contract", () => {
+    const healthy = buildTerminalOperationalExplanationPresentation({
+      health: "online",
+      operationalExplanation: {
+        blockingDomain: "none",
+        detail: "Fresh runtime evidence reports sale authority.",
+        evidenceReferences: [],
+        headline: "Ready for sales",
+        lane: "able_to_transact_now",
+        nextStep: "No support action needed.",
+        primaryOwner: "none",
+        saleImpact: "can_transact_now",
+        secondaryActions: [],
+        severity: "info",
+        summaryMeta: {
+          hasSecondarySafeRepair: false,
+          reviewBacklogCount: 0,
+          targetResolutionIncomplete: false,
+        },
+        supportAction: "none",
+      },
+      runtimeStatus: null,
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+    const manualReview = buildTerminalOperationalExplanationPresentation({
+      health: "needs_attention",
+      operationalExplanation: {
+        blockingDomain: "manual_review",
+        detail: "Manual review must finish before support repairs this terminal.",
+        evidenceReferences: [
+          {
+            source: "cloud_repair",
+            summary:
+              "A cloud sync conflict needs manual review before support can repair this terminal.",
+            type: "unsafe_cloud_conflict",
+          },
+        ],
+        headline: "Manager review needed",
+        lane: "needs_manual_review",
+        nextStep: "Use the linked review workspace before running support repair.",
+        primaryOwner: "manager",
+        saleImpact: "not_ready",
+        secondaryActions: [],
+        severity: "critical",
+        summaryMeta: {
+          hasSecondarySafeRepair: false,
+          reviewBacklogCount: 1,
+          targetResolutionIncomplete: false,
+        },
+        supportAction: "manual_review",
+      },
+      runtimeStatus: null,
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    expect(healthy).toEqual(
+      expect.objectContaining({
+        label: "Ready",
+        lane: "able_to_transact_now",
+        saleImpactLabel: "Sales can continue",
+        supportActionLabel: "No support action",
+      }),
+    );
+    expect(manualReview).toEqual(
+      expect.objectContaining({
+        label: "Manager review needed",
+        lane: "needs_manual_review",
+        saleImpactLabel: "Sales not ready",
+        supportActionLabel: "Manual review",
+        toneClassName: "border-danger/25 bg-danger/10 text-danger",
+      }),
+    );
+  });
+
+  it("falls back to legacy evidence for sale-ready review backlog", () => {
+    const presentation = buildTerminalOperationalExplanationPresentation({
+      health: "needs_attention",
+      recovery: {
+        readiness: {
+          status: "able_to_transact_now",
+          summary:
+            "Able to transact now. Drawer, cashier, and sale authority are active.",
+        },
+      },
+      runtimeStatus: {
+        receivedAt: Date.now(),
+        localStore: { available: true, terminalSeedReady: true },
+        staffAuthority: { status: "ready" },
+        sync: {
+          failedEventCount: 0,
+          pendingEventCount: 0,
+          reviewEventCount: 3,
+          status: "needs_review",
+          uploadableEventCount: 0,
+        },
+      },
+      syncEvidence: { unresolvedConflictCount: 2 },
+      terminal: { status: "active" },
+    });
+
+    expect(presentation).toEqual(
+      expect.objectContaining({
+        detail: "Sales can continue.",
+        headline: "Review needed",
+        label: "Review needed",
+        lane: "sale_ready_with_review_backlog",
+        nextStep:
+          "Review the open work or cash-control backlog. Do not block new sales from this terminal.",
+        ownerLabel: "Operations",
+        saleImpactLabel: "Sales can continue",
+      }),
+    );
+    expect(presentation.evidenceReferences).toEqual([
+      expect.objectContaining({
+        count: 5,
+        label: "Review backlog",
+      }),
+    ]);
+  });
+
   it("derives app-update state from fresh runtime evidence without creating support blockers", () => {
     const ready = buildTerminalRecoveryPresentation({
       recoveryPreview: {
@@ -301,7 +498,8 @@ describe("terminal health presentation", () => {
         recovery: {
           readiness: {
             status: "able_to_transact_now",
-            summary: "Able to transact now. Drawer, cashier, and sale authority are active.",
+            summary:
+              "Able to transact now. Drawer, cashier, and sale authority are active.",
           },
         },
         runtimeStatus: null,
@@ -444,7 +642,9 @@ describe("terminal health presentation", () => {
         kind: "cloud_repair",
       }),
     );
-    expect(presentation.groups.terminalRequired.map((blocker) => blocker.action)).toEqual([
+    expect(
+      presentation.groups.terminalRequired.map((blocker) => blocker.action),
+    ).toEqual([
       expect.objectContaining({
         commandType: "repair_terminal_seed",
         expectedEvidence: { terminalIntegrityStatus: "healthy" },
@@ -913,7 +1113,9 @@ describe("terminal health presentation", () => {
       "Manual review required. Use the linked operations or cash-control review before support repairs this terminal.",
     );
     expect(presentation.safeActions.map((action) => action.kind)).toEqual([]);
-    expect(renderedCopy).not.toMatch(/register_opened|already open|authorization_failed|sync secret/i);
+    expect(renderedCopy).not.toMatch(
+      /register_opened|already open|authorization_failed|sync secret/i,
+    );
   });
 
   it("classifies missing check-ins, stale check-ins, pending sync, and review work", () => {
@@ -1072,7 +1274,8 @@ describe("terminal health presentation", () => {
         attentionReasons: [
           {
             source: "terminal_runtime",
-            summary: "Terminal setup data is not ready on this checkout station.",
+            summary:
+              "Terminal setup data is not ready on this checkout station.",
             type: "terminal_seed_missing",
           },
         ],
@@ -1093,7 +1296,8 @@ describe("terminal health presentation", () => {
       }),
     ).toEqual(
       expect.objectContaining({
-        description: "Terminal setup data is not ready on this checkout station.",
+        description:
+          "Terminal setup data is not ready on this checkout station.",
         label: "Setup needed",
       }),
     );
@@ -1105,7 +1309,8 @@ describe("terminal health presentation", () => {
         attentionReasons: [
           {
             source: "terminal_runtime",
-            summary: "Terminal setup data is not ready on this checkout station.",
+            summary:
+              "Terminal setup data is not ready on this checkout station.",
             type: "terminal_seed_missing",
           },
         ],
@@ -1334,32 +1539,35 @@ describe("terminal health presentation", () => {
         type: "cloud_rejected" as const,
       },
     },
-  ])("classifies $reason.type attention reasons", ({ expectedLabel, reason }) => {
-    expect(
-      classifyTerminalHealth({
-        attentionReasons: [reason],
-        health: "needs_attention",
-        runtimeStatus: {
-          receivedAt: Date.now(),
-          localStore: { available: true, terminalSeedReady: true },
-          sync: {
-            failedEventCount: 0,
-            pendingEventCount: 0,
-            reviewEventCount: 0,
-            status: "idle",
-            uploadableEventCount: 0,
+  ])(
+    "classifies $reason.type attention reasons",
+    ({ expectedLabel, reason }) => {
+      expect(
+        classifyTerminalHealth({
+          attentionReasons: [reason],
+          health: "needs_attention",
+          runtimeStatus: {
+            receivedAt: Date.now(),
+            localStore: { available: true, terminalSeedReady: true },
+            sync: {
+              failedEventCount: 0,
+              pendingEventCount: 0,
+              reviewEventCount: 0,
+              status: "idle",
+              uploadableEventCount: 0,
+            },
           },
-        },
-        syncEvidence: { unresolvedConflictCount: 0 },
-        terminal: { status: "active" },
-      }),
-    ).toEqual(
-      expect.objectContaining({
-        description: reason.summary,
-        label: expectedLabel,
-      }),
-    );
-  });
+          syncEvidence: { unresolvedConflictCount: 0 },
+          terminal: { status: "active" },
+        }),
+      ).toEqual(
+        expect.objectContaining({
+          description: reason.summary,
+          label: expectedLabel,
+        }),
+      );
+    },
+  );
 
   it("formats timestamps and snapshot ages in operator-readable labels", () => {
     vi.setSystemTime(new Date("2026-05-20T12:00:00.000Z"));

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
@@ -728,8 +728,8 @@ describe("terminal health presentation", () => {
           },
         ],
         commandStatus: {
-          commandType: "retry_sync",
-          label: "Sync retry",
+          commandType: "collect_local_review",
+          label: "Collect local review items",
           status: "pending",
           verificationStatus: "waiting_for_acknowledgement",
         },
@@ -738,13 +738,13 @@ describe("terminal health presentation", () => {
           {
             commandContext: {
               expectedBlockerType: "local_review",
-              reason: "Local review items need a terminal sync retry.",
+              reason: "Local review items need terminal-local evidence collection.",
             },
-            commandType: "retry_sync",
+            commandType: "collect_local_review",
             expectedEvidence: {
-              syncStatus: "idle",
+              localReviewDetailsCollected: true,
             },
-            reason: "Local review items need a terminal sync retry.",
+            reason: "Local review items need terminal-local evidence collection.",
           },
         ],
       },
@@ -758,17 +758,17 @@ describe("terminal health presentation", () => {
     expect(presentation.groups.terminalRequired).toEqual([
       expect.objectContaining({
         action: expect.objectContaining({
-          commandType: "retry_sync",
+          commandType: "collect_local_review",
           status: "pending",
         }),
-        summary: "Sync retry command is queued for this checkout station.",
-        title: "Terminal sync retry",
+        summary: "Local review collection is queued for this checkout station.",
+        title: "Local review collection",
       }),
     ]);
     expect(presentation.safeActions).toEqual([]);
     expect(presentation.commandStatus).toEqual(
       expect.objectContaining({
-        label: "Sync retry",
+        label: "Collect local review items",
         status: "Pending",
         verificationStatus: "Waiting For Acknowledgement",
       }),
@@ -889,7 +889,7 @@ describe("terminal health presentation", () => {
     );
   });
 
-  it("presents local review backlog recovery as a terminal sync retry", () => {
+  it("presents local review backlog recovery as terminal-local evidence collection", () => {
     const presentation = buildTerminalRecoveryPresentation({
       recovery: {
         commandStatus: {
@@ -902,13 +902,13 @@ describe("terminal health presentation", () => {
           {
             commandContext: {
               expectedBlockerType: "local_review",
-              reason: "Local review items need a terminal sync retry.",
+              reason: "Local review items need terminal-local evidence collection.",
             },
-            commandType: "retry_sync",
+            commandType: "collect_local_review",
             expectedEvidence: {
-              syncStatus: "idle",
+              localReviewDetailsCollected: true,
             },
-            reason: "Local review items need a terminal sync retry.",
+            reason: "Local review items need terminal-local evidence collection.",
           },
         ],
       },
@@ -919,15 +919,136 @@ describe("terminal health presentation", () => {
 
     expect(presentation.groups.terminalRequired[0]).toEqual(
       expect.objectContaining({
-        detail: "Expected after check-in: Sync Idle.",
-        summary: "Local review items need a terminal sync retry.",
-        title: "Terminal sync retry",
+        detail: "Expected after check-in: Local review details collected.",
+        summary: "Local review items need terminal-local evidence collection.",
+        title: "Local review collection",
       }),
     );
     expect(presentation.safeActions[0]).toEqual(
       expect.objectContaining({
-        commandType: "retry_sync",
-        label: "Retry terminal sync",
+        commandType: "collect_local_review",
+        label: "Collect local review items",
+      }),
+    );
+  });
+
+  it("keeps local review collection available when latest runtime still reports review items", () => {
+    const presentation = buildTerminalRecoveryPresentation({
+      recovery: {
+        commandStatus: {
+          commandType: "collect_local_review",
+          label: "Collect local review items",
+          status: "completed",
+          verificationStatus: "verified",
+        },
+        terminalActions: [
+          {
+            commandContext: {
+              expectedBlockerType: "local_review",
+              reason: "Local review items need terminal-local evidence collection.",
+            },
+            commandType: "collect_local_review",
+            expectedEvidence: {
+              localReviewDetailsCollected: true,
+            },
+            reason: "Local review items need terminal-local evidence collection.",
+          },
+        ],
+      },
+      runtimeStatus: {
+        receivedAt: Date.now(),
+        sync: {
+          failedEventCount: 0,
+          localOnlyEventCount: 0,
+          pendingEventCount: 0,
+          reviewEventCount: 84,
+          reviewEvents: [],
+          status: "needs_review",
+          uploadableEventCount: 0,
+        },
+      },
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    expect(presentation.groups.terminalRequired[0]).toEqual(
+      expect.objectContaining({
+        action: expect.objectContaining({
+          commandType: "collect_local_review",
+          status: "available",
+        }),
+        summary: "Local review items need terminal-local evidence collection.",
+        title: "Local review collection",
+      }),
+    );
+    expect(presentation.safeActions[0]).toEqual(
+      expect.objectContaining({
+        commandType: "collect_local_review",
+        status: "available",
+      }),
+    );
+  });
+
+  it("presents local review cleanup as a safe terminal action", () => {
+    const presentation = buildTerminalRecoveryPresentation({
+      recovery: {
+        terminalActions: [
+          {
+            commandContext: {
+              expectedBlockerType: "local_review",
+              localReviewEventIds: ["event-review-1"],
+              reason: "Uploaded local review items can be cleared from this terminal.",
+            },
+            commandType: "clear_local_review_items",
+            expectedEvidence: {
+              localReviewEventCount: 0,
+            },
+            reason: "Uploaded local review items can be cleared from this terminal.",
+          },
+        ],
+      },
+      runtimeStatus: {
+        receivedAt: Date.now(),
+        sync: {
+          failedEventCount: 0,
+          localOnlyEventCount: 0,
+          pendingEventCount: 0,
+          reviewEventCount: 1,
+          reviewEvents: [
+            {
+              createdAt: Date.now() - 1_000,
+              localEventId: "event-review-1",
+              sequence: 12,
+              status: "needs_review",
+              type: "transaction.completed",
+              uploaded: true,
+              uploadSequence: 12,
+            },
+          ],
+          status: "needs_review",
+          uploadableEventCount: 0,
+        },
+      },
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    expect(presentation.groups.terminalRequired[0]).toEqual(
+      expect.objectContaining({
+        action: expect.objectContaining({
+          commandType: "clear_local_review_items",
+          label: "Clear local review items",
+          status: "available",
+        }),
+        detail: "Expected after check-in: 0 local review items remaining.",
+        summary: "Uploaded local review items can be cleared from this terminal.",
+        title: "Local review cleanup",
+      }),
+    );
+    expect(presentation.safeActions[0]).toEqual(
+      expect.objectContaining({
+        commandType: "clear_local_review_items",
+        label: "Clear local review items",
       }),
     );
   });

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
@@ -1085,7 +1085,7 @@ function buildRecoveryBlockers(
   }
 
   if (recovery) {
-    return buildRecoveryBlockersFromPreview(recovery);
+    return buildRecoveryBlockersFromPreview(summary, recovery);
   }
 
   return deriveRecoveryBlockers(summary);
@@ -1471,6 +1471,7 @@ function getPreviewCommandActionStatus(
 }
 
 function buildRecoveryBlockersFromPreview(
+  summary: TerminalHealthClassificationInput,
   preview: TerminalRecoveryPreview,
 ): RecoveryBlockerWithCategory[] {
   const blockers: RecoveryBlockerWithCategory[] = [];
@@ -1497,8 +1498,9 @@ function buildRecoveryBlockersFromPreview(
   }
 
   preview.terminalActions?.forEach((action, index) => {
-    const actionStatus = getPreviewCommandActionStatus(
-      preview.commandStatus,
+    const actionStatus = getTerminalActionStatusForCurrentRuntime(
+      summary,
+      preview,
       action.commandType,
     );
     if (actionStatus === "verified") {
@@ -1540,6 +1542,34 @@ function buildRecoveryBlockersFromPreview(
   });
 
   return blockers;
+}
+
+function getTerminalActionStatusForCurrentRuntime(
+  summary: TerminalHealthClassificationInput,
+  preview: TerminalRecoveryPreview,
+  commandType: TerminalRecoveryCommandType,
+) {
+  const actionStatus = getPreviewCommandActionStatus(
+    preview.commandStatus,
+    commandType,
+  );
+  if (
+    actionStatus === "verified" &&
+    commandType === "collect_local_review" &&
+    latestRuntimeStillNeedsLocalReviewDrain(summary)
+  ) {
+    return undefined;
+  }
+  return actionStatus;
+}
+
+function latestRuntimeStillNeedsLocalReviewDrain(
+  summary: TerminalHealthClassificationInput,
+) {
+  const sync = summary.runtimeStatus?.sync;
+  return Boolean(
+    sync && (sync.status === "needs_review" || (sync.reviewEventCount ?? 0) > 0),
+  );
 }
 
 export function isRecoveryActionIssuable(action: TerminalRecoveryAction) {
@@ -1735,6 +1765,10 @@ function getTerminalCommandActionLabel(
   switch (commandType) {
     case "update_app":
       return "Update app";
+    case "collect_local_review":
+      return "Collect local review items";
+    case "clear_local_review_items":
+      return "Clear local review items";
     case "repair_terminal_seed":
       return "Send terminal setup repair";
     case "clear_stale_drawer_authority":
@@ -1756,6 +1790,10 @@ function getTerminalCommandTitle(
   switch (commandType) {
     case "update_app":
       return "App update";
+    case "collect_local_review":
+      return "Local review collection";
+    case "clear_local_review_items":
+      return "Local review cleanup";
     case "repair_terminal_seed":
       return "Terminal setup repair";
     case "clear_stale_drawer_authority":
@@ -1778,11 +1816,18 @@ function getTerminalCommandRecoverySummary(
   const commandName =
     commandType === "update_app"
       ? "Update app command"
+      : commandType === "collect_local_review"
+        ? "Local review collection"
+      : commandType === "clear_local_review_items"
+        ? "Local review cleanup"
       : commandType === "clear_stale_drawer_authority"
         ? "Drawer repair command"
         : commandType === "retry_sync"
           ? "Sync retry command"
           : "Terminal repair command";
+  if (status === "verified" && commandType === "collect_local_review") {
+    return "Local review collection completed, but the terminal still reports local review items.";
+  }
   if (status === "verified") {
     return `${commandName} was verified by the latest terminal check-in.`;
   }
@@ -1817,6 +1862,12 @@ function getExpectedEvidenceSummary(
       : null,
     evidence.syncStatus
       ? `Sync ${formatStatusLabel(evidence.syncStatus)}`
+      : null,
+    evidence.localReviewDetailsCollected === true
+      ? "Local review details collected"
+      : null,
+    evidence.localReviewEventCount !== undefined
+      ? `${evidence.localReviewEventCount} local review items remaining`
       : null,
     evidence.terminalSeedReady === true ? "Terminal seed ready" : null,
     evidence.localStoreAvailable === true ? "Local store available" : null,

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
@@ -12,6 +12,13 @@ import type {
   TerminalRecoveryReadinessStatus,
   TerminalAppUpdatePreview,
   TerminalAppUpdateStatus,
+  TerminalOperationalExplanation,
+  TerminalOperationalExplanationEvidenceReference,
+  TerminalOperationalExplanationLane,
+  TerminalOperationalExplanationPrimaryOwner,
+  TerminalOperationalExplanationSaleImpact,
+  TerminalOperationalExplanationSeverity,
+  TerminalOperationalExplanationSupportAction,
 } from "./terminalHealthTypes";
 
 export type TerminalHealthClassification = {
@@ -67,9 +74,39 @@ export type TerminalAppUpdatePresentation = {
   toneClassName: string;
 };
 
+export type TerminalOperationalExplanationPresentation = {
+  detail: string;
+  evidenceReferences: Array<
+    TerminalOperationalExplanationEvidenceReference & {
+      label: string;
+    }
+  >;
+  headline: string;
+  label: string;
+  lane: TerminalOperationalExplanationLane;
+  nextStep: string;
+  ownerLabel: string;
+  primaryOwner: TerminalOperationalExplanationPrimaryOwner;
+  saleImpact: TerminalOperationalExplanationSaleImpact;
+  saleImpactLabel: string;
+  secondaryActions: TerminalOperationalExplanation["secondaryActions"];
+  severity: TerminalOperationalExplanationSeverity;
+  summaryMeta: TerminalOperationalExplanation["summaryMeta"];
+  supportAction: TerminalOperationalExplanationSupportAction;
+  supportActionLabel: string;
+  toneClassName: string;
+};
+
 type TerminalHealthClassificationInput = {
   attentionReasons?: TerminalHealthAttentionReason[];
-  health?: "needs_attention" | "offline" | "online" | "stale" | "unknown" | string;
+  health?:
+    | "needs_attention"
+    | "offline"
+    | "online"
+    | "stale"
+    | "unknown"
+    | string;
+  operationalExplanation?: TerminalOperationalExplanation | null;
   recovery?: TerminalRecoveryPreview | null;
   recoveryPreview?: TerminalRecoveryPreview | null;
   runtimeStatus:
@@ -100,7 +137,8 @@ export function formatTerminalTimestamp(timestamp?: number | null) {
     { divisor: 1_000, unit: "second" },
   ] as const;
   const formatter = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
-  const selected = units.find((unit) => absoluteDelta >= unit.divisor) ?? units[3];
+  const selected =
+    units.find((unit) => absoluteDelta >= unit.divisor) ?? units[3];
 
   return formatter.format(Math.round(delta / selected.divisor), selected.unit);
 }
@@ -219,6 +257,532 @@ export function getPrimaryTerminalAttentionReason(
   return getTerminalAttentionReasons(summary)[0] ?? null;
 }
 
+export function buildTerminalOperationalExplanationPresentation(
+  summary: TerminalHealthClassificationInput,
+): TerminalOperationalExplanationPresentation {
+  const serverExplanation = summary.operationalExplanation;
+  if (serverExplanation) {
+    return normalizeServerOperationalExplanation(serverExplanation);
+  }
+
+  return buildLegacyOperationalExplanation(summary);
+}
+
+function normalizeServerOperationalExplanation(
+  explanation: TerminalOperationalExplanation,
+): TerminalOperationalExplanationPresentation {
+  const lane = normalizeOperationalLane(explanation.lane);
+  const severity = normalizeOperationalSeverity(explanation.severity);
+  const fallback = getOperationalLaneFallback(lane, severity);
+  const saleImpact = normalizeSaleImpact(explanation.saleImpact);
+  const supportAction = normalizeSupportAction(explanation.supportAction);
+  const primaryOwner = normalizePrimaryOwner(explanation.primaryOwner);
+
+  const headline =
+    lane === "sale_ready_with_review_backlog"
+      ? "Review needed"
+      : sanitizeOperationalCopy(explanation.headline, fallback.headline);
+  const detail =
+    lane === "sale_ready_with_review_backlog"
+      ? "Sales can continue."
+      : sanitizeOperationalCopy(explanation.detail, fallback.detail);
+
+  return {
+    detail,
+    evidenceReferences: normalizeOperationalEvidenceReferences(
+      explanation.evidenceReferences,
+    ),
+    headline,
+    label: fallback.label,
+    lane,
+    nextStep: sanitizeOperationalCopy(explanation.nextStep, fallback.nextStep),
+    ownerLabel: getPrimaryOwnerLabel(primaryOwner),
+    primaryOwner,
+    saleImpact,
+    saleImpactLabel: getSaleImpactLabel(saleImpact),
+    secondaryActions: normalizeOperationalSecondaryActions(
+      explanation.secondaryActions,
+    ),
+    severity,
+    summaryMeta: normalizeOperationalSummaryMeta(explanation.summaryMeta),
+    supportAction,
+    supportActionLabel: getSupportActionLabel(supportAction),
+    toneClassName: getOperationalSeverityToneClassName(severity),
+  };
+}
+
+function buildLegacyOperationalExplanation(
+  summary: TerminalHealthClassificationInput,
+): TerminalOperationalExplanationPresentation {
+  const recovery = buildTerminalRecoveryPresentation(summary);
+  const runtimeStatus = summary.runtimeStatus;
+  const runtimeSync = runtimeStatus?.sync;
+  const reviewCount =
+    (runtimeSync?.reviewEventCount ?? 0) +
+    getReviewEvidenceCount(summary.syncEvidence);
+  const isSaleReady =
+    recovery.readiness.status === "able_to_transact_now" ||
+    (runtimeStatus?.staffAuthority?.status === "ready" &&
+      runtimeStatus.localStore?.available !== false &&
+      Boolean(runtimeStatus.activeRegisterSession));
+
+  if (reviewCount > 0 && isSaleReady) {
+    return {
+      detail: "Sales can continue.",
+      evidenceReferences: [
+        {
+          count: reviewCount,
+          label: "Review backlog",
+          source: "sync_evidence",
+          summary: "Review backlog",
+          type: "review_backlog",
+        },
+      ],
+      headline: "Review needed",
+      label: "Review needed",
+      lane: "sale_ready_with_review_backlog",
+      nextStep:
+        "Review the open work or cash-control backlog. Do not block new sales from this terminal.",
+      ownerLabel: "Operations",
+      primaryOwner: "operations",
+      saleImpact: "can_transact_now",
+      saleImpactLabel: "Sales can continue",
+      secondaryActions: [],
+      severity: "warning",
+      summaryMeta: {
+        hasSecondarySafeRepair: false,
+        reviewBacklogCount: reviewCount,
+        targetResolutionIncomplete: false,
+      },
+      supportAction: "review_open_work",
+      supportActionLabel: "Review open work",
+      toneClassName: getOperationalSeverityToneClassName("warning"),
+    };
+  }
+
+  if (recovery.groups.manualReview.length > 0) {
+    return buildStaticOperationalExplanation({
+      detail:
+        recovery.groups.manualReview[0]?.summary ??
+        "Manager or operations review is required before support repairs this terminal.",
+      lane: "needs_manual_review",
+      nextStep:
+        "Review cash-control or operations work before support repairs this terminal.",
+      primaryOwner: "cash_controls",
+      saleImpact: "unknown",
+      severity: "danger",
+      supportAction: "review_cash_controls",
+    });
+  }
+
+  if (recovery.groups.terminalRequired.length > 0) {
+    return buildStaticOperationalExplanation({
+      detail:
+        recovery.groups.terminalRequired[0]?.summary ??
+        "The checkout station needs terminal-side recovery before Athena can verify it.",
+      lane: "needs_terminal_action",
+      nextStep: "Send the safe terminal command or wait for a fresh check-in.",
+      primaryOwner: "terminal",
+      saleImpact: "unknown",
+      severity: "warning",
+      supportAction: "run_terminal_command",
+    });
+  }
+
+  if (recovery.groups.cloudRepair.length > 0) {
+    return buildStaticOperationalExplanation({
+      detail:
+        recovery.groups.cloudRepair[0]?.summary ??
+        "A safe cloud repair is available for stale terminal evidence.",
+      lane: "needs_cloud_repair",
+      nextStep: "Resolve the safe cloud repair item.",
+      primaryOwner: "support",
+      saleImpact: "unknown",
+      severity: "warning",
+      supportAction: "resolve_safe_cloud_repair",
+    });
+  }
+
+  if (
+    runtimeSync?.status === "failed" ||
+    (runtimeSync?.failedEventCount ?? 0) > 0
+  ) {
+    return buildStaticOperationalExplanation({
+      detail: "The latest terminal sync attempt failed.",
+      lane: "sync_failed",
+      nextStep: "Retry terminal sync or wait for the next check-in.",
+      primaryOwner: "terminal",
+      saleImpact: "unknown",
+      severity: "danger",
+      supportAction: "retry_terminal_sync",
+    });
+  }
+
+  const classification = classifyTerminalHealth(summary);
+  if (
+    classification.label === "No check-in" ||
+    classification.label === "Stale"
+  ) {
+    return buildStaticOperationalExplanation({
+      detail: "Athena is waiting for a current terminal check-in.",
+      lane: "stale_runtime",
+      nextStep: "Refresh terminal health or wait for the next check-in.",
+      primaryOwner: "terminal",
+      saleImpact: "unknown",
+      severity: "warning",
+      supportAction: "wait_for_check_in",
+    });
+  }
+
+  return buildStaticOperationalExplanation({
+    detail: "Current terminal evidence has no repair or review blockers.",
+    lane: "healthy",
+    nextStep: "No action is needed for terminal health.",
+    primaryOwner: "none",
+    saleImpact:
+      recovery.readiness.status === "able_to_transact_now"
+        ? "can_transact_now"
+        : "open_drawer_or_sign_in",
+    severity: "info",
+    supportAction: "none",
+  });
+}
+
+function buildStaticOperationalExplanation({
+  detail,
+  lane,
+  nextStep,
+  primaryOwner,
+  saleImpact,
+  severity,
+  supportAction,
+}: {
+  detail: string;
+  lane: TerminalOperationalExplanationLane;
+  nextStep: string;
+  primaryOwner: TerminalOperationalExplanationPrimaryOwner;
+  saleImpact: TerminalOperationalExplanationSaleImpact;
+  severity: TerminalOperationalExplanationSeverity;
+  supportAction: TerminalOperationalExplanationSupportAction;
+}): TerminalOperationalExplanationPresentation {
+  const fallback = getOperationalLaneFallback(lane, severity);
+  const normalizedDetail = sanitizeOperationalCopy(detail, fallback.detail);
+
+  return {
+    detail: normalizedDetail,
+    evidenceReferences: [],
+    headline: fallback.headline,
+    label: fallback.label,
+    lane,
+    nextStep,
+    ownerLabel: getPrimaryOwnerLabel(primaryOwner),
+    primaryOwner,
+    saleImpact,
+    saleImpactLabel: getSaleImpactLabel(saleImpact),
+    secondaryActions: [],
+    severity,
+    summaryMeta: {
+      hasSecondarySafeRepair: false,
+      reviewBacklogCount: 0,
+      targetResolutionIncomplete: false,
+    },
+    supportAction,
+    supportActionLabel: getSupportActionLabel(supportAction),
+    toneClassName: getOperationalSeverityToneClassName(severity),
+  };
+}
+
+function normalizeOperationalEvidenceReferences(
+  evidenceReferences: TerminalOperationalExplanationEvidenceReference[],
+) {
+  return evidenceReferences.map((reference) => ({
+    ...(typeof reference.count === "number" ? { count: reference.count } : {}),
+    label: sanitizeOperationalCopy(reference.summary, "Review evidence"),
+    source: reference.source,
+    summary: sanitizeOperationalCopy(reference.summary, "Review evidence"),
+    type: reference.type,
+  }));
+}
+
+function normalizeOperationalSecondaryActions(
+  secondaryActions: TerminalOperationalExplanation["secondaryActions"],
+) {
+  return secondaryActions.map((action) => ({
+    ...action,
+    label: sanitizeOperationalCopy(
+      action.label,
+      getSupportActionLabel(action.supportAction),
+    ),
+    supportAction: action.supportAction,
+  }));
+}
+
+function normalizeOperationalSummaryMeta(
+  summaryMeta: TerminalOperationalExplanation["summaryMeta"],
+) {
+  return {
+    hasSecondarySafeRepair: Boolean(summaryMeta.hasSecondarySafeRepair),
+    reviewBacklogCount: normalizeCount(summaryMeta.reviewBacklogCount),
+    targetResolutionIncomplete: Boolean(summaryMeta.targetResolutionIncomplete),
+  };
+}
+
+function normalizeCount(value: number) {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+function normalizeOperationalLane(lane: TerminalOperationalExplanationLane) {
+  switch (lane) {
+    case "able_to_transact_now":
+    case "drawer_open":
+    case "healthy_idle":
+    case "healthy":
+    case "sale_ready_with_review_backlog":
+    case "needs_manual_review":
+    case "needs_terminal_action":
+    case "needs_cloud_repair":
+    case "sync_failed":
+    case "stale_runtime":
+      return lane;
+    default:
+      return "unknown";
+  }
+}
+
+function normalizeOperationalSeverity(
+  severity: TerminalOperationalExplanationSeverity,
+) {
+  if (severity === "critical" || severity === "danger" || severity === "warning") {
+    return severity;
+  }
+  return "info";
+}
+
+function normalizeSaleImpact(
+  saleImpact: TerminalOperationalExplanationSaleImpact,
+) {
+  switch (saleImpact) {
+    case "can_transact_now":
+    case "can_continue_local_sales":
+    case "open_drawer_or_sign_in":
+    case "not_ready":
+    case "blocked":
+      return saleImpact;
+    default:
+      return "unknown";
+  }
+}
+
+function normalizeSupportAction(
+  supportAction: TerminalOperationalExplanationSupportAction,
+) {
+  switch (supportAction) {
+    case "manual_review":
+    case "none":
+    case "safe_cloud_repair":
+    case "terminal_command":
+    case "terminal_sync_retry":
+    case "review_cash_controls":
+    case "review_open_work":
+    case "resolve_safe_cloud_repair":
+    case "run_terminal_command":
+    case "retry_terminal_sync":
+    case "wait_for_check_in":
+      return supportAction;
+    default:
+      return "diagnostic_only";
+  }
+}
+
+function normalizePrimaryOwner(
+  primaryOwner: TerminalOperationalExplanationPrimaryOwner,
+) {
+  switch (primaryOwner) {
+    case "none":
+    case "cash_controls":
+    case "manager":
+    case "operations":
+    case "terminal":
+    case "support":
+      return primaryOwner;
+    default:
+      return "system";
+  }
+}
+
+function getOperationalLaneFallback(
+  lane: TerminalOperationalExplanationLane,
+  severity: TerminalOperationalExplanationSeverity,
+) {
+  switch (lane) {
+    case "able_to_transact_now":
+      return {
+        detail: "Fresh runtime evidence reports sale authority.",
+        headline: "Ready for sales",
+        label: "Ready",
+        nextStep: "No action is needed for terminal health.",
+      };
+    case "drawer_open":
+      return {
+        detail: "A drawer is open for this terminal.",
+        headline: "Drawer open",
+        label: "Drawer open",
+        nextStep: "No action is needed for terminal health.",
+      };
+    case "healthy_idle":
+    case "healthy":
+      return {
+        detail: "Current terminal evidence has no repair or review blockers.",
+        headline: "No action needed",
+        label: "Healthy",
+        nextStep: "No action is needed for terminal health.",
+      };
+    case "sale_ready_with_review_backlog":
+      return {
+        detail: "Sales can continue.",
+        headline: "Review needed",
+        label: "Review needed",
+        nextStep:
+          "Review the open work or cash-control backlog. Do not block new sales from this terminal.",
+      };
+    case "needs_manual_review":
+      return {
+        detail:
+          "Manager or operations review is required before support repairs this terminal.",
+        headline: "Manager review needed",
+        label: "Manager review needed",
+        nextStep:
+          "Review cash-control or operations work before support repairs this terminal.",
+      };
+    case "needs_terminal_action":
+      return {
+        detail:
+          "The checkout station needs terminal-side recovery before Athena can verify it.",
+        headline: "Terminal action needed",
+        label: "Terminal action needed",
+        nextStep:
+          "Send the safe terminal command or wait for a fresh check-in.",
+      };
+    case "needs_cloud_repair":
+      return {
+        detail: "A safe cloud repair is available for stale terminal evidence.",
+        headline: "Safe cloud repair available",
+        label: "Cloud repair",
+        nextStep: "Resolve the safe cloud repair item.",
+      };
+    case "sync_failed":
+      return {
+        detail: "The latest terminal sync attempt failed.",
+        headline: "Sync failed",
+        label: "Sync failed",
+        nextStep: "Retry terminal sync or wait for the next check-in.",
+      };
+    case "stale_runtime":
+      return {
+        detail: "Athena is waiting for a current terminal check-in.",
+        headline: "Waiting for check-in",
+        label: "Waiting for check-in",
+        nextStep: "Refresh terminal health or wait for the next check-in.",
+      };
+    default:
+      return {
+        detail:
+          "Athena does not have enough current evidence to explain this terminal.",
+        headline: "Terminal status needs review",
+        label:
+          severity === "critical" || severity === "danger"
+            ? "Needs attention"
+            : "Unknown",
+        nextStep: "Refresh terminal health or wait for the next check-in.",
+      };
+  }
+}
+
+function getOperationalSeverityToneClassName(
+  severity: TerminalOperationalExplanationSeverity,
+) {
+  switch (severity) {
+    case "critical":
+    case "danger":
+      return "border-danger/25 bg-danger/10 text-danger";
+    case "warning":
+      return "border-warning/30 bg-warning/15 text-warning";
+    default:
+      return "border-success/30 bg-success/10 text-success";
+  }
+}
+
+function getSaleImpactLabel(
+  saleImpact: TerminalOperationalExplanationSaleImpact,
+) {
+  switch (saleImpact) {
+    case "can_transact_now":
+      return "Sales can continue";
+    case "can_continue_local_sales":
+      return "Local sales can continue";
+    case "open_drawer_or_sign_in":
+      return "Open drawer or sign in";
+    case "not_ready":
+      return "Sales not ready";
+    case "blocked":
+      return "Sales blocked";
+    default:
+      return "Sale impact unknown";
+  }
+}
+
+function getSupportActionLabel(
+  supportAction: TerminalOperationalExplanationSupportAction,
+) {
+  switch (supportAction) {
+    case "manual_review":
+      return "Manual review";
+    case "none":
+      return "No support action";
+    case "safe_cloud_repair":
+      return "Safe cloud repair";
+    case "terminal_command":
+      return "Terminal command";
+    case "terminal_sync_retry":
+      return "Retry terminal sync";
+    case "review_cash_controls":
+      return "Review cash controls";
+    case "review_open_work":
+      return "Review open work";
+    case "resolve_safe_cloud_repair":
+      return "Resolve safe cloud repair";
+    case "run_terminal_command":
+      return "Run terminal command";
+    case "retry_terminal_sync":
+      return "Retry terminal sync";
+    case "wait_for_check_in":
+      return "Wait for check-in";
+    default:
+      return "Diagnostic review";
+  }
+}
+
+function getPrimaryOwnerLabel(
+  primaryOwner: TerminalOperationalExplanationPrimaryOwner,
+) {
+  switch (primaryOwner) {
+    case "none":
+      return "No owner";
+    case "cash_controls":
+      return "Cash controls";
+    case "manager":
+      return "Manager";
+    case "operations":
+      return "Operations";
+    case "terminal":
+      return "Terminal";
+    case "support":
+      return "Support";
+    default:
+      return "System";
+  }
+}
+
 export function getSupportSafeAttentionReasonSummary(
   reason: TerminalHealthAttentionReason,
 ) {
@@ -324,7 +888,8 @@ export function classifyTerminalHealth(
   ) {
     return {
       description:
-        primaryReason?.summary ?? "Local activity needs manager or support review.",
+        primaryReason?.summary ??
+        "Local activity needs manager or support review.",
       label: "Needs review",
       toneClassName: "border-warning/30 bg-warning/15 text-warning",
     };
@@ -452,8 +1017,12 @@ export function buildTerminalRecoveryPresentation(
   const recovery = getTerminalRecoveryPreview(summary);
   const blockers = buildRecoveryBlockers(summary, recovery);
   const groups = {
-    cloudRepair: blockers.filter((blocker) => blocker.category === "cloud_repair"),
-    manualReview: blockers.filter((blocker) => blocker.category === "manual_review"),
+    cloudRepair: blockers.filter(
+      (blocker) => blocker.category === "cloud_repair",
+    ),
+    manualReview: blockers.filter(
+      (blocker) => blocker.category === "manual_review",
+    ),
     terminalRequired: blockers.filter(
       (blocker) => blocker.category === "terminal_required",
     ),
@@ -470,7 +1039,9 @@ export function buildTerminalRecoveryPresentation(
     appUpdate,
     commandStatus: {
       commandType: recovery?.commandStatus?.commandType,
-      label: normalizeSupportCopy(recovery?.commandStatus?.label) ?? "No command issued",
+      label:
+        normalizeSupportCopy(recovery?.commandStatus?.label) ??
+        "No command issued",
       latestAcknowledgement: normalizeSupportCopy(
         recovery?.commandStatus?.latestAcknowledgement,
       ),
@@ -492,7 +1063,9 @@ export function buildTerminalRecoveryPresentation(
       ),
       summary:
         normalizeSupportCopy(recovery?.verification?.summary) ??
-        getRecoveryVerificationSummary(recovery?.commandStatus?.verificationStatus) ??
+        getRecoveryVerificationSummary(
+          recovery?.commandStatus?.verificationStatus,
+        ) ??
         "Athena has not received recovery verification from a fresh terminal check-in.",
     },
   };
@@ -500,7 +1073,10 @@ export function buildTerminalRecoveryPresentation(
 
 function buildRecoveryBlockers(
   summary: TerminalHealthClassificationInput,
-  recovery: TerminalRecoveryPreview | null | undefined = getTerminalRecoveryPreview(summary),
+  recovery:
+    | TerminalRecoveryPreview
+    | null
+    | undefined = getTerminalRecoveryPreview(summary),
 ): RecoveryBlockerWithCategory[] {
   if (recovery?.blockers && !hasStructuredRecoveryPreview(recovery)) {
     return recovery.blockers.map((blocker, index) =>
@@ -515,7 +1091,9 @@ function buildRecoveryBlockers(
   return deriveRecoveryBlockers(summary);
 }
 
-function getTerminalRecoveryPreview(summary: TerminalHealthClassificationInput) {
+function getTerminalRecoveryPreview(
+  summary: TerminalHealthClassificationInput,
+) {
   return summary.recoveryPreview ?? summary.recovery ?? null;
 }
 
@@ -603,13 +1181,17 @@ function normalizeTerminalAppUpdatePreview(
         ? record.stagingFailedAssetCount
         : undefined,
     stagingReason:
-      typeof record.stagingReason === "string" ? record.stagingReason : undefined,
+      typeof record.stagingReason === "string"
+        ? record.stagingReason
+        : undefined,
     stagingRejectedAssetCount:
       typeof record.stagingRejectedAssetCount === "number"
         ? record.stagingRejectedAssetCount
         : undefined,
     stagingStatus:
-      typeof record.stagingStatus === "string" ? record.stagingStatus : undefined,
+      typeof record.stagingStatus === "string"
+        ? record.stagingStatus
+        : undefined,
     status,
     summary:
       typeof record.summary === "string"
@@ -618,7 +1200,7 @@ function normalizeTerminalAppUpdatePreview(
           ? normalizeAppUpdateBlockerSummary(record.blockerSummary)
           : typeof record.selectedBlockerCode === "string"
             ? normalizeAppUpdateBlockerSummary(record.selectedBlockerCode)
-          : undefined,
+            : undefined,
   };
 }
 
@@ -842,16 +1424,21 @@ function normalizeAppUpdateBlockerSummary(value: string) {
 function hasStructuredRecoveryPreview(recovery: TerminalRecoveryPreview) {
   return Boolean(
     (recovery.cloudRepair?.safeConflictIds.length ?? 0) > 0 ||
-      (recovery.terminalActions?.length ?? 0) > 0 ||
-      (recovery.manualReview?.length ?? 0) > 0,
+    (recovery.terminalActions?.length ?? 0) > 0 ||
+    (recovery.manualReview?.length ?? 0) > 0,
   );
 }
 
-function getRecoveryVerificationSummary(status?: TerminalRecoveryActionStatus | null) {
+function getRecoveryVerificationSummary(
+  status?: TerminalRecoveryActionStatus | null,
+) {
   if (status === "verified") {
     return "Recovery was verified by the latest terminal check-in.";
   }
-  if (status === "runtime_verification_ready" || status === "waiting_for_check_in") {
+  if (
+    status === "runtime_verification_ready" ||
+    status === "waiting_for_check_in"
+  ) {
     return "Command completed locally. Waiting for a fresh terminal check-in before verification.";
   }
   if (status === "waiting_for_acknowledgement") {
@@ -969,9 +1556,7 @@ export function isRecoveryActionIssuable(action: TerminalRecoveryAction) {
   }
 
   return Boolean(
-    action.commandType &&
-      action.commandContext &&
-      action.expectedEvidence,
+    action.commandType && action.commandContext && action.expectedEvidence,
   );
 }
 
@@ -1010,7 +1595,8 @@ function buildRecoveryReadiness(
           ? "needs_terminal_action"
           : "healthy_idle";
   const status =
-    explicitStatus && explicitReadinessMatchesVisibleEvidence(explicitStatus, groups)
+    explicitStatus &&
+    explicitReadinessMatchesVisibleEvidence(explicitStatus, groups)
       ? explicitStatus
       : derivedStatus;
 
@@ -1018,8 +1604,9 @@ function buildRecoveryReadiness(
 
   return {
     description:
-      normalizeSupportCopy(typeof readiness === "string" ? undefined : readiness?.summary) ??
-      fallback.description,
+      normalizeSupportCopy(
+        typeof readiness === "string" ? undefined : readiness?.summary,
+      ) ?? fallback.description,
     label: fallback.label,
     status,
     toneClassName: fallback.toneClassName,
@@ -1107,7 +1694,8 @@ function normalizeBackendRecoveryBlocker(
     ["cloud_repair", "terminal_command"].includes(blocker.action.kind)
       ? {
           ...blocker.action,
-          label: normalizeSupportCopy(blocker.action.label) ?? blocker.action.label,
+          label:
+            normalizeSupportCopy(blocker.action.label) ?? blocker.action.label,
           status: normalizeActionStatus(blocker.action.status),
         }
       : undefined;
@@ -1119,7 +1707,8 @@ function normalizeBackendRecoveryBlocker(
     detail: normalizeSupportCopy(blocker.detail),
     id: blocker.id ?? `${category}-${index}`,
     status: blocker.status ?? blocker.action?.status,
-    summary: normalizeSupportCopy(blocker.summary) ?? defaultBlockerSummary(category),
+    summary:
+      normalizeSupportCopy(blocker.summary) ?? defaultBlockerSummary(category),
     title:
       normalizeSupportCopy(blocker.title) ??
       (category === "cloud_repair"
@@ -1190,10 +1779,10 @@ function getTerminalCommandRecoverySummary(
     commandType === "update_app"
       ? "Update app command"
       : commandType === "clear_stale_drawer_authority"
-      ? "Drawer repair command"
-      : commandType === "retry_sync"
-        ? "Sync retry command"
-      : "Terminal repair command";
+        ? "Drawer repair command"
+        : commandType === "retry_sync"
+          ? "Sync retry command"
+          : "Terminal repair command";
   if (status === "verified") {
     return `${commandName} was verified by the latest terminal check-in.`;
   }
@@ -1226,7 +1815,9 @@ function getExpectedEvidenceSummary(
     evidence.staffAuthorityStatus
       ? `Staff authority ${formatStatusLabel(evidence.staffAuthorityStatus)}`
       : null,
-    evidence.syncStatus ? `Sync ${formatStatusLabel(evidence.syncStatus)}` : null,
+    evidence.syncStatus
+      ? `Sync ${formatStatusLabel(evidence.syncStatus)}`
+      : null,
     evidence.terminalSeedReady === true ? "Terminal seed ready" : null,
     evidence.localStoreAvailable === true ? "Local store available" : null,
   ].filter(Boolean);
@@ -1250,7 +1841,10 @@ function deriveRecoveryBlockerFromReason(
 ): RecoveryBlockerWithCategory {
   const normalizedSummary = normalizeSupportCopy(reason.summary);
 
-  if (reason.type === "cloud_conflict" && isSafeDuplicateDrawerOpen(reason.summary)) {
+  if (
+    reason.type === "cloud_conflict" &&
+    isSafeDuplicateDrawerOpen(reason.summary)
+  ) {
     return {
       action: {
         kind: "cloud_repair",
@@ -1310,7 +1904,9 @@ function normalizeRecoveryCategory(
   return "manual_review";
 }
 
-function defaultBlockerSummary(category: RecoveryBlockerWithCategory["category"]) {
+function defaultBlockerSummary(
+  category: RecoveryBlockerWithCategory["category"],
+) {
   if (category === "cloud_repair") {
     return "Cloud repair is available for stale terminal evidence.";
   }
@@ -1320,7 +1916,9 @@ function defaultBlockerSummary(category: RecoveryBlockerWithCategory["category"]
   return "Manual review required. Use the linked operations or cash-control review before support repairs this terminal.";
 }
 
-function terminalRequiredSummary(reasonType: TerminalHealthAttentionReason["type"]) {
+function terminalRequiredSummary(
+  reasonType: TerminalHealthAttentionReason["type"],
+) {
   if (reasonType === "terminal_authorization_failed") {
     return "Terminal authorization needs refresh. This checkout station must reconnect before Athena can verify it.";
   }
@@ -1360,6 +1958,21 @@ function normalizeSupportCopy(value?: string | null) {
     return "Duplicate drawer-open attempts can be resolved. No sales, payments, or inventory will be changed.";
   }
   return value;
+}
+
+function sanitizeOperationalCopy(value: string | undefined, fallback: string) {
+  const normalized = normalizeSupportCopy(value);
+  if (!normalized || containsUnsafeOperationalCopy(normalized)) {
+    return fallback;
+  }
+
+  return normalized;
+}
+
+function containsUnsafeOperationalCopy(value: string) {
+  return /sync secret|authorization_failed|staff proof|pin\b|password|token|otp|payment payload|customer payload|card payload|raw payload|backend exception|stack trace|traceback|returnsvalidationerror|conflict[-_][a-z0-9-]+|poslocalsyncconflict/i.test(
+    value,
+  );
 }
 
 function isAppSessionLocalContinuation(

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
@@ -186,7 +186,11 @@ export type TerminalSyncEvent = {
 
 export type TerminalSyncReviewEvent = Pick<
   TerminalSyncEvent,
-  "eventType" | "localEventId" | "localRegisterSessionId" | "sequence" | "status"
+  | "eventType"
+  | "localEventId"
+  | "localRegisterSessionId"
+  | "sequence"
+  | "status"
 >;
 
 export type TerminalSyncConflict = {
@@ -386,15 +390,16 @@ export type TerminalRecoveryPreview = {
   };
   manualReview?: Array<{
     reason: string;
-    source:
-      | "cloud_repair"
-      | TerminalHealthAttentionReason["source"];
+    source: "cloud_repair" | TerminalHealthAttentionReason["source"];
     type: "unsafe_cloud_conflict" | TerminalHealthAttentionReason["type"];
   }>;
-  readiness?: {
-    status?: TerminalRecoveryReadinessStatus;
-    summary?: string;
-  } | TerminalRecoveryReadinessStatus | null;
+  readiness?:
+    | {
+        status?: TerminalRecoveryReadinessStatus;
+        summary?: string;
+      }
+    | TerminalRecoveryReadinessStatus
+    | null;
   runtimeFresh?: boolean;
   terminalActions?: Array<{
     commandContext: TerminalRecoveryCommandContext;
@@ -434,9 +439,124 @@ export type TerminalAppUpdatePreview = {
   summary?: string;
 };
 
+export type TerminalOperationalExplanationServerLane =
+  | "able_to_transact_now"
+  | "drawer_open"
+  | "healthy_idle"
+  | "sale_ready_with_review_backlog"
+  | "needs_manual_review"
+  | "needs_terminal_action"
+  | "needs_cloud_repair"
+  | "stale_runtime"
+  | "unknown";
+
+export type TerminalOperationalExplanationLane =
+  | TerminalOperationalExplanationServerLane
+  | "healthy"
+  | "sync_failed";
+
+export type TerminalOperationalExplanationServerSeverity =
+  | "info"
+  | "warning"
+  | "critical";
+
+export type TerminalOperationalExplanationSeverity =
+  | TerminalOperationalExplanationServerSeverity
+  | "danger";
+
+export type TerminalOperationalExplanationBlockingDomain =
+  | "cloud_repair"
+  | "manual_review"
+  | "none"
+  | "sync_review"
+  | "terminal_runtime";
+
+export type TerminalOperationalExplanationServerSaleImpact =
+  | "can_transact_now"
+  | "not_ready"
+  | "unknown";
+
+export type TerminalOperationalExplanationSaleImpact =
+  | TerminalOperationalExplanationServerSaleImpact
+  | "can_continue_local_sales"
+  | "open_drawer_or_sign_in"
+  | "blocked";
+
+export type TerminalOperationalExplanationServerSupportAction =
+  | "manual_review"
+  | "none"
+  | "safe_cloud_repair"
+  | "terminal_command"
+  | "terminal_sync_retry"
+  | "wait_for_check_in";
+
+export type TerminalOperationalExplanationSupportAction =
+  | TerminalOperationalExplanationServerSupportAction
+  | "review_cash_controls"
+  | "review_open_work"
+  | "resolve_safe_cloud_repair"
+  | "run_terminal_command"
+  | "retry_terminal_sync"
+  | "diagnostic_only";
+
+export type TerminalOperationalExplanationServerPrimaryOwner =
+  | "none"
+  | "cash_controls"
+  | "manager"
+  | "operations"
+  | "terminal"
+  | "support";
+
+export type TerminalOperationalExplanationPrimaryOwner =
+  | TerminalOperationalExplanationServerPrimaryOwner
+  | "system";
+
+export type TerminalOperationalExplanationEvidenceReference = {
+  count?: number;
+  source: string;
+  summary: string;
+  type: string;
+};
+
+export type TerminalOperationalExplanationSecondaryAction = {
+  actionTarget?: TerminalHealthAttentionActionTarget;
+  label: string;
+  primaryOwner: Exclude<TerminalOperationalExplanationServerPrimaryOwner, "none">;
+  supportAction: Exclude<
+    TerminalOperationalExplanationServerSupportAction,
+    "none" | "wait_for_check_in"
+  >;
+};
+
+export type TerminalOperationalExplanation = {
+  blockingDomain: TerminalOperationalExplanationBlockingDomain;
+  detail: string;
+  evidenceReferences: TerminalOperationalExplanationEvidenceReference[];
+  headline: string;
+  lane: TerminalOperationalExplanationServerLane;
+  nextStep: string;
+  primaryOwner: TerminalOperationalExplanationServerPrimaryOwner;
+  saleImpact: TerminalOperationalExplanationServerSaleImpact;
+  secondaryActions: TerminalOperationalExplanationSecondaryAction[];
+  severity: TerminalOperationalExplanationServerSeverity;
+  summaryMeta: {
+    hasSecondarySafeRepair: boolean;
+    reviewBacklogCount: number;
+    targetResolutionIncomplete: boolean;
+  };
+  supportAction: TerminalOperationalExplanationServerSupportAction;
+};
+
 export type TerminalHealthSummary = {
   attentionReasons?: TerminalHealthAttentionReason[];
-  health?: "needs_attention" | "offline" | "online" | "stale" | "unknown" | string;
+  health?:
+    | "needs_attention"
+    | "offline"
+    | "online"
+    | "stale"
+    | "unknown"
+    | string;
+  operationalExplanation?: TerminalOperationalExplanation | null;
   registerSessionLink?: {
     registerSessionId: Id<"registerSession"> | string;
     status: "active" | "open";

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
@@ -304,6 +304,8 @@ export type TerminalRecoveryAction = {
 
 export type TerminalRecoveryCommandType =
   | "retry_sync"
+  | "collect_local_review"
+  | "clear_local_review_items"
   | "repair_terminal_seed"
   | "clear_stale_drawer_authority"
   | "refresh_staff_authority"
@@ -316,6 +318,9 @@ export type TerminalRecoveryCommandContext = {
   expectedBlockerType?: string;
   expectedConflictIds?: Array<Id<"posLocalSyncConflict">>;
   expectedTerminalSeedIdentity?: string;
+  localReviewClearAll?: boolean;
+  localReviewClearLimit?: number;
+  localReviewEventIds?: string[];
   localRegisterSessionId?: string;
   reason?: string;
 };
@@ -333,6 +338,8 @@ export type TerminalRecoveryExpectedEvidence = {
   drawerAuthorityStatus?: "healthy" | "blocked";
   localRegisterSessionId?: string;
   localStoreAvailable?: boolean;
+  localReviewDetailsCollected?: boolean;
+  localReviewEventCount?: number;
   saleAuthorityStatus?: "ready" | "missing" | "blocked" | "unknown";
   staffAuthorityStatus?: "ready" | "missing" | "expired" | "unknown";
   syncStatus?:
@@ -381,6 +388,19 @@ export type TerminalRecoveryPreview = {
     commandType?: TerminalRecoveryCommandType;
     label?: string;
     latestAcknowledgement?: string;
+    localReviewEvents?: Array<{
+      createdAt: number;
+      localEventId: string;
+      localPosSessionId?: string;
+      localRegisterSessionId?: string;
+      localTransactionId?: string;
+      sequence: number;
+      staffProfileId?: string;
+      status: string;
+      type: string;
+      uploaded?: boolean;
+      uploadSequence?: number;
+    }>;
     status?: TerminalRecoveryActionStatus;
     verificationStatus?: TerminalRecoveryActionStatus;
   } | null;

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localSyncDrainCoordinator.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localSyncDrainCoordinator.ts
@@ -70,7 +70,11 @@ export function buildRuntimeSyncDebug(
   );
   const failedEvents = events.filter((event) => event.sync.status === "failed");
   const oldestPendingEvent = [...events]
-    .filter((event) => event.sync.status !== "synced")
+    .filter(
+      (event) =>
+        event.sync.status !== "synced" &&
+        event.sync.status !== "locally_resolved",
+    )
     .sort((left, right) => left.createdAt - right.createdAt)
     .at(0);
 
@@ -130,7 +134,7 @@ function getReviewDiagnosticsEvents(
   return events
     .slice()
     .sort(compareUploadableEventOrder)
-    .slice(0, 10)
+    .slice(0, 100)
     .map((event) => ({
       createdAt: event.createdAt,
       localEventId: event.localEventId,

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
@@ -1459,6 +1459,101 @@ describe("posLocalStore", () => {
     }
   });
 
+  it("clears only requested local review events without retaining staff proof", async () => {
+    let nextLocalId = 1;
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 4_000,
+      createLocalId: () => `local-event-${nextLocalId++}`,
+    });
+
+    await store.appendEvent({
+      initialSyncStatus: "needs_review",
+      localRegisterSessionId: "local-register-session-1",
+      payload: { total: 25 },
+      staffProfileId: "staff_cloud_1",
+      staffProofToken: "proof-token-1",
+      storeId: "store_cloud_1",
+      terminalId: "local-terminal-1",
+      type: "transaction.completed",
+    });
+    await store.markEventsNeedsReview(["local-event-1"], undefined, {
+      uploaded: true,
+    });
+    await store.appendEvent({
+      localRegisterSessionId: "local-register-session-1",
+      payload: { openingFloat: 100 },
+      staffProfileId: "staff_cloud_1",
+      staffProofToken: "proof-token-2",
+      storeId: "store_cloud_1",
+      terminalId: "local-terminal-1",
+      type: "register.opened",
+    });
+    await store.appendEvent({
+      initialSyncStatus: "needs_review",
+      localRegisterSessionId: "local-register-session-1",
+      payload: { total: 40 },
+      staffProfileId: "staff_cloud_1",
+      staffProofToken: "proof-token-3",
+      storeId: "store_cloud_1",
+      terminalId: "local-terminal-1",
+      type: "transaction.completed",
+    });
+
+    await expect(
+      store.clearLocalReviewEvents([
+        "local-event-1",
+        "local-event-2",
+        "missing-event",
+      ]),
+    ).resolves.toEqual({
+      ok: true,
+      value: [
+        expect.objectContaining({
+          localEventId: "local-event-1",
+          sync: expect.objectContaining({
+            localResolution: {
+              reason: "terminal_recovery_command",
+              resolvedAt: 4_000,
+              status: "local_review_cleared",
+            },
+            status: "locally_resolved",
+          }),
+        }),
+      ],
+    });
+
+    const listed = await store.listEvents();
+
+    expect(listed).toEqual({
+      ok: true,
+      value: [
+        expect.objectContaining({
+          localEventId: "local-event-1",
+          sync: expect.objectContaining({
+            localResolution: expect.objectContaining({
+              status: "local_review_cleared",
+            }),
+            status: "locally_resolved",
+          }),
+        }),
+        expect.objectContaining({
+          localEventId: "local-event-2",
+          staffProofToken: "proof-token-2",
+          sync: expect.objectContaining({ status: "pending" }),
+        }),
+        expect.objectContaining({
+          localEventId: "local-event-3",
+          staffProofToken: "proof-token-3",
+          sync: expect.objectContaining({ status: "needs_review" }),
+        }),
+      ],
+    });
+    if (listed.ok) {
+      expect(listed.value[0]).not.toHaveProperty("staffProofToken");
+    }
+  });
+
   it("returns an explicit failure for unsupported local schema versions", async () => {
     const adapter = createMemoryPosLocalStorageAdapter({
       schemaVersion: POS_LOCAL_STORE_SCHEMA_VERSION + 1,

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
@@ -53,8 +53,17 @@ export type PosLocalSyncEventStatus =
   | "pending"
   | "syncing"
   | "synced"
+  | "locally_resolved"
   | "needs_review"
   | "failed";
+
+export type PosLocalReviewResolutionReason = "terminal_recovery_command";
+
+export interface PosLocalReviewResolutionMetadata {
+  reason: PosLocalReviewResolutionReason;
+  resolvedAt: number;
+  status: "local_review_cleared";
+}
 
 export type PosLocalEventValidationFlag =
   | "app-session-unverified"
@@ -117,6 +126,7 @@ export interface PosLocalEventRecord {
     status: PosLocalSyncEventStatus;
     cloudEventId?: string;
     error?: string;
+    localResolution?: PosLocalReviewResolutionMetadata;
     uploaded?: boolean;
   };
 }
@@ -1520,6 +1530,60 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
                   status: "needs_review" as const,
                   ...(error ? { error } : {}),
                   ...(markOptions?.uploaded ? { uploaded: true } : {}),
+                },
+              };
+              await transaction.put(
+                "events",
+                String(event.sequence),
+                nextEvent,
+              );
+              updated.push(nextEvent);
+            }
+
+            return updated.sort(
+              (left, right) => left.sequence - right.sequence,
+            );
+          },
+        );
+
+        return { ok: true, value };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
+    async clearLocalReviewEvents(
+      eventIds: string[],
+      clearOptions?: { reason?: PosLocalReviewResolutionReason },
+    ): Promise<PosLocalStoreResult<PosLocalEventRecord[]>> {
+      try {
+        const value = await options.adapter.transaction(
+          "readwrite",
+          ["meta", "events"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readwrite");
+            const eventIdSet = new Set(eventIds);
+            const events =
+              await transaction.getAll<PosLocalEventRecord>("events");
+            const updated: PosLocalEventRecord[] = [];
+            const resolvedAt = clock();
+
+            for (const event of events) {
+              if (!eventIdSet.has(event.localEventId)) continue;
+              if (event.sync.status !== "needs_review") continue;
+              const eventWithoutProof = omitStaffProofToken(event);
+              const nextEvent = {
+                ...eventWithoutProof,
+                sync: {
+                  ...event.sync,
+                  error: undefined,
+                  localResolution: {
+                    reason:
+                      clearOptions?.reason ?? "terminal_recovery_command",
+                    resolvedAt,
+                    status: "local_review_cleared" as const,
+                  },
+                  status: "locally_resolved" as const,
                 },
               };
               await transaction.put(

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.test.ts
@@ -108,6 +108,34 @@ describe("derivePosLocalSyncStatus", () => {
     });
   });
 
+  it("treats locally resolved review items as terminal-settled without reporting cloud sync", () => {
+    expect(
+      derivePosLocalSyncStatus({
+        events: [
+          event(1, "synced"),
+          event(2, "locally_resolved", {
+            sync: {
+              localResolution: {
+                reason: "terminal_recovery_command",
+                resolvedAt: 10,
+                status: "local_review_cleared",
+              },
+              status: "locally_resolved",
+              uploaded: true,
+            },
+          }),
+        ],
+        isOnline: true,
+      }),
+    ).toMatchObject({
+      state: "synced",
+      pendingCount: 0,
+      failedCount: 0,
+      lastSyncedSequence: 2,
+      nextPendingSequence: null,
+    });
+  });
+
   it("marks unsynced work as offline when the browser is offline", () => {
     expect(
       derivePosLocalSyncStatus({

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.ts
@@ -75,7 +75,7 @@ export function derivePosLocalSyncStatus(input: {
   const uploadBlockingEvents = orderedEvents.filter(
     (event) =>
       typeof event.uploadSequence === "number" &&
-      event.sync.status !== "synced",
+      !isLocallySettledSyncStatus(event.sync.status),
   );
   const pendingCount = uploadBlockingEvents.filter((event) =>
     event.sync.status === "pending" || event.sync.status === "syncing",
@@ -113,10 +113,16 @@ function getContiguousSyncedSequence(events: PosLocalEventRecord[]) {
       lastSyncedSequence = event.sequence;
       continue;
     }
-    if (event.sync.status !== "synced") break;
+    if (!isLocallySettledSyncStatus(event.sync.status)) break;
     lastSyncedSequence = event.sequence;
   }
   return lastSyncedSequence;
+}
+
+export function isLocallySettledSyncStatus(
+  status: PosLocalEventRecord["sync"]["status"],
+) {
+  return status === "synced" || status === "locally_resolved";
 }
 
 function getSyncState(input: {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts
@@ -868,6 +868,409 @@ describe("terminalRecoveryCommands", () => {
     });
   });
 
+  it("collects terminal-local review item counts and requests a sync drain", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      createLocalId: () => "event-review-1",
+    });
+    const appended = await store.appendEvent({
+      initialSyncStatus: "needs_review",
+      localRegisterSessionId: "register-local-1",
+      localTransactionId: "transaction-local-1",
+      payload: { payments: [{ amount: 1000 }], customer: "redacted" },
+      staffProfileId: "staff-1",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+      type: "transaction.completed",
+    });
+    expect(appended.ok).toBe(true);
+    if (appended.ok) {
+      await store.markEventsNeedsReview(
+        [appended.value.localEventId],
+        "Needs manager review.",
+        { uploaded: true },
+      );
+    }
+
+    const onRetrySync = vi.fn();
+    const result = await executeTerminalRecoveryCommand({
+      command: buildCommand({ type: "collect_local_review" }),
+      onRetrySync,
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(result).toEqual({
+      commandId: "command-1",
+      diagnostics: {
+        reviewEventCount: 1,
+        terminalId: "terminal-cloud-1",
+        uploadedReviewEventCount: 1,
+      },
+      message: "1 local review item was collected and queued for sync retry.",
+      localReviewEvents: [
+        {
+          createdAt: expect.any(Number),
+          localEventId: "event-review-1",
+          localRegisterSessionId: "register-local-1",
+          sequence: 1,
+          status: "needs_review",
+          type: "transaction.completed",
+          uploaded: true,
+          uploadSequence: 1,
+        },
+      ],
+      status: "completed",
+      type: "collect_local_review",
+    });
+    expect(JSON.stringify(result)).not.toMatch(
+      /transaction-local-1|staff-1|payments|customer|proof/i,
+    );
+    expect(onRetrySync).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(result)).not.toContain("payments");
+    expect(JSON.stringify(result)).not.toContain("customer");
+  });
+
+  it("clears requested terminal-local review items and reports remaining review count", async () => {
+    let nextLocalId = 1;
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 4_000,
+      createLocalId: () => `event-review-${nextLocalId++}`,
+    });
+    await store.appendEvent({
+      initialSyncStatus: "needs_review",
+      localRegisterSessionId: "register-local-1",
+      localTransactionId: "transaction-local-1",
+      payload: { payments: [{ amount: 1000 }], customer: "redacted" },
+      staffProfileId: "staff-1",
+      staffProofToken: "proof-token-1",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+      type: "transaction.completed",
+    });
+    await store.markEventsNeedsReview(["event-review-1"], undefined, {
+      uploaded: true,
+    });
+    await store.appendEvent({
+      localRegisterSessionId: "register-local-1",
+      payload: { openingFloat: 100 },
+      staffProfileId: "staff-1",
+      staffProofToken: "proof-token-2",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+      type: "register.opened",
+    });
+    await store.appendEvent({
+      initialSyncStatus: "needs_review",
+      localRegisterSessionId: "register-local-1",
+      localTransactionId: "transaction-local-2",
+      payload: { payments: [{ amount: 500 }] },
+      staffProfileId: "staff-1",
+      staffProofToken: "proof-token-3",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+      type: "transaction.completed",
+    });
+
+    const result = await executeTerminalRecoveryCommand({
+      command: buildCommand({
+        commandContext: {
+          localReviewEventIds: ["event-review-1"],
+        },
+        type: "clear_local_review_items",
+      }),
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(result).toEqual({
+      clearedLocalReviewEventIds: ["event-review-1"],
+      commandId: "command-1",
+      diagnostics: {
+        clearedReviewEventCount: 1,
+        remainingReviewEventCount: 0,
+        terminalId: "terminal-cloud-1",
+      },
+      message: "1 local review item was cleared on this terminal.",
+      status: "completed",
+      type: "clear_local_review_items",
+    });
+    const events = await store.listEvents();
+    expect(events).toMatchObject({
+      ok: true,
+      value: [
+        {
+          localEventId: "event-review-1",
+          sync: {
+            localResolution: {
+              reason: "terminal_recovery_command",
+              resolvedAt: 4_000,
+              status: "local_review_cleared",
+            },
+            status: "locally_resolved",
+          },
+        },
+        {
+          localEventId: "event-review-2",
+          staffProofToken: "proof-token-2",
+          sync: { status: "pending" },
+        },
+        {
+          localEventId: "event-review-3",
+          staffProofToken: "proof-token-3",
+          sync: { status: "needs_review" },
+        },
+      ],
+    });
+    if (events.ok) {
+      expect(events.value[0]).not.toHaveProperty("staffProofToken");
+    }
+    expect(JSON.stringify(result)).not.toMatch(/payments|customer|proof-token/i);
+
+    const retryResult = await executeTerminalRecoveryCommand({
+      command: buildCommand({
+        commandContext: {
+          localReviewEventIds: ["event-review-1"],
+        },
+        type: "clear_local_review_items",
+      }),
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(retryResult).toEqual({
+      clearedLocalReviewEventIds: ["event-review-1"],
+      commandId: "command-1",
+      diagnostics: {
+        clearedReviewEventCount: 0,
+        remainingReviewEventCount: 0,
+        terminalId: "terminal-cloud-1",
+      },
+      message: "No local review items matched this recovery command.",
+      status: "completed",
+      type: "clear_local_review_items",
+    });
+  });
+
+  it("fails local review clear commands when any requested id is not clearable", async () => {
+    let nextLocalId = 1;
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      createLocalId: () => `event-review-${nextLocalId++}`,
+    });
+    await store.appendEvent({
+      initialSyncStatus: "needs_review",
+      localRegisterSessionId: "register-local-1",
+      payload: { total: 1000 },
+      staffProfileId: "staff-1",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+      type: "transaction.completed",
+    });
+    await store.markEventsNeedsReview(["event-review-1"], undefined, {
+      uploaded: true,
+    });
+    await store.appendEvent({
+      initialSyncStatus: "needs_review",
+      localRegisterSessionId: "register-local-1",
+      payload: { total: 2000 },
+      staffProfileId: "staff-1",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+      type: "register.closeout_started",
+    });
+
+    const result = await executeTerminalRecoveryCommand({
+      command: buildCommand({
+        commandContext: {
+          localReviewEventIds: [
+            "event-review-1",
+            "event-review-2",
+            "missing-event",
+          ],
+        },
+        type: "clear_local_review_items",
+      }),
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(result).toEqual({
+      commandId: "command-1",
+      message: "Terminal evidence changed before this recovery command could run.",
+      reason: "precondition_failed",
+      status: "precondition_failed",
+      type: "clear_local_review_items",
+    });
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: [
+        expect.objectContaining({
+          localEventId: "event-review-1",
+          sync: expect.objectContaining({ status: "needs_review" }),
+        }),
+        expect.objectContaining({
+          localEventId: "event-review-2",
+          sync: expect.objectContaining({ status: "needs_review" }),
+        }),
+      ],
+    });
+  });
+
+  it("fails local review clear commands without explicit ids", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      createLocalId: () => "event-review-1",
+    });
+    await store.appendEvent({
+      initialSyncStatus: "needs_review",
+      localRegisterSessionId: "register-local-1",
+      payload: { total: 1000 },
+      staffProfileId: "staff-1",
+      staffProofToken: "proof-token-1",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+      type: "transaction.completed",
+    });
+
+    const result = await executeTerminalRecoveryCommand({
+      command: buildCommand({ type: "clear_local_review_items" }),
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(result).toEqual({
+      commandId: "command-1",
+      message: "Terminal evidence changed before this recovery command could run.",
+      reason: "precondition_failed",
+      status: "precondition_failed",
+      type: "clear_local_review_items",
+    });
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: [
+        expect.objectContaining({
+          localEventId: "event-review-1",
+          staffProofToken: "proof-token-1",
+          sync: { status: "needs_review" },
+        }),
+      ],
+    });
+  });
+
+  it("fails clear-all local review cleanup commands without explicit ids", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      createLocalId: () => "event-review-1",
+    });
+    await store.appendEvent({
+      initialSyncStatus: "needs_review",
+      localRegisterSessionId: "register-local-1",
+      payload: { total: 1000 },
+      staffProfileId: "staff-1",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+      type: "transaction.completed",
+    });
+    await store.markEventsNeedsReview(["event-review-1"], undefined, {
+      uploaded: true,
+    });
+
+    const result = await executeTerminalRecoveryCommand({
+      command: buildCommand({
+        commandContext: {
+          localReviewClearAll: true,
+        },
+        type: "clear_local_review_items",
+      }),
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(result).toEqual({
+      commandId: "command-1",
+      message: "Terminal evidence changed before this recovery command could run.",
+      reason: "precondition_failed",
+      status: "precondition_failed",
+      type: "clear_local_review_items",
+    });
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: [
+        expect.objectContaining({
+          localEventId: "event-review-1",
+          sync: expect.objectContaining({ status: "needs_review" }),
+        }),
+      ],
+    });
+  });
+
+  it("clears a 100-item local review cleanup batch", async () => {
+    let nextLocalId = 1;
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      createLocalId: () => `event-review-${nextLocalId++}`,
+    });
+    for (let index = 0; index < 101; index += 1) {
+      await store.appendEvent({
+        initialSyncStatus: "needs_review",
+        localRegisterSessionId: "register-local-1",
+        payload: { total: index },
+        staffProfileId: "staff-1",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+        type: "transaction.completed",
+      });
+    }
+    await store.markEventsNeedsReview(
+      Array.from({ length: 101 }, (_, index) => `event-review-${index + 1}`),
+      undefined,
+      { uploaded: true },
+    );
+
+    const result = await executeTerminalRecoveryCommand({
+      command: buildCommand({
+        commandContext: {
+          localReviewEventIds: Array.from(
+            { length: 100 },
+            (_, index) => `event-review-${index + 1}`,
+          ),
+        },
+        type: "clear_local_review_items",
+      }),
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(result).toMatchObject({
+      clearedLocalReviewEventIds: Array.from(
+        { length: 100 },
+        (_, index) => `event-review-${index + 1}`,
+      ),
+      diagnostics: {
+        clearedReviewEventCount: 100,
+        remainingReviewEventCount: 1,
+      },
+      status: "completed",
+      type: "clear_local_review_items",
+    });
+  });
+
   it("fails unsupported command types without invoking local callbacks", async () => {
     const onRetrySync = vi.fn();
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts
@@ -14,6 +14,8 @@ import type {
 
 export type PosTerminalRecoveryCommandType =
   | "retry_sync"
+  | "collect_local_review"
+  | "clear_local_review_items"
   | "repair_terminal_seed"
   | "clear_stale_drawer_authority"
   | "refresh_staff_authority"
@@ -36,8 +38,10 @@ export type PosTerminalRecoveryCommand = {
 };
 
 export type PosTerminalRecoveryCommandResult = {
+  clearedLocalReviewEventIds?: string[];
   commandId: string;
   diagnostics?: Record<string, string | number | boolean | null>;
+  localReviewEvents?: PosTerminalRecoveryLocalReviewEvent[];
   message?: string;
   onAcknowledgeFailed?: () => void;
   postAcknowledge?: () =>
@@ -54,6 +58,18 @@ export type PosTerminalRecoveryCommandResult = {
     | "unsafe_authority_state";
   status: "completed" | "failed" | "ignored" | "precondition_failed";
   type: string;
+};
+
+export type PosTerminalRecoveryLocalReviewEvent = {
+  createdAt: number;
+  localEventId: string;
+  localPosSessionId?: string;
+  localRegisterSessionId?: string;
+  sequence: number;
+  status: string;
+  type: string;
+  uploaded?: boolean;
+  uploadSequence?: number;
 };
 
 export type PosTerminalRecoveryCommandCallbackResult = {
@@ -118,8 +134,15 @@ type ClearStaleDrawerAuthorityPreconditions = {
   localRegisterSessionId: string;
 };
 
+type ClearLocalReviewItemsRequest = { localEventIds: string[] };
+
+const CLEAR_LOCAL_REVIEW_ITEMS_HARD_CAP = 100;
+const COLLECT_LOCAL_REVIEW_ITEMS_HARD_CAP = 100;
+
 const SUPPORTED_COMMAND_TYPES = new Set<string>([
   "retry_sync",
+  "collect_local_review",
+  "clear_local_review_items",
   "repair_terminal_seed",
   "clear_stale_drawer_authority",
   "refresh_staff_authority",
@@ -156,6 +179,10 @@ export async function executeTerminalRecoveryCommand(
     switch (commandType) {
       case "retry_sync":
         return executeRetrySync(context);
+      case "collect_local_review":
+        return executeCollectLocalReview(context);
+      case "clear_local_review_items":
+        return executeClearLocalReviewItems(context);
       case "repair_terminal_seed":
         return executeRepairTerminalSeed(context);
       case "clear_stale_drawer_authority":
@@ -278,6 +305,127 @@ async function executeRetrySync(
   await context.onRetrySync?.();
   return completed(context.command, {
     diagnostics: { terminalId: context.terminalId },
+  });
+}
+
+async function executeCollectLocalReview(
+  context: PosTerminalRecoveryCommandContext,
+): Promise<PosTerminalRecoveryCommandResult> {
+  const events = await context.store.listEvents();
+  if (!events.ok) {
+    return failed(context.command, "local_store_failure", {
+      message: events.error.message,
+    });
+  }
+
+  const reviewEvents = getScopedLocalReviewEvents(events.value, context);
+  const uploadedReviewEventCount = reviewEvents.filter(
+    (event) => event.sync.uploaded === true,
+  ).length;
+  if (reviewEvents.length > 0) {
+    await context.onRetrySync?.();
+  }
+
+  return completed(context.command, {
+    diagnostics: {
+      reviewEventCount: reviewEvents.length,
+      terminalId: context.terminalId,
+      uploadedReviewEventCount,
+    },
+    localReviewEvents: reviewEvents
+      .slice(0, COLLECT_LOCAL_REVIEW_ITEMS_HARD_CAP)
+      .map(toLocalReviewEvidence),
+    message:
+      reviewEvents.length === 0
+        ? "No local review items were found on this terminal."
+        : `${reviewEvents.length} local review item${reviewEvents.length === 1 ? "" : "s"} ${reviewEvents.length === 1 ? "was" : "were"} collected and queued for sync retry.`,
+  });
+}
+
+function toLocalReviewEvidence(
+  event: PosLocalEventRecord,
+): PosTerminalRecoveryLocalReviewEvent {
+  return {
+    createdAt: event.createdAt,
+    localEventId: event.localEventId,
+    ...(event.localPosSessionId
+      ? { localPosSessionId: event.localPosSessionId }
+      : {}),
+    ...(event.localRegisterSessionId
+      ? { localRegisterSessionId: event.localRegisterSessionId }
+      : {}),
+    sequence: event.sequence,
+    status: event.sync.status,
+    type: event.type,
+    ...(event.sync.uploaded !== undefined
+      ? { uploaded: event.sync.uploaded }
+      : {}),
+    ...(typeof event.uploadSequence === "number"
+      ? { uploadSequence: event.uploadSequence }
+      : {}),
+  };
+}
+
+async function executeClearLocalReviewItems(
+  context: PosTerminalRecoveryCommandContext,
+): Promise<PosTerminalRecoveryCommandResult> {
+  const request = toClearLocalReviewItemsRequest(context.command);
+  if (!request) {
+    return preconditionFailed(context.command);
+  }
+
+  const events = await context.store.listEvents();
+  if (!events.ok) {
+    return failed(context.command, "local_store_failure", {
+      message: events.error.message,
+    });
+  }
+
+  const reviewEvents = getScopedLocalReviewEvents(events.value, context);
+  const previouslyClearedEvents = getScopedTerminalRecoveryClearedReviewEvents(
+    events.value,
+    context,
+  );
+  const selection = selectLocalReviewEventIdsForClear(
+    request,
+    reviewEvents,
+    previouslyClearedEvents,
+  );
+  if (!selection.allRequestedIdsAccountedFor) {
+    return preconditionFailed(context.command);
+  }
+
+  const clear = await context.store.clearLocalReviewEvents(selection.idsToClear);
+  if (!clear.ok) {
+    return failed(context.command, "local_store_failure", {
+      message: clear.error.message,
+    });
+  }
+
+  const remainingEvents = await context.store.listEvents();
+  if (!remainingEvents.ok) {
+    return failed(context.command, "local_store_failure", {
+      message: remainingEvents.error.message,
+    });
+  }
+
+  const clearedReviewEventCount = clear.value.length;
+  const remainingReviewEventCount = getScopedLocalReviewEvents(
+    remainingEvents.value,
+    context,
+  ).length;
+
+  return completed(context.command, {
+    clearedLocalReviewEventIds: request.localEventIds,
+    diagnostics: {
+      clearedReviewEventCount,
+      remainingReviewEventCount,
+      terminalId: context.terminalId,
+    },
+    message:
+      clearedReviewEventCount === 0
+        ? "No local review items matched this recovery command."
+        : `${clearedReviewEventCount} local review item${clearedReviewEventCount === 1 ? "" : "s"} ${clearedReviewEventCount === 1 ? "was" : "were"} cleared on this terminal.`,
   });
 }
 
@@ -523,8 +671,75 @@ function hasSettledLifecycleEvents(input: {
   );
 }
 
+function getScopedLocalReviewEvents(
+  events: PosLocalEventRecord[],
+  context: PosTerminalRecoveryCommandContext,
+) {
+  const scopeIds = terminalScopeIds(context);
+  return events
+    .filter(
+      (event) =>
+        event.storeId === context.storeId &&
+        scopeIds.has(event.terminalId) &&
+        event.sync.status === "needs_review" &&
+        event.sync.uploaded === true,
+    )
+    .sort(compareLocalReviewEventOrder);
+}
+
+function getScopedTerminalRecoveryClearedReviewEvents(
+  events: PosLocalEventRecord[],
+  context: PosTerminalRecoveryCommandContext,
+) {
+  const scopeIds = terminalScopeIds(context);
+  return events.filter(
+    (event) =>
+      event.storeId === context.storeId &&
+      scopeIds.has(event.terminalId) &&
+      event.sync.status === "locally_resolved" &&
+      event.sync.localResolution?.reason === "terminal_recovery_command",
+  );
+}
+
+function selectLocalReviewEventIdsForClear(
+  request: ClearLocalReviewItemsRequest,
+  reviewEvents: PosLocalEventRecord[],
+  previouslyClearedEvents: PosLocalEventRecord[],
+) {
+  const scopedReviewIds = new Set(
+    reviewEvents.map((event) => event.localEventId),
+  );
+  const scopedPreviouslyClearedIds = new Set(
+    previouslyClearedEvents.map((event) => event.localEventId),
+  );
+  const idsToClear = request.localEventIds
+    .filter((localEventId) => scopedReviewIds.has(localEventId))
+    .slice(0, CLEAR_LOCAL_REVIEW_ITEMS_HARD_CAP);
+  return {
+    allRequestedIdsAccountedFor: request.localEventIds.every(
+      (localEventId) =>
+        scopedReviewIds.has(localEventId) ||
+        scopedPreviouslyClearedIds.has(localEventId),
+    ),
+    idsToClear,
+  };
+}
+
+function compareLocalReviewEventOrder(
+  left: PosLocalEventRecord,
+  right: PosLocalEventRecord,
+) {
+  const leftUploadSequence = left.uploadSequence ?? Number.POSITIVE_INFINITY;
+  const rightUploadSequence = right.uploadSequence ?? Number.POSITIVE_INFINITY;
+  if (leftUploadSequence !== rightUploadSequence) {
+    return leftUploadSequence - rightUploadSequence;
+  }
+
+  return left.sequence - right.sequence;
+}
+
 function isSettledLocalSyncStatus(status: PosLocalSyncEventStatus) {
-  return status === "synced";
+  return status === "synced" || status === "locally_resolved";
 }
 
 function isDrawerAuthorityLifecycleEvent(event: PosLocalEventRecord) {
@@ -580,6 +795,50 @@ function toClearDrawerAuthorityPreconditions(
   return value;
 }
 
+function toClearLocalReviewItemsRequest(
+  command: PosTerminalRecoveryCommand,
+): ClearLocalReviewItemsRequest | null {
+  const candidates = [command.commandContext, command.payload];
+  for (const candidate of candidates) {
+    const ids = firstLocalReviewEventIds(candidate);
+    if (ids.length > 0) {
+      return { localEventIds: ids };
+    }
+  }
+
+  return null;
+}
+
+function firstLocalReviewEventIds(value: unknown): string[] {
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  for (const key of [
+    "localReviewEventIds",
+    "localEventIds",
+    "reviewEventIds",
+  ]) {
+    const ids = uniqueStrings(value[key]);
+    if (ids.length > 0) {
+      return ids;
+    }
+  }
+
+  if (Array.isArray(value.localReviewEvents)) {
+    const ids = uniqueStrings(
+      value.localReviewEvents.map((eventRecord) =>
+        isRecord(eventRecord) ? eventRecord.localEventId : undefined,
+      ),
+    );
+    if (ids.length > 0) {
+      return ids;
+    }
+  }
+
+  return [];
+}
+
 function firstDrawerAuthorityPreconditions(
   value: unknown,
 ): ClearStaleDrawerAuthorityPreconditions | null {
@@ -606,6 +865,20 @@ function firstDrawerAuthorityPreconditions(
     localEventSettlement: "settled",
     localRegisterSessionId: value.localRegisterSessionId,
   };
+}
+
+function uniqueStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      value.filter(
+        (item): item is string => typeof item === "string" && item.length > 0,
+      ),
+    ),
+  );
 }
 
 function isProvisionedTerminalSeed(
@@ -636,7 +909,9 @@ function isDrawerAuthorityBlockReason(
 function completed(
   command: PosTerminalRecoveryCommand,
   options: {
+    clearedLocalReviewEventIds?: string[];
     diagnostics?: Record<string, string | number | boolean | null>;
+    localReviewEvents?: PosTerminalRecoveryLocalReviewEvent[];
     message?: string;
     onAcknowledgeFailed?: () => void;
     postAcknowledge?: PosTerminalRecoveryCommandResult["postAcknowledge"];
@@ -644,11 +919,18 @@ function completed(
 ): PosTerminalRecoveryCommandResult {
   return {
     commandId: getCommandId(command),
+    ...(options.clearedLocalReviewEventIds &&
+    options.clearedLocalReviewEventIds.length > 0
+      ? { clearedLocalReviewEventIds: options.clearedLocalReviewEventIds }
+      : {}),
     ...(options.diagnostics
       ? { diagnostics: redactDiagnostics(options.diagnostics) }
       : {}),
     ...(options.message
       ? { message: safeRecoveryMessage(options.message) }
+      : {}),
+    ...(options.localReviewEvents && options.localReviewEvents.length > 0
+      ? { localReviewEvents: options.localReviewEvents }
       : {}),
     ...(options.onAcknowledgeFailed
       ? { onAcknowledgeFailed: options.onAcknowledgeFailed }

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts
@@ -165,6 +165,49 @@ describe("terminalRuntimeStatus", () => {
     expect(JSON.stringify(status)).not.toContain("payments");
   });
 
+  it("treats locally resolved review items as settled in runtime sync metrics", () => {
+    const status = buildPosTerminalRuntimeStatus({
+      browserInfo: { online: true },
+      clock: () => 3_000,
+      events: [
+        buildLocalEvent({
+          createdAt: 1_000,
+          localEventId: "event-local-review",
+          sequence: 1,
+          sync: {
+            localResolution: {
+              reason: "terminal_recovery_command",
+              resolvedAt: 2_500,
+              status: "local_review_cleared",
+            },
+            status: "locally_resolved",
+            uploaded: true,
+          },
+          uploadSequence: 1,
+        }),
+        buildLocalEvent({
+          createdAt: 2_000,
+          localEventId: "event-pending",
+          sequence: 2,
+          sync: { status: "pending" },
+          uploadSequence: 2,
+        }),
+      ],
+      source: "support-diagnostics",
+    });
+
+    expect(status.sync).toEqual(
+      expect.objectContaining({
+        lastSyncedSequence: 1,
+        nextPendingUploadSequence: 2,
+        oldestPendingEventAt: 2_000,
+        pendingEventCount: 1,
+        reviewEventCount: 0,
+        uploadableEventCount: 1,
+      }),
+    );
+  });
+
   it("builds copy diagnostics with identifiers, counts, sequences, timestamps, and labels only", () => {
     const diagnostics = buildPosTerminalRuntimeCopyDiagnostics({
       clock: () => 2_000,
@@ -264,9 +307,7 @@ describe("terminalRuntimeStatus", () => {
         localEventId: "event-sale",
         localPosSessionId: "sale-1",
         localRegisterSessionId: "register-1",
-        localTransactionId: "transaction-1",
         sequence: 2,
-        staffProfileId: "staff-1",
         status: "failed",
         type: "transaction.completed",
         uploadSequence: 2,
@@ -281,6 +322,8 @@ describe("terminalRuntimeStatus", () => {
     expect(serialized).not.toContain("Customer Name");
     expect(serialized).not.toContain("sync-secret-hash");
     expect(serialized).not.toContain("123456789012345678901234");
+    expect(serialized).not.toContain("transaction-1");
+    expect(serialized).not.toContain("staff-1");
   });
 
   it("includes sanitized local review event samples in server check-ins", () => {
@@ -310,9 +353,7 @@ describe("terminalRuntimeStatus", () => {
         localEventId: "event-review",
         localPosSessionId: "sale-1",
         localRegisterSessionId: "register-1",
-        localTransactionId: "transaction-1",
         sequence: 5,
-        staffProfileId: "staff-1",
         status: "needs_review",
         type: "transaction.completed",
         uploaded: true,
@@ -323,6 +364,10 @@ describe("terminalRuntimeStatus", () => {
     expect(JSON.stringify(status.sync.reviewEvents)).not.toContain(
       "customer@example.com",
     );
+    expect(JSON.stringify(status.sync.reviewEvents)).not.toContain(
+      "transaction-1",
+    );
+    expect(JSON.stringify(status.sync.reviewEvents)).not.toContain("staff-1");
   });
 
   it("keeps local review samples from sync debug when event state is stale", () => {
@@ -355,6 +400,37 @@ describe("terminalRuntimeStatus", () => {
         localEventId: "event-review",
         sequence: 5,
         type: "transaction.completed",
+      }),
+    ]);
+  });
+
+  it("falls back to local event review samples when sync debug only reports a count", () => {
+    const status = buildPosTerminalRuntimeStatus({
+      clock: () => 2_000,
+      events: [
+        buildLocalEvent({
+          localEventId: "event-review",
+          sequence: 5,
+          sync: { status: "needs_review", uploaded: true },
+          type: "transaction.completed",
+          uploadSequence: 2,
+        }),
+      ],
+      source: "register",
+      syncDebug: {
+        reviewEventCount: 84,
+        reviewEvents: [],
+      },
+    });
+
+    expect(status.sync.reviewEventCount).toBe(84);
+    expect(status.sync.reviewEvents).toEqual([
+      expect.objectContaining({
+        localEventId: "event-review",
+        sequence: 5,
+        status: "needs_review",
+        type: "transaction.completed",
+        uploaded: true,
       }),
     ]);
   });

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
@@ -12,7 +12,10 @@ import {
   type PosTerminalIntegrityState,
   type PosProvisionedTerminalSeed,
 } from "./posLocalStore";
-import { derivePosLocalSyncStatus } from "./syncStatus";
+import {
+  derivePosLocalSyncStatus,
+  isLocallySettledSyncStatus,
+} from "./syncStatus";
 import {
   isSyncablePosLocalEvent,
   isUploadDeferredByValidation,
@@ -285,9 +288,7 @@ export type PosTerminalRuntimeDiagnosticsEvent = {
   localEventId: string;
   localPosSessionId?: string;
   localRegisterSessionId?: string;
-  localTransactionId?: string;
   sequence: number;
-  staffProfileId?: string;
   status: PosLocalEventRecord["sync"]["status"];
   type: PosLocalEventRecord["type"];
   uploaded?: boolean;
@@ -440,8 +441,7 @@ export function buildPosTerminalRuntimeStatus(
       localOnlyEventCount: sync.localOnlyEventCount,
       pendingEventCount: sync.pendingEventCount,
       reviewEventCount: sync.reviewEventCount,
-      reviewEvents:
-        input.syncDebug?.reviewEvents ?? getReviewDiagnosticsEvents(input.events),
+      reviewEvents: getRuntimeReviewDiagnosticsEvents(input),
       status: sync.status,
       uploadableEventCount: sync.uploadableEventCount,
       lastSyncedSequence: sync.lastSyncedSequence,
@@ -536,7 +536,7 @@ export function buildPosTerminalRuntimeCopyDiagnostics(
       .slice()
       .sort((left, right) => left.sequence - right.sequence)
       .slice(-20)
-      .map(toDiagnosticsEvent),
+      .map(toPosTerminalRuntimeDiagnosticsEvent),
     failures: {
       ...(localStoreFailure ? { localStore: localStoreFailure } : {}),
       ...(syncFailure ? { sync: syncFailure } : {}),
@@ -668,11 +668,14 @@ function buildSyncMetrics(
   input: PosTerminalRuntimeStatusInput,
 ): PosTerminalRuntimeSyncMetrics {
   const uploadableEvents = input.events.filter(
-    (event) => event.sync.status !== "synced" && isSyncablePosLocalEvent(event),
+    (event) =>
+      !isLocallySettledSyncStatus(event.sync.status) &&
+      isSyncablePosLocalEvent(event),
   );
   const localOnlyEvents = input.events.filter(
     (event) =>
-      event.sync.status !== "synced" && !isSyncablePosLocalEvent(event),
+      !isLocallySettledSyncStatus(event.sync.status) &&
+      !isSyncablePosLocalEvent(event),
   );
   const failedEventCount =
     input.syncDebug?.failedEventCount ??
@@ -695,7 +698,7 @@ function buildSyncMetrics(
     isOnline: input.browserInfo?.online ?? true,
   });
   const oldestPendingEvent = input.events
-    .filter((event) => event.sync.status !== "synced")
+    .filter((event) => !isLocallySettledSyncStatus(event.sync.status))
     .sort((left, right) => left.createdAt - right.createdAt)
     .at(0);
   const nextUploadableEvent = uploadableEvents
@@ -911,7 +914,7 @@ function snapshotAges(
   };
 }
 
-function toDiagnosticsEvent(
+export function toPosTerminalRuntimeDiagnosticsEvent(
   event: PosLocalEventRecord,
 ): PosTerminalRuntimeDiagnosticsEvent {
   return {
@@ -923,11 +926,7 @@ function toDiagnosticsEvent(
     ...(event.localRegisterSessionId
       ? { localRegisterSessionId: event.localRegisterSessionId }
       : {}),
-    ...(event.localTransactionId
-      ? { localTransactionId: event.localTransactionId }
-      : {}),
     sequence: event.sequence,
-    ...(event.staffProfileId ? { staffProfileId: event.staffProfileId } : {}),
     status: event.sync.status,
     type: event.type,
     ...(event.sync.uploaded !== undefined
@@ -946,8 +945,46 @@ function getReviewDiagnosticsEvents(
     .filter((event) => event.sync.status === "needs_review")
     .slice()
     .sort(compareUploadableEventOrder)
-    .slice(0, 10)
-    .map(toDiagnosticsEvent);
+    .slice(0, 100)
+    .map(toPosTerminalRuntimeDiagnosticsEvent);
+}
+
+function getRuntimeReviewDiagnosticsEvents(
+  input: PosTerminalRuntimeStatusInput,
+): PosTerminalRuntimeDiagnosticsEvent[] {
+  const debugReviewEvents = input.syncDebug?.reviewEvents;
+  if (debugReviewEvents && debugReviewEvents.length > 0) {
+    return debugReviewEvents.map(toSafeRuntimeDiagnosticsEvent);
+  }
+
+  const eventReviewEvents = getReviewDiagnosticsEvents(input.events);
+  if (eventReviewEvents.length > 0) {
+    return eventReviewEvents;
+  }
+
+  return debugReviewEvents?.map(toSafeRuntimeDiagnosticsEvent) ?? [];
+}
+
+function toSafeRuntimeDiagnosticsEvent(
+  event: PosTerminalRuntimeDiagnosticsEvent,
+): PosTerminalRuntimeDiagnosticsEvent {
+  return {
+    createdAt: event.createdAt,
+    localEventId: event.localEventId,
+    ...(event.localPosSessionId
+      ? { localPosSessionId: event.localPosSessionId }
+      : {}),
+    ...(event.localRegisterSessionId
+      ? { localRegisterSessionId: event.localRegisterSessionId }
+      : {}),
+    sequence: event.sequence,
+    status: event.status,
+    type: event.type,
+    ...(event.uploaded !== undefined ? { uploaded: event.uploaded } : {}),
+    ...(typeof event.uploadSequence === "number"
+      ? { uploadSequence: event.uploadSequence }
+      : {}),
+  };
 }
 
 function compareUploadableEventOrder(

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -65,6 +65,7 @@ import {
   collectServerSyncedLocalEventIds,
   derivePosLocalRuntimeSyncStatus,
   getRuntimeStatusSignature,
+  isPosLocalRuntimeDrainCandidate,
   usePosLocalSyncRuntimeStatus,
   writeReturnedLocalCloudMappings,
 } from "./usePosLocalSyncRuntime";
@@ -864,10 +865,17 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     expect(result.current?.debug?.reviewEventCount).toBe(1);
     expect(mocks.ingestLocalEvents).not.toHaveBeenCalled();
 
-    act(() => {
+    await act(async () => {
       result.current?.onRetrySync?.();
     });
 
+    await waitFor(() =>
+      expect(result.current?.debug).toEqual(
+        expect.objectContaining({
+          lastTrigger: "manual-retry",
+        }),
+      ),
+    );
     await waitFor(() =>
       expect(mocks.ingestLocalEvents).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -891,6 +899,32 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       storeId: "store-1",
       terminalId: "local-terminal-1",
     });
+  });
+
+  it("selects syncable local review events for support-triggered review drains", () => {
+    const reviewEvent = buildLocalEvent({
+      localEventId: "event-closeout",
+      payload: {
+        countedCash: 100,
+        notes: "End of day",
+      },
+      sequence: 1,
+      sync: { status: "needs_review" },
+      type: "register.closeout_started",
+    });
+
+    expect(
+      isPosLocalRuntimeDrainCandidate(reviewEvent, {
+        includeReviewEvents: true,
+        onlyReviewEvents: true,
+      }),
+    ).toBe(true);
+    expect(
+      isPosLocalRuntimeDrainCandidate(reviewEvent, {
+        includeUploadedReviewEvents: true,
+        onlyUploadedReviewEvents: true,
+      }),
+    ).toBe(false);
   });
 
   it("self-heals uploaded register open reviews from status-only route entry", async () => {
@@ -1022,7 +1056,26 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     expect(store.markEventsNeedsReview).not.toHaveBeenCalled();
   });
 
-  it("does not manually retry review events that were never uploaded", async () => {
+  it("manually retries syncable review events even when they were never marked uploaded", async () => {
+    mocks.ingestLocalEvents.mockResolvedValue({
+      kind: "ok",
+      data: {
+        accepted: [
+          {
+            localEventId: "event-closeout",
+            sequence: 1,
+            status: "projected",
+          },
+        ],
+        held: [],
+        mappings: [],
+        conflicts: [],
+        syncCursor: {
+          localRegisterSessionId: "register-1",
+          acceptedThroughSequence: 1,
+        },
+      },
+    });
     const store = {
       listEvents: vi.fn(async () => ({
         ok: true,
@@ -1088,8 +1141,23 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     await waitFor(() =>
       expect(store.listEvents.mock.calls.length).toBeGreaterThan(1),
     );
-    expect(mocks.ingestLocalEvents).not.toHaveBeenCalled();
-    expect(store.markEventsSynced).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(mocks.ingestLocalEvents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          events: [
+            expect.objectContaining({
+              eventType: "register_closed",
+              localEventId: "event-closeout",
+            }),
+          ],
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(store.markEventsSynced).toHaveBeenCalledWith(["event-closeout"], {
+        uploaded: true,
+      }),
+    );
     expect(store.markEventsNeedsReview).not.toHaveBeenCalled();
   });
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -71,10 +71,12 @@ import {
 import {
   buildPosTerminalRuntimeCopyDiagnostics,
   buildPosTerminalRuntimeStatus,
+  toPosTerminalRuntimeDiagnosticsEvent,
   toReportablePosTerminalRuntimeStatus,
   type PosTerminalRuntimeAppUpdateInput,
   type PosTerminalRuntimeAppSessionRecoveryInput,
   type PosTerminalRuntimeCopyDiagnostics,
+  type PosTerminalRuntimeDiagnosticsEvent,
   type PosTerminalRuntimeStatusPayload,
   type PosTerminalRuntimeStatusSource,
   type PosTerminalRuntimeSyncDebugInput,
@@ -96,16 +98,30 @@ type AppUpdateCommandCorrelation = {
   commandIssuedAt?: number;
 };
 
+export type PosLocalRuntimeDrainOptions = {
+  includeReviewEvents?: boolean;
+  includeUploadedReviewEvents?: boolean;
+  onlyReviewEvents?: boolean;
+  onlyUploadedRegisterOpenReviewEvents?: boolean;
+  onlyUploadedReviewEvents?: boolean;
+};
+
 export type PosLocalRuntimeSyncStatusSource = {
   copyDiagnostics?: PosTerminalRuntimeCopyDiagnostics;
   debug?: PosLocalRuntimeSyncDebug;
   description?: string | null;
   label?: string | null;
+  localEvents?: PosLocalRuntimeDiagnosticsEvent[];
   onRetrySync?: (() => void) | null;
   pendingEventCount?: number | null;
   runtimeStatus?: PosTerminalRuntimeStatusPayload;
   status?: string | null;
 };
+
+export type PosLocalRuntimeDiagnosticsEvent =
+  PosTerminalRuntimeDiagnosticsEvent & {
+    syncUploadable?: boolean;
+  };
 
 export type PosLocalRuntimeSyncDebug = {
   activeRegisterSessionRepair?: {
@@ -424,11 +440,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
 
       const createDrainScheduler = (
         syncSeed: NonNullable<typeof provisionedSeed>,
-        options: {
-          includeUploadedReviewEvents?: boolean;
-          onlyUploadedRegisterOpenReviewEvents?: boolean;
-          onlyUploadedReviewEvents?: boolean;
-        } = {},
+        options: PosLocalRuntimeDrainOptions = {},
       ) =>
         createPosLocalSyncScheduler({
           isOnline: () =>
@@ -465,29 +477,9 @@ export function usePosLocalSyncRuntimeStatus(input: {
               setReadError(pending.error.message);
               throw new Error(pending.error.message);
             }
-            const uploadableEvents = pending.value.events
-              .filter((event) => {
-                const isUploadedReviewEvent =
-                  options.includeUploadedReviewEvents === true &&
-                  event.sync.status === "needs_review" &&
-                  event.sync.uploaded;
-                const isUploadedRegisterOpenReviewEvent =
-                  isUploadedReviewEvent && event.type === "register.opened";
-                if (options.onlyUploadedRegisterOpenReviewEvents === true) {
-                  return isUploadedRegisterOpenReviewEvent;
-                }
-                if (options.onlyUploadedReviewEvents === true) {
-                  return isUploadedReviewEvent;
-                }
-
-                return (
-                  event.sync.status === "pending" ||
-                  event.sync.status === "syncing" ||
-                  event.sync.status === "failed" ||
-                  isUploadedReviewEvent
-                );
-              })
-              .filter((event) => isSyncablePosLocalEvent(event, uploadSupport));
+            const uploadableEvents = pending.value.events.filter((event) =>
+              isPosLocalRuntimeDrainCandidate(event, options, uploadSupport),
+            );
             if (!shouldStop()) {
               setDebug((current) => ({
                 ...current,
@@ -811,10 +803,9 @@ export function usePosLocalSyncRuntimeStatus(input: {
 
           if (trigger === "manual-retry") {
             const scheduler = createDrainScheduler(provisionedSeed, {
-              includeUploadedReviewEvents: true,
-              onlyUploadedReviewEvents: true,
+              includeReviewEvents: true,
+              onlyReviewEvents: true,
             });
-            stopSchedulers.push(() => scheduler.stop());
             scheduler.trigger("manual-retry", { priority: "high" });
           }
         }
@@ -834,9 +825,8 @@ export function usePosLocalSyncRuntimeStatus(input: {
 
       if (trigger === "manual-retry") {
         const manualRetryScheduler = createDrainScheduler(provisionedSeed, {
-          includeUploadedReviewEvents: true,
+          includeReviewEvents: true,
         });
-        stopSchedulers.push(() => manualRetryScheduler.stop());
         manualRetryScheduler.trigger("manual-retry", { priority: "high" });
         return;
       }
@@ -950,6 +940,14 @@ export function usePosLocalSyncRuntimeStatus(input: {
   const copyDiagnostics = useMemo(
     () => buildPosTerminalRuntimeCopyDiagnostics(runtimeStatusInput),
     [runtimeStatusInput],
+  );
+  const localDiagnosticsEvents = useMemo(
+    () =>
+      events
+        .slice()
+        .sort((left, right) => left.sequence - right.sequence)
+        .map((event) => toLocalRuntimeDiagnosticsEvent(event, uploadSupport)),
+    [events, uploadSupport],
   );
   const runtimeStatusTerminalId =
     runtimeReadiness.terminalSeed?.cloudTerminalId ?? terminalId ?? null;
@@ -1446,8 +1444,10 @@ export function usePosLocalSyncRuntimeStatus(input: {
         }
         const acknowledged = await acknowledgeTerminalRecoveryCommand({
           commandId: claimResult.data._id,
+          clearedLocalReviewEventIds: localResult.clearedLocalReviewEventIds,
           ...(executionId ? { executionId } : {}),
           message: localResult.message,
+          localReviewEvents: localResult.localReviewEvents,
           result: ackResult,
           storeId: storeId as Id<"store">,
           syncSecretHash: runtimeStatusSyncSecretHash,
@@ -1541,6 +1541,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
           "Local register activity could not be read. Check this terminal before continuing.",
         debug,
         label: "Local sync unavailable",
+        localEvents: localDiagnosticsEvents,
         onRetrySync: requestRetry,
         pendingEventCount: 1,
         runtimeStatus,
@@ -1554,13 +1555,20 @@ export function usePosLocalSyncRuntimeStatus(input: {
       staffProfileId,
     });
     if (source) {
-      return { ...source, copyDiagnostics, debug, runtimeStatus };
+      return {
+        ...source,
+        copyDiagnostics,
+        debug,
+        localEvents: localDiagnosticsEvents,
+        runtimeStatus,
+      };
     }
 
     return debug.lastTrigger
       ? {
           copyDiagnostics,
           debug,
+          localEvents: localDiagnosticsEvents,
           onRetrySync: requestRetry,
           runtimeStatus,
         }
@@ -1570,6 +1578,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
     debug,
     events,
     isOnline,
+    localDiagnosticsEvents,
     readError,
     requestRetry,
     runtimeStatus,
@@ -1938,6 +1947,37 @@ async function readScopedPosLocalUploadEvents(input: {
   };
 }
 
+function toLocalRuntimeDiagnosticsEvent(
+  event: PosLocalEventRecord,
+  uploadSupport: PosLocalSyncUploadSupport,
+): PosLocalRuntimeDiagnosticsEvent {
+  return {
+    ...toPosTerminalRuntimeDiagnosticsEvent(event),
+    ...(isRuntimeUploadableDiagnosticsEvent(event, uploadSupport)
+      ? { syncUploadable: true }
+      : {}),
+  };
+}
+
+function isRuntimeUploadableDiagnosticsEvent(
+  event: PosLocalEventRecord,
+  uploadSupport: PosLocalSyncUploadSupport,
+) {
+  return (
+    isPendingUploadCandidate(event) &&
+    isSyncablePosLocalEvent(event, uploadSupport)
+  );
+}
+
+function isPendingUploadCandidate(event: PosLocalEventRecord) {
+  return (
+    event.sync.status === "pending" ||
+    event.sync.status === "syncing" ||
+    event.sync.status === "failed" ||
+    (event.sync.status === "needs_review" && event.sync.uploaded)
+  );
+}
+
 function getAppSessionUploadSupport(
   recovery?: PosTerminalRuntimeAppSessionRecoveryInput | null,
 ): PosLocalSyncUploadSupport {
@@ -1951,6 +1991,44 @@ function getAppSessionUploadSupport(
         ? "supported"
         : "unverified",
   };
+}
+
+export function isPosLocalRuntimeDrainCandidate(
+  event: PosLocalEventRecord,
+  options: PosLocalRuntimeDrainOptions = {},
+  uploadSupport: PosLocalSyncUploadSupport = {},
+) {
+  const isReviewEvent = event.sync.status === "needs_review";
+  const isUploadedReviewEvent =
+    isReviewEvent && event.sync.uploaded === true;
+  const isIncludedReviewEvent =
+    options.includeReviewEvents === true
+      ? isReviewEvent
+      : options.includeUploadedReviewEvents === true && isUploadedReviewEvent;
+  const isUploadedRegisterOpenReviewEvent =
+    isIncludedReviewEvent && event.type === "register.opened";
+
+  if (options.onlyUploadedRegisterOpenReviewEvents === true) {
+    return (
+      isUploadedRegisterOpenReviewEvent &&
+      isSyncablePosLocalEvent(event, uploadSupport)
+    );
+  }
+
+  if (
+    options.onlyReviewEvents === true ||
+    options.onlyUploadedReviewEvents === true
+  ) {
+    return isIncludedReviewEvent && isSyncablePosLocalEvent(event, uploadSupport);
+  }
+
+  return (
+    (event.sync.status === "pending" ||
+      event.sync.status === "syncing" ||
+      event.sync.status === "failed" ||
+      isIncludedReviewEvent) &&
+    isSyncablePosLocalEvent(event, uploadSupport)
+  );
 }
 
 export function collectServerSyncedLocalEventIds(

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -462,6 +462,19 @@ export interface RegisterViewModel {
           nextPendingUploadSequence?: number;
           pendingEventCount?: number;
           reviewEventCount?: number;
+          reviewEvents?: Array<{
+            createdAt: number;
+            localEventId: string;
+            localPosSessionId?: string;
+            localRegisterSessionId?: string;
+            localTransactionId?: string;
+            sequence: number;
+            staffProfileId?: string;
+            status: string;
+            type: string;
+            uploaded?: boolean;
+            uploadSequence?: number;
+          }>;
           status: string;
           uploadableEventCount?: number;
         };
@@ -470,6 +483,20 @@ export interface RegisterViewModel {
           status: string;
         };
       };
+      events?: Array<{
+        createdAt: number;
+        localEventId: string;
+        localPosSessionId?: string;
+        localRegisterSessionId?: string;
+        localTransactionId?: string;
+        sequence: number;
+        staffProfileId?: string;
+        status: string;
+        syncUploadable?: boolean;
+        type: string;
+        uploaded?: boolean;
+        uploadSequence?: number;
+      }>;
       localReadModel?: {
         activeRegisterSession?: {
           cloudRegisterSessionId?: string;

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -5611,6 +5611,11 @@ export function useRegisterViewModel(): RegisterViewModel {
               },
             }
           : {}),
+        ...(localRuntimeSyncSource?.localEvents
+          ? {
+              events: localRuntimeSyncSource.localEvents,
+            }
+          : {}),
         ...(localRuntimeSyncSource?.debug?.activeRegisterSessionRepair
           ? {
               repair:


### PR DESCRIPTION
## Summary
- Adds the terminal health reconciliation plan artifacts and documents the reusable review-lane learning.
- Adds bounded sync review evidence to terminal health summaries and uses current unresolved review state instead of stale historical event counts.
- Builds operational explanations from resolved action targets so owners/next steps align with Open Work, Cash Controls, terminal action, and sale-ready states.
- Updates terminal roster/detail UI to show bounded explanations while preserving detailed conflict/local review evidence, with limited lists for long sections.

## Validation
- Reviewer loop: correctness, API contract, security, data integrity, frontend race/presentation, testing, and maintainability approved after fixes.
- Focused backend: `bun run test -- convex/pos/application/terminals.test.ts convex/pos/application/terminalOperationalState/policy.test.ts convex/pos/application/queries/terminals.test.ts convex/pos/public/terminals.test.ts convex/pos/infrastructure/repositories/terminalRepository.test.ts convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.test.ts`
- Focused UI: `bun run test -- src/components/pos/terminals/terminalHealthPresentation.test.ts src/components/pos/terminals/POSTerminalHealthView.test.tsx src/components/pos/terminals/POSTerminalDetailView.test.tsx`
- Typecheck: `bun run --filter '@athena/webapp' typecheck`
- Generated/graph: `bun run pre-commit:generated-artifacts`, `bun run graphify:check`
- Pre-push gate: passed full validation, including 415 webapp test files / 4234 tests, POS E2E, production POS checks, behavior scenarios, and inferential review.

Refs V26-892 V26-893 V26-894 V26-895 V26-896 V26-897
