### PR TITLE
Fix EOD Review completion edge cases

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8272 nodes · 9836 edges · 2072 communities detected
+- 8273 nodes · 9837 edges · 2072 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2115,7 +2115,7 @@ Nodes (84): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShad
 
 ### Community 1 - "Community 1"
 Cohesion: 0.05
-Nodes (70): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildApprovalRequestsById(), buildDailyCloseApprovalSubject() (+62 more)
+Nodes (71): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildApprovalRequestsById(), buildDailyCloseApprovalSubject() (+63 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.06
@@ -2126,12 +2126,12 @@ Cohesion: 0.06
 Nodes (64): attentionSeverity(), automationRunClassification(), automationStatusBucketForRun(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildRegisterCloseoutTimelineMessage() (+56 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.04
-Nodes (34): buildDailyCloseExpenseSearch(), buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), getBucketCountClassName(), getCarryForwardWorkItemId(), getDailyCloseSalesMetricLabels(), getDailyCloseStatus() (+26 more)
-
-### Community 5 - "Community 5"
 Cohesion: 0.09
 Nodes (61): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), capNonCashPaymentsToExpectedTotal(), collectExistingSaleMappings() (+53 more)
+
+### Community 5 - "Community 5"
+Cohesion: 0.04
+Nodes (32): buildDailyCloseExpenseSearch(), buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), getBucketCountClassName(), getDailyCloseSalesMetricLabels(), getDailyCloseStatus(), getDisplayMetadataLabel() (+24 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.09
@@ -2670,60 +2670,60 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 140 - "Community 140"
-Cohesion: 0.36
-Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 141 - "Community 141"
 Cohesion: 0.36
-Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
+Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
 ### Community 142 - "Community 142"
+Cohesion: 0.36
+Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
+
+### Community 143 - "Community 143"
 Cohesion: 0.2
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.25
 Nodes (5): getRuntimeStatusPublishMaterialSignature(), getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusPublishMaterial(), normalizeRuntimeStatusSignature()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.25
 Nodes (7): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
-
-### Community 153 - "Community 153"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 154 - "Community 154"
 Cohesion: 0.18
@@ -2750,84 +2750,84 @@ Cohesion: 0.31
 Nodes (7): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
 
 ### Community 160 - "Community 160"
+Cohesion: 0.22
+Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
+
+### Community 161 - "Community 161"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.27
 Nodes (5): clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), runProcess(), writePrAthenaProviderEvidence()
 
-### Community 173 - "Community 173"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
 ### Community 174 - "Community 174"
-Cohesion: 0.25
-Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
-
-### Community 175 - "Community 175"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 176 - "Community 176"
+### Community 175 - "Community 175"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 177 - "Community 177"
+### Community 176 - "Community 176"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 178 - "Community 178"
+### Community 177 - "Community 177"
 Cohesion: 0.31
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 179 - "Community 179"
+### Community 178 - "Community 178"
 Cohesion: 0.22
 Nodes (0):
+
+### Community 179 - "Community 179"
+Cohesion: 0.39
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 180 - "Community 180"
 Cohesion: 0.39
@@ -2898,12 +2898,12 @@ Cohesion: 0.22
 Nodes (0):
 
 ### Community 197 - "Community 197"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
-
-### Community 198 - "Community 198"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 198 - "Community 198"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.22
@@ -3354,8 +3354,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 311 - "Community 311"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 312 - "Community 312"
 Cohesion: 0.33
@@ -3370,80 +3370,80 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 315 - "Community 315"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 316 - "Community 316"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 317 - "Community 317"
+### Community 316 - "Community 316"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
-### Community 318 - "Community 318"
+### Community 317 - "Community 317"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 319 - "Community 319"
+### Community 318 - "Community 318"
 Cohesion: 0.53
 Nodes (5): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
-### Community 320 - "Community 320"
+### Community 319 - "Community 319"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 321 - "Community 321"
+### Community 320 - "Community 320"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 322 - "Community 322"
+### Community 321 - "Community 321"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 323 - "Community 323"
+### Community 322 - "Community 322"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 324 - "Community 324"
+### Community 323 - "Community 323"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 324 - "Community 324"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 325 - "Community 325"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 326 - "Community 326"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 327 - "Community 327"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 328 - "Community 328"
+### Community 327 - "Community 327"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 329 - "Community 329"
+### Community 328 - "Community 328"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 329 - "Community 329"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 330 - "Community 330"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 331 - "Community 331"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 332 - "Community 332"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 333 - "Community 333"
+### Community 332 - "Community 332"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 333 - "Community 333"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 334 - "Community 334"
 Cohesion: 0.53
@@ -13107,6 +13107,6 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 3` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**
-  _Cohesion score 0.04 - nodes in this community are weakly interconnected._
-- **Should `Community 5` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._
+- **Should `Community 5` be split into smaller, more focused modules?**
+  _Cohesion score 0.04 - nodes in this community are weakly interconnected._

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,17 +8,17 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2145
-- Graph nodes: 8272
-- Graph edges: 9836
+- Graph nodes: 8273
+- Graph edges: 9837
 - Communities: 2072
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (85 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `dailyClose.ts` (83 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (84 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `terminalHealthPresentation.ts` (75 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (67 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `DailyCloseView.tsx` (66 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `projectLocalEvents.ts` (65 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `DailyCloseView.tsx` (65 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `projectLocalEvents.ts` (65 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 6) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 - `posLocalStore.ts` (50 edges, Community 7) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,11 +17,11 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `dailyClose.ts` (83 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (84 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `terminalHealthPresentation.ts` (75 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (67 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `DailyCloseView.tsx` (66 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `projectLocalEvents.ts` (65 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `DailyCloseView.tsx` (65 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `projectLocalEvents.ts` (65 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
+import * as athenaUserAuth from "../lib/athenaUserAuth";
 import {
   buildDailyCloseSnapshotWithCtx,
   completeDailyClose,
@@ -15,6 +16,11 @@ import {
   reopenDailyCloseWithCtx,
 } from "./dailyClose";
 import { assertConformsToExportedReturns } from "../lib/returnValidatorContract";
+
+vi.mock("../lib/athenaUserAuth", () => ({
+  requireAuthenticatedAthenaUserWithCtx: vi.fn(),
+  requireOrganizationMemberRoleWithCtx: vi.fn(),
+}));
 
 type TableName =
   | "approvalProof"
@@ -371,6 +377,25 @@ function completedDailyCloseRow(overrides: Partial<Row> = {}): Row {
     updatedAt: Date.UTC(2026, 4, 7, 22),
     ...overrides,
   };
+}
+
+function mockDailyCloseSnapshotAccess(role: "full_admin" | "pos_only") {
+  vi.mocked(
+    athenaUserAuth.requireAuthenticatedAthenaUserWithCtx,
+  ).mockResolvedValue({
+    _creationTime: 0,
+    _id: "user-1" as Id<"athenaUser">,
+    email: "pos@wigclub.store",
+  });
+  vi.mocked(
+    athenaUserAuth.requireOrganizationMemberRoleWithCtx,
+  ).mockResolvedValue({
+    _creationTime: 0,
+    _id: `member-${role}` as Id<"organizationMember">,
+    organizationId: "org-1" as Id<"organization">,
+    role,
+    userId: "user-1" as Id<"athenaUser">,
+  });
 }
 
 describe("end-of-day review backend foundation", () => {
@@ -1045,6 +1070,7 @@ describe("end-of-day review backend foundation", () => {
   });
 
   it("preserves active register blocker context on the exported snapshot query", async () => {
+    mockDailyCloseSnapshotAccess("pos_only");
     const { db } = createDb({
       posTerminal: [
         {
@@ -1111,7 +1137,76 @@ describe("end-of-day review backend foundation", () => {
     expect(snapshot.blockers[0].metadata).not.toHaveProperty("variance");
   });
 
+  it("returns financial metric amounts on the exported snapshot query for full admins", async () => {
+    mockDailyCloseSnapshotAccess("full_admin");
+    const completedAt = Date.UTC(2026, 5, 27, 14);
+    const transactions = Array.from({ length: 7 }, (_, index) => {
+      const isCash = index < 5;
+      const total = (index + 1) * 1000;
+
+      return {
+        _id: `txn-${index + 1}`,
+        completedAt: completedAt + index,
+        payments: [
+          {
+            amount: total,
+            method: isCash ? "cash" : "mobile_money",
+            timestamp: completedAt + index,
+          },
+        ],
+        status: "completed",
+        storeId: "store-1",
+        subtotal: total,
+        tax: 0,
+        total,
+        totalPaid: total,
+        transactionNumber: `TXN-${index + 1}`,
+      };
+    });
+    const { db } = createDb({
+      posTransaction: transactions,
+      store: [store],
+    });
+    const handler = getHandler<
+      {
+        operatingDate: string;
+        storeId: Id<"store">;
+      },
+      Promise<Awaited<ReturnType<typeof buildDailyCloseSnapshotWithCtx>>>
+    >(getDailyCloseSnapshot);
+
+    const snapshot = await handler(
+      { db } as unknown as QueryCtx,
+      {
+        operatingDate: "2026-06-27",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(snapshot.summary).toMatchObject({
+      currentDayCashTotal: 15000,
+      currentDayCashTransactionCount: 5,
+      salesTotal: 28000,
+      transactionCount: 7,
+    });
+    expect(snapshot.summary.paymentTotals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          amount: 15000,
+          method: "cash",
+          transactionCount: 5,
+        }),
+        expect.objectContaining({
+          amount: 13000,
+          method: "mobile_money",
+          transactionCount: 2,
+        }),
+      ]),
+    );
+  });
+
   it("redacts completed automation review evidence on the exported snapshot query", async () => {
+    mockDailyCloseSnapshotAccess("pos_only");
     const reportSnapshot = completedDailyCloseSnapshot({
       closeMetadata: {
         ...completedDailyCloseSnapshot().closeMetadata,
@@ -2131,8 +2226,8 @@ describe("end-of-day review backend foundation", () => {
     expect(inserts).toEqual([]);
   });
 
-  it("requires review item acknowledgement before completion", async () => {
-    const { db } = createDb({
+  it("requires manager approval before completing a review-only day", async () => {
+    const { db, inserts } = createDb({
       posTransaction: [
         {
           _id: "txn-void",
@@ -2159,15 +2254,15 @@ describe("end-of-day review backend foundation", () => {
     );
 
     expect(result).toMatchObject({
-      kind: "user_error",
-      error: {
-        code: "precondition_failed",
-        metadata: {
-          reviewItemCount: 1,
-          unreviewedItemKeys: ["pos_transaction:txn-void:void"],
+      kind: "approval_required",
+      approval: {
+        action: {
+          key: "operations.daily_close.complete",
+          label: "Complete EOD Review",
         },
       },
     });
+    expect(inserts).toEqual([]);
   });
 
   it("requires manager approval before completing a ready day", async () => {
@@ -2395,6 +2490,162 @@ describe("end-of-day review backend foundation", () => {
         approvedByStaffProfileId: "staff-manager-1",
       },
     });
+  });
+
+  it("completes review-only days and records command-time review evidence", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 7, 22));
+    const { db } = createDb({
+      approvalProof: [dailyCloseApprovalProof()],
+      posTransaction: [
+        {
+          _id: "txn-void",
+          completedAt: Date.UTC(2026, 4, 7, 15),
+          payments: [],
+          status: "void",
+          storeId: "store-1",
+          subtotal: 500,
+          tax: 0,
+          total: 500,
+          totalPaid: 500,
+          transactionNumber: "TXN-2",
+        },
+      ],
+      store: [store],
+    });
+
+    const result = await completeDailyCloseWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        approvalProofId: "approval-proof-1" as Id<"approvalProof">,
+        operatingDate: "2026-05-07",
+        reviewedItemKeys: [],
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "completed",
+        dailyClose: {
+          readiness: {
+            reviewCount: 1,
+            status: "needs_review",
+          },
+          reportSnapshot: {
+            closeMetadata: {
+              reviewedItemKeys: ["pos_transaction:txn-void:void"],
+            },
+            reviewedItems: [
+              {
+                key: "pos_transaction:txn-void:void",
+              },
+            ],
+          },
+          reviewedItemKeys: ["pos_transaction:txn-void:void"],
+          status: "completed",
+        },
+      },
+    });
+    expect(() =>
+      assertConformsToExportedReturns(completeDailyClose, result),
+    ).not.toThrow();
+  });
+
+  it("completes an open carry-forward close without duplicating preserved work", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 7, 22));
+    const { db } = createDb({
+      approvalProof: [dailyCloseApprovalProof()],
+      dailyClose: [
+        {
+          _id: "daily-close-open",
+          carryForwardWorkItemIds: ["work-existing"],
+          createdAt: Date.UTC(2026, 4, 7, 20),
+          isCurrent: true,
+          operatingDate: "2026-05-07",
+          organizationId: "org-1",
+          readiness: {
+            blockerCount: 0,
+            carryForwardCount: 1,
+            readyCount: 0,
+            reviewCount: 0,
+            status: "ready",
+          },
+          sourceSubjects: [],
+          status: "open",
+          storeId: "store-1",
+          summary: {
+            carryForwardWorkItemCount: 1,
+          },
+          updatedAt: Date.UTC(2026, 4, 7, 20),
+        },
+      ],
+      operationalWorkItem: [
+        {
+          _id: "work-existing",
+          approvalState: "not_required",
+          createdAt: 4,
+          organizationId: "org-1",
+          priority: "normal",
+          status: "open",
+          storeId: "store-1",
+          title: "Call customer tomorrow",
+          type: "customer_follow_up",
+        },
+      ],
+      store: [store],
+    });
+
+    const result = await completeDailyCloseWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        approvalProofId: "approval-proof-1" as Id<"approvalProof">,
+        carryForwardWorkItemIds: [
+          "work-existing" as Id<"operationalWorkItem">,
+          "work-existing" as Id<"operationalWorkItem">,
+        ],
+        operatingDate: "2026-05-07",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "completed",
+        carryForwardWorkItems: [
+          {
+            _id: "work-existing",
+          },
+        ],
+        dailyClose: {
+          _id: "daily-close-open",
+          carryForwardWorkItemIds: ["work-existing"],
+          readiness: {
+            carryForwardCount: 1,
+          },
+          reportSnapshot: {
+            carryForwardItems: [
+              {
+                key: "operational_work_item:work-existing:carry_forward",
+              },
+            ],
+            closeMetadata: {
+              carryForwardWorkItemIds: ["work-existing"],
+            },
+          },
+          status: "completed",
+          summary: {
+            carryForwardWorkItemCount: 1,
+          },
+        },
+      },
+    });
+    expect(() =>
+      assertConformsToExportedReturns(completeDailyClose, result),
+    ).not.toThrow();
   });
 
   it("completes a ready day through automation with durable attribution and no approval proof metadata", async () => {

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -26,6 +26,10 @@ import {
   getLatestDailyOperationsAutomationStatusWithCtx,
   type DailyOperationsAutomationStatus,
 } from "./dailyOperationsAutomation";
+import {
+  requireAuthenticatedAthenaUserWithCtx,
+  requireOrganizationMemberRoleWithCtx,
+} from "../lib/athenaUserAuth";
 import { buildPaymentTotals, transactionCashDelta } from "./paymentTotals";
 import type { AutomationDecisionEvidence } from "../automation/runLedger";
 
@@ -2940,6 +2944,12 @@ async function validateCarryForwardWorkItemIds(
   };
 }
 
+function uniqueOperationalWorkItemIds(
+  workItemIds: Id<"operationalWorkItem">[],
+) {
+  return Array.from(new Set(workItemIds));
+}
+
 function carryForwardWorkItemIdFromItem(
   item: DailyCloseItem,
 ): Id<"operationalWorkItem"> | null {
@@ -3237,26 +3247,11 @@ export async function completeDailyCloseWithCtx(
     });
   }
 
-  const reviewedItemKeys = new Set(args.reviewedItemKeys ?? []);
-  const unreviewedItemKeys = snapshot.reviewItems
-    .map((item) => item.key)
-    .filter((key) => !reviewedItemKeys.has(key));
-
-  if (unreviewedItemKeys.length > 0) {
-    return userError({
-      code: "precondition_failed",
-      message:
-        "EOD Review items must be acknowledged before completion.",
-      metadata: {
-        reviewItemCount: snapshot.reviewItems.length,
-        unreviewedItemKeys,
-      },
-    });
-  }
-
   const linkedWorkItemResult = await validateCarryForwardWorkItemIds(ctx, {
     storeId: args.storeId,
-    workItemIds: args.carryForwardWorkItemIds ?? [],
+    workItemIds: uniqueOperationalWorkItemIds(
+      args.carryForwardWorkItemIds ?? [],
+    ),
   });
 
   if (!linkedWorkItemResult.ok) {
@@ -3309,13 +3304,21 @@ export async function completeDailyCloseWithCtx(
 
   const now = Date.now();
   const completedByStaffProfileId = approvalProof.data.approvedByStaffProfileId;
-  const carryForwardWorkItems = [
-    ...linkedWorkItemResult.workItems,
-    ...createdWorkItemResult.workItems,
-  ];
-  const carryForwardWorkItemIds = carryForwardWorkItems.map(
-    (workItem) => workItem._id,
+  const reviewedItemKeys = snapshot.reviewItems.map((item) => item.key);
+  const carryForwardWorkItemIds = uniqueOperationalWorkItemIds(
+    [
+      ...(snapshot.existingClose?.carryForwardWorkItemIds ?? []),
+      ...linkedWorkItemResult.workItems.map((workItem) => workItem._id),
+      ...createdWorkItemResult.workItems.map((workItem) => workItem._id),
+    ] as Id<"operationalWorkItem">[],
   );
+  const carryForwardWorkItems = (
+    await Promise.all(
+      carryForwardWorkItemIds.map((workItemId) =>
+        ctx.db.get("operationalWorkItem", workItemId),
+      ),
+    )
+  ).filter(Boolean) as Array<Doc<"operationalWorkItem">>;
   const notes = trimOptional(args.notes);
   const readiness = {
     ...snapshot.readiness,
@@ -3344,12 +3347,12 @@ export async function completeDailyCloseWithCtx(
       actorType: "human",
       notes,
       readiness,
-      reviewedItemKeys: args.reviewedItemKeys,
+      reviewedItemKeys,
       snapshot,
       summary,
     }),
     carryForwardWorkItemIds,
-    reviewedItemKeys: args.reviewedItemKeys,
+    reviewedItemKeys,
     notes,
     updatedAt: now,
     completedAt: now,
@@ -4062,11 +4065,25 @@ export const getDailyCloseSnapshot = query({
     startAt: v.optional(v.number()),
     storeId: v.id("store"),
   },
-  handler: (ctx, args) =>
-    buildDailyCloseSnapshotWithCtx(ctx, {
+  handler: async (ctx, args) => {
+    const store = await ctx.db.get("store", args.storeId);
+    if (!store) {
+      throw new Error("Store not found.");
+    }
+
+    const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
+    const membership = await requireOrganizationMemberRoleWithCtx(ctx, {
+      allowedRoles: ["full_admin", "pos_only"],
+      failureMessage: "You cannot view EOD Review for this store.",
+      organizationId: store.organizationId,
+      userId: athenaUser._id,
+    });
+
+    return buildDailyCloseSnapshotWithCtx(ctx, {
       ...args,
-      includeManagerReviewEvidence: false,
-    }),
+      includeManagerReviewEvidence: membership.role === "full_admin",
+    });
+  },
 });
 
 export const completeDailyClose = mutation({

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -1427,6 +1427,11 @@ describe("DailyCloseViewContent", () => {
           description: "Check missing receipt during opening.",
           id: "carry-1",
           statusLabel: "Carry forward",
+          subject: {
+            id: "carry-1",
+            label: "Receipt follow-up",
+            type: "operational_work_item",
+          },
           title: "Receipt follow-up",
         },
       ],
@@ -1449,7 +1454,50 @@ describe("DailyCloseViewContent", () => {
         endAt: readySnapshot.endAt,
         notes: "",
         operatingDate: "2026-05-07",
-        reviewedItemKeys: ["review-1"],
+        reviewedItemKeys: [],
+        startAt: readySnapshot.startAt,
+      });
+    });
+  });
+
+  it("does not send redacted carry-forward placeholders as completion ids", async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn(async () => ok({ closeId: "close-1" }));
+    const snapshot: DailyCloseSnapshot = {
+      ...readySnapshot,
+      carryForwardItems: [
+        {
+          description: "Check missing receipt during opening.",
+          id: "carry-redacted",
+          statusLabel: "Carry forward",
+          subject: {
+            id: "redacted",
+            label: "Receipt follow-up",
+            type: "operational_work_item",
+          },
+          title: "Receipt follow-up",
+        },
+      ],
+      status: "carry_forward",
+      summary: {
+        ...baseSummary,
+        carryForwardCount: 1,
+      },
+    };
+
+    renderContent(snapshot, { onComplete });
+
+    await user.click(
+      screen.getByRole("button", { name: /complete EOD review/i }),
+    );
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalledWith({
+        carryForwardWorkItemIds: [],
+        endAt: readySnapshot.endAt,
+        notes: "",
+        operatingDate: "2026-05-07",
+        reviewedItemKeys: [],
         startAt: readySnapshot.startAt,
       });
     });

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -871,18 +871,19 @@ function getItemId(item: DailyCloseItem) {
   );
 }
 
-function getReviewedItemKeys(items: DailyCloseItem[]) {
-  return items.map((item) => item.key ?? getItemId(item));
-}
-
 function getCarryForwardWorkItemId(item: DailyCloseItem) {
-  return item.subject?.type === "operational_work_item"
-    ? item.subject.id
-    : getItemId(item);
+  if (item.subject?.type !== "operational_work_item") {
+    return null;
+  }
+
+  return isUsableRouteIdentifier(item.subject.id) ? item.subject.id : null;
 }
 
 function getCarryForwardWorkItemIds(items: DailyCloseItem[]) {
-  return items.map(getCarryForwardWorkItemId);
+  return items.flatMap((item) => {
+    const workItemId = getCarryForwardWorkItemId(item);
+    return workItemId ? [workItemId] : [];
+  });
 }
 
 function getItemDescription(item: DailyCloseItem) {
@@ -2304,6 +2305,9 @@ function BucketSection({
         ) : (
           paginatedItems.map((item) => {
             const selectionId = getCarryForwardWorkItemId(item);
+            const isSelectable = Boolean(
+              selectionId && selectedIds && onSelectedIdsChange,
+            );
 
             return (
               <DailyCloseItemCard
@@ -2312,7 +2316,9 @@ function BucketSection({
                 item={item}
                 key={getItemId(item)}
                 onSelectedChange={(isSelected) => {
-                  if (!selectedIds || !onSelectedIdsChange) return;
+                  if (!selectionId || !selectedIds || !onSelectedIdsChange) {
+                    return;
+                  }
 
                   onSelectedIdsChange(
                     isSelected
@@ -2321,8 +2327,8 @@ function BucketSection({
                   );
                 }}
                 orgUrlSlug={orgUrlSlug}
-                selectable={Boolean(selectedIds && onSelectedIdsChange)}
-                selected={selectedIds?.includes(selectionId)}
+                selectable={isSelectable}
+                selected={selectionId ? selectedIds?.includes(selectionId) : false}
                 storeUrlSlug={storeUrlSlug}
               />
             );
@@ -3295,7 +3301,7 @@ export function DailyCloseViewContent({
       endAt: snapshot.endAt,
       notes,
       operatingDate: snapshot.operatingDate,
-      reviewedItemKeys: getReviewedItemKeys(snapshot.reviewItems),
+      reviewedItemKeys: [],
       startAt: snapshot.startAt,
     };
 


### PR DESCRIPTION
## Summary
- filter carry-forward completion payloads to real operational work-item IDs and preserve selected carry-forward work on completion
- allow manager-approved completion with review evidence while keeping automation policy gates strict
- include manager-visible financial evidence in trusted daily-close snapshots so metric cards show actual amounts
- refresh Graphify artifacts for the changed operations surface

## Why
EOD Review completion was failing when redacted carry-forward placeholders were submitted, review-only days were blocked without an explicit acknowledgement action, and trusted metric cards could show zero totals despite transaction activity.

## Validation
- `bun run test -- convex/operations/dailyClose.test.ts`
- `bun run test -- src/components/operations/DailyCloseView.test.tsx`
- `bun run --filter '@athena/webapp' lint:convex:changed`\n- `bun run --filter '@athena/webapp' lint:frontend:changed` (passes with existing Fast Refresh warning in `DailyCloseView.tsx`)\n- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`\n- `git diff --cached --check`\n- `bun run pr:athena`\n\nBrowser validation intentionally left to user.