### PR TITLE
fix(pos): refine store hours automation settings

### DIFF
--- a/docs/solutions/architecture/athena-pos-store-hours-settings-polish-2026-06-29.md
+++ b/docs/solutions/architecture/athena-pos-store-hours-settings-polish-2026-06-29.md
@@ -1,0 +1,96 @@
+---
+title: Athena POS Store Hours Settings Should Present Derived Times As Operator Context
+date: 2026-06-29
+category: architecture
+module: athena-webapp
+problem_type: pos_store_hours_settings_polish
+component: pos
+symptoms:
+  - "Store Hours settings can show raw 24-hour schedule values beside 12-hour select inputs"
+  - "Automation settings can expose offsets without the projected run time"
+  - "Full-width setting cards make compact POS controls harder to scan"
+  - "POS recovery failures can imply a bad code when the account lacks POS-only access"
+root_cause: schedule_configuration_rendered_raw_policy_values_instead_of_operator_ready_context
+resolution_type: schedule_context_presentation
+severity: medium
+tags:
+  - pos
+  - store-hours
+  - automation
+  - settings
+  - recovery
+---
+
+# Athena POS Store Hours Settings Should Present Derived Times As Operator Context
+
+## Problem
+
+Store Hours and POS automation settings are policy surfaces, but operators read
+them as immediate work instructions. Raw `HH:mm` values, full-row controls, and
+generic recovery errors make the page look technically correct while still
+leaving the next operational action ambiguous.
+
+The risk is highest around derived scheduling. A configured opening time, an
+automation offset, and the current local store time are different facts. If the
+UI presents only the source value, the operator cannot tell when Athena will
+actually act.
+
+## Solution
+
+Keep the policy values structured, then format derived scheduling context at the
+edge of the UI:
+
+- Use shared select and calendar controls for scheduling inputs so Store Hours
+  follows the repository's form interaction patterns.
+- Format local store times as operator-facing 12-hour labels when they appear in
+  summaries, automation descriptions, and POS timing callouts.
+- Derive Store Hours summary rows from current local context. If the store is
+  closed now, show today's closed state before the next open and next close. If
+  the store is currently operating, show today's opening context before the next
+  close and following open.
+- Pair automation offsets with both the source store-hours time and the
+  projected run time, for example opening at `09:00 AM` and running at
+  `08:00 AM`.
+- Let compact setting cards fit their content inside the larger settings grid
+  with `w-fit max-w-full justify-self-start` so single-purpose controls do not
+  read as full-width panels.
+- Keep POS recovery errors access-aware. When POS-only authorization can be the
+  problem, the message should mention admin access confirmation instead of only
+  asking the cashier to re-enter the code.
+
+## Implementation Notes
+
+The scheduling helpers should stay local and deterministic. They can operate on
+minute-of-day values and store-local dates without changing persisted policy
+shape.
+
+For responsive layout, content-fit controls should still keep `max-w-full` so
+long copy wraps rather than overflowing narrow viewports. Use full-width bands
+only where the content is intentionally a section-wide status or save boundary.
+
+## Prevention
+
+- Do not render persisted `HH:mm` schedule values directly in operator-facing
+  POS settings copy. Route them through the same local-time formatter used by
+  the related controls.
+- When adding a new automation offset, show the source time and projected run
+  time together so review does not require mental arithmetic.
+- Prefer repository form primitives for scheduling inputs before introducing
+  native browser fields on Store Hours or POS automation surfaces.
+- Keep compact setting rows content-sized unless the control is intentionally a
+  full-width status band or repeated card grid.
+- Normalize recovery and access failures before display so cashier-facing copy
+  names the next operational check instead of repeating provider wording.
+
+## Validation
+
+Focused coverage should prove:
+
+- Store Hours selects and date exceptions keep the existing save payload shape.
+- Summary rows format times consistently and change order based on current
+  store-local operating state.
+- Store-day auto-start and EOD completion labels include projected run times.
+- POS recovery copy handles POS-only access failures without leaking backend
+  wording.
+- Settings controls remain reachable and content-fit without breaking form
+  submission.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8257 nodes · 9812 edges · 2072 communities detected
+- 8272 nodes · 9836 edges · 2072 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2354,300 +2354,300 @@ Cohesion: 0.1
 Nodes (6): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onIssueTerminalRecoveryCommand(), onStartRemoteAssist(), submitUpdateApp()
 
 ### Community 61 - "Community 61"
+Cohesion: 0.13
+Nodes (11): dateInputToCalendarDate(), formatDateLabel(), formatNextCloseSummaryLabel(), formatNextOpenSummaryLabel(), formatScheduleSummaryLabel(), formatTimeLabel(), getCurrentOpenWindow(), getDayLabel() (+3 more)
+
+### Community 62 - "Community 62"
 Cohesion: 0.21
 Nodes (21): detectFormat(), extractJsonRows(), flattenJsonRows(), inferProductName(), isRecord(), looksLikeLabel(), normalizeKey(), normalizeLegacyRow() (+13 more)
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.25
 Nodes (21): asRecord(), errorFor(), getLocalExpenseSessionId(), getOrCreateSession(), isExpenseEvent(), itemSource(), itemSourceKey(), numberField() (+13 more)
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.18
 Nodes (18): assertValidEodLocalCompletionWindowMinutes(), assertValidEodThreshold(), assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getEodAutoCompletePolicyConfigWithCtx() (+10 more)
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.11
 Nodes (6): asBoolean(), asNumber(), asRecord(), buildRegisterCloseoutVarianceTimelineMessage(), formatCloseoutVarianceAmount(), getCashControlsConfig()
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.21
 Nodes (18): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), formatRecoveryCode(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode() (+10 more)
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.13
 Nodes (9): asCloudOperableSession(), countPendingSyncableLocalEventsForStaff(), hasSyncedSaleLocalEventsForStaff(), hasUploadedLocalEventsForStaff(), isCloudOperableSession(), isEmptyLocalSaleShell(), selectPassiveCloseoutBlockedRegisterSession(), trimOptional() (+1 more)
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.27
 Nodes (18): assertConformsToExportedReturns(), collectReturnValidatorIssues(), decodeSerializedFloat64(), decodeSerializedInt64(), decodeSerializedLiteralValue(), describeValue(), formatReturnValidatorIssues(), isConvexValue() (+10 more)
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.22
 Nodes (15): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), classifyRegisterSessionSyncReview(), findProjectedRegisterSessionIdForRepairableMissingMapping(), findTransactionIdForSyncEvent(), hasInventoryReviewWorkItemForProjectedSale(), isNonSaleMissingRegisterSessionMappingConflict() (+7 more)
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.22
 Nodes (18): assertPrAthenaProofReady(), classifySnapshotError(), collectFilesUnder(), collectProofSnapshot(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof() (+10 more)
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.17
 Nodes (13): buildProviderRegistry(), createIntelligenceRun(), defaultFakeOutput(), failedGenerationResult(), getStoreInsightsSnapshotFallback(), isActivityTrend(), isDeviceDistribution(), isInsightGenerationInProgressError() (+5 more)
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.16
 Nodes (10): buildProductSkuSearchProjection(), buildSearchText(), hydrateCanonicalProjection(), normalizeAttributes(), normalizeLookup(), projectionsEqual(), requireProductSkuSearchAccess(), requireProductSkuSearchAdmin() (+2 more)
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.25
 Nodes (17): getRegisterCatalogPrice(), isActiveProvisionalImportSkuForStore(), isDraftAllowedInTrustedRegisterCatalog(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailability(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogAvailabilitySkus() (+9 more)
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.22
 Nodes (15): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+7 more)
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
+Cohesion: 0.12
+Nodes (3): formatMinuteOfDayLabel(), formatStoreHoursTimeLabel(), parseStoreHoursTimeLabel()
+
+### Community 82 - "Community 82"
+Cohesion: 0.14
+Nodes (7): getBlockedPosTerminalShellCopy(), getBrowserPathWithSearch(), getLoginHref(), getPosHubRouteParams(), getRouteParamsForPattern(), getStoreWorkspaceRouteParams(), PosTerminalBlockedShell()
+
+### Community 83 - "Community 83"
 Cohesion: 0.25
 Nodes (16): buildStorefrontContextEvent(), buildStorefrontIdempotencyKey(), compactScalarPayload(), createStorefrontContextTrackingEnvelope(), createStorefrontRouteViewedContextEvent(), getCartChange(), getCartContextEventInput(), getCheckoutBlocker() (+8 more)
 
-### Community 81 - "Community 81"
+### Community 84 - "Community 84"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 82 - "Community 82"
+### Community 85 - "Community 85"
 Cohesion: 0.22
 Nodes (14): assertActorMatchesStore(), buildCompiledContextBundle(), buildStoreInsightsContextBundleFromContextEvents(), buildUserInsightsContextBundleFromContextEvents(), compileContextEvent(), compileContextEventsWithReport(), getDataWindow(), getStoreFrontActorById() (+6 more)
 
-### Community 83 - "Community 83"
+### Community 86 - "Community 86"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 84 - "Community 84"
+### Community 87 - "Community 87"
 Cohesion: 0.13
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
-### Community 85 - "Community 85"
-Cohesion: 0.15
-Nodes (7): buildStoreSchedulePayload(), handleSave(), hasDuplicateExceptionDates(), normalizeWeeklyHours(), resetForm(), timeInputToMinute(), validate()
-
-### Community 86 - "Community 86"
-Cohesion: 0.14
-Nodes (5): getBlockedPosTerminalShellCopy(), getPosHubRouteParams(), getRouteParamsForPattern(), getStoreWorkspaceRouteParams(), PosTerminalBlockedShell()
-
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.23
 Nodes (13): buildAbusePartitionKey(), buildServerContextTrackingEnvelope(), deriveBrowserFamily(), deriveContextEnvironment(), deriveOsFamily(), derivePrimarySubject(), isAcceptedSyntheticContext(), isRecord() (+5 more)
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.19
 Nodes (10): buildLatestRunDebugPayload(), getBoundedDebugRunsByCapability(), getLatestDebugRunByCapability(), getLatestDebugRunBySubject(), isActiveRunStale(), isActiveRunStatus(), selectLatestDebugRunFromCandidates(), shouldRecoverActiveRun() (+2 more)
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.13
 Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.24
 Nodes (15): buildGeneratedControlId(), captureRemoteAssistCoBrowseFrame(), collectSanitizedSurface(), collectSensitiveRegions(), collectVisibleText(), getControlId(), getControlPriority(), getElementLabel() (+7 more)
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.22
 Nodes (11): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), getInvalidationNodes(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline() (+3 more)
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.23
 Nodes (13): collectConvexReturnValidatorContractFindings(), escapeRegExp(), extractConvexPublicFunctionsWithReturns(), fileExists(), findMatchingDefinitionEnd(), hasConvexReturnContractProofForExport(), isConvexReturnContractSourcePath(), isRelevantConvexContractProofPath() (+5 more)
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.22
 Nodes (9): buildHistoricalContextEventAppendArgs(), buildHistoricalImportIdempotencyKey(), buildPrimarySubject(), buildStoppedReport(), countOmittedFields(), createEmptyReport(), increment(), planHistoricalStorefrontContextImport() (+1 more)
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.32
 Nodes (14): buildPosOperatorSnapshot(), buildRecentDayBuckets(), buildSummaryTrendBucket(), buildTransactionDateBuckets(), calculateDeltaPercent(), formatHourLabel(), formatPaymentMethodLabel(), formatShortDate() (+6 more)
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.28
 Nodes (14): buildActorRefs(), buildReturnExchangeTraceEvent(), buildReturnExchangeTraceRecord(), buildTraceEvent(), buildTraceRecord(), compactDetails(), recordOnlineOrderReturnExchangeTraceBestEffort(), recordOnlineOrderTraceBestEffort() (+6 more)
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.2
 Nodes (9): canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), drawerAuthorityMatchesActiveRegisterSession(), getSaleBlockingDrawerAuthority(), isDrawerAuthoritySaleBlocking(), isRegisterSessionConflictBlocking(), isRegisterSessionReplacementBlocking(), isRegisterSessionSaleUsable() (+1 more)
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.17
 Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.18
 Nodes (7): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.22
 Nodes (10): extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), normalizeIdentifier(), parseCatalogSearchInput(), searchByText(), searchRegisterCatalog() (+2 more)
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.22
 Nodes (10): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), canProjectRegisterOpenForTerminalCloudRepair(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), getRepairOpenRegisterCloseoutReviewState(), getRepairRegisterSessionCloseoutBoundaryAt(), isDuplicateRegisterOpenConflict() (+2 more)
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.14
 Nodes (0):
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.16
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.26
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.22
 Nodes (6): buildParticipantIdentity(), getDataPublishRouting(), getParticipantRole(), isAllowedSender(), LiveKitRemoteAssistClient, parseParticipantRole()
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.26
 Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.31
 Nodes (12): backfillStoreSchedulesFromLegacyPolicyWithCtx(), buildBackfillRow(), buildCandidateWeeklyWindows(), compatibilityMetadata(), compatibilityOnlyRow(), findExistingScheduleToSkip(), firstPolicy(), isValidMinute() (+4 more)
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.22
 Nodes (6): buildTrustedInventoryFinalizationPayload(), buildTrustedInventoryMoneyPayload(), getTrustedInventoryReviewValidationMessage(), isNonNegativeInteger(), parseVariantDisplayMoney(), resolveTrustedInventoryReviewState()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.18
 Nodes (4): formatProductLineMeta(), formatServiceLabel(), formatServiceLineMeta(), formatStoredAmount()
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.17
 Nodes (2): getNextTransactionPageSearch(), getNextTransactionTimeFilterSearch()
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.29
 Nodes (10): applyTheme(), emitThemeChange(), getStorage(), getStoredThemeMode(), getSystemTheme(), getThemeSnapshot(), initializeAthenaTheme(), isThemeMode() (+2 more)
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.2
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
-
-### Community 134 - "Community 134"
-Cohesion: 0.17
-Nodes (0):
 
 ### Community 135 - "Community 135"
 Cohesion: 0.21
@@ -2670,60 +2670,60 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 140 - "Community 140"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 141 - "Community 141"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 142 - "Community 142"
+### Community 141 - "Community 141"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 143 - "Community 143"
+### Community 142 - "Community 142"
 Cohesion: 0.2
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 144 - "Community 144"
+### Community 143 - "Community 143"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 145 - "Community 145"
+### Community 144 - "Community 144"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 146 - "Community 146"
+### Community 145 - "Community 145"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 147 - "Community 147"
+### Community 146 - "Community 146"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 148 - "Community 148"
+### Community 147 - "Community 147"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 149 - "Community 149"
+### Community 148 - "Community 148"
 Cohesion: 0.25
 Nodes (5): getRuntimeStatusPublishMaterialSignature(), getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusPublishMaterial(), normalizeRuntimeStatusSignature()
 
-### Community 150 - "Community 150"
+### Community 149 - "Community 149"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 151 - "Community 151"
+### Community 150 - "Community 150"
 Cohesion: 0.25
 Nodes (7): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus()
 
-### Community 152 - "Community 152"
+### Community 151 - "Community 151"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 153 - "Community 153"
+### Community 152 - "Community 152"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
+
+### Community 153 - "Community 153"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 154 - "Community 154"
 Cohesion: 0.18
@@ -2802,32 +2802,32 @@ Cohesion: 0.27
 Nodes (5): clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), runProcess(), writePrAthenaProviderEvidence()
 
 ### Community 173 - "Community 173"
+Cohesion: 0.39
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+
+### Community 174 - "Community 174"
 Cohesion: 0.25
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.31
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.22
 Nodes (0):
-
-### Community 179 - "Community 179"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 180 - "Community 180"
 Cohesion: 0.39
@@ -2898,12 +2898,12 @@ Cohesion: 0.22
 Nodes (0):
 
 ### Community 197 - "Community 197"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 198 - "Community 198"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+
+### Community 198 - "Community 198"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.22
@@ -3642,80 +3642,80 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 383 - "Community 383"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 384 - "Community 384"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 384 - "Community 384"
+### Community 385 - "Community 385"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 385 - "Community 385"
+### Community 386 - "Community 386"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 386 - "Community 386"
+### Community 387 - "Community 387"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 387 - "Community 387"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 388 - "Community 388"
 Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 389 - "Community 389"
 Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
 ### Community 390 - "Community 390"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 391 - "Community 391"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 391 - "Community 391"
+### Community 392 - "Community 392"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 392 - "Community 392"
+### Community 393 - "Community 393"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 393 - "Community 393"
+### Community 394 - "Community 394"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 394 - "Community 394"
+### Community 395 - "Community 395"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 395 - "Community 395"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 396 - "Community 396"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 397 - "Community 397"
 Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 398 - "Community 398"
+Cohesion: 0.6
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+
+### Community 399 - "Community 399"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 399 - "Community 399"
+### Community 400 - "Community 400"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 400 - "Community 400"
+### Community 401 - "Community 401"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
-
-### Community 401 - "Community 401"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 402 - "Community 402"
 Cohesion: 0.4
@@ -3726,132 +3726,132 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 404 - "Community 404"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 405 - "Community 405"
 Cohesion: 0.5
-Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 406 - "Community 406"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
 ### Community 407 - "Community 407"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 408 - "Community 408"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 409 - "Community 409"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 410 - "Community 410"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 411 - "Community 411"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 411 - "Community 411"
+### Community 412 - "Community 412"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 412 - "Community 412"
+### Community 413 - "Community 413"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 413 - "Community 413"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 414 - "Community 414"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 415 - "Community 415"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 416 - "Community 416"
-Cohesion: 0.6
-Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
-
-### Community 417 - "Community 417"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 417 - "Community 417"
+Cohesion: 0.6
+Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
+
 ### Community 418 - "Community 418"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 419 - "Community 419"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 419 - "Community 419"
+### Community 420 - "Community 420"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 420 - "Community 420"
+### Community 421 - "Community 421"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 421 - "Community 421"
+### Community 422 - "Community 422"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 422 - "Community 422"
+### Community 423 - "Community 423"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 423 - "Community 423"
+### Community 424 - "Community 424"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 424 - "Community 424"
+### Community 425 - "Community 425"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 425 - "Community 425"
+### Community 426 - "Community 426"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 426 - "Community 426"
+### Community 427 - "Community 427"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 427 - "Community 427"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 428 - "Community 428"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 429 - "Community 429"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
-
-### Community 430 - "Community 430"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 430 - "Community 430"
+Cohesion: 0.67
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 431 - "Community 431"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 432 - "Community 432"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 433 - "Community 433"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 433 - "Community 433"
+### Community 434 - "Community 434"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 434 - "Community 434"
-Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 435 - "Community 435"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 436 - "Community 436"
 Cohesion: 0.5
@@ -3870,68 +3870,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 440 - "Community 440"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 441 - "Community 441"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 441 - "Community 441"
+### Community 442 - "Community 442"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 442 - "Community 442"
+### Community 443 - "Community 443"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 443 - "Community 443"
+### Community 444 - "Community 444"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 444 - "Community 444"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 445 - "Community 445"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 446 - "Community 446"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 447 - "Community 447"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 448 - "Community 448"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 448 - "Community 448"
+### Community 449 - "Community 449"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 449 - "Community 449"
+### Community 450 - "Community 450"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 450 - "Community 450"
+### Community 451 - "Community 451"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 451 - "Community 451"
+### Community 452 - "Community 452"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 452 - "Community 452"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 453 - "Community 453"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 454 - "Community 454"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 455 - "Community 455"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 456 - "Community 456"
 Cohesion: 0.5
@@ -3942,24 +3942,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 458 - "Community 458"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 459 - "Community 459"
 Cohesion: 0.67
 Nodes (2): buildCtx(), buildQueryCtx()
 
-### Community 459 - "Community 459"
+### Community 460 - "Community 460"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 460 - "Community 460"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
 
 ### Community 461 - "Community 461"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 462 - "Community 462"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 463 - "Community 463"
 Cohesion: 0.5
@@ -3974,36 +3974,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 466 - "Community 466"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 467 - "Community 467"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 467 - "Community 467"
+### Community 468 - "Community 468"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 468 - "Community 468"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 469 - "Community 469"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 470 - "Community 470"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 471 - "Community 471"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 472 - "Community 472"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 473 - "Community 473"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 474 - "Community 474"
 Cohesion: 0.5
@@ -4014,32 +4014,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 476 - "Community 476"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 477 - "Community 477"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 477 - "Community 477"
+### Community 478 - "Community 478"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 478 - "Community 478"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 479 - "Community 479"
 Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 480 - "Community 480"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 481 - "Community 481"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 482 - "Community 482"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 483 - "Community 483"
 Cohesion: 0.5
@@ -4070,12 +4070,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 490 - "Community 490"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
-
-### Community 491 - "Community 491"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 491 - "Community 491"
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 492 - "Community 492"
 Cohesion: 0.5
@@ -4086,12 +4086,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 494 - "Community 494"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 495 - "Community 495"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 495 - "Community 495"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 496 - "Community 496"
 Cohesion: 0.5
@@ -4102,120 +4102,120 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 498 - "Community 498"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 499 - "Community 499"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 499 - "Community 499"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 500 - "Community 500"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 501 - "Community 501"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 502 - "Community 502"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 503 - "Community 503"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 504 - "Community 504"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 505 - "Community 505"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 505 - "Community 505"
+### Community 506 - "Community 506"
 Cohesion: 0.67
 Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
-### Community 506 - "Community 506"
+### Community 507 - "Community 507"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 507 - "Community 507"
+### Community 508 - "Community 508"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 508 - "Community 508"
+### Community 509 - "Community 509"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 509 - "Community 509"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 510 - "Community 510"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 511 - "Community 511"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 512 - "Community 512"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 513 - "Community 513"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 514 - "Community 514"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 514 - "Community 514"
+### Community 515 - "Community 515"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 515 - "Community 515"
+### Community 516 - "Community 516"
 Cohesion: 0.83
 Nodes (3): completedEvent(), event(), item()
 
-### Community 516 - "Community 516"
+### Community 517 - "Community 517"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 517 - "Community 517"
+### Community 518 - "Community 518"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 518 - "Community 518"
+### Community 519 - "Community 519"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
-
-### Community 519 - "Community 519"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 520 - "Community 520"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 521 - "Community 521"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 522 - "Community 522"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 522 - "Community 522"
+### Community 523 - "Community 523"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 523 - "Community 523"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 524 - "Community 524"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 525 - "Community 525"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 526 - "Community 526"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 527 - "Community 527"
 Cohesion: 0.5
@@ -4246,63 +4246,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 534 - "Community 534"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 535 - "Community 535"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 536 - "Community 536"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 537 - "Community 537"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 537 - "Community 537"
+### Community 538 - "Community 538"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 538 - "Community 538"
+### Community 539 - "Community 539"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 539 - "Community 539"
+### Community 540 - "Community 540"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 540 - "Community 540"
+### Community 541 - "Community 541"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 541 - "Community 541"
+### Community 542 - "Community 542"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 542 - "Community 542"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 543 - "Community 543"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 544 - "Community 544"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 545 - "Community 545"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 545 - "Community 545"
+### Community 546 - "Community 546"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 546 - "Community 546"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 547 - "Community 547"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 548 - "Community 548"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 549 - "Community 549"
@@ -4310,12 +4310,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 550 - "Community 550"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 551 - "Community 551"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 551 - "Community 551"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 552 - "Community 552"
 Cohesion: 0.67
@@ -4374,32 +4374,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 566 - "Community 566"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 567 - "Community 567"
 Cohesion: 1.0
-Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 568 - "Community 568"
 Cohesion: 1.0
-Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
 ### Community 569 - "Community 569"
 Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
+Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 570 - "Community 570"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 571 - "Community 571"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 572 - "Community 572"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 573 - "Community 573"
 Cohesion: 0.67
@@ -4414,12 +4414,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 576 - "Community 576"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 577 - "Community 577"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 577 - "Community 577"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 578 - "Community 578"
 Cohesion: 0.67
@@ -4442,12 +4442,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 583 - "Community 583"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 584 - "Community 584"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 584 - "Community 584"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 585 - "Community 585"
 Cohesion: 0.67
@@ -4462,16 +4462,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 588 - "Community 588"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 589 - "Community 589"
 Cohesion: 1.0
-Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 590 - "Community 590"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
 
 ### Community 591 - "Community 591"
 Cohesion: 0.67
@@ -4482,28 +4482,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 593 - "Community 593"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 594 - "Community 594"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 595 - "Community 595"
 Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 596 - "Community 596"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 597 - "Community 597"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 598 - "Community 598"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 598 - "Community 598"
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 599 - "Community 599"
 Cohesion: 0.67
@@ -4511,11 +4511,11 @@ Nodes (0):
 
 ### Community 600 - "Community 600"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 601 - "Community 601"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 602 - "Community 602"
 Cohesion: 0.67
@@ -4530,12 +4530,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 605 - "Community 605"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 606 - "Community 606"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 606 - "Community 606"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 607 - "Community 607"
 Cohesion: 0.67
@@ -4554,28 +4554,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 611 - "Community 611"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 612 - "Community 612"
 Cohesion: 1.0
 Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
-### Community 612 - "Community 612"
-Cohesion: 0.67
-Nodes (1): FadeIn()
-
 ### Community 613 - "Community 613"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 614 - "Community 614"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 615 - "Community 615"
-Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
-
-### Community 616 - "Community 616"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 616 - "Community 616"
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 617 - "Community 617"
 Cohesion: 0.67
@@ -4583,15 +4583,15 @@ Nodes (0):
 
 ### Community 618 - "Community 618"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 619 - "Community 619"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
 
 ### Community 620 - "Community 620"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 621 - "Community 621"
 Cohesion: 0.67
@@ -4602,16 +4602,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 623 - "Community 623"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 624 - "Community 624"
 Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 625 - "Community 625"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 626 - "Community 626"
 Cohesion: 0.67
@@ -4646,12 +4646,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 634 - "Community 634"
-Cohesion: 1.0
-Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
-
-### Community 635 - "Community 635"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 635 - "Community 635"
+Cohesion: 1.0
+Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
 
 ### Community 636 - "Community 636"
 Cohesion: 0.67
@@ -4671,79 +4671,79 @@ Nodes (0):
 
 ### Community 640 - "Community 640"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 641 - "Community 641"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 642 - "Community 642"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 643 - "Community 643"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 644 - "Community 644"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 645 - "Community 645"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 646 - "Community 646"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 647 - "Community 647"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 648 - "Community 648"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 648 - "Community 648"
+### Community 649 - "Community 649"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 649 - "Community 649"
+### Community 650 - "Community 650"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 650 - "Community 650"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 651 - "Community 651"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 652 - "Community 652"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 653 - "Community 653"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 654 - "Community 654"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 655 - "Community 655"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 656 - "Community 656"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 657 - "Community 657"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 658 - "Community 658"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 659 - "Community 659"
 Cohesion: 0.67
@@ -4775,11 +4775,11 @@ Nodes (0):
 
 ### Community 666 - "Community 666"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 667 - "Community 667"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 668 - "Community 668"
 Cohesion: 0.67
@@ -4806,44 +4806,44 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 674 - "Community 674"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 675 - "Community 675"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 675 - "Community 675"
+### Community 676 - "Community 676"
 Cohesion: 0.67
 Nodes (1): isInMaintenanceMode()
 
-### Community 676 - "Community 676"
+### Community 677 - "Community 677"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 677 - "Community 677"
+### Community 678 - "Community 678"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 678 - "Community 678"
+### Community 679 - "Community 679"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 679 - "Community 679"
-Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 680 - "Community 680"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 681 - "Community 681"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 682 - "Community 682"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 683 - "Community 683"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 683 - "Community 683"
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 684 - "Community 684"
 Cohesion: 0.67
@@ -4870,76 +4870,76 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 690 - "Community 690"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 691 - "Community 691"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 692 - "Community 692"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 693 - "Community 693"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 694 - "Community 694"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 695 - "Community 695"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 696 - "Community 696"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 697 - "Community 697"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 698 - "Community 698"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 699 - "Community 699"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 700 - "Community 700"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 701 - "Community 701"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 702 - "Community 702"
 Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 703 - "Community 703"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 704 - "Community 704"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 705 - "Community 705"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 706 - "Community 706"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 707 - "Community 707"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 708 - "Community 708"
 Cohesion: 0.67
@@ -4954,12 +4954,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 711 - "Community 711"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 712 - "Community 712"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 712 - "Community 712"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 713 - "Community 713"
 Cohesion: 0.67
@@ -4970,12 +4970,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 715 - "Community 715"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 716 - "Community 716"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 716 - "Community 716"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 717 - "Community 717"
 Cohesion: 0.67
@@ -5042,16 +5042,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 733 - "Community 733"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 734 - "Community 734"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 735 - "Community 735"
+### Community 734 - "Community 734"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 735 - "Community 735"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 736 - "Community 736"
 Cohesion: 1.0
@@ -5066,20 +5066,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 739 - "Community 739"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 740 - "Community 740"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 741 - "Community 741"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 742 - "Community 742"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 743 - "Community 743"
 Cohesion: 1.0
@@ -10400,365 +10400,363 @@ Nodes (0):
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 742`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 743`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 744`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 745`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 746`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 747`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 748`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 749`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 750`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 751`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 752`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 753`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 754`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 755`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 756`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 757`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 758`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 759`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 760`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 761`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 762`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 763`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 764`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 765`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 766`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 767`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 768`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 769`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 770`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 771`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 772`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 773`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 774`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 775`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 776`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 777`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 778`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 779`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 780`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 781`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 782`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 783`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 784`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 785`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 786`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 787`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 788`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 789`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 790`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 791`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 792`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 793`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 794`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 795`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 796`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 797`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 798`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 799`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 800`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 801`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 802`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 803`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 804`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 805`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 806`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 807`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 808`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 809`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 810`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 811`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 812`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 813`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 814`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 815`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 816`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 817`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 818`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 819`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 820`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 821`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 822`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 823`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 824`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 825`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 826`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 827`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 828`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 829`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 830`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 831`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 832`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 833`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 834`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 835`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 836`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 837`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 838`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 839`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 840`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 841`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 842`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 843`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 844`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 845`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 846`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 847`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 848`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 849`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 850`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 851`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 852`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 853`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 854`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 855`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 856`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 857`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 858`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 859`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 860`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 861`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 862`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 863`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 864`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 865`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 866`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 867`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 868`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 869`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 870`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 871`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 872`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 873`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 874`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 875`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 876`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 877`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 878`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 879`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 880`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 881`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 882`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 883`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 884`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 885`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 886`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 887`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 888`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 889`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 890`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 891`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 892`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 893`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 894`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 895`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 896`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 897`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 898`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 899`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 900`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 901`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 902`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 903`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 904`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 905`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 906`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
+- **Thin community `Community 907`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 908`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 909`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 910`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 911`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 912`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 913`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 914`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 915`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 916`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 917`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 918`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 919`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 920`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
+- **Thin community `Community 921`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 922`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2145
-- Graph nodes: 8257
-- Graph edges: 9812
+- Graph nodes: 8272
+- Graph edges: 9836
 - Communities: 2072
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 10) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 10) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 63) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `storefrontContextEvents.ts` (17 edges, Community 80) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
-- `checkoutSession.ts` (14 edges, Community 94) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `getStoreConfigV2()` (17 edges, Community 64) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storefrontContextEvents.ts` (17 edges, Community 83) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
+- `checkoutSession.ts` (14 edges, Community 95) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (15 edges, Community 95) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (15 edges, Community 96) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `app.test.js` (6 edges, Community 199) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 95) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossCluster()` (4 edges, Community 95) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossClusterWithPipeline()` (4 edges, Community 95) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisClient()` (4 edges, Community 96) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossCluster()` (4 edges, Community 96) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossClusterWithPipeline()` (4 edges, Community 96) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.test.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.test.tsx
@@ -74,7 +74,7 @@ describe("PosRecoveryCodeForm", () => {
     );
   });
 
-  it("uses generic failure copy for rejected recovery sign-in", async () => {
+  it("uses access-aware failure copy for rejected recovery sign-in", async () => {
     const user = userEvent.setup();
     mocked.signIn.mockResolvedValue({ signingIn: false });
 
@@ -91,7 +91,7 @@ describe("PosRecoveryCodeForm", () => {
 
     expect(
       await screen.findByText(
-        "Sign-in details not recognized. Enter the recovery code again.",
+        "POS sign-in failed. Check the recovery code or ask an admin to confirm POS-only access.",
       ),
     ).toBeInTheDocument();
     expect(mocked.navigate).not.toHaveBeenCalled();

--- a/packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.tsx
@@ -11,7 +11,7 @@ import { startAthenaAuthSyncHandoff } from "./authSyncHandoff";
 
 const POS_RECOVERY_ACCOUNT_EMAIL = "pos@wigclub.store";
 const RECOVERY_FAILURE_COPY =
-  "Sign-in details not recognized. Enter the recovery code again.";
+  "POS sign-in failed. Check the recovery code or ask an admin to confirm POS-only access.";
 
 function navigationTargetForRedirect(redirectTo: string) {
   const [pathname, queryString] = redirectTo.split("?", 2);

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
@@ -3,6 +3,7 @@ import type {
   ButtonHTMLAttributes,
   InputHTMLAttributes,
   LabelHTMLAttributes,
+  ReactElement,
   ReactNode,
 } from "react";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -131,6 +132,92 @@ vi.mock("@/components/ui/loading-button", () => ({
   },
 }));
 
+vi.mock("@/components/ui/select", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  type SelectItemProps = {
+    children?: ReactNode;
+    value: string;
+  };
+  type SelectRootProps = {
+    children?: ReactNode;
+    onValueChange?: (value: string) => void;
+    value?: string;
+  };
+  type SelectTriggerProps = React.SelectHTMLAttributes<HTMLSelectElement>;
+
+  const SelectContent = ({ children }: { children?: ReactNode }) => (
+    <>{children}</>
+  );
+  const SelectItem = ({ children }: SelectItemProps) => <>{children}</>;
+  const SelectValue = () => null;
+  const SelectTrigger = ({ children }: SelectTriggerProps) => <>{children}</>;
+
+  function collectItems(children?: ReactNode): Array<
+    React.ReactElement<SelectItemProps>
+  > {
+    const items: Array<React.ReactElement<SelectItemProps>> = [];
+
+    React.Children.forEach(children, (child) => {
+      if (!React.isValidElement(child)) return;
+      if (child.type === SelectItem) {
+        items.push(child as React.ReactElement<SelectItemProps>);
+        return;
+      }
+
+      items.push(...collectItems(child.props.children));
+    });
+
+    return items;
+  }
+
+  function findTrigger(
+    children?: ReactNode,
+  ): React.ReactElement<SelectTriggerProps> | null {
+    let trigger: React.ReactElement<SelectTriggerProps> | null = null;
+
+    React.Children.forEach(children, (child) => {
+      if (trigger || !React.isValidElement(child)) return;
+      if (child.type === SelectTrigger) {
+        trigger = child as React.ReactElement<SelectTriggerProps>;
+        return;
+      }
+
+      trigger = findTrigger(child.props.children);
+    });
+
+    return trigger;
+  }
+
+  const Select = ({ children, onValueChange, value }: SelectRootProps) => {
+    const trigger = findTrigger(children);
+    const { children: _children, ...triggerProps } = trigger?.props ?? {};
+    void _children;
+
+    return (
+      <select
+        {...triggerProps}
+        onChange={(event) => onValueChange?.(event.currentTarget.value)}
+        value={value}
+      >
+        {collectItems(children).map((item) => (
+          <option key={item.props.value} value={item.props.value}>
+            {item.props.children}
+          </option>
+        ))}
+      </select>
+    );
+  };
+
+  return {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+  };
+});
+
 vi.mock("@/lib/browserFingerprint", () => ({
   generateBrowserFingerprint: mocks.generateBrowserFingerprint,
 }));
@@ -164,6 +251,12 @@ async function waitForFingerprintEffect() {
       expect.any(String),
     ),
   );
+}
+
+async function renderPOSSettingsView(view: ReactElement = <POSSettingsView />) {
+  const result = render(view);
+  await waitForFingerprintEffect();
+  return result;
 }
 
 describe("registerAndProvisionPosTerminal", () => {
@@ -307,7 +400,7 @@ describe("registerAndProvisionPosTerminal", () => {
       },
     }));
 
-    render(
+    await renderPOSSettingsView(
       <POSSettingsView
         storeFactory={() =>
           ({
@@ -387,7 +480,7 @@ describe("registerAndProvisionPosTerminal", () => {
       },
     }));
 
-    render(
+    await renderPOSSettingsView(
       <POSSettingsView
         storeFactory={() =>
           ({
@@ -433,7 +526,7 @@ describe("registerAndProvisionPosTerminal", () => {
   });
 
   it("shows the current POS recovery code from status", async () => {
-    render(<POSSettingsView />);
+    await renderPOSSettingsView();
 
     expect(await screen.findByText("mintlamp42")).toBeInTheDocument();
     expect(
@@ -444,7 +537,7 @@ describe("registerAndProvisionPosTerminal", () => {
   it("lets full admins rotate the POS recovery code and keeps plaintext visible", async () => {
     const user = userEvent.setup();
 
-    render(<POSSettingsView />);
+    await renderPOSSettingsView();
 
     await user.click(
       await screen.findByRole("button", { name: /rotate recovery code/i }),
@@ -472,7 +565,7 @@ describe("registerAndProvisionPosTerminal", () => {
         : null,
     );
 
-    render(<POSSettingsView />);
+    await renderPOSSettingsView();
 
     await user.click(await screen.findByRole("button", { name: /unlock/i }));
 
@@ -486,7 +579,7 @@ describe("registerAndProvisionPosTerminal", () => {
   it("lets full admins revoke an active POS recovery code", async () => {
     const user = userEvent.setup();
 
-    render(<POSSettingsView />);
+    await renderPOSSettingsView();
 
     await user.click(await screen.findByRole("button", { name: /revoke/i }));
 
@@ -498,7 +591,7 @@ describe("registerAndProvisionPosTerminal", () => {
   });
 
   it("shows full admins the store-day automation policy", async () => {
-    render(<POSSettingsView />);
+    await renderPOSSettingsView();
 
     expect(await screen.findByText("Store day automation")).toBeInTheDocument();
     expect(
@@ -507,6 +600,14 @@ describe("registerAndProvisionPosTerminal", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Enable store-day auto-start")).toBeChecked();
+    expect(
+      screen.getByRole("combobox", { name: "Store day auto-start offset" }),
+    ).toHaveTextContent("At opening");
+    expect(
+      screen.getByText(
+        "Opening 08:30 AM. Runs 08:30 AM.",
+      ),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("combobox", { name: "Store day start hour" }),
     ).not.toBeInTheDocument();
@@ -519,8 +620,46 @@ describe("registerAndProvisionPosTerminal", () => {
     });
   });
 
+  it("formats raw Store Hours opening times in the auto-start summary", async () => {
+    mocks.useQuery.mockImplementation((ref) =>
+      ref === "getOpeningAutoStartPolicy"
+        ? {
+            localStartMinutes: 480,
+            mode: "enabled",
+            openingBlockerHandling: "start_with_manager_review",
+            operatingTimezoneOffsetMinutes: -120,
+          }
+        : ref === "getStoreScheduleSummary"
+          ? {
+              context: {
+                currentWindow: {
+                  localEndLabel: "19:00",
+                  localStartLabel: "09:00",
+                },
+                isOpen: true,
+                nextWindow: null,
+                phase: "during_window",
+                timezone: "Africa/Accra",
+              },
+              schedule: {
+                timezone: "Africa/Accra",
+              },
+            }
+          : null,
+    );
+
+    await renderPOSSettingsView();
+
+    expect(await screen.findByText("Store day automation")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Opening 09:00 AM. Runs 08:00 AM.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("shows full admins a distinct EOD completion automation policy", async () => {
-    render(<POSSettingsView />);
+    await renderPOSSettingsView();
 
     expect(
       await screen.findByText("EOD completion automation"),
@@ -535,6 +674,14 @@ describe("registerAndProvisionPosTerminal", () => {
     expect(
       screen.queryByRole("combobox", { name: "EOD completion hour" }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: "EOD completion offset" }),
+    ).toHaveTextContent("At close");
+    expect(
+      screen.getByText(
+        "Close 06:30 PM. Runs 06:30 PM.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText("Cash variance threshold")).toHaveValue(500);
     expect(screen.getByLabelText("Voided sale count threshold")).toHaveValue(1);
     expect(screen.getByLabelText("Voided sale total threshold")).toHaveValue(2500);
@@ -546,7 +693,7 @@ describe("registerAndProvisionPosTerminal", () => {
   it("saves the EOD completion automation policy with thresholds", async () => {
     const user = userEvent.setup();
 
-    render(<POSSettingsView />);
+    await renderPOSSettingsView();
 
     await screen.findByText("EOD completion automation");
     await waitFor(() =>
@@ -563,6 +710,15 @@ describe("registerAndProvisionPosTerminal", () => {
     fireEvent.change(screen.getByLabelText("Voided sale total threshold"), {
       target: { value: "9000" },
     });
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "EOD completion offset" }),
+      "60",
+    );
+    expect(
+      screen.getByText(
+        "Close 06:30 PM. Runs 07:30 PM.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText("Enable EOD completion")).toBeChecked();
     expect(screen.getByLabelText("Enable blocker-free completion")).not.toBeChecked();
     expect(screen.getByLabelText("Cash variance threshold")).toHaveValue(750);
@@ -575,7 +731,7 @@ describe("registerAndProvisionPosTerminal", () => {
     await waitFor(() =>
       expect(mocks.updateEodAutoCompletePolicy).toHaveBeenCalledWith({
         cleanDayAutoCompleteEnabled: false,
-        localCompletionWindowMinutes: 1110,
+        localCompletionWindowMinutes: 1170,
         maxAbsoluteCashVariance: 750,
         maxVoidedSaleCount: 2,
         maxVoidedSaleTotal: 9000,
@@ -589,16 +745,20 @@ describe("registerAndProvisionPosTerminal", () => {
   it("saves the store-day automation policy without owning business hours", async () => {
     const user = userEvent.setup();
 
-    render(<POSSettingsView />);
+    await renderPOSSettingsView();
 
     await user.click(await screen.findByLabelText("Enable store-day auto-start"));
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Store day auto-start offset" }),
+      "-30",
+    );
     await user.click(
       screen.getByRole("button", { name: "Save store-day automation" }),
     );
 
     await waitFor(() =>
       expect(mocks.updateOpeningAutoStartPolicy).toHaveBeenCalledWith({
-        localStartMinutes: 510,
+        localStartMinutes: 480,
         mode: "disabled",
         openingBlockerHandling: "start_with_manager_review",
         operatingTimezoneOffsetMinutes: -120,
@@ -643,7 +803,7 @@ describe("registerAndProvisionPosTerminal", () => {
           : null,
     );
 
-    render(<POSSettingsView />);
+    await renderPOSSettingsView();
 
     await user.click(await screen.findByLabelText("Enable store-day auto-start"));
     await user.click(
@@ -652,7 +812,7 @@ describe("registerAndProvisionPosTerminal", () => {
 
     await waitFor(() =>
       expect(mocks.updateOpeningAutoStartPolicy).toHaveBeenCalledWith({
-        localStartMinutes: 480,
+        localStartMinutes: 510,
         mode: "enabled",
         openingBlockerHandling: "start_with_manager_review",
         operatingTimezoneOffsetMinutes: undefined,
@@ -662,20 +822,55 @@ describe("registerAndProvisionPosTerminal", () => {
   });
 
   it("summarizes POS automation timing from Store Hours", async () => {
-    render(<POSSettingsView />);
+    await renderPOSSettingsView();
 
     expect(await screen.findByText("Store Hours timing")).toBeInTheDocument();
     expect(screen.getByText("Timing comes from Store Hours")).toBeInTheDocument();
     expect(
       screen.getByText("Athena uses Store Hours to time Opening and EOD automation."),
     ).toBeInTheDocument();
-    expect(screen.getByText("Opening at 8:30 AM")).toBeInTheDocument();
-    expect(screen.getByText("EOD after 6:30 PM")).toBeInTheDocument();
+    expect(screen.getByText("Opening at 08:30 AM")).toBeInTheDocument();
+    expect(screen.getByText("EOD after 06:30 PM")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open Store Hours" }))
       .toHaveAttribute("href", "/acme/store/downtown/configuration");
     expect(mocks.useQuery).toHaveBeenCalledWith("getStoreScheduleSummary", {
       storeId: "store-1",
     });
+  });
+
+  it("formats raw Store Hours timing labels in the timing readout", async () => {
+    mocks.useQuery.mockImplementation((ref) =>
+      ref === "getOpeningAutoStartPolicy"
+        ? {
+            localStartMinutes: 480,
+            mode: "enabled",
+            openingBlockerHandling: "start_with_manager_review",
+            operatingTimezoneOffsetMinutes: -120,
+          }
+        : ref === "getStoreScheduleSummary"
+          ? {
+              context: {
+                currentWindow: {
+                  localEndLabel: "19:00",
+                  localStartLabel: "09:00",
+                },
+                isOpen: true,
+                nextWindow: null,
+                phase: "during_window",
+                timezone: "Africa/Accra",
+              },
+              schedule: {
+                timezone: "Africa/Accra",
+              },
+            }
+          : null,
+    );
+
+    await renderPOSSettingsView();
+
+    expect(await screen.findByText("Store Hours timing")).toBeInTheDocument();
+    expect(screen.getByText("Opening at 09:00 AM")).toBeInTheDocument();
+    expect(screen.getByText("EOD after 07:00 PM")).toBeInTheDocument();
   });
 
   it("disables revoke for revoked POS recovery codes", async () => {
@@ -691,7 +886,7 @@ describe("registerAndProvisionPosTerminal", () => {
         : null,
     );
 
-    render(<POSSettingsView />);
+    await renderPOSSettingsView();
 
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /revoke/i })).toBeDisabled(),
@@ -704,7 +899,7 @@ describe("registerAndProvisionPosTerminal", () => {
       isLoading: false,
     });
 
-    render(<POSSettingsView />);
+    await renderPOSSettingsView();
     await waitForFingerprintEffect();
 
     expect(screen.queryByText("POS recovery code")).not.toBeInTheDocument();
@@ -737,7 +932,7 @@ describe("registerAndProvisionPosTerminal", () => {
       new Error("internal duplicate_policy stack"),
     );
 
-    render(<POSSettingsView />);
+    await renderPOSSettingsView();
 
     await user.click(
       screen.getByRole("button", {
@@ -768,7 +963,7 @@ describe("registerAndProvisionPosTerminal", () => {
       new Error("internal threshold_policy stack"),
     );
 
-    render(<POSSettingsView />);
+    await renderPOSSettingsView();
 
     await user.click(
       screen.getByRole("button", {
@@ -791,7 +986,7 @@ describe("registerAndProvisionPosTerminal", () => {
   });
 
   it("hands off roster and support work to terminal health", async () => {
-    render(<POSSettingsView />);
+    await renderPOSSettingsView();
 
     expect(screen.getByText("Terminal health")).toBeInTheDocument();
     await waitFor(() =>
@@ -826,6 +1021,19 @@ describe("registerAndProvisionPosTerminal", () => {
   });
 
   it("links terminal health to the current terminal and keeps settings as the origin", async () => {
+    const existingTerminal = {
+      _id: "terminal-existing",
+      _creationTime: 1,
+      browserInfo: { userAgent: "test" },
+      displayName: "Front counter",
+      fingerprintHash: "fingerprint-1",
+      registeredAt: 1,
+      registeredByUserId: "user-1",
+      registerNumber: "3",
+      status: "active",
+      storeId: "store-1",
+    };
+
     mocks.useQuery.mockImplementation((ref) =>
       ref === "getRecoveryCodeStatus"
         ? {
@@ -844,22 +1052,11 @@ describe("registerAndProvisionPosTerminal", () => {
               operatingTimezoneOffsetMinutes: 0,
             }
           : ref === "getTerminalByFingerprint"
-            ? {
-                _id: "terminal-existing",
-                _creationTime: 1,
-                browserInfo: { userAgent: "test" },
-                displayName: "Front counter",
-                fingerprintHash: "fingerprint-1",
-                registeredAt: 1,
-                registeredByUserId: "user-1",
-                registerNumber: "3",
-                status: "active",
-                storeId: "store-1",
-              }
+            ? existingTerminal
             : null,
     );
 
-    render(<POSSettingsView />);
+    await renderPOSSettingsView();
 
     expect(screen.getByText("Terminal health")).toBeInTheDocument();
     expect(
@@ -909,7 +1106,7 @@ describe("registerAndProvisionPosTerminal", () => {
       },
     });
 
-    render(
+    await renderPOSSettingsView(
       <POSSettingsView
         storeFactory={() =>
           ({

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
@@ -8,6 +8,13 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { FadeIn } from "../../common/FadeIn";
 import { PageLevelHeader, PageWorkspace } from "../../common/PageLevelHeader";
 import View from "../../View";
@@ -66,6 +73,23 @@ const HealthLink = Link as unknown as ComponentType<HealthLinkProps>;
 type AutomationPolicyMode = "disabled" | "dry_run" | "enabled";
 const DEFAULT_OPENING_LOCAL_START_MINUTES = 8 * 60;
 const DEFAULT_EOD_LOCAL_COMPLETION_WINDOW_MINUTES = 22 * 60;
+const AUTOMATION_START_OFFSET_OPTIONS = [
+  { value: "-60", label: "1 hour before opening" },
+  { value: "-30", label: "30 minutes before opening" },
+  { value: "-15", label: "15 minutes before opening" },
+  { value: "0", label: "At opening" },
+  { value: "15", label: "15 minutes after opening" },
+  { value: "30", label: "30 minutes after opening" },
+  { value: "60", label: "1 hour after opening" },
+];
+const EOD_COMPLETION_OFFSET_OPTIONS = [
+  { value: "0", label: "At close" },
+  { value: "15", label: "15 minutes after close" },
+  { value: "30", label: "30 minutes after close" },
+  { value: "60", label: "1 hour after close" },
+  { value: "120", label: "2 hours after close" },
+  { value: "180", label: "3 hours after close" },
+];
 const terminalCapabilityOptions: Array<{
   value: PosTerminalTransactionCapability;
   label: string;
@@ -254,7 +278,7 @@ function FingerprintRegistrationCard({
         <div className="space-y-layout-xs">
           <Label>Terminal login</Label>
           <RadioGroup
-            className="grid gap-layout-sm sm:grid-cols-2"
+            className="grid w-fit max-w-full gap-layout-sm sm:grid-cols-[repeat(2,minmax(0,20rem))]"
             value={loginMode}
             onValueChange={(value) =>
               onLoginModeChange(normalizePosTerminalLoginMode(value))
@@ -416,6 +440,92 @@ function parseNonNegativeIntegerInput(value: string) {
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
 }
 
+function normalizeMinuteOfDay(value: number) {
+  return ((value % (24 * 60)) + 24 * 60) % (24 * 60);
+}
+
+function parseStoreHoursTimeLabel(value?: string | null) {
+  if (!value) return null;
+
+  const match = value.trim().match(/^(\d{1,2}):(\d{2})(?:\s*([AP]M))?$/i);
+  if (!match) return null;
+
+  let hour = Number(match[1]);
+  const minute = Number(match[2]);
+  const meridiem = match[3]?.toUpperCase();
+  if (
+    !Number.isInteger(hour) ||
+    !Number.isInteger(minute) ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return null;
+  }
+
+  if (meridiem) {
+    if (hour < 1 || hour > 12) return null;
+    hour = hour % 12;
+    if (meridiem === "PM") hour += 12;
+  } else if (hour < 0 || hour > 23) {
+    return null;
+  }
+
+  return hour * 60 + minute;
+}
+
+function formatStoreHoursTimeLabel(value?: string | null) {
+  const minutes = parseStoreHoursTimeLabel(value);
+  if (minutes === null) return value ?? "Store Hours opening time";
+
+  return formatMinuteOfDayLabel(minutes);
+}
+
+function formatMinuteOfDayLabel(minutes: number) {
+  const hour24 = Math.floor(minutes / 60);
+  const minute = minutes % 60;
+  const hour12 = hour24 % 12 || 12;
+  const meridiem = hour24 < 12 ? "AM" : "PM";
+
+  return `${String(hour12).padStart(2, "0")}:${String(minute).padStart(
+    2,
+    "0",
+  )} ${meridiem}`;
+}
+
+function formatOffsetFromStoreHours(offsetMinutes: number) {
+  const option = AUTOMATION_START_OFFSET_OPTIONS.find(
+    (entry) => Number(entry.value) === offsetMinutes,
+  );
+  if (option) return option.label;
+
+  const absoluteMinutes = Math.abs(offsetMinutes);
+  const unitLabel = absoluteMinutes === 1 ? "minute" : "minutes";
+  if (offsetMinutes < 0) {
+    return `${absoluteMinutes} ${unitLabel} before opening`;
+  }
+  if (offsetMinutes > 0) {
+    return `${absoluteMinutes} ${unitLabel} after opening`;
+  }
+  return "At opening";
+}
+
+function formatOffsetFromStoreClose(offsetMinutes: number) {
+  const option = EOD_COMPLETION_OFFSET_OPTIONS.find(
+    (entry) => Number(entry.value) === offsetMinutes,
+  );
+  if (option) return option.label;
+
+  const absoluteMinutes = Math.abs(offsetMinutes);
+  const unitLabel = absoluteMinutes === 1 ? "minute" : "minutes";
+  if (offsetMinutes < 0) {
+    return `${absoluteMinutes} ${unitLabel} before close`;
+  }
+  if (offsetMinutes > 0) {
+    return `${absoluteMinutes} ${unitLabel} after close`;
+  }
+  return "At close";
+}
+
 type StoreScheduleSummary = {
   context?: {
     currentWindow?: {
@@ -471,13 +581,17 @@ function StoreHoursTimingReadout({
     scheduleContext?.currentWindow ?? scheduleContext?.nextWindow ?? null;
   const openingTiming =
     currentOrNextWindow?.localStartLabel
-      ? `Opening at ${currentOrNextWindow.localStartLabel}`
+      ? `Opening at ${formatStoreHoursTimeLabel(
+          currentOrNextWindow.localStartLabel,
+        )}`
       : scheduleContext?.phase === "closed"
         ? "Store is closed today."
         : "Opening timing is waiting for Store Hours.";
   const eodTiming =
     currentOrNextWindow?.localEndLabel
-      ? `EOD after ${currentOrNextWindow.localEndLabel}`
+      ? `EOD after ${formatStoreHoursTimeLabel(
+          currentOrNextWindow.localEndLabel,
+        )}`
       : "EOD timing is waiting for Store Hours.";
   const timezone =
     scheduleContext?.timezone ??
@@ -549,12 +663,19 @@ function EodCompletionAutomationAdminPanel({
       ? { storeId }
       : "skip",
   ) as EodAutoCompletePolicy | null | undefined;
+  const scheduleSummary = useQuery(
+    storeScheduleApi.getStoreScheduleSummary,
+    !isLoading && hasFullAdminAccess && storeId
+      ? { storeId }
+      : "skip",
+  ) as StoreScheduleSummary | null | undefined;
   const updateEodAutoCompletePolicy = useMutation(
     api.operations.dailyOperationsAutomation.updateEodAutoCompletePolicy,
   ) as unknown as UpdateEodAutoCompletePolicy;
   const [mode, setMode] = useState<AutomationPolicyMode>("disabled");
   const [cleanDayAutoCompleteEnabled, setCleanDayAutoCompleteEnabled] =
     useState(false);
+  const [completionOffsetMinutes, setCompletionOffsetMinutes] = useState(0);
   const [maxAbsoluteCashVariance, setMaxAbsoluteCashVariance] = useState("0");
   const [maxVoidedSaleCount, setMaxVoidedSaleCount] = useState("0");
   const [maxVoidedSaleTotal, setMaxVoidedSaleTotal] = useState("0");
@@ -569,6 +690,53 @@ function EodCompletionAutomationAdminPanel({
   const policyMaxAbsoluteCashVariance = policy?.maxAbsoluteCashVariance;
   const policyMaxVoidedSaleCount = policy?.maxVoidedSaleCount;
   const policyMaxVoidedSaleTotal = policy?.maxVoidedSaleTotal;
+  const scheduleContext = scheduleSummary?.context;
+  const currentOrNextWindow =
+    scheduleContext?.currentWindow ?? scheduleContext?.nextWindow ?? null;
+  const storeCloseMinute = parseStoreHoursTimeLabel(
+    currentOrNextWindow?.localEndLabel,
+  );
+  const selectedCompletionMinute =
+    storeCloseMinute === null
+      ? (policy?.localCompletionWindowMinutes ??
+        DEFAULT_EOD_LOCAL_COMPLETION_WINDOW_MINUTES)
+      : normalizeMinuteOfDay(storeCloseMinute + completionOffsetMinutes);
+  const selectedCompletionOffsetLabel = formatOffsetFromStoreClose(
+    completionOffsetMinutes,
+  );
+  const completionOffsetOptions = EOD_COMPLETION_OFFSET_OPTIONS.some(
+    (option) => Number(option.value) === completionOffsetMinutes,
+  )
+    ? EOD_COMPLETION_OFFSET_OPTIONS
+    : [
+        ...EOD_COMPLETION_OFFSET_OPTIONS,
+        {
+          value: String(completionOffsetMinutes),
+          label: selectedCompletionOffsetLabel,
+        },
+      ].sort((left, right) => Number(left.value) - Number(right.value));
+  const storeCloseLabel = formatStoreHoursTimeLabel(
+    currentOrNextWindow?.localEndLabel,
+  );
+  const selectedCompletionTimeLabel = formatMinuteOfDayLabel(
+    selectedCompletionMinute,
+  );
+
+  useEffect(() => {
+    if (policy?.localCompletionWindowMinutes == null || storeCloseMinute === null) {
+      setCompletionOffsetMinutes(0);
+      return;
+    }
+
+    const rawOffset = policy.localCompletionWindowMinutes - storeCloseMinute;
+    const normalizedOffset =
+      rawOffset > 12 * 60
+        ? rawOffset - 24 * 60
+        : rawOffset < -12 * 60
+          ? rawOffset + 24 * 60
+          : rawOffset;
+    setCompletionOffsetMinutes(normalizedOffset);
+  }, [policy?.localCompletionWindowMinutes, storeCloseMinute]);
 
   useEffect(() => {
     if (
@@ -642,9 +810,7 @@ function EodCompletionAutomationAdminPanel({
     try {
       await updateEodAutoCompletePolicy({
         cleanDayAutoCompleteEnabled,
-        localCompletionWindowMinutes:
-          policy?.localCompletionWindowMinutes ??
-          DEFAULT_EOD_LOCAL_COMPLETION_WINDOW_MINUTES,
+        localCompletionWindowMinutes: selectedCompletionMinute,
         maxAbsoluteCashVariance: parsedMaxAbsoluteCashVariance,
         maxVoidedSaleCount: parsedMaxVoidedSaleCount,
         maxVoidedSaleTotal: parsedMaxVoidedSaleTotal,
@@ -696,7 +862,7 @@ function EodCompletionAutomationAdminPanel({
         </div>
 
         <RadioGroup
-          className="grid gap-layout-sm sm:grid-cols-3"
+          className="grid gap-layout-sm sm:grid-cols-[repeat(3,minmax(10rem,18rem))]"
           value={mode}
           onValueChange={(value) =>
             setMode(normalizeAutomationPolicyMode(value as AutomationPolicyMode))
@@ -744,7 +910,39 @@ function EodCompletionAutomationAdminPanel({
         </RadioGroup>
 
         <div className="grid gap-layout-md">
-          <label className="flex min-h-[5rem] items-start gap-layout-sm rounded-md border border-border bg-background p-layout-sm text-sm">
+          <div className="max-w-[18rem] space-y-layout-xs">
+            <Label htmlFor="eod-completion-offset">
+              EOD completion offset
+            </Label>
+            <Select
+              onValueChange={(value) =>
+                setCompletionOffsetMinutes(Number(value))
+              }
+              value={String(completionOffsetMinutes)}
+            >
+              <SelectTrigger
+                aria-label="EOD completion offset"
+                className="h-control-standard bg-background"
+                id="eod-completion-offset"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {completionOffsetOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-sm leading-5 text-muted-foreground">
+              {storeCloseMinute === null
+                ? " Set a close time to derive timing."
+                : `Close ${storeCloseLabel}. Runs ${selectedCompletionTimeLabel}.`}
+            </p>
+          </div>
+
+          <label className="flex min-h-[5rem] w-fit max-w-full justify-self-start items-start gap-layout-sm rounded-md border border-border bg-background p-layout-sm text-sm">
             <Checkbox
               aria-label="Enable blocker-free completion"
               checked={cleanDayAutoCompleteEnabled}
@@ -763,10 +961,11 @@ function EodCompletionAutomationAdminPanel({
               </span>
             </span>
           </label>
+
         </div>
 
-        <div className="grid gap-layout-md sm:grid-cols-3">
-          <div className="space-y-layout-xs">
+        <div className="grid gap-layout-md sm:grid-cols-[repeat(3,minmax(10rem,14rem))]">
+          <div className="space-y-layout-xs min-w-0">
             <Label htmlFor="eod-cash-variance-threshold">
               Cash variance threshold
             </Label>
@@ -780,7 +979,7 @@ function EodCompletionAutomationAdminPanel({
               value={maxAbsoluteCashVariance}
             />
           </div>
-          <div className="space-y-layout-xs">
+          <div className="space-y-layout-xs min-w-0">
             <Label htmlFor="eod-voided-sale-count-threshold">
               Voided sale count threshold
             </Label>
@@ -792,7 +991,7 @@ function EodCompletionAutomationAdminPanel({
               value={maxVoidedSaleCount}
             />
           </div>
-          <div className="space-y-layout-xs">
+          <div className="space-y-layout-xs min-w-0">
             <Label htmlFor="eod-voided-sale-total-threshold">
               Voided sale total threshold
             </Label>
@@ -844,16 +1043,45 @@ function StoreDayAutomationAdminPanel({
     api.operations.dailyOperationsAutomation.getOpeningAutoStartPolicy,
     !isLoading && hasFullAdminAccess && storeId ? { storeId } : "skip",
   ) as StoreDayAutomationPolicy | null | undefined;
+  const scheduleSummary = useQuery(
+    storeScheduleApi.getStoreScheduleSummary,
+    !isLoading && hasFullAdminAccess && storeId ? { storeId } : "skip",
+  ) as StoreScheduleSummary | null | undefined;
   const updateOpeningAutoStartPolicy = useMutation(
     api.operations.dailyOperationsAutomation.updateOpeningAutoStartPolicy,
   ) as unknown as UpdateOpeningAutoStartPolicy;
   const [isEnabled, setIsEnabled] = useState(false);
+  const [startOffsetMinutes, setStartOffsetMinutes] = useState(0);
   const [isSaving, setIsSaving] = useState(false);
   const [message, setMessage] = useState<{
     kind: "error" | "success";
     text: string;
   } | null>(null);
   const policyMode = policy?.mode;
+  const scheduleContext = scheduleSummary?.context;
+  const currentOrNextWindow =
+    scheduleContext?.currentWindow ?? scheduleContext?.nextWindow ?? null;
+  const storeOpeningMinute = parseStoreHoursTimeLabel(
+    currentOrNextWindow?.localStartLabel,
+  );
+  const selectedStartMinute =
+    storeOpeningMinute === null
+      ? (policy?.localStartMinutes ?? DEFAULT_OPENING_LOCAL_START_MINUTES)
+      : normalizeMinuteOfDay(storeOpeningMinute + startOffsetMinutes);
+  const selectedStartOffsetLabel = formatOffsetFromStoreHours(
+    startOffsetMinutes,
+  );
+  const startOffsetOptions = AUTOMATION_START_OFFSET_OPTIONS.some(
+    (option) => Number(option.value) === startOffsetMinutes,
+  )
+    ? AUTOMATION_START_OFFSET_OPTIONS
+    : [
+        ...AUTOMATION_START_OFFSET_OPTIONS,
+        { value: String(startOffsetMinutes), label: selectedStartOffsetLabel },
+      ].sort((left, right) => Number(left.value) - Number(right.value));
+  const storeOpeningLabel =
+    formatStoreHoursTimeLabel(currentOrNextWindow?.localStartLabel);
+  const selectedStartTimeLabel = formatMinuteOfDayLabel(selectedStartMinute);
 
   useEffect(() => {
     if (policyMode == null) {
@@ -862,6 +1090,22 @@ function StoreDayAutomationAdminPanel({
 
     setIsEnabled(policyMode === "enabled");
   }, [policyMode]);
+
+  useEffect(() => {
+    if (policy?.localStartMinutes == null || storeOpeningMinute === null) {
+      setStartOffsetMinutes(0);
+      return;
+    }
+
+    const rawOffset = policy.localStartMinutes - storeOpeningMinute;
+    const normalizedOffset =
+      rawOffset > 12 * 60
+        ? rawOffset - 24 * 60
+        : rawOffset < -12 * 60
+          ? rawOffset + 24 * 60
+          : rawOffset;
+    setStartOffsetMinutes(normalizedOffset);
+  }, [policy?.localStartMinutes, storeOpeningMinute]);
 
   if (isLoading || !hasFullAdminAccess) {
     return null;
@@ -882,8 +1126,7 @@ function StoreDayAutomationAdminPanel({
     setMessage(null);
     try {
       await updateOpeningAutoStartPolicy({
-        localStartMinutes:
-          policy?.localStartMinutes ?? DEFAULT_OPENING_LOCAL_START_MINUTES,
+        localStartMinutes: selectedStartMinute,
         mode: isEnabled ? "enabled" : "disabled",
         openingBlockerHandling: "start_with_manager_review",
         operatingTimezoneOffsetMinutes:
@@ -930,7 +1173,7 @@ function StoreDayAutomationAdminPanel({
         </div>
 
         <div className="grid gap-layout-md">
-          <label className="flex min-h-[5rem] items-start gap-layout-sm rounded-md border border-border bg-background p-layout-sm text-sm">
+          <label className="flex min-h-[5rem] w-fit max-w-full justify-self-start items-start gap-layout-sm rounded-md border border-border bg-background p-layout-sm text-sm">
             <Checkbox
               aria-label="Enable store-day auto-start"
               checked={isEnabled}
@@ -942,11 +1185,39 @@ function StoreDayAutomationAdminPanel({
                 Enable store-day auto-start
               </span>
               <span className="mt-1 block leading-5 text-muted-foreground">
-                Athena starts Opening Handoff from Store Hours timing. Review
-                items are not resolved by automation.
+                {storeOpeningMinute === null
+                  ? " Set an opening time to derive timing."
+                  : `Opening ${storeOpeningLabel}. Runs ${selectedStartTimeLabel}.`}
               </span>
             </span>
           </label>
+
+          <div className="max-w-[18rem] space-y-layout-xs">
+            <div className="space-y-layout-xs">
+              <Label htmlFor="store-day-auto-start-offset">
+                Auto-start offset
+              </Label>
+              <Select
+                onValueChange={(value) => setStartOffsetMinutes(Number(value))}
+                value={String(startOffsetMinutes)}
+              >
+                <SelectTrigger
+                  aria-label="Store day auto-start offset"
+                  className="h-control-standard bg-background"
+                  id="store-day-auto-start-offset"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {startOffsetOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
         </div>
 
         {message ? (
@@ -1099,7 +1370,7 @@ function POSRecoveryCodeAdminPanel({
 
         {currentRecoveryCode ? (
           <div
-            className="rounded-md border border-signal/30 bg-signal/10 px-layout-md py-layout-sm"
+            className="w-fit max-w-full rounded-md border border-signal/30 bg-signal/10 px-layout-md py-layout-sm"
             role="status"
           >
             <p className="text-sm font-medium text-foreground">

--- a/packages/athena-webapp/src/components/store-configuration/components/StoreHoursView.test.tsx
+++ b/packages/athena-webapp/src/components/store-configuration/components/StoreHoursView.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useQuery } from "convex/react";
 
 import { StoreHoursView } from "./StoreHoursView";
@@ -85,6 +85,10 @@ describe("StoreHoursView", () => {
     mockUpdateSchedule.mockResolvedValue(undefined);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("shows candidate store hours and requires full-admin confirmation before saving", async () => {
     const user = userEvent.setup();
 
@@ -97,16 +101,16 @@ describe("StoreHoursView", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("Needs admin review")).toBeInTheDocument();
-    expect(screen.getByText("Open today, 9:00 AM to 5:00 PM")).toBeInTheDocument();
-    expect(screen.getByLabelText("Store timezone")).toHaveValue(
-      "America/New_York",
-    );
+    expect(screen.getByRole("combobox", { name: "Store timezone" }))
+      .toHaveTextContent("America/New_York");
     expect(screen.getByRole("button", { name: "Save store hours" }))
       .toBeDisabled();
 
     await user.click(screen.getByLabelText("Confirm suggested store hours"));
-    await user.clear(screen.getByLabelText("Monday close time"));
-    await user.type(screen.getByLabelText("Monday close time"), "18:30");
+    await user.click(screen.getByRole("combobox", { name: "Store timezone" }));
+    await user.click(await screen.findByRole("option", { name: "Africa/Accra" }));
+    await user.click(screen.getByRole("combobox", { name: "Monday close time" }));
+    await user.click(await screen.findByRole("option", { name: "06:30 PM" }));
     await user.click(screen.getByRole("button", { name: "Save store hours" }));
 
     await waitFor(() =>
@@ -121,7 +125,7 @@ describe("StoreHoursView", () => {
                 note: "Holiday",
               }),
             ]),
-            timezone: "America/New_York",
+            timezone: "Africa/Accra",
             weeklyClosedDays: expect.arrayContaining([0]),
             weeklyWindows: expect.arrayContaining([
               expect.objectContaining({
@@ -183,32 +187,115 @@ describe("StoreHoursView", () => {
     );
   });
 
-  it("associates validation copy with inputs and announces errors", async () => {
+  it("renders store timezone as a selectable combobox", async () => {
     const user = userEvent.setup();
 
     render(<StoreHoursView />);
 
-    await user.click(screen.getByLabelText("Confirm suggested store hours"));
-    await user.clear(screen.getByLabelText("Store timezone"));
-    await user.click(screen.getByRole("button", { name: "Save store hours" }));
+    const timezoneSelect = screen.getByRole("combobox", {
+      name: "Store timezone",
+    });
+    expect(timezoneSelect).toHaveTextContent("America/New_York");
 
-    const alert = await screen.findByRole("alert");
-    expect(alert).toHaveTextContent("Choose a valid store timezone.");
-    expect(screen.getByLabelText("Store timezone")).toHaveAttribute(
-      "aria-describedby",
-      "store-hours-message",
+    await user.click(timezoneSelect);
+
+    expect(
+      await screen.findByRole("option", { name: "Africa/Accra" }),
+    ).toBeInTheDocument();
+  });
+
+  it("formats raw 24-hour summary times for display", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-28T12:00:00.000Z"));
+    mockedUseQuery.mockReturnValue({
+      ...candidateSchedule,
+      nextCloseLabel: "19:00",
+      nextOpenLabel: "09:00",
+      todayScheduleLabel: "Next open 09:00.",
+      timezone: "Africa/Accra",
+      weeklyHours: [
+        {
+          closed: false,
+          day: "monday",
+          windows: [{ openTime: "09:00", closeTime: "19:00" }],
+        },
+        {
+          closed: true,
+          day: "sunday",
+          windows: [],
+        },
+      ],
+    } as never);
+
+    render(<StoreHoursView />);
+
+    const summary = screen.getByText("Today").closest("dl");
+    expect(summary).not.toBeNull();
+    expect(within(summary!).getByText("Closed today.")).toBeInTheDocument();
+    expect(within(summary!).getByText("Monday 09:00 AM")).toBeInTheDocument();
+    expect(within(summary!).getByText("Monday 07:00 PM")).toBeInTheDocument();
+    expect(summary).toHaveTextContent(
+      "TodayClosed today.Next openMonday 09:00 AMNext closeMonday 07:00 PM",
     );
-    expect(mockUpdateSchedule).not.toHaveBeenCalled();
+  });
+
+  it("orders the summary around the active store window", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-29T12:00:00.000Z"));
+    mockedUseQuery.mockReturnValue({
+      ...candidateSchedule,
+      nextCloseLabel: "19:00",
+      nextOpenLabel: "09:00",
+      timezone: "Africa/Accra",
+      weeklyHours: [
+        {
+          closed: false,
+          day: "monday",
+          windows: [{ openTime: "09:00", closeTime: "19:00" }],
+        },
+        {
+          closed: false,
+          day: "tuesday",
+          windows: [{ openTime: "09:00", closeTime: "19:00" }],
+        },
+      ],
+    } as never);
+
+    render(<StoreHoursView />);
+
+    const summary = screen.getByText("Today").closest("dl");
+    expect(summary).not.toBeNull();
+    expect(within(summary!).getByText("Opened 09:00 AM.")).toBeInTheDocument();
+    expect(within(summary!).getByText("Monday 07:00 PM")).toBeInTheDocument();
+    expect(within(summary!).getByText("Tuesday 09:00 AM")).toBeInTheDocument();
+    expect(summary).toHaveTextContent(
+      "TodayOpened 09:00 AM.Next closeMonday 07:00 PMNext openTuesday 09:00 AM",
+    );
   });
 
   it("validates overlapping date exceptions before saving", async () => {
     const user = userEvent.setup();
+    mockedUseQuery.mockReturnValue({
+      ...candidateSchedule,
+      exceptions: [
+        {
+          closed: true,
+          date: "2026-07-04",
+          label: "Holiday",
+          windows: [],
+        },
+        {
+          closed: true,
+          date: "2026-07-04",
+          label: "Special closure",
+          windows: [],
+        },
+      ],
+    } as never);
 
     render(<StoreHoursView />);
 
     await user.click(screen.getByLabelText("Confirm suggested store hours"));
-    await user.click(screen.getByRole("button", { name: "Add exception" }));
-    await user.type(screen.getByLabelText("Exception 2 date"), "2026-07-04");
     await user.click(screen.getByRole("button", { name: "Save store hours" }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent(

--- a/packages/athena-webapp/src/components/store-configuration/components/StoreHoursView.test.tsx
+++ b/packages/athena-webapp/src/components/store-configuration/components/StoreHoursView.test.tsx
@@ -89,56 +89,66 @@ describe("StoreHoursView", () => {
     vi.useRealTimers();
   });
 
-  it("shows candidate store hours and requires full-admin confirmation before saving", async () => {
-    const user = userEvent.setup();
+  it(
+    "shows candidate store hours and requires full-admin confirmation before saving",
+    async () => {
+      const user = userEvent.setup();
 
-    render(<StoreHoursView />);
+      render(<StoreHoursView />);
 
-    expect(screen.getByText("Store Hours")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Review these suggested hours before Athena uses them as the store schedule.",
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Needs admin review")).toBeInTheDocument();
-    expect(screen.getByRole("combobox", { name: "Store timezone" }))
-      .toHaveTextContent("America/New_York");
-    expect(screen.getByRole("button", { name: "Save store hours" }))
-      .toBeDisabled();
+      expect(screen.getByText("Store Hours")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Review these suggested hours before Athena uses them as the store schedule.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Needs admin review")).toBeInTheDocument();
+      expect(screen.getByRole("combobox", { name: "Store timezone" }))
+        .toHaveTextContent("America/New_York");
+      expect(screen.getByRole("button", { name: "Save store hours" }))
+        .toBeDisabled();
 
-    await user.click(screen.getByLabelText("Confirm suggested store hours"));
-    await user.click(screen.getByRole("combobox", { name: "Store timezone" }));
-    await user.click(await screen.findByRole("option", { name: "Africa/Accra" }));
-    await user.click(screen.getByRole("combobox", { name: "Monday close time" }));
-    await user.click(await screen.findByRole("option", { name: "06:30 PM" }));
-    await user.click(screen.getByRole("button", { name: "Save store hours" }));
+      await user.click(screen.getByLabelText("Confirm suggested store hours"));
+      await user.click(
+        screen.getByRole("combobox", { name: "Store timezone" }),
+      );
+      await user.click(
+        await screen.findByRole("option", { name: "Africa/Accra" }),
+      );
+      await user.click(
+        screen.getByRole("combobox", { name: "Monday close time" }),
+      );
+      await user.click(await screen.findByRole("option", { name: "06:30 PM" }));
+      await user.click(screen.getByRole("button", { name: "Save store hours" }));
 
-    await waitFor(() =>
-      expect(mockUpdateSchedule).toHaveBeenCalledWith(
-        expect.objectContaining({
-          storeId: "store-1",
-          schedule: expect.objectContaining({
-            dateExceptions: expect.arrayContaining([
-              expect.objectContaining({
-                closed: true,
-                localDate: "2026-07-04",
-                note: "Holiday",
-              }),
-            ]),
-            timezone: "Africa/Accra",
-            weeklyClosedDays: expect.arrayContaining([0]),
-            weeklyWindows: expect.arrayContaining([
-              expect.objectContaining({
-                dayOfWeek: 1,
-                endMinute: 18 * 60 + 30,
-                startMinute: 9 * 60,
-              }),
-            ]),
+      await waitFor(() =>
+        expect(mockUpdateSchedule).toHaveBeenCalledWith(
+          expect.objectContaining({
+            storeId: "store-1",
+            schedule: expect.objectContaining({
+              dateExceptions: expect.arrayContaining([
+                expect.objectContaining({
+                  closed: true,
+                  localDate: "2026-07-04",
+                  note: "Holiday",
+                }),
+              ]),
+              timezone: "Africa/Accra",
+              weeklyClosedDays: expect.arrayContaining([0]),
+              weeklyWindows: expect.arrayContaining([
+                expect.objectContaining({
+                  dayOfWeek: 1,
+                  endMinute: 18 * 60 + 30,
+                  startMinute: 9 * 60,
+                }),
+              ]),
+            }),
           }),
-        }),
-      ),
-    );
-  });
+        ),
+      );
+    },
+    15_000,
+  );
 
   it("keeps non-full-admin accounts in a read-only summary state", () => {
     mockHasFullAdminAccess = false;

--- a/packages/athena-webapp/src/components/store-configuration/components/StoreHoursView.tsx
+++ b/packages/athena-webapp/src/components/store-configuration/components/StoreHoursView.tsx
@@ -1,13 +1,23 @@
 import { useEffect, useMemo, useState } from "react";
-import { CalendarClock, Plus, Trash2 } from "lucide-react";
+import { CalendarClock, CalendarIcon, Plus, Trash2 } from "lucide-react";
 import { useQuery } from "convex/react";
 import type { FunctionReference } from "convex/server";
 
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { LoadingButton } from "@/components/ui/loading-button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
 import { usePermissions } from "@/hooks/usePermissions";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
 import { api } from "~/convex/_generated/api";
@@ -109,6 +119,13 @@ const DAY_OF_WEEK_BY_KEY: Record<StoreScheduleDayKey, number> = {
   saturday: 6,
 };
 
+const DAY_KEY_BY_DAY_OF_WEEK = Object.fromEntries(
+  Object.entries(DAY_OF_WEEK_BY_KEY).map(([day, dayOfWeek]) => [
+    dayOfWeek,
+    day,
+  ]),
+) as Record<number, StoreScheduleDayKey>;
+
 const DEFAULT_WEEKLY_HOURS: StoreScheduleWeeklyDayInput[] = WEEKDAYS.map(
   ({ day }) => ({
     closed: day === "sunday",
@@ -117,6 +134,37 @@ const DEFAULT_WEEKLY_HOURS: StoreScheduleWeeklyDayInput[] = WEEKDAYS.map(
       day === "sunday" ? [] : [{ openTime: "09:00", closeTime: "17:00" }],
   }),
 );
+
+const TIME_OPTIONS = Array.from({ length: 24 * 4 }, (_entry, index) => {
+  const totalMinutes = index * 15;
+  return minuteToTimeInput(totalMinutes);
+});
+
+const TIMEZONE_OPTIONS = [
+  "Africa/Abidjan",
+  "Africa/Accra",
+  "Africa/Cairo",
+  "Africa/Casablanca",
+  "Africa/Johannesburg",
+  "Africa/Lagos",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/New_York",
+  "America/Phoenix",
+  "America/Toronto",
+  "America/Vancouver",
+  "Asia/Dubai",
+  "Asia/Hong_Kong",
+  "Asia/Singapore",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+  "Europe/Amsterdam",
+  "Europe/Berlin",
+  "Europe/London",
+  "Europe/Paris",
+  "UTC",
+];
 
 function normalizeWeeklyHours(
   weeklyHours?: StoreScheduleWeeklyDayInput[] | null,
@@ -199,6 +247,303 @@ function minuteToTimeInput(minute: number) {
   const hour = Math.floor(normalized / 60);
   const minuteOfHour = normalized % 60;
   return `${String(hour).padStart(2, "0")}:${String(minuteOfHour).padStart(2, "0")}`;
+}
+
+function formatTimeLabel(value: string) {
+  const minute = timeInputToMinute(value);
+  if (minute === null) {
+    return value;
+  }
+
+  const hour = Math.floor(minute / 60);
+  const minuteOfHour = minute % 60;
+  const period = hour >= 12 ? "PM" : "AM";
+  const displayHour = hour % 12 || 12;
+
+  return `${String(displayHour).padStart(2, "0")}:${String(minuteOfHour).padStart(2, "0")} ${period}`;
+}
+
+function formatScheduleSummaryLabel(value: string) {
+  return value.replace(/\b([01]\d|2[0-3]):([0-5]\d)\b/g, (time) =>
+    formatTimeLabel(time),
+  );
+}
+
+function getStoreLocalNowParts(timezone: string) {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      hour: "2-digit",
+      hourCycle: "h23",
+      minute: "2-digit",
+      timeZone: timezone,
+      weekday: "long",
+    }).formatToParts(new Date());
+    const partByType = Object.fromEntries(
+      parts.map((part) => [part.type, part.value]),
+    );
+    const dayOfWeek = WEEKDAYS.find(
+      (entry) => entry.label === partByType.weekday,
+    );
+
+    if (!dayOfWeek) {
+      return null;
+    }
+
+    return {
+      dayOfWeek: DAY_OF_WEEK_BY_KEY[dayOfWeek.day],
+      minute: Number(partByType.hour) * 60 + Number(partByType.minute),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function getNextWindowDayLabel(args: {
+  timezone: string;
+  time: string;
+  type: "close" | "open";
+  weeklyHours: StoreScheduleWeeklyDayInput[];
+}) {
+  const nextWindowMinute = timeInputToMinute(args.time);
+  const localNow = getStoreLocalNowParts(args.timezone);
+  if (nextWindowMinute === null || !localNow) {
+    return null;
+  }
+
+  for (let offset = 0; offset < 7; offset += 1) {
+    const dayOfWeek = (localNow.dayOfWeek + offset) % 7;
+    const day = DAY_KEY_BY_DAY_OF_WEEK[dayOfWeek];
+    const daySchedule = args.weeklyHours.find((entry) => entry.day === day);
+    if (!daySchedule || daySchedule.closed) {
+      continue;
+    }
+
+    const hasMatchingNextOpen = daySchedule.windows.some((window) => {
+      const windowMinute = timeInputToMinute(
+        args.type === "open" ? window.openTime : window.closeTime,
+      );
+      return (
+        windowMinute === nextWindowMinute &&
+        (offset > 0 || windowMinute > localNow.minute)
+      );
+    });
+    if (hasMatchingNextOpen) {
+      return getDayLabel(day);
+    }
+  }
+
+  return null;
+}
+
+function getCurrentOpenWindow(args: {
+  timezone: string;
+  weeklyHours: StoreScheduleWeeklyDayInput[];
+}) {
+  const localNow = getStoreLocalNowParts(args.timezone);
+  if (!localNow) {
+    return null;
+  }
+
+  const localDay = DAY_KEY_BY_DAY_OF_WEEK[localNow.dayOfWeek];
+  const daySchedule = args.weeklyHours.find((entry) => entry.day === localDay);
+  if (!daySchedule || daySchedule.closed) {
+    return null;
+  }
+
+  return (
+    daySchedule.windows.find((window) => {
+      const openMinute = timeInputToMinute(window.openTime);
+      const closeMinute = timeInputToMinute(window.closeTime);
+      return (
+        openMinute !== null &&
+        closeMinute !== null &&
+        localNow.minute >= openMinute &&
+        localNow.minute < closeMinute
+      );
+    }) ?? null
+  );
+}
+
+function formatNextCloseSummaryLabel(args: {
+  timezone: string;
+  value: string;
+  weeklyHours: StoreScheduleWeeklyDayInput[];
+}) {
+  const trimmedValue = args.value.trim();
+  const dayLabel = trimmedValue.match(/^([01]\d|2[0-3]):([0-5]\d)$/)
+    ? getNextWindowDayLabel({
+        timezone: args.timezone,
+        time: trimmedValue,
+        type: "close",
+        weeklyHours: args.weeklyHours,
+      })
+    : null;
+  const formattedValue = formatScheduleSummaryLabel(args.value);
+
+  return dayLabel ? `${dayLabel} ${formattedValue}` : formattedValue;
+}
+
+function formatNextOpenSummaryLabel(args: {
+  timezone: string;
+  value: string;
+  weeklyHours: StoreScheduleWeeklyDayInput[];
+}) {
+  const trimmedValue = args.value.trim();
+  const dayLabel = trimmedValue.match(/^([01]\d|2[0-3]):([0-5]\d)$/)
+    ? getNextWindowDayLabel({
+        timezone: args.timezone,
+        time: trimmedValue,
+        type: "open",
+        weeklyHours: args.weeklyHours,
+      })
+    : null;
+  const formattedValue = formatScheduleSummaryLabel(args.value);
+
+  return dayLabel ? `${dayLabel} ${formattedValue}` : formattedValue;
+}
+
+function dateInputToCalendarDate(value: string) {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) {
+    return undefined;
+  }
+
+  return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+}
+
+function calendarDateToDateInput(date: Date) {
+  return `${String(date.getFullYear()).padStart(4, "0")}-${String(
+    date.getMonth() + 1,
+  ).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+function formatDateLabel(value: string) {
+  const date = dateInputToCalendarDate(value);
+  if (!date) {
+    return "Pick a date";
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(date);
+}
+
+function StoreHoursTimeSelect({
+  id,
+  label,
+  onChange,
+  value,
+}: {
+  id: string;
+  label: string;
+  onChange: (value: string) => void;
+  value: string;
+}) {
+  const options = TIME_OPTIONS.includes(value)
+    ? TIME_OPTIONS
+    : [...TIME_OPTIONS, value].sort((first, second) => {
+        const firstMinute = timeInputToMinute(first) ?? Number.MAX_SAFE_INTEGER;
+        const secondMinute = timeInputToMinute(second) ?? Number.MAX_SAFE_INTEGER;
+        return firstMinute - secondMinute;
+      });
+
+  return (
+    <Select onValueChange={onChange} value={value}>
+      <SelectTrigger
+        aria-label={label}
+        className="h-control-standard bg-background"
+        id={id}
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem key={option} value={option}>
+            {formatTimeLabel(option)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function StoreHoursTimezoneSelect({
+  describedBy,
+  onChange,
+  value,
+}: {
+  describedBy?: string;
+  onChange: (value: string) => void;
+  value: string;
+}) {
+  const options = TIMEZONE_OPTIONS.includes(value)
+    ? TIMEZONE_OPTIONS
+    : [...TIMEZONE_OPTIONS, value].sort();
+
+  return (
+    <Select onValueChange={onChange} value={value}>
+      <SelectTrigger
+        aria-describedby={describedBy}
+        aria-label="Store timezone"
+        className="h-control-standard bg-background"
+        id="store-hours-timezone"
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem key={option} value={option}>
+            {option}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function StoreHoursDatePicker({
+  id,
+  label,
+  onChange,
+  value,
+}: {
+  id: string;
+  label: string;
+  onChange: (value: string) => void;
+  value: string;
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          aria-label={label}
+          className={cn(
+            "h-control-standard w-full justify-start bg-background text-left font-normal",
+            !value && "text-muted-foreground",
+          )}
+          id={id}
+          type="button"
+          variant="outline"
+        >
+          <CalendarIcon className="mr-2 h-4 w-4" />
+          {formatDateLabel(value)}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-auto p-0">
+        <Calendar
+          mode="single"
+          onSelect={(date) => {
+            if (date) {
+              onChange(calendarDateToDateInput(date));
+            }
+          }}
+          selected={dateInputToCalendarDate(value)}
+        />
+      </PopoverContent>
+    </Popover>
+  );
 }
 
 function normalizeScheduleForForm(schedule?: StoreScheduleQueryResult | null) {
@@ -384,34 +729,58 @@ export const StoreHoursView = () => {
 
   const candidateSchedule = isCandidateSchedule(schedule);
   const statusLabel = candidateSchedule ? "Needs admin review" : "Admin confirmed";
-  const summary = useMemo(
-    () => ({
-      nextClose:
-        schedule?.summary?.nextCloseLabel ??
-        schedule?.nextCloseLabel ??
-        "Next close not available",
-      nextOpen:
-        schedule?.summary?.nextOpenLabel ??
-        schedule?.nextOpenLabel ??
-        "Next open not available",
-      timezone:
-        schedule?.summary?.timezoneLabel ??
-        schedule?.timezone ??
-        timezone,
-      today:
-        schedule?.summary?.todayScheduleLabel ??
-        schedule?.todayScheduleLabel ??
-        "Today follows the weekly store hours.",
-    }),
-    [schedule, timezone],
-  );
+  const summary = useMemo(() => {
+    const summaryTimezone =
+      schedule?.summary?.timezoneLabel ?? schedule?.timezone ?? timezone;
+    const summaryWeeklyHours = normalizeWeeklyHours(schedule?.weeklyHours);
+    const activeWindow = getCurrentOpenWindow({
+      timezone: summaryTimezone,
+      weeklyHours: summaryWeeklyHours,
+    });
+    const nextOpenLabel =
+      schedule?.summary?.nextOpenLabel ??
+      schedule?.nextOpenLabel ??
+      "Next open not available";
+    const nextCloseLabel =
+      schedule?.summary?.nextCloseLabel ??
+      schedule?.nextCloseLabel ??
+      "Next close not available";
+    const today = activeWindow
+      ? `Opened ${formatTimeLabel(activeWindow.openTime)}.`
+      : "Closed today.";
+    const nextClose = formatNextCloseSummaryLabel({
+      timezone: summaryTimezone,
+      value: nextCloseLabel,
+      weeklyHours: summaryWeeklyHours,
+    });
+    const nextOpen = formatNextOpenSummaryLabel({
+      timezone: summaryTimezone,
+      value: nextOpenLabel,
+      weeklyHours: summaryWeeklyHours,
+    });
+
+    return {
+      items: activeWindow
+        ? [
+            { label: "Today", value: today },
+            { label: "Next close", value: nextClose },
+            { label: "Next open", value: nextOpen },
+          ]
+        : [
+            { label: "Today", value: today },
+            { label: "Next open", value: nextOpen },
+            { label: "Next close", value: nextClose },
+          ],
+      timezone: summaryTimezone,
+    };
+  }, [schedule, timezone]);
 
   useEffect(() => {
     if (schedule === undefined) {
       return;
     }
 
-    setTimezone(schedule?.timezone ?? "America/New_York");
+    setTimezone(schedule?.timezone || "America/New_York");
     setWeeklyHours(normalizeWeeklyHours(schedule?.weeklyHours));
     setExceptions((schedule?.exceptions ?? []).map(normalizeException));
     setConfirmCandidate(false);
@@ -462,7 +831,7 @@ export const StoreHoursView = () => {
   };
 
   const resetForm = () => {
-    setTimezone(schedule?.timezone ?? "America/New_York");
+    setTimezone(schedule?.timezone || "America/New_York");
     setWeeklyHours(normalizeWeeklyHours(schedule?.weeklyHours));
     setExceptions((schedule?.exceptions ?? []).map(normalizeException));
     setConfirmCandidate(false);
@@ -569,24 +938,14 @@ export const StoreHoursView = () => {
         </div>
 
         <dl className="grid gap-layout-sm text-sm sm:grid-cols-3">
-          <div>
-            <dt className="font-medium text-foreground">Today</dt>
-            <dd className="mt-layout-2xs text-muted-foreground">
-              {summary.today}
-            </dd>
-          </div>
-          <div>
-            <dt className="font-medium text-foreground">Next close</dt>
-            <dd className="mt-layout-2xs text-muted-foreground">
-              {summary.nextClose}
-            </dd>
-          </div>
-          <div>
-            <dt className="font-medium text-foreground">Next open</dt>
-            <dd className="mt-layout-2xs text-muted-foreground">
-              {summary.nextOpen}
-            </dd>
-          </div>
+          {summary.items.map((item) => (
+            <div key={item.label}>
+              <dt className="font-medium text-foreground">{item.label}</dt>
+              <dd className="mt-layout-2xs text-muted-foreground">
+                {item.value}
+              </dd>
+            </div>
+          ))}
         </dl>
 
         {candidateSchedule ? (
@@ -604,19 +963,18 @@ export const StoreHoursView = () => {
           <>
             <div className="space-y-layout-xs">
               <Label htmlFor="store-hours-timezone">Store timezone</Label>
-              <Input
-                aria-describedby={message?.kind === "error" ? "store-hours-message" : undefined}
-                className="h-control-standard bg-background"
-                id="store-hours-timezone"
-                onChange={(event) => {
-                  setTimezone(event.target.value);
+              <StoreHoursTimezoneSelect
+                describedBy={
+                  message?.kind === "error" ? "store-hours-message" : undefined
+                }
+                onChange={(value) => {
+                  setTimezone(value);
                   setIsDirty(true);
                 }}
-                placeholder="America/New_York"
                 value={timezone}
               />
               <p className="text-xs text-muted-foreground">
-                Use an IANA timezone such as America/New_York.
+                Choose the store-local IANA timezone.
               </p>
             </div>
 
@@ -675,21 +1033,20 @@ export const StoreHoursView = () => {
                             <Label htmlFor={`${entry.day}-open`}>
                               {dayLabel} open time
                             </Label>
-                            <Input
-                              className="h-control-standard bg-background"
+                            <StoreHoursTimeSelect
                               id={`${entry.day}-open`}
-                              onChange={(event) =>
+                              label={`${dayLabel} open time`}
+                              onChange={(value) =>
                                 updateDay(entry.day, (current) => ({
                                   ...current,
                                   windows: [
                                     {
                                       ...window,
-                                      openTime: event.target.value,
+                                      openTime: value,
                                     },
                                   ],
                                 }))
                               }
-                              type="time"
                               value={window.openTime}
                             />
                           </div>
@@ -697,21 +1054,20 @@ export const StoreHoursView = () => {
                             <Label htmlFor={`${entry.day}-close`}>
                               {dayLabel} close time
                             </Label>
-                            <Input
-                              className="h-control-standard bg-background"
+                            <StoreHoursTimeSelect
                               id={`${entry.day}-close`}
-                              onChange={(event) =>
+                              label={`${dayLabel} close time`}
+                              onChange={(value) =>
                                 updateDay(entry.day, (current) => ({
                                   ...current,
                                   windows: [
                                     {
                                       ...window,
-                                      closeTime: event.target.value,
+                                      closeTime: value,
                                     },
                                   ],
                                 }))
                               }
-                              type="time"
                               value={window.closeTime}
                             />
                           </div>
@@ -757,16 +1113,15 @@ export const StoreHoursView = () => {
                           <Label htmlFor={`exception-${index}-date`}>
                             {label} date
                           </Label>
-                          <Input
-                            className="h-control-standard bg-background"
+                          <StoreHoursDatePicker
                             id={`exception-${index}-date`}
-                            onChange={(event) =>
+                            label={`${label} date`}
+                            onChange={(value) =>
                               updateException(index, (current) => ({
                                 ...current,
-                                date: event.target.value,
+                                date: value,
                               }))
                             }
-                            type="date"
                             value={exception.date}
                           />
                         </div>
@@ -826,21 +1181,20 @@ export const StoreHoursView = () => {
                               <Label htmlFor={`exception-${index}-open`}>
                                 {label} open time
                               </Label>
-                              <Input
-                                className="h-control-standard bg-background"
+                              <StoreHoursTimeSelect
                                 id={`exception-${index}-open`}
-                                onChange={(event) =>
+                                label={`${label} open time`}
+                                onChange={(value) =>
                                   updateException(index, (current) => ({
                                     ...current,
                                     windows: [
                                       {
                                         ...window,
-                                        openTime: event.target.value,
+                                        openTime: value,
                                       },
                                     ],
                                   }))
                                 }
-                                type="time"
                                 value={window.openTime}
                               />
                             </div>
@@ -848,21 +1202,20 @@ export const StoreHoursView = () => {
                               <Label htmlFor={`exception-${index}-close`}>
                                 {label} close time
                               </Label>
-                              <Input
-                                className="h-control-standard bg-background"
+                              <StoreHoursTimeSelect
                                 id={`exception-${index}-close`}
-                                onChange={(event) =>
+                                label={`${label} close time`}
+                                onChange={(value) =>
                                   updateException(index, (current) => ({
                                     ...current,
                                     windows: [
                                       {
                                         ...window,
-                                        closeTime: event.target.value,
+                                        closeTime: value,
                                       },
                                     ],
                                   }))
                                 }
-                                type="time"
                                 value={window.closeTime}
                               />
                             </div>

--- a/packages/athena-webapp/src/routes/-authed-layout.tsx
+++ b/packages/athena-webapp/src/routes/-authed-layout.tsx
@@ -1,10 +1,6 @@
 import { OrganizationModal } from "@/components/ui/modals/organization-modal";
 import { StoreModal } from "@/components/ui/modals/store-modal";
-import {
-  Outlet,
-  useNavigate,
-  useRouterState,
-} from "@tanstack/react-router";
+import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 import {
   type Dispatch,
   type CSSProperties,
@@ -24,12 +20,20 @@ import { AppSidebar } from "../components/app-sidebar";
 import { useAuth } from "../hooks/useAuth";
 import { usePermissions } from "../hooks/usePermissions";
 import { PermissionsProvider } from "../contexts/PermissionsContext";
-import { Monitor, Moon, ShieldCheck, Sun, UserCircle } from "lucide-react";
+import {
+  ArrowUpRight,
+  Monitor,
+  Moon,
+  ShieldCheck,
+  Sun,
+  UserCircle,
+} from "lucide-react";
 import { AppHeader } from "@/components/Navbar";
 import { cn } from "@/lib/utils";
 import { useAuthActions } from "@convex-dev/auth/react";
 import { LOGGED_IN_USER_ID_KEY, POS_APP_ACCOUNT_ID_KEY } from "@/lib/constants";
 import { Badge } from "@/components/ui/badge";
+import { buttonVariants } from "@/components/ui/button";
 import {
   ManagerElevationProvider,
   useManagerElevation,
@@ -61,7 +65,6 @@ import {
 } from "@/lib/pos/infrastructure/terminal/posTerminalAppSessionRecoveryContext";
 import type { PosTerminalRuntimeAppSessionRecoveryInput } from "@/lib/pos/infrastructure/local/terminalRuntimeStatus";
 import { type AthenaThemeMode, useAthenaTheme } from "@/lib/theme";
-
 
 const POS_TERMINAL_FULLSCREEN_PATH_PATTERN =
   /^\/(?<orgUrlSlug>[^/]+)\/store\/(?<storeUrlSlug>[^/]+)\/pos\/(?:register|expense)\/?$/;
@@ -133,6 +136,15 @@ function getRedirectPathWithSearch(
   return browserPathWithSearch;
 }
 
+function getLoginHref(redirectTo: string) {
+  if (!redirectTo) {
+    return "/login";
+  }
+
+  const params = new URLSearchParams({ redirectTo });
+  return `/login?${params.toString()}`;
+}
+
 function isUnknownRouterPath(pathname?: string) {
   return !pathname || pathname === "/";
 }
@@ -178,6 +190,9 @@ function getBlockedPosTerminalShellCopy({
       title: "POS terminal recovery unavailable",
       message:
         "This checkout station cannot reopen the register. Sign in again or reconnect this register from POS Settings before using checkout.",
+      action: {
+        label: "Sign in to POS",
+      },
     };
   }
 
@@ -227,6 +242,9 @@ function PosTerminalBlockedShell({
     entryContext,
     recoveryReason,
   });
+  const actionHref = copy.action
+    ? getLoginHref(getBrowserPathWithSearch())
+    : null;
 
   return (
     <section className="flex h-full min-h-0 items-center justify-center bg-background p-6">
@@ -240,6 +258,15 @@ function PosTerminalBlockedShell({
         <p className="mt-4 text-base leading-7 text-muted-foreground">
           {copy.message}
         </p>
+        {actionHref && copy.action ? (
+          <a
+            className={cn(buttonVariants({ variant: "workflow" }), "mt-6")}
+            href={actionHref}
+          >
+            <span>{copy.action.label}</span>
+            <ArrowUpRight aria-hidden="true" className="h-4 w-4" />
+          </a>
+        ) : null}
       </div>
     </section>
   );
@@ -366,7 +393,9 @@ function UserMenu({ userEmail }: { userEmail: string }) {
         <DropdownMenuLabel className="flex flex-col gap-1">
           <span>Appearance</span>
           <span className="text-xs font-normal text-muted-foreground">
-            {resolvedTheme === "dark" ? "Dark mode active" : "Light mode active"}
+            {resolvedTheme === "dark"
+              ? "Dark mode active"
+              : "Light mode active"}
           </span>
         </DropdownMenuLabel>
         <DropdownMenuRadioGroup

--- a/packages/athena-webapp/src/routes/_authed.test.tsx
+++ b/packages/athena-webapp/src/routes/_authed.test.tsx
@@ -987,6 +987,11 @@ describe("Authed layout", () => {
     mocked.useRouterState.mockImplementation(({ select }) =>
       select({ location: { pathname: "/wigclub/store/wigclub/pos/register" } }),
     );
+    window.history.replaceState(
+      {},
+      "",
+      "/wigclub/store/wigclub/pos/register?drawer=front",
+    );
 
     render(<Layout />);
 
@@ -1000,6 +1005,12 @@ describe("Authed layout", () => {
         "This checkout station cannot reopen the register. Sign in again or reconnect this register from POS Settings before using checkout.",
       ),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Sign in to POS" }),
+    ).toHaveAttribute(
+      "href",
+      "/login?redirectTo=%2Fwigclub%2Fstore%2Fwigclub%2Fpos%2Fregister%3Fdrawer%3Dfront",
+    );
     expect(screen.queryByText(/terminal_revoked/)).not.toBeInTheDocument();
     expect(screen.queryByTestId("app-sidebar")).not.toBeInTheDocument();
     expect(screen.queryByTestId("app-header")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

POS and Store Hours settings now present schedule policy as operator-ready context instead of raw values. Store Hours uses the shared select and calendar controls, formats summary times consistently, and orders the status strip based on whether the store is currently open or closed.

This also tightens POS settings around the same scheduling source of truth: store-day auto-start and EOD completion offsets show their projected run times, compact controls fit their content, POS recovery links back to the POS sign-in flow with the workflow affordance, and recovery-code failures now mention POS-only access as a possible admin check.

A solution note captures the reusable schedule-context and content-fit patterns for future settings work.

## Validation

- `bun run pr:athena`
- Focused Vitest coverage for Store Hours, POS settings, POS recovery-code login, and the authed POS recovery guard
