### PR TITLE
fix(operations): start store days from opening policy

### DIFF
--- a/docs/solutions/architecture/athena-store-day-auto-start-review-2026-06-11.md
+++ b/docs/solutions/architecture/athena-store-day-auto-start-review-2026-06-11.md
@@ -42,6 +42,10 @@ Use a store-scoped automation policy for `daily_operations/opening.auto_start`:
   prevents the cron from recording a run before the configured local time.
 - `openingBlockerHandling` controls whether blockers are skipped or routed to
   manager review.
+- Canonical store hours are customer-facing windows. When a store schedule
+  exists, Opening auto-start should still use `openingLocalStartMinutes` as the
+  operational trigger, even when that trigger is before or after customer-facing
+  opening.
 
 When the policy allows manager review, the automation path may start Opening
 with blockers, review items, and carry-forward items. Those items are copied
@@ -60,6 +64,9 @@ that bypass and continues to require blocker resolution and acknowledgement.
   rule.
 - Avoid recording skipped cron runs before the configured local start time; early
   checks are scheduler noise, not business decisions.
+- Do not treat customer-facing store hours as a hard lower bound for Opening
+  auto-start. POS settings intentionally stores an offset from those hours so
+  the store day can start before customers arrive.
 
 ## Prevention
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8273 nodes · 9837 edges · 2072 communities detected
+- 8281 nodes · 9853 edges · 2072 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2159,7 +2159,7 @@ Nodes (40): completed(), executeCallbackCommand(), executeClearLocalReviewItems(
 
 ### Community 12 - "Community 12"
 Cohesion: 0.06
-Nodes (22): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+14 more)
+Nodes (24): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+16 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.09
@@ -2186,56 +2186,56 @@ Cohesion: 0.11
 Nodes (33): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+25 more)
 
 ### Community 19 - "Community 19"
+Cohesion: 0.1
+Nodes (31): automationErrorMessage(), automationIdempotencyKey(), configuredEodAutoCompleteStoreDayContext(), configuredOpeningOperatingDate(), eodAutoCompleteDecision(), eodAutoCompletePolicyCronWindow(), eodAutoCompleteTiming(), eodDecision() (+23 more)
+
+### Community 20 - "Community 20"
 Cohesion: 0.12
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.07
 Nodes (15): buildMissingDraftResult(), formatQueueWorkItemValue(), formatWorkItemTitle(), getQueueWorkItemArrayMetadataCount(), getQueueWorkItemInventoryReviewLineCount(), getQueueWorkItemStockAdjustmentSkuId(), getQueueWorkItemStringMetadata(), getQueueWorkItemTransactionId() (+7 more)
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.08
 Nodes (20): buildDisplaySafeConflictSummary(), buildTerminalSyncReviewSummary(), classifyTerminalSyncReviewConflict(), dedupeConflictsById(), emptyTerminalSyncReviewSummary(), getConflictBusinessKey(), getCurrentConflictKey(), getLatestRuntimeStatusForTerminal() (+12 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.07
 Nodes (11): formatCompactTextList(), formatPaymentMethods(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary(), formatReviewTypeSummary(), formatTimestamp() (+3 more)
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.11
 Nodes (21): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), buildLocalAvailabilityEventIndex(), cartItemLineEventKey(), cartItemLineKey(), cartItemsFromLocalRegisterModel(), cartLineSourceKey(), formatLocalPendingCheckoutSku() (+13 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.12
 Nodes (25): buildDiagnosticEvidence(), buildTerminalOperationalExplanation(), buildTerminalOperationalState(), buildTerminalRecoveryActions(), buildTerminalRecoveryManualReview(), classifySalesReadiness(), classifySupportRecovery(), classifyTerminalHealth() (+17 more)
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.12
 Nodes (26): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildInventorySnapshotRowsForProductSkusWithCtx(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle() (+18 more)
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.11
 Nodes (24): buildGitProcessEnv(), buildProviderSkip(), collectCommandsForChangedFiles(), commandDisplayName(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs() (+16 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.16
 Nodes (26): addDays(), addField(), contextWindowsForDate(), dayOfWeek(), exceptionWindowsOverlap(), findNextWindow(), getFormatter(), getMissingStoreScheduleContext() (+18 more)
-
-### Community 31 - "Community 31"
-Cohesion: 0.12
-Nodes (24): automationErrorMessage(), automationIdempotencyKey(), eodAutoCompleteDecision(), eodAutoCompletePolicyCronWindow(), eodAutoCompleteTiming(), eodDecision(), getLatestDailyOperationsAutomationStatusWithCtx(), getOpeningAutoStartPolicyForApi() (+16 more)
 
 ### Community 32 - "Community 32"
 Cohesion: 0.14
@@ -2670,60 +2670,60 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 140 - "Community 140"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 141 - "Community 141"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 142 - "Community 142"
+### Community 141 - "Community 141"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 143 - "Community 143"
+### Community 142 - "Community 142"
 Cohesion: 0.2
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 144 - "Community 144"
+### Community 143 - "Community 143"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 145 - "Community 145"
+### Community 144 - "Community 144"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 146 - "Community 146"
+### Community 145 - "Community 145"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 147 - "Community 147"
+### Community 146 - "Community 146"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 148 - "Community 148"
+### Community 147 - "Community 147"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 149 - "Community 149"
+### Community 148 - "Community 148"
 Cohesion: 0.25
 Nodes (5): getRuntimeStatusPublishMaterialSignature(), getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusPublishMaterial(), normalizeRuntimeStatusSignature()
 
-### Community 150 - "Community 150"
+### Community 149 - "Community 149"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 151 - "Community 151"
+### Community 150 - "Community 150"
 Cohesion: 0.25
 Nodes (7): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus()
 
-### Community 152 - "Community 152"
+### Community 151 - "Community 151"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 153 - "Community 153"
+### Community 152 - "Community 152"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
+
+### Community 153 - "Community 153"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 154 - "Community 154"
 Cohesion: 0.18
@@ -2882,28 +2882,28 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 193 - "Community 193"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 194 - "Community 194"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 195 - "Community 195"
+### Community 194 - "Community 194"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 196 - "Community 196"
+### Community 195 - "Community 195"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 197 - "Community 197"
+### Community 196 - "Community 196"
 Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 198 - "Community 198"
+### Community 197 - "Community 197"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+
+### Community 198 - "Community 198"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.22
@@ -3354,8 +3354,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 311 - "Community 311"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 312 - "Community 312"
 Cohesion: 0.33
@@ -3370,80 +3370,80 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 315 - "Community 315"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 316 - "Community 316"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 316 - "Community 316"
+### Community 317 - "Community 317"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
-### Community 317 - "Community 317"
+### Community 318 - "Community 318"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.53
 Nodes (5): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 321 - "Community 321"
+### Community 322 - "Community 322"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 322 - "Community 322"
+### Community 323 - "Community 323"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 323 - "Community 323"
+### Community 324 - "Community 324"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 324 - "Community 324"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 325 - "Community 325"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 326 - "Community 326"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 327 - "Community 327"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 328 - "Community 328"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 329 - "Community 329"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 330 - "Community 330"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 331 - "Community 331"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 332 - "Community 332"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 332 - "Community 332"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 333 - "Community 333"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 334 - "Community 334"
 Cohesion: 0.53

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2145
-- Graph nodes: 8273
-- Graph edges: 9837
+- Graph nodes: 8281
+- Graph edges: 9853
 - Communities: 2072
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
@@ -1259,17 +1259,116 @@ describe("daily operations automation adapter", () => {
     expect(inserts.map((insert) => insert.table)).toEqual(["automationRun"]);
   });
 
-  it("derives configured EOD auto-complete operating dates from policy local timezone", async () => {
+  it("runs configured EOD auto-complete before customer-facing close when the policy offset is earlier", async () => {
     const { db, inserts } = createDb({
       automationPolicy: [
-        policy("eod.auto_complete", "dry_run", {
+        policy("eod.auto_complete", "enabled", {
           eodCleanDayAutoCompleteEnabled: true,
-          eodLocalCompletionWindowMinutes: 21 * 60,
-          operatingTimezoneOffsetMinutes: 240,
+          eodLocalCompletionWindowMinutes: 16 * 60,
+          operatingTimezoneOffsetMinutes: 0,
+        }),
+      ],
+      posTransaction: [completedTransaction()],
+      registerSession: [
+        closedRegisterSession({
+          closedAt: Date.UTC(2026, 5, 8, 15),
+        }),
+      ],
+      store: [store],
+      storeSchedule: [
+        storeSchedule({
+          timezone: "UTC",
+          weeklyWindows: [
+            {
+              dayOfWeek: 1,
+              endMinute: 19 * 60,
+              startMinute: 9 * 60,
+            },
+          ],
+        }),
+      ],
+    });
+
+    const result = await runConfiguredDailyOperationsAutomationWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        now: Date.UTC(2026, 5, 8, 16),
+      },
+    );
+
+    expect(result.eodAutoCompleteResults).toHaveLength(1);
+    expect(inserts).toContainEqual(
+      expect.objectContaining({
+        table: "automationRun",
+        value: expect.objectContaining({
+          action: "eod.auto_complete",
+          decisionEvidence: expect.objectContaining({
+            observed: expect.objectContaining({
+              scheduleEvidenceSource: "canonical_schedule",
+              storeScheduleId: "storeSchedule-1",
+            }),
+          }),
+          operatingDate: "2026-06-08",
+          outcome: "applied",
+        }),
+      }),
+    );
+  });
+
+  it("waits after customer-facing close when the EOD policy offset is later", async () => {
+    const { db, inserts } = createDb({
+      automationPolicy: [
+        policy("eod.auto_complete", "enabled", {
+          eodCleanDayAutoCompleteEnabled: true,
+          eodLocalCompletionWindowMinutes: 18 * 60,
+          operatingTimezoneOffsetMinutes: 0,
         }),
       ],
       posTransaction: [completedTransaction()],
       registerSession: [closedRegisterSession()],
+      store: [store],
+      storeSchedule: [
+        storeSchedule({
+          timezone: "UTC",
+          weeklyWindows: [
+            {
+              dayOfWeek: 1,
+              endMinute: 17 * 60,
+              startMinute: 9 * 60,
+            },
+          ],
+        }),
+      ],
+    });
+
+    const result = await runConfiguredDailyOperationsAutomationWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        now: Date.UTC(2026, 5, 8, 17, 30),
+      },
+    );
+
+    expect(result.eodAutoCompleteResults).toHaveLength(0);
+    expect(inserts.filter((insert) => insert.table === "automationRun")).toEqual(
+      [],
+    );
+  });
+
+  it("derives configured EOD auto-complete operating dates from policy local timezone", async () => {
+    const { db, inserts } = createDb({
+      automationPolicy: [
+        policy("eod.auto_complete", "enabled", {
+          eodCleanDayAutoCompleteEnabled: true,
+          eodLocalCompletionWindowMinutes: 16 * 60,
+          operatingTimezoneOffsetMinutes: 0,
+        }),
+      ],
+      posTransaction: [completedTransaction()],
+      registerSession: [
+        closedRegisterSession({
+          closedAt: Date.UTC(2026, 5, 8, 15),
+        }),
+      ],
       store: [store],
     });
 
@@ -1287,48 +1386,7 @@ describe("daily operations automation adapter", () => {
         value: expect.objectContaining({
           action: "eod.auto_complete",
           operatingDate: "2026-06-08",
-          outcome: "dry_run",
-        }),
-      }),
-    );
-  });
-
-  it("uses stored canonical schedules for configured EOD auto-complete timing", async () => {
-    const { db, inserts } = createDb({
-      automationPolicy: [
-        policy("eod.auto_complete", "dry_run", {
-          eodCleanDayAutoCompleteEnabled: true,
-          eodLocalCompletionWindowMinutes: 21 * 60,
-          operatingTimezoneOffsetMinutes: 240,
-        }),
-      ],
-      posTransaction: [completedTransaction()],
-      registerSession: [closedRegisterSession()],
-      store: [store],
-      storeSchedule: [storeSchedule()],
-    });
-
-    const result = await runConfiguredDailyOperationsAutomationWithCtx(
-      { db } as unknown as MutationCtx,
-      {
-        now: Date.UTC(2026, 5, 8, 18),
-      },
-    );
-
-    expect(result.eodAutoCompleteResults).toHaveLength(1);
-    expect(inserts).toContainEqual(
-      expect.objectContaining({
-        table: "automationRun",
-        value: expect.objectContaining({
-          action: "eod.auto_complete",
-          decisionEvidence: expect.objectContaining({
-            observed: expect.objectContaining({
-              scheduleEvidenceSource: "canonical_schedule",
-              storeScheduleId: "storeSchedule-1",
-            }),
-          }),
-          operatingDate: "2026-06-08",
-          outcome: "dry_run",
+          outcome: "applied",
         }),
       }),
     );
@@ -1822,6 +1880,89 @@ describe("daily operations automation adapter", () => {
           outcome: "applied",
         }),
       }),
+    );
+  });
+
+  it("runs configured Opening cron before customer-facing hours when the policy offset is earlier", async () => {
+    const { db, inserts } = createDb({
+      automationPolicy: [
+        policy("opening.auto_start", "enabled", {
+          openingBlockerHandling: "manager_review",
+          openingLocalStartMinutes: 8 * 60,
+          operatingTimezoneOffsetMinutes: 0,
+        }),
+      ],
+      dailyClose: [completedDailyClose()],
+      store: [store],
+      storeSchedule: [
+        storeSchedule({
+          timezone: "UTC",
+          weeklyWindows: [
+            {
+              dayOfWeek: 1,
+              endMinute: 19 * 60,
+              startMinute: 9 * 60,
+            },
+          ],
+        }),
+      ],
+    });
+
+    const result = await runConfiguredDailyOperationsAutomationWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        now: Date.UTC(2026, 5, 8, 8),
+      },
+    );
+
+    expect(result.openingResults).toHaveLength(1);
+    expect(inserts).toContainEqual(
+      expect.objectContaining({
+        table: "automationRun",
+        value: expect.objectContaining({
+          action: "opening.auto_start",
+          operatingDate: "2026-06-08",
+          outcome: "applied",
+        }),
+      }),
+    );
+  });
+
+  it("waits during customer-facing hours when the policy offset is later than opening", async () => {
+    const { db, inserts } = createDb({
+      automationPolicy: [
+        policy("opening.auto_start", "enabled", {
+          openingBlockerHandling: "manager_review",
+          openingLocalStartMinutes: 10 * 60,
+          operatingTimezoneOffsetMinutes: 0,
+        }),
+      ],
+      dailyClose: [completedDailyClose()],
+      store: [store],
+      storeSchedule: [
+        storeSchedule({
+          timezone: "UTC",
+          weeklyWindows: [
+            {
+              dayOfWeek: 1,
+              endMinute: 19 * 60,
+              startMinute: 9 * 60,
+            },
+          ],
+        }),
+      ],
+    });
+
+    const result = await runConfiguredDailyOperationsAutomationWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        now: Date.UTC(2026, 5, 8, 9),
+      },
+    );
+
+    expect(result.openingResults).toEqual([]);
+    expect(inserts.filter((insert) => insert.table === "automationRun")).toEqual(
+      [],
     );
   });
 

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
@@ -41,6 +41,7 @@ const EOD_AUTO_COMPLETE_LOW_RISK_REVIEW_CATEGORIES = new Set([
   "cash_variance",
   "voided_sale",
 ]);
+const MINUTE_MS = 60 * 1000;
 
 export const dailyOperationsOpeningAutoStartAction = defineAutomationAction({
   action: OPENING_AUTO_START_ACTION,
@@ -109,7 +110,9 @@ export type DailyOperationsAutomationStoreDayContext = {
   openedAt?: number;
   closedAt?: number;
   openingEvaluationAt?: number;
+  openingWindowStartMinutes?: number;
   eodEvaluationAt?: number;
+  eodWindowEndMinutes?: number;
 };
 
 type DailyOperationsAutomationTimingEvidence = {
@@ -856,6 +859,152 @@ function openingPolicyCronWindow(args: {
   };
 }
 
+function openingLocalStartMinutesForPolicy(policy: Doc<"automationPolicy">) {
+  return typeof policy.openingLocalStartMinutes === "number" &&
+    Number.isInteger(policy.openingLocalStartMinutes)
+    ? policy.openingLocalStartMinutes
+    : DEFAULT_OPENING_LOCAL_START_MINUTES;
+}
+
+function normalizedPolicyOffsetFromScheduleStart(args: {
+  policyLocalStartMinutes: number;
+  scheduleStartMinutes: number;
+}) {
+  const rawOffset = args.policyLocalStartMinutes - args.scheduleStartMinutes;
+
+  return rawOffset > 12 * 60
+    ? rawOffset - 24 * 60
+    : rawOffset < -12 * 60
+      ? rawOffset + 24 * 60
+      : rawOffset;
+}
+
+function eodLocalCompletionWindowMinutesForPolicy(
+  policy: Doc<"automationPolicy">,
+) {
+  return typeof policy.eodLocalCompletionWindowMinutes === "number" &&
+    Number.isInteger(policy.eodLocalCompletionWindowMinutes)
+    ? policy.eodLocalCompletionWindowMinutes
+    : DEFAULT_EOD_LOCAL_COMPLETION_WINDOW_MINUTES;
+}
+
+function openingPolicyStartAtForStoreDay(args: {
+  policy: Doc<"automationPolicy">;
+  storeDayContext: DailyOperationsAutomationStoreDayContext;
+}) {
+  if (
+    typeof args.storeDayContext.openedAt !== "number" ||
+    typeof args.storeDayContext.openingWindowStartMinutes !== "number"
+  ) {
+    return null;
+  }
+
+  const offsetMinutes = normalizedPolicyOffsetFromScheduleStart({
+    policyLocalStartMinutes: openingLocalStartMinutesForPolicy(args.policy),
+    scheduleStartMinutes: args.storeDayContext.openingWindowStartMinutes,
+  });
+
+  return args.storeDayContext.openedAt + offsetMinutes * MINUTE_MS;
+}
+
+function eodPolicyCompletionAtForStoreDay(args: {
+  policy: Doc<"automationPolicy">;
+  storeDayContext: DailyOperationsAutomationStoreDayContext;
+}) {
+  if (
+    typeof args.storeDayContext.closedAt !== "number" ||
+    typeof args.storeDayContext.eodWindowEndMinutes !== "number"
+  ) {
+    return null;
+  }
+
+  const offsetMinutes = normalizedPolicyOffsetFromScheduleStart({
+    policyLocalStartMinutes: eodLocalCompletionWindowMinutesForPolicy(args.policy),
+    scheduleStartMinutes: args.storeDayContext.eodWindowEndMinutes,
+  });
+
+  return args.storeDayContext.closedAt + offsetMinutes * MINUTE_MS;
+}
+
+function configuredOpeningOperatingDate(args: {
+  cronWindow: ReturnType<typeof openingPolicyCronWindow>;
+  now: number;
+  policy: Doc<"automationPolicy">;
+  scheduleContext: ConfiguredStoreScheduleContext;
+}) {
+  const storeDayContext = args.scheduleContext.storeDayContext;
+
+  if (!storeDayContext) {
+    return args.cronWindow?.operatingDate ?? null;
+  }
+
+  if (
+    args.scheduleContext.phase === "closed" ||
+    args.scheduleContext.phase === "after_last_window"
+  ) {
+    return null;
+  }
+
+  const policyStartAt = openingPolicyStartAtForStoreDay({
+    policy: args.policy,
+    storeDayContext,
+  });
+
+  if (typeof policyStartAt === "number") {
+    return args.now >= policyStartAt ? storeDayContext.operatingDate : null;
+  }
+
+  if (
+    args.scheduleContext.phase === "during_window" ||
+    args.scheduleContext.phase === "between_windows"
+  ) {
+    return storeDayContext.operatingDate;
+  }
+
+  return args.cronWindow?.operatingDate === storeDayContext.operatingDate
+    ? storeDayContext.operatingDate
+    : null;
+}
+
+function configuredEodAutoCompleteStoreDayContext(args: {
+  cronWindow: ReturnType<typeof eodAutoCompletePolicyCronWindow>;
+  policy: Doc<"automationPolicy">;
+  scheduleContext: ConfiguredStoreScheduleContext;
+}) {
+  if (args.cronWindow?.completionWindowSatisfied === false) {
+    return {
+      completionWindowSatisfied: false,
+      operatingDate: null,
+      storeDayContext: undefined,
+    };
+  }
+
+  const operatingDate = args.cronWindow?.operatingDate ?? null;
+  const storeDayContext = args.scheduleContext.storeDayContext;
+
+  if (!operatingDate || storeDayContext?.operatingDate !== operatingDate) {
+    return {
+      completionWindowSatisfied: args.cronWindow?.completionWindowSatisfied,
+      operatingDate,
+      storeDayContext: undefined,
+    };
+  }
+
+  const policyCompletionAt = eodPolicyCompletionAtForStoreDay({
+    policy: args.policy,
+    storeDayContext,
+  });
+
+  return {
+    completionWindowSatisfied: true,
+    operatingDate,
+    storeDayContext:
+      typeof policyCompletionAt === "number"
+        ? { ...storeDayContext, eodEvaluationAt: policyCompletionAt }
+        : storeDayContext,
+  };
+}
+
 function scheduleEvidenceForStoreDayContext(
   storeDayContext: DailyOperationsAutomationStoreDayContext | undefined,
   action: "opening.auto_start" | "eod.auto_complete",
@@ -949,8 +1098,13 @@ async function resolveConfiguredStoreScheduleContext(
         context.phase === "after_last_window"
           ? args.now
           : relevantWindow?.endsAt,
+      eodWindowEndMinutes:
+        context.phase === "after_last_window"
+          ? undefined
+          : relevantWindow?.endMinute,
       openedAt: relevantWindow?.startsAt,
       openingEvaluationAt: relevantWindow?.startsAt,
+      openingWindowStartMinutes: relevantWindow?.startMinute,
       operatingDate: context.operatingDate,
       scheduleVersion: context.scheduleVersionId,
       source: "canonical_schedule",
@@ -1190,16 +1344,12 @@ export async function runConfiguredDailyOperationsAutomationWithCtx(
         now,
         policy,
       });
-      const operatingDate =
-        scheduleContext.storeDayContext &&
-        (scheduleContext.phase === "during_window" ||
-          scheduleContext.phase === "between_windows")
-          ? scheduleContext.storeDayContext.operatingDate
-          : scheduleContext.phase === "closed" ||
-              scheduleContext.phase === "before_first_window" ||
-              scheduleContext.phase === "after_last_window"
-            ? null
-            : cronWindow?.operatingDate ?? null;
+      const operatingDate = configuredOpeningOperatingDate({
+        cronWindow,
+        now,
+        policy,
+        scheduleContext,
+      });
 
       return runConfiguredPolicySafely(ctx, {
         action: OPENING_AUTO_START_ACTION,
@@ -1252,27 +1402,23 @@ export async function runConfiguredDailyOperationsAutomationWithCtx(
         now,
         policy,
       });
-      const operatingDate =
-        scheduleContext.storeDayContext
-          ? scheduleContext.phase === "after_last_window"
-            ? scheduleContext.storeDayContext.operatingDate
-            : null
-          : cronWindow?.completionWindowSatisfied === false
-          ? null
-          : cronWindow?.operatingDate ?? null;
+      const eodStoreDayContext = configuredEodAutoCompleteStoreDayContext({
+        cronWindow,
+        policy,
+        scheduleContext,
+      });
 
       return runConfiguredPolicySafely(ctx, {
         action: EOD_AUTO_COMPLETE_ACTION,
-        operatingDate,
+        operatingDate: eodStoreDayContext.operatingDate,
         policy,
         run: (operatingDate) =>
           runDailyCloseAutoCompleteEligibilityWithCtx(ctx, {
-            completionWindowSatisfied: scheduleContext.storeDayContext
-              ? scheduleContext.phase === "after_last_window"
-              : cronWindow?.completionWindowSatisfied,
+            completionWindowSatisfied:
+              eodStoreDayContext.completionWindowSatisfied,
             now,
             operatingDate,
-            storeDayContext: scheduleContext.storeDayContext,
+            storeDayContext: eodStoreDayContext.storeDayContext,
             storeId: policy.storeId,
           }),
       });

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
@@ -146,6 +146,55 @@ vi.mock("./CommandApprovalDialog", () => ({
     ) : null,
 }));
 
+vi.mock("../staff-auth/StaffAuthenticationDialog", () => ({
+  StaffAuthenticationDialog: ({
+    onAuthenticate,
+    onAuthenticated,
+    onDismiss,
+    open,
+  }: {
+    onAuthenticate: (args: {
+      pinHash: string;
+      username: string;
+    }) => Promise<{
+      data?: {
+        staffProfileId: Id<"staffProfile">;
+        staffProfile: { fullName?: string | null };
+      };
+      kind: string;
+    }>;
+    onAuthenticated: (result: {
+      staffProfileId: Id<"staffProfile">;
+      staffProfile: { fullName?: string | null };
+    }) => void;
+    onDismiss: () => void;
+    open: boolean;
+  }) =>
+    open ? (
+      <div aria-label="Confirm staff credentials" role="dialog">
+        <p>Confirm staff credentials</p>
+        <button
+          onClick={async () => {
+            const result = await onAuthenticate({
+              pinHash: "pin-hash",
+              username: "cashier",
+            });
+
+            if (result.kind === "ok" && result.data) {
+              onAuthenticated(result.data);
+            }
+          }}
+          type="button"
+        >
+          Confirm staff
+        </button>
+        <button onClick={onDismiss} type="button">
+          Cancel
+        </button>
+      </div>
+    ) : null,
+}));
+
 vi.mock("~/convex/_generated/api", () => ({
   api: {
     operations: {
@@ -655,6 +704,46 @@ describe("DailyOpeningViewContent", () => {
         "Drawer closed. Open the drawer before starting the store day.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("collects staff credentials before starting Opening Handoff", async () => {
+    const user = userEvent.setup();
+    const onAuthenticateStaff = vi.fn(async () =>
+      ok({
+        staffProfile: { fullName: "Ama Mensah" },
+        staffProfileId: "staff-1" as Id<"staffProfile">,
+      }),
+    );
+    const onStartDay = vi.fn(async () => ok({ openingId: "opening-1" }));
+
+    renderContent(readySnapshot, {
+      onAuthenticateStaff,
+      onStartDay,
+    });
+
+    await user.click(screen.getByRole("button", { name: /start day/i }));
+
+    expect(onStartDay).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("dialog", { name: "Confirm staff credentials" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /confirm staff/i }));
+
+    await waitFor(() => {
+      expect(onAuthenticateStaff).toHaveBeenCalledWith({
+        pinHash: "pin-hash",
+        username: "cashier",
+      });
+      expect(onStartDay).toHaveBeenCalledWith({
+        acknowledgedItemKeys: [],
+        actorStaffProfileId: "staff-1",
+        endAt: readySnapshot.endAt,
+        notes: "",
+        operatingDate: "2026-05-08",
+        startAt: readySnapshot.startAt,
+      });
+    });
   });
 
   it("starts the store day directly even when manager approval support is available", async () => {

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
@@ -53,6 +53,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { OperationReviewWorkspace } from "./OperationReviewWorkspace";
 import { OperationReviewItemCard } from "./OperationReviewItemCard";
 import { OperationsSummaryMetric } from "./OperationsSummaryMetric";
+import {
+  StaffAuthenticationDialog,
+  type StaffAuthenticationResult,
+} from "../staff-auth/StaffAuthenticationDialog";
 
 type DailyOpeningApi = {
   getDailyOpeningSnapshot?: unknown;
@@ -170,9 +174,13 @@ type DailyOpeningViewContentProps = {
   isLoadingAccess: boolean;
   isLoadingSnapshot: boolean;
   isStarting: boolean;
-  onStartDay: (args: StartDayArgs) => Promise<NormalizedCommandResult<unknown>>;
+  onAuthenticateStaff?: (args: {
+    pinHash: string;
+    username: string;
+  }) => Promise<NormalizedCommandResult<StaffAuthenticationResult>>;
   onAuthenticateForApproval?: CommandApprovalDialogProps["onAuthenticateForApproval"];
   onOperatingDateChange?: (date: Date) => void;
+  onStartDay: (args: StartDayArgs) => Promise<NormalizedCommandResult<unknown>>;
   orgUrlSlug: string;
   snapshot?: DailyOpeningSnapshot;
   storeId?: Id<"store">;
@@ -1592,6 +1600,7 @@ export function DailyOpeningViewContent({
   isLoadingAccess,
   isLoadingSnapshot,
   isStarting,
+  onAuthenticateStaff,
   onOperatingDateChange,
   onStartDay,
   orgUrlSlug,
@@ -1605,6 +1614,9 @@ export function DailyOpeningViewContent({
     kind: "error" | "success";
     message: string;
   } | null>(null);
+  const [pendingStaffStartArgs, setPendingStaffStartArgs] =
+    useState<StartDayArgs | null>(null);
+  const [isStaffAuthOpen, setIsStaffAuthOpen] = useState(false);
   const navigate = useNavigate();
   const search = useSearch({ strict: false }) as {
     page?: unknown;
@@ -1672,34 +1684,13 @@ export function DailyOpeningViewContent({
   const acknowledgedRequiredCount = requiredAcknowledgementKeys.filter((key) =>
     acknowledgedKeys.includes(key),
   ).length;
-  const submitStartDay = async (approval?: {
-    approvalProofId: Id<"approvalProof">;
-    approvedByStaffProfileId: Id<"staffProfile">;
-  }) => {
-    if (!snapshot || isStarted) return;
 
-    const acknowledgementComplete =
-      acknowledgedRequiredCount >= requiredAcknowledgementKeys.length;
-
-    if (!acknowledgementComplete) return;
-
-    setCommandMessage(null);
-
-    const result = await onStartDay({
-      acknowledgedItemKeys: requiredAcknowledgementKeys,
-      ...(approval
-        ? {
-            actorStaffProfileId: approval.approvedByStaffProfileId,
-            approvalProofId: approval.approvalProofId,
-          }
-        : {}),
-      endAt: snapshot.endAt,
-      notes,
-      operatingDate: snapshot.operatingDate,
-      startAt: snapshot.startAt,
-    });
+  const startDayWithArgs = async (args: StartDayArgs) => {
+    const result = await onStartDay(args);
 
     if (result.kind === "ok") {
+      setPendingStaffStartArgs(null);
+      setIsStaffAuthOpen(false);
       setCommandMessage({
         kind: "success",
         message: "Store day started.",
@@ -1713,8 +1704,58 @@ export function DailyOpeningViewContent({
     });
   };
 
+  const submitStartDay = async (approval?: {
+    approvalProofId: Id<"approvalProof">;
+    approvedByStaffProfileId: Id<"staffProfile">;
+  }) => {
+    if (!snapshot || isStarted) return;
+
+    const acknowledgementComplete =
+      acknowledgedRequiredCount >= requiredAcknowledgementKeys.length;
+
+    if (!acknowledgementComplete) return;
+
+    setCommandMessage(null);
+
+    const startArgs = {
+      acknowledgedItemKeys: requiredAcknowledgementKeys,
+      ...(approval
+        ? {
+            actorStaffProfileId: approval.approvedByStaffProfileId,
+            approvalProofId: approval.approvalProofId,
+          }
+        : {}),
+      endAt: snapshot.endAt,
+      notes,
+      operatingDate: snapshot.operatingDate,
+      startAt: snapshot.startAt,
+    };
+
+    if (approval || !onAuthenticateStaff) {
+      await startDayWithArgs(startArgs);
+      return;
+    }
+
+    setPendingStaffStartArgs(startArgs);
+    setIsStaffAuthOpen(true);
+  };
+
   const handleStartDay = () => {
     void submitStartDay();
+  };
+
+  const handleStaffAuthenticatedForStart = (
+    result: StaffAuthenticationResult,
+  ) => {
+    if (!pendingStaffStartArgs) {
+      setIsStaffAuthOpen(false);
+      return;
+    }
+
+    void startDayWithArgs({
+      ...pendingStaffStartArgs,
+      actorStaffProfileId: result.staffProfileId,
+    });
   };
 
   const handleBucketValueChange = (value: BucketStatus) => {
@@ -1737,7 +1778,8 @@ export function DailyOpeningViewContent({
   };
 
   return (
-    <OperationReviewWorkspace
+    <>
+      <OperationReviewWorkspace
       actions={
         snapshot ? (
           <OperatingDatePicker
@@ -1849,7 +1891,25 @@ export function DailyOpeningViewContent({
         <DailyOpeningStatusTitle status={status} title={displayCopy.title} />
       }
       title="Opening Handoff"
-    />
+      />
+      {onAuthenticateStaff ? (
+        <StaffAuthenticationDialog
+          copy={{
+            description: "Start the store day with your staff sign-in.",
+            submitLabel: "Start day",
+            title: "Confirm staff credentials",
+          }}
+          hideAlternateAction
+          onAuthenticate={(args) => onAuthenticateStaff(args)}
+          onAuthenticated={handleStaffAuthenticatedForStart}
+          onDismiss={() => {
+            setIsStaffAuthOpen(false);
+            setPendingStaffStartArgs(null);
+          }}
+          open={isStaffAuthOpen}
+        />
+      ) : null}
+    </>
   );
 }
 
@@ -1914,9 +1974,36 @@ function DailyOpeningConnectedView({
       : "skip",
   ) as DailyOpeningSnapshot | undefined;
   const startStoreDayMutation = useExpectedDailyOpeningMutation(startStoreDay);
+  const authenticateStaffCredential = useMutation(
+    api.operations.staffCredentials.authenticateStaffCredential,
+  );
   const authenticateStaffCredentialForApproval = useMutation(
     api.operations.staffCredentials.authenticateStaffCredentialForApproval,
   );
+
+  async function handleAuthenticateStaff(args: {
+    pinHash: string;
+    username: string;
+  }): Promise<NormalizedCommandResult<StaffAuthenticationResult>> {
+    if (!activeStore?._id) {
+      return {
+        kind: "user_error",
+        error: {
+          code: "authentication_failed",
+          message: "Select a store before confirming staff credentials.",
+        },
+      };
+    }
+
+    return runCommand(() =>
+      authenticateStaffCredential({
+        allowedRoles: ["cashier", "manager"],
+        pinHash: args.pinHash,
+        storeId: activeStore._id,
+        username: args.username,
+      }) as Promise<CommandResult<StaffAuthenticationResult>>,
+    );
+  }
 
   async function handleAuthenticateForApproval(args: {
     actionKey: string;
@@ -2009,6 +2096,7 @@ function DailyOpeningConnectedView({
       isLoadingAccess={isLoadingAccess}
       isLoadingSnapshot={snapshot === undefined}
       isStarting={isStarting}
+      onAuthenticateStaff={handleAuthenticateStaff}
       onAuthenticateForApproval={handleAuthenticateForApproval}
       onOperatingDateChange={handleOperatingDateChange}
       onStartDay={handleStartDay}


### PR DESCRIPTION
## Summary

Store-day Opening and EOD automation now use their configured policy times as the automation gates instead of treating customer-facing store hours as hard run boundaries. That lets Wig Club schedule Opening before public opening, and lets EOD auto-complete respect the configured completion window even when it is earlier or later than the public close time.

The Opening Handoff start flow now collects staff credentials up front when the signed-in operator does not already have a linked staff profile. This avoids depending on brittle backend error text and sends the authenticated staff profile with the start-day mutation.

## Testing

- `bun run test -- src/components/operations/DailyOpeningView.test.tsx`
- `bun run test -- convex/operations/dailyOperationsAutomation.test.ts`
- `bun run lint:frontend:changed`
- `bun run lint:convex:changed`
- `bun run graphify:rebuild`
- `git diff --check`
- pre-push suite: graphify check, architecture checks, full `@athena/webapp` test run, Convex audit, changed-file linters, focused operations tests, TypeScript, production build, behavior scenarios, inferential review

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
