### PR TITLE
feat(operations): automate historic EOD close

### DIFF
--- a/docs/plans/2026-06-29-001-feat-historic-eod-auto-close-plan.html
+++ b/docs/plans/2026-06-29-001-feat-historic-eod-auto-close-plan.html
@@ -1,0 +1,268 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>feat: Add historic EOD auto-close automation</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --ink: #17202a;
+        --muted: #5d6975;
+        --line: #d7dde4;
+        --panel: #f7f9fb;
+        --accent: #0f6b5f;
+      }
+      body {
+        margin: 0;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+        color: var(--ink);
+        background: white;
+      }
+      main {
+        max-width: 1040px;
+        margin: 0 auto;
+        padding: 40px 28px 64px;
+      }
+      header {
+        border-bottom: 1px solid var(--line);
+        margin-bottom: 28px;
+        padding-bottom: 20px;
+      }
+      h1 {
+        font-size: 34px;
+        line-height: 1.18;
+        margin: 0 0 12px;
+      }
+      h2 {
+        font-size: 22px;
+        line-height: 1.25;
+        margin: 32px 0 12px;
+      }
+      h3 {
+        font-size: 17px;
+        margin: 24px 0 10px;
+      }
+      p,
+      li {
+        font-size: 15px;
+        line-height: 1.55;
+      }
+      ul,
+      ol {
+        padding-left: 22px;
+      }
+      code {
+        background: #edf1f4;
+        border-radius: 4px;
+        padding: 1px 4px;
+        font-size: 0.92em;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 14px 0 24px;
+        font-size: 14px;
+      }
+      th,
+      td {
+        border: 1px solid var(--line);
+        padding: 10px 12px;
+        text-align: left;
+        vertical-align: top;
+      }
+      th {
+        background: var(--panel);
+      }
+      .meta {
+        color: var(--muted);
+        font-size: 14px;
+      }
+      .summary {
+        border-left: 4px solid var(--accent);
+        background: var(--panel);
+        padding: 14px 16px;
+      }
+      .unit {
+        border-top: 1px solid var(--line);
+        padding-top: 18px;
+      }
+      .mermaid-note {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        padding: 12px 14px;
+        color: var(--muted);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="meta">Plan · 2026-06-29 · status: active</div>
+        <h1>feat: Add historic EOD auto-close automation</h1>
+        <p class="summary">
+          Add an automation-first path for Athena to retroactively close eligible
+          historic store days. The work starts with register-session date indexes
+          and source completeness verification, then adds a bounded support-owned
+          historic runner on the existing Daily Close automation completion rail.
+        </p>
+      </header>
+
+      <section>
+        <h2>Problem Frame</h2>
+        <p>
+          Current EOD automation can complete the active store day, but historic
+          missing days still require manual date-by-date work. That is both slow
+          and risky because Daily Close currently uses capped source reads in
+          several places. Historic automation also needs a currentness mode so
+          old closes do not demote the live current close.
+        </p>
+      </section>
+
+      <section>
+        <h2>Requirements</h2>
+        <ol>
+          <li>Add date-indexed register-session support before any historic close mutation path.</li>
+          <li>Keep completed history as <code>dailyClose</code> rows with stored <code>reportSnapshot</code>.</li>
+          <li>Use Store Schedule local operating ranges, not UTC calendar days.</li>
+          <li>Bound support-owned internal runs by explicit store/date range, batch size, mode, and oldest-first ordering.</li>
+          <li>Reuse current <code>eod.auto_complete</code> policy gates and fail closed on blockers.</li>
+          <li>Never overwrite human-completed closes.</li>
+          <li>Never demote the live/current close from a historic run.</li>
+          <li>Align <code>dailyClose</code>, report snapshot, <code>automationRun</code>, and operational-event evidence.</li>
+          <li>Expose skipped, failed, and dry-run reasons safely.</li>
+          <li>Quarantine incomplete or ambiguous source data durably in per-date automation evidence.</li>
+          <li>Cover scale, timezone, currentness, idempotency, and batch resume regressions.</li>
+        </ol>
+      </section>
+
+      <section>
+        <h2>Technical Decisions</h2>
+        <ul>
+          <li>Add optional derived register-session date fields, schedule evidence, and indexes first.</li>
+          <li>Match existing Daily Close date ownership semantics when deriving closeout dates, and quarantine when Store Schedule cannot resolve durable local-day evidence.</li>
+          <li>Use widen-migrate-narrow: optional fields, dual-write, backfill, verify, then rely on indexes.</li>
+          <li>Use a distinct historic run namespace while keeping policy semantics equivalent to <code>eod.auto_complete</code>; batch evidence lives in per-date <code>automationRun</code> rows plus backend results.</li>
+          <li>Add historical currentness mode to Daily Close automation completion.</li>
+          <li>Process multi-day ranges oldest-first through a per-date internal mutation so close, event, and run evidence cannot diverge.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Implementation Flow</h2>
+        <p class="mermaid-note">
+          Explicit range -> Store Schedule resolver -> oldest-first candidates ->
+          source-complete Daily Close snapshot -> policy gate -> dry-run, quarantine, or
+          historical-currentness completion -> completed snapshot/event/run evidence.
+        </p>
+      </section>
+
+      <section>
+        <h2>State Safety Matrix</h2>
+        <table>
+          <thead>
+            <tr><th>Existing state</th><th>Historic run result</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>No close and eligible snapshot</td><td>Insert/apply completed close with automation attribution.</td></tr>
+            <tr><td>Open/review close and eligible snapshot</td><td>Complete without marking it store-wide current.</td></tr>
+            <tr><td>Human-completed close</td><td>No-op; preserve human record.</td></tr>
+            <tr><td>Automation-completed close for same historic key</td><td>Idempotent no-op.</td></tr>
+            <tr><td>Reopened or superseded close</td><td>Skip/quarantine.</td></tr>
+            <tr><td>Live current close</td><td>Unchanged by old-date historic runs.</td></tr>
+            <tr><td>Incomplete register-session evidence</td><td>Skip/quarantine.</td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Implementation Units</h2>
+
+        <article class="unit">
+          <h3>U1. Register-session date foundation</h3>
+          <p>
+            Add optional derived date fields, schedule evidence, indexes, and dual-write support in
+            register-session close, reject, reopen, correction, and local sync
+            paths. Cover >200 session ranges and reopened closeouts.
+          </p>
+        </article>
+
+        <article class="unit">
+          <h3>U2. Indexed Daily Close snapshot reads</h3>
+          <p>
+            Replace capped broad source scans with indexed or completeness-aware
+            helpers while preserving final semantic filtering and conservative
+            legacy fallback evidence.
+          </p>
+        </article>
+
+        <article class="unit">
+          <h3>U3. Historic currentness mode</h3>
+          <p>
+            Extend automation completion so historic records can complete with
+            snapshots and events without marking themselves current or demoting
+            the live current close.
+          </p>
+        </article>
+
+        <article class="unit">
+          <h3>U4. Historic EOD runner</h3>
+          <p>
+            Add explicit support-owned dry-run and apply modes for bounded
+            store/date ranges, using oldest-first processing, distinct historic
+            idempotency keys, and transactional per-date writes.
+          </p>
+        </article>
+
+        <article class="unit">
+          <h3>U5. Safe visibility and audit</h3>
+          <p>
+            Preserve read-only Daily Close History, show Athena attribution for
+            historic completed snapshots, and keep restricted details behind
+            existing permissions. No operator-facing backlog toggle ships here.
+          </p>
+        </article>
+
+        <article class="unit">
+          <h3>U6. Backfill and verification sensors</h3>
+          <p>
+            Add paginated register-session date backfill and source completeness
+            verification. Count updated, skipped, ambiguous, and already-current
+            sessions without collecting whole production tables.
+          </p>
+        </article>
+
+        <article class="unit">
+          <h3>U7. Regression and delivery sensors</h3>
+          <p>
+            Run focused Daily Close, automation, and cash-controls tests; Convex
+            audit and changed lint; typecheck; build; Graphify rebuild; and
+            <code>bun run pr:athena</code> before PR merge, root alignment, and
+            production deploy.
+          </p>
+        </article>
+      </section>
+
+      <section>
+        <h2>Tracking Plan</h2>
+        <table>
+          <thead>
+            <tr><th>Ticket</th><th>Unit</th><th>Posture</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Add register-session date indexes and dual-write fields</td><td>U1</td><td>test-first</td></tr>
+            <tr><td>Backfill register-session date fields and add source completeness verification</td><td>U6</td><td>test-first</td></tr>
+            <tr><td>Replace Daily Close source scans with indexed/completeness-aware helpers</td><td>U2</td><td>characterization-first</td></tr>
+            <tr><td>Make Daily Close automation completion safe for historic currentness</td><td>U3</td><td>test-first</td></tr>
+            <tr><td>Add bounded historic EOD auto-close runner</td><td>U4</td><td>test-first</td></tr>
+            <tr><td>Surface historic automation evidence safely</td><td>U5</td><td>characterization-first</td></tr>
+            <tr><td>Validate, regenerate artifacts, merge, align root, deploy</td><td>U7</td><td>sensor-only</td></tr>
+          </tbody>
+        </table>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/plans/2026-06-29-001-feat-historic-eod-auto-close-plan.md
+++ b/docs/plans/2026-06-29-001-feat-historic-eod-auto-close-plan.md
@@ -1,0 +1,447 @@
+---
+title: "feat: Add historic EOD auto-close automation"
+type: feat
+status: active
+date: 2026-06-29
+---
+
+# feat: Add historic EOD auto-close automation
+
+## Summary
+
+Add an automation-first path for Athena to retroactively close eligible historic store days. The delivery starts by fixing register-session date indexes so Daily Close snapshots can be complete at historic scale, then adds a bounded, replayable historic EOD auto-close runner that uses the existing policy-gated Daily Close completion rail without corrupting live current-day state.
+
+---
+
+## Problem Frame
+
+Athena can already complete current EOD Review through `eod.auto_complete` when policy allows it, but historic missing days still require manual navigation date by date. That manual shape does not scale and is risky: the current register-session read path broad-scans store/status rows and filters in memory, so a historic close can miss sessions once there are more than 200 relevant register-session records. Historic completion also cannot call the current completion helper unchanged, because that helper marks one close as the store-wide current close.
+
+This work should be automation-oriented, not a manager shortcut. It should produce durable `dailyClose` records with frozen snapshots, `automationRun` evidence, and operational events only when source data is complete enough to make an authoritative close.
+
+---
+
+## Requirements
+
+- R1. Add date-indexed register-session support before shipping any historic close mutation path.
+- R2. Preserve the existing Daily Close source-of-truth model: completed history is `dailyClose` rows with stored `reportSnapshot`, not a separate history table or recomputed read-only view.
+- R3. Historic automation must use store-local operating ranges from Store Schedule context, not UTC calendar days or browser-local inference.
+- R4. Historic automation must be bounded by explicit store/date range, batch size, dry-run/application mode, and oldest-first ordering.
+- R5. Historic completion must use the same policy gates as `eod.auto_complete`: blockers, open/closing registers, pending approvals, unresolved POS sessions, unsupported review categories, threshold failures, reopened/superseded state, and carry-forward conflicts all fail closed.
+- R6. Already-completed human closes must never be overwritten. Already-completed automation closes must be idempotent no-ops unless the run is explicitly dry-run/report-only.
+- R7. Historic completion must not demote the live/current close or set an old close as store-wide current by accident.
+- R8. Each applied date must persist aligned audit evidence across `dailyClose.automationRunId`, `reportSnapshot.closeMetadata`, `automationRun.decisionEvidence`, and `daily_close_completed` operational events.
+- R9. Skipped, failed, and dry-run dates must expose support-useful reasons without leaking restricted financial/review details to broad readers.
+- R10. Ambiguous or incomplete source data must quarantine the date for review instead of creating authoritative-looking financial history from partial evidence.
+- R11. The implementation must include focused regression coverage for >200 register sessions, local day ranges crossing UTC midnight, currentness safety, idempotency, and batch resume behavior.
+
+---
+
+## Scope Boundaries
+
+- This plan does not add LLM judgement or probabilistic classification. Eligibility remains deterministic and policy-based.
+- This plan does not repair business facts such as sales, payments, closeouts, variances, or manager approvals.
+- This plan does not make Daily Close History a mutation surface; historic automation is support-owned and runs through internal tooling, not an operator settings toggle.
+- This plan does not weaken manual EOD approval, reopen, or carry-forward rules.
+- This plan does not add customer-facing copy or external Slack/email notifications.
+- This plan does not rely on capped in-memory scans as a completeness boundary.
+
+### Deferred to Follow-Up Work
+
+- Any operator-facing settings toggle, backlog scheduling UI, or rich admin UI for configuring ongoing historic backlog schedules.
+- Advanced quarantine triage workflows for ambiguous source data.
+- Broader schedule-history browsing for operators.
+- Intelligence-layer suggestions for which historic ranges to backfill.
+
+---
+
+## Context & Research
+
+### Subagent Findings
+
+- Repository research confirmed that EOD automation is already split between `eod.prepare` and `eod.auto_complete`, with `dailyClose.ts` owning command-time snapshots and completion.
+- Learnings research confirmed that automated EOD completion must record Athena policy evidence, preserve carry-forward work, and use stored completed snapshots for historical display.
+- Flow analysis identified two critical blockers: register-session date queries are unsafe for historic scale, and current completion marks other store closes non-current across the whole store.
+- Data-integrity review recommended widen-migrate-narrow for register-session date fields, stable historic idempotency keys, all-or-nothing audit consistency, and quarantining ambiguous dates.
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/convex/operations/dailyClose.ts` builds Daily Close snapshots, applies manual and automation completion, persists `reportSnapshot`, and currently uses `DAILY_CLOSE_QUERY_LIMIT = 200` in multiple query paths.
+- `packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts` evaluates `eod.auto_complete` policy and calls `completeDailyCloseForAutomationWithCtx`.
+- `packages/athena-webapp/convex/automation/runLedger.ts` owns `automationPolicy` and `automationRun` decision evidence, outcome patching, and idempotency patterns.
+- `packages/athena-webapp/convex/schemas/operations/registerSession.ts` stores `openedAt`, `closedAt`, and `closeoutRecords`, but no top-level derived date fields for closeout ownership.
+- `packages/athena-webapp/convex/schema.ts` indexes `registerSession` by store/status/register/terminal/approval, but not by opened/closed/closeout date.
+- `packages/athena-webapp/convex/operations/registerSessions.ts` and `packages/athena-webapp/convex/cashControls/closeouts.ts` own the register close, reject, reopen, and correction write paths that must dual-write derived date fields.
+- `packages/athena-webapp/convex/inventory/storeSchedule.ts` owns store-local schedule context and should remain the business-time source for historic ranges.
+- `packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx` already presents completed historical closes and should continue reading stored snapshots.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-eod-review-automation-completion-2026-06-22.md`: EOD completion is a policy-gated automation action with command-time snapshot revalidation and durable Athena attribution.
+- `docs/solutions/architecture/athena-store-schedule-foundation-2026-06-27.md`: Store Schedule owns business time; automation persists schedule-derived evidence so later schedule edits do not reinterpret history.
+- `docs/solutions/logic-errors/athena-daily-close-history-snapshots-2026-05-09.md`: completed historical views must render persisted `reportSnapshot`, not recompute from live state.
+- `docs/solutions/logic-errors/athena-register-closeout-generic-holds-2026-06-26.md`: register lifecycle and closeout holds must remain shared policy, not one-off Daily Close logic.
+- `docs/solutions/logic-errors/athena-terminal-sync-review-currentness-2026-06-28.md`: stale sync/conflict evidence must not be treated as clean business state.
+
+### External References
+
+- None. Athena’s Convex automation, Daily Close, Store Schedule, and register lifecycle patterns are the source of truth.
+
+---
+
+## Key Technical Decisions
+
+- **Add derived register-session date fields before historic mutation:** Use optional top-level fields for raw closeout ownership timestamp, ownership source, resolved store-local operating date/range, and schedule evidence, plus status/opened-date and status/operating-date indexes so historic snapshots can query by range without capped status scans.
+- **Match current Daily Close date ownership semantics:** Derive closeout ownership from closed closeout record `occurredAt`, then submitted variance approval timing where available, then `closedAt`, and only fall back to opened/closed intersection for non-authoritative range membership. If Store Schedule cannot resolve the authoritative operating date/range for the ownership timestamp, clear the authoritative derived date field and quarantine apply-mode automation.
+- **Use widen-migrate-narrow:** Add optional fields and dual-write first, backfill existing sessions in batches, verify, then route snapshot queries through indexed helpers with conservative legacy fallback only where needed.
+- **Use existing automation evidence with a distinct historic run identity:** Keep policy semantics equivalent to `eod.auto_complete`, but identify support/batch runs separately, such as `historic_eod.auto_complete`, so normal scheduled EOD completion and backlog cleanup remain distinguishable. Batch-level evidence for v1 lives in existing per-date `automationRun` rows plus the backend run result; do not add a separate support ledger unless implementation proves the existing ledger cannot represent the batch safely.
+- **Do not create a parallel completion engine:** Historic automation should call the existing Daily Close snapshot and automation completion boundary after adding a currentness mode that preserves live current close state.
+- **Add historical currentness mode:** Current-day completion can keep setting `isCurrent: true` and marking other store closes non-current. Historic completion must write completed snapshots without changing the store-wide current close.
+- **Process oldest-first:** Multi-day ranges close oldest eligible dates first so later snapshots see prior completed close and carry-forward context.
+- **Quarantine incomplete dates durably:** Missing/ambiguous source evidence, capped/incomplete source reads, or unsupported lifecycle state must create or update an idempotent per-date `automationRun` with a stable quarantine classification/reason code, distinct from ordinary policy skips. Broad readers see only redacted operational copy.
+- **Keep UI narrow:** Daily Close History stays read-only. Operator surfaces may show safe attribution/status, but the first delivery exposes support run results through backend return values and existing automation evidence rather than a new settings toggle or backlog UI.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should this be manual/admin date-by-date close?** No. The user explicitly requested automation-oriented delivery.
+- **Can the existing completion helper be reused unchanged?** No. It currently updates store-wide currentness and would demote the live close during historic backfill.
+- **Is `closedAt` alone a sufficient register-session date index?** No. Daily Close already uses closeout record and approval evidence before `closedAt`.
+- **Can ambiguous historical source data be auto-repaired?** No. This work may close eligible days, but it must not repair sales/payments/closeout business facts.
+
+### Deferred to Implementation
+
+- None. Batch evidence uses existing per-date `automationRun` rows plus backend run results for this delivery, and historic backfill remains support-owned with no operator-facing settings toggle.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  Range["Explicit store/date range"] --> Schedule["Store Schedule range resolver"]
+  Schedule --> Candidates["Oldest-first historic candidates"]
+  Candidates --> Snapshot["Indexed Daily Close snapshot"]
+  Snapshot --> Policy["Existing eod.auto_complete policy evaluation"]
+  Policy --> Gate{"Eligible?"}
+  Gate -->|No| Quarantine["Skip/quarantine with evidence"]
+  Gate -->|Dry run| DryRun["Record/report dry-run evidence"]
+  Gate -->|Apply| Complete["Daily Close automation completion"]
+  Complete --> Currentness["Historical currentness mode"]
+  Currentness --> Close["Completed dailyClose + reportSnapshot"]
+  Close --> Event["daily_close_completed event"]
+  Event --> Run["automationRun outcome patched"]
+  Run --> History["Daily Close History reads stored snapshot"]
+```
+
+### State Safety Matrix
+
+| Existing state | Historic run result |
+| --- | --- |
+| No close and clean eligible snapshot | Insert/apply completed close with automation attribution. |
+| Existing open/review close and eligible snapshot | Complete the date without marking it store-wide current. |
+| Existing human-completed close | No-op; preserve human record. |
+| Existing automation-completed close for same historic key | Idempotent no-op. |
+| Reopened or superseded close | Skip/quarantine. |
+| Current/live close for latest day | Unchanged by old-date historic runs. |
+| Incomplete register-session source evidence | Skip/quarantine. |
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 Register-session date foundation"] --> U6["U6 Backfill and verification sensors"]
+  U6 --> U2["U2 Indexed Daily Close snapshot reads"]
+  U2 --> U3["U3 Historic completion currentness mode"]
+  U3 --> U4["U4 Historic EOD automation runner"]
+  U6 --> U4
+  U4 --> U5["U5 Visibility, audit, and redaction"]
+  U2 --> U7["U7 Regression and merge sensors"]
+  U3 --> U7
+  U4 --> U7
+  U5 --> U7
+  U6 --> U7
+```
+
+- U1. **Add register-session date foundation**
+
+**Goal:** Add optional derived register-session date fields, indexes, and dual-write support needed for historic range queries.
+
+**Requirements:** R1, R3, R10, R11
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/schemas/operations/registerSession.ts`
+- Modify: `packages/athena-webapp/convex/schema.ts`
+- Modify: `packages/athena-webapp/convex/operations/registerSessions.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.ts`
+- Modify as needed: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Test: `packages/athena-webapp/convex/cashControls/registerSessions.test.ts`
+- Test: `packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts`
+
+**Approach:**
+- Add optional derived fields for closeout date ownership and closeout submission/review timing, with names that make ownership explicit.
+- Derived closeout ownership fields must include raw ownership timestamp, ownership source enum, resolved store-local operating date, resolved range start/end, and Store Schedule version/evidence used for the derivation.
+- Add indexes for store/status/opened date and store/status/resolved operating date; add store/date indexes without status only if existing query plans need them.
+- Implement one shared helper for deriving closeout ownership from a register session, optional approval request, and Store Schedule resolver so daily close, backfill, and write paths share semantics.
+- Dual-write derived fields when a register session closes, enters closeout review, is approved/rejected, is reopened, or receives a local/offline closeout projection.
+- Reopen/correction paths must preserve historical closeout records while updating the top-level date field to the latest authoritative ownership value or clearing it when no authoritative value remains.
+- Ambiguous or missing schedule evidence must clear authoritative operating-date fields and mark the session as incomplete for apply-mode historic automation.
+
+**Test scenarios:**
+- Closed session with a closed closeout record sets closeout ownership date from `closeoutRecords[].occurredAt`.
+- Variance-review submission sets the submission/review date without pretending the close is closed.
+- Reopen clears or recalculates derived fields consistently.
+- More than 200 closed sessions in a store/date range are all addressable by indexed query.
+- Sessions opened before a range and closed inside the range are still included.
+- Ambiguous schedule evidence clears authoritative operating-date fields and blocks apply-mode historic automation.
+
+**Verification:**
+- Register-session date fields are optional, dual-written, and queryable without changing existing lifecycle meaning.
+
+---
+
+- U2. **Route Daily Close source reads through indexed helpers**
+
+**Goal:** Replace capped broad scans in Daily Close source reads with date-indexed or completeness-aware range helpers while preserving existing snapshot semantics.
+
+**Requirements:** R1, R2, R3, R5, R10, R11
+
+**Dependencies:** U6
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/dailyClose.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyClose.test.ts`
+- Test: `packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts`
+
+**Approach:**
+- Extract register-session range query helpers for closed, active/intersecting, and approval/review sessions.
+- Use new date indexes for closeout-owned sessions and opened/intersecting sessions.
+- Preserve `registerSessionBelongsToRange` as the final semantic filter, but do not let `take(200)` before date filtering be the completeness boundary.
+- Treat legacy sessions missing derived fields conservatively: include them through a bounded fallback only for compatibility, and mark evidence as incomplete where automation needs full confidence.
+- Audit every Daily Close source contributor that still uses `DAILY_CLOSE_QUERY_LIMIT`, including transactions, payment allocations/deposits, adjustments, approvals, open POS sessions, work items, expenses, and prior completed close lookup.
+- Where indexed day-range reads already exist, use those indexes in complete pagination loops or bounded page helpers rather than one capped `take`.
+- For any source that cannot be made complete in this delivery, add explicit source-completeness evidence and make historic apply mode quarantine the date instead of completing.
+- Add snapshot evidence showing when every source read is complete enough for automation to apply.
+
+**Test scenarios:**
+- Historic day with more than 200 closed sessions includes all date-owned sessions.
+- Store day crossing UTC midnight includes only sessions belonging to that local range.
+- Open/active session intersecting the historic range blocks completion.
+- Session closed outside the range is excluded.
+- Missing derived date fields produce conservative automation evidence rather than silent completion.
+- A non-register source that still hits a cap marks source completeness false and blocks historic apply mode.
+
+**Verification:**
+- Daily Close snapshots stay behaviorally equivalent for normal days and become complete or explicitly incomplete for historic ranges.
+
+---
+
+- U3. **Add automation completion currentness modes**
+
+**Goal:** Make Daily Close completion safe for historical dates without changing current-day completion semantics.
+
+**Requirements:** R2, R5, R6, R7, R8, R11
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/dailyClose.ts`
+- Modify as needed: `packages/athena-webapp/convex/schemas/operations/dailyClose.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyClose.test.ts`
+
+**Approach:**
+- Add an internal currentness option to automation completion, such as `currentnessMode: "mark_current" | "historical_record"`.
+- Keep existing manual/current automation behavior as `mark_current`.
+- In `historical_record` mode, complete the target date and write frozen report snapshot/evidence without calling store-wide `markOtherDailyClosesNotCurrent` and without setting the historic record as store-wide current.
+- Reject human-completed, reopened, superseded, or mismatched existing closes before mutation.
+- Preserve all automation attribution and operational event behavior.
+
+**Test scenarios:**
+- Current `eod.auto_complete` still marks current close and demotes prior current closes.
+- Historic completion writes `isCurrent: false` and does not demote the latest close.
+- Existing human-completed close is preserved.
+- Reopened/superseded close is skipped.
+- Duplicate historic automation attempt is idempotent.
+
+**Verification:**
+- Historic completion cannot corrupt live currentness, while existing current-day completion behavior remains unchanged.
+
+---
+
+- U4. **Add bounded historic EOD automation runner**
+
+**Goal:** Add support-owned automation that discovers and applies eligible historic store days oldest-first.
+
+**Requirements:** R3, R4, R5, R6, R8, R9, R10, R11
+
+**Dependencies:** U1, U2, U3, U6
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts`
+- Modify: `packages/athena-webapp/convex/automation/actionRegistry.ts`
+- Modify: `packages/athena-webapp/convex/automation/runLedger.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts`
+
+**Approach:**
+- Add a support-owned internal action only as a batch orchestrator for explicit `storeId`, `startOperatingDate`, `endOperatingDate`, `mode`, and `maxDays`; it must not own per-date partial writes.
+- Add a per-date internal mutation that, in one Convex transaction, gets or creates the per-date historic `automationRun`, re-reads the command-time snapshot, completes or no-ops the `dailyClose`, records the operational event when applied, and patches run outcome/evidence.
+- Add an explicit Store Schedule helper such as `resolveStoreOperatingRangeForDateWithCtx(ctx, { storeId, operatingDate })`, returning `startAt`, `endAt`, timezone, schedule version/evidence, and skip/quarantine reasons for missing, closed, or ambiguous schedules.
+- Resolve each date through that helper and skip current/future dates.
+- Use a distinct historic run key namespace so retries do not collide with scheduled current-day `eod.auto_complete`.
+- Process oldest-first and stop or continue according to an explicit run option, defaulting to safe stop-on-failure for apply mode.
+- In dry-run mode, return per-date eligibility and skipped reasons without mutating Daily Close.
+- In apply mode, require verified date-index/backfill/source completeness for the target store/date range before any per-date apply mutation can run.
+- In apply mode, call the existing eligibility/completion rail with historical currentness mode from the per-date mutation.
+- In quarantine cases, create or update the stable per-date historic `automationRun` with a durable quarantine classification/reason code and redacted evidence.
+- Return aggregate counts: candidates, applied, already completed, skipped, failed, quarantined, and next cursor/date.
+
+**Test scenarios:**
+- Bounded date range dry-run reports eligible and skipped dates with no mutation.
+- Apply mode closes only eligible old dates.
+- Oldest-first processing is observable in run evidence.
+- Already completed dates are no-ops.
+- Current/future dates are skipped.
+- Duplicate invocation produces stable idempotent behavior.
+- Batch limit returns resumable cursor/date.
+- Apply mode rejects a range whose register-session date backfill/source completeness verification has not passed.
+- A simulated failure cannot leave `dailyClose`, `automationRun`, and operational event evidence disagreeing for a date.
+
+**Verification:**
+- Historic automation is explicit, bounded, replayable, and distinguishable from normal scheduled EOD automation.
+
+---
+
+- U5. **Expose safe visibility and audit evidence**
+
+**Goal:** Make historic automation outcomes inspectable without turning history into a mutation UI or leaking restricted details.
+
+**Requirements:** R2, R8, R9
+
+**Dependencies:** U3, U4
+
+**Files:**
+- Modify as needed: `packages/athena-webapp/convex/operations/dailyOperations.ts`
+- Modify as needed: `packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx`
+- Modify as needed: `packages/athena-webapp/src/components/operations/DailyOperationsView.tsx`
+- Test as needed: `packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx`
+- Test as needed: `packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx`
+
+**Approach:**
+- Preserve Daily Close History as read-only stored-snapshot display.
+- Ensure Athena-completed historic closes render as automation attribution rather than manager approval.
+- Keep full decision details behind existing financial/detail permissions.
+- Surface batch support evidence through backend return values and per-date automation run details first; no operator-facing historic toggle or backlog scheduling UI ships in this delivery.
+- Normalize skipped/quarantined copy to calm operational language.
+- Quarantine evidence is durable, idempotent, and distinct from disabled/dry-run/policy-skipped outcomes.
+
+**Test scenarios:**
+- Athena-completed historic close renders stored snapshot attribution.
+- Broad reader does not see raw run IDs, internal decision codes, or restricted financial evidence.
+- Completed lifecycle suppresses stale dry-run/skipped noise in operator status.
+
+**Verification:**
+- Operators can trust completed history, and support can trace automation decisions.
+
+---
+
+- U6. **Add backfill and verification sensors**
+
+**Goal:** Safely populate derived register-session date fields and verify historic source completeness before relying on indexes.
+
+**Requirements:** R1, R10, R11
+
+**Dependencies:** U1
+
+**Files:**
+- Create or modify: `packages/athena-webapp/convex/migrations/*registerSession*`
+- Test: migration coverage near existing Convex migration tests
+- Modify as needed: package validation registry if generated harness coverage changes
+
+**Approach:**
+- Add a paginated internal migration/backfill for derived register-session date fields.
+- Never `.collect()` all production register sessions.
+- Record counts for updated, skipped, ambiguous, and already-current sessions.
+- Use the same derivation helper as live write paths.
+- Add a verification query/action for store/date source completeness before historic automation applies.
+- Verification must cover register-session derived date coverage and any other Daily Close source that can still hit an incomplete capped read.
+- Historic apply mode is structurally dry-run/quarantine-only until verification passes for the requested store/date range.
+
+**Test scenarios:**
+- Backfill populates fields from closeout records.
+- Backfill falls back to approval/closed timestamps only according to documented semantics and only when Store Schedule can resolve the ownership timestamp into durable local-day evidence.
+- Ambiguous sessions are skipped and counted.
+- Cursor resumes without duplicate mutation.
+- Verification rejects a range when any source contributor lacks complete indexed coverage.
+
+**Verification:**
+- Register-session date indexes are populated enough for historic automation to rely on them.
+
+---
+
+- U7. **Regression and delivery sensors**
+
+**Goal:** Prove backend, UI, generated artifacts, graph, and merge/deploy readiness.
+
+**Requirements:** R11
+
+**Dependencies:** U1-U6
+
+**Files:**
+- Modify tests and generated artifacts as required by implementation.
+
+**Approach:**
+- Add focused tests before implementation where behavior is clear.
+- Run the Daily Close/cash-controls focused suite from `packages/athena-webapp`.
+- Run Convex audit and changed Convex lint.
+- Refresh generated Convex artifacts if public/internal refs or schema changes require it.
+- Run `bun run graphify:rebuild` after code changes.
+- Run `bun run pr:athena` before merge-ready handoff.
+- Merge by PR, fast-forward local root to the merged `origin/main`, then deploy relevant local production surfaces from the clean root.
+
+**Expected sensors:**
+- `bun run test -- convex/operations/dailyClose.test.ts convex/operations/dailyOperationsAutomation.test.ts convex/cashControls/registerSessions.test.ts`
+- `bun run --filter '@athena/webapp' audit:convex`
+- `bun run --filter '@athena/webapp' lint:convex:changed`
+- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
+- `bun run --filter '@athena/webapp' build`
+- `bun run graphify:rebuild`
+- `bun run pr:athena`
+
+**Verification:**
+- The branch is safe to merge through PR and deploy from aligned root.
+
+---
+
+## Linear Tracking Plan
+
+| Ticket | Unit | Dependencies | Execution Posture |
+| --- | --- | --- | --- |
+| Add register-session date indexes and dual-write fields | U1 | None | test-first |
+| Backfill register-session date fields and add source completeness verification | U6 | U1 | test-first |
+| Replace Daily Close source scans with indexed/completeness-aware range helpers | U2 | U6 | characterization-first |
+| Make Daily Close automation completion safe for historic currentness | U3 | U2 | test-first |
+| Add bounded historic EOD auto-close runner | U4 | U3, U6 | test-first |
+| Surface historic automation evidence safely | U5 | U4 | characterization-first |
+| Validate, regenerate artifacts, merge, align root, deploy | U7 | U1-U6 | sensor-only |
+
+---
+
+## Review Checklist
+
+- Register-session date indexes exist before historic mutation is enabled.
+- No historic path uses capped source scans as its completeness boundary.
+- Apply mode requires successful date-index/backfill/source-completeness verification for the requested range.
+- Per-date apply writes are transactional; the batch orchestrator never owns partial audit writes.
+- Historic completion cannot mark an old day as the live current close.
+- Human-completed closes are never overwritten.
+- Automation run keys distinguish historic batch work from normal scheduled EOD.
+- Store Schedule evidence is persisted or referenced so later schedule edits do not reinterpret historical closes.
+- Ambiguous data produces durable quarantine automation-run evidence, not authoritative completed history.
+- Focused and repo-level sensors run before merge.

--- a/docs/solutions/architecture/athena-historic-eod-auto-close-2026-06-29.md
+++ b/docs/solutions/architecture/athena-historic-eod-auto-close-2026-06-29.md
@@ -1,0 +1,74 @@
+---
+title: "Athena historic EOD automation needs indexed source evidence"
+date: 2026-06-29
+category: architecture
+module: athena-webapp
+problem_type: historic_eod_automation_boundary
+component: daily-operations
+resolution_type: indexed_completeness_aware_automation
+severity: high
+tags:
+  - automation
+  - daily-operations
+  - daily-close
+  - register-sessions
+  - cash-controls
+  - audit
+---
+
+## Problem
+
+Athena sometimes needs to close historic store days after the fact. The
+dangerous version of that work is a support script that scans old register
+sessions by broad status, assumes capped reads are complete, and writes a
+closed Daily Close as if it were the live current close.
+
+That creates three risks:
+
+- historic days can be completed from partial source reads;
+- old completions can demote the actual current Daily Close for the store; and
+- register sessions without date-indexed ownership force automation to infer
+  operating dates from stale or unbounded scans.
+
+## Solution
+
+Historic EOD automation needs its own evidence path:
+
+- register sessions carry opened and closeout operating-date evidence;
+- register-session indexes support store, status, opened date, and closeout
+  date queries;
+- Daily Close snapshots persist `sourceCompleteness` alongside source counts;
+- automation completion accepts `currentnessMode: "historical_record"` so
+  historic records stay non-current and do not demote live current closes;
+- support-owned historic runs process bounded oldest-first ranges with stable
+  idempotency keys; and
+- incomplete source evidence records a quarantine run instead of applying a
+  close.
+
+The runner should reuse the same Daily Close completion boundary rather than
+creating a second closeout writer. The difference is the caller mode and the
+eligibility evidence: historic apply requires complete source reads and writes a
+historical record; normal same-day automation can still mark the close current.
+
+## Safety Boundary
+
+Do not let historic automation repair missing source indexes by widening the
+mutation-time scan. If a register session cannot provide sufficient operating
+date evidence, classify the run as skipped or quarantined and leave a durable
+automation run explaining the missing source boundary.
+
+Historic apply mode must be support-owned, bounded by an explicit date range,
+and idempotent by store, date, mode, and automation action. Dry runs should use
+the same eligibility path as apply, without mutating Daily Close state.
+
+## Prevention
+
+- Add date-index fields before adding automation that depends on historic
+  session ownership.
+- Persist source completeness with the Daily Close snapshot, not only in logs.
+- Use `historical_record` for retroactive completion so live currentness is not
+  rewritten.
+- Quarantine incomplete reads instead of guessing.
+- Test dry-run/apply parity, currentness preservation, duplicate/idempotent
+  runs, incomplete source reads, closeout-derived session dates, and index
+  presence together.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8281 nodes · 9853 edges · 2072 communities detected
+- 8305 nodes · 9915 edges · 2072 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2110,12 +2110,12 @@
 ## Communities
 
 ### Community 0 - "Community 0"
-Cohesion: 0.06
-Nodes (84): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectConvexQueryWriteBoundaryFindings(), collectConvexReturnValidatorContractFindings(), collectHandlerDbAliases() (+76 more)
+Cohesion: 0.05
+Nodes (75): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildApprovalRequestsById(), buildDailyCloseApprovalSubject() (+67 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.05
-Nodes (71): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildApprovalRequestsById(), buildDailyCloseApprovalSubject() (+63 more)
+Cohesion: 0.06
+Nodes (84): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectConvexQueryWriteBoundaryFindings(), collectConvexReturnValidatorContractFindings(), collectHandlerDbAliases() (+76 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.06
@@ -2150,44 +2150,44 @@ Cohesion: 0.09
 Nodes (48): buildFinalTrustedQuantitiesByRowNumber(), buildProductPageFinalizationMetadata(), buildProductPageFinalizationPayloadHash(), buildProvisionalSkuPatch(), buildSaleEvidenceFingerprint(), buildSkuInsert(), buildSkuPatch(), buildTrustedSkuFingerprint() (+40 more)
 
 ### Community 10 - "Community 10"
+Cohesion: 0.08
+Nodes (42): addDaysToOperatingDate(), automationErrorMessage(), automationIdempotencyKey(), configuredEodAutoCompleteStoreDayContext(), configuredOpeningOperatingDate(), eodAutoCompleteDecision(), eodAutoCompletePolicyCronWindow(), eodAutoCompleteTiming() (+34 more)
+
+### Community 11 - "Community 11"
 Cohesion: 0.09
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
 
-### Community 11 - "Community 11"
+### Community 12 - "Community 12"
 Cohesion: 0.12
 Nodes (40): completed(), executeCallbackCommand(), executeClearLocalReviewItems(), executeClearStaleDrawerAuthority(), executeCollectLocalReview(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand() (+32 more)
 
-### Community 12 - "Community 12"
+### Community 13 - "Community 13"
 Cohesion: 0.06
 Nodes (24): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+16 more)
 
-### Community 13 - "Community 13"
+### Community 14 - "Community 14"
 Cohesion: 0.09
 Nodes (28): buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalOperationalStateForSummary(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryPreview(), createTerminalCloudRepairQueryRepository(), formatRuntimeAppUpdateAssetSummary() (+20 more)
 
-### Community 14 - "Community 14"
+### Community 15 - "Community 15"
 Cohesion: 0.07
 Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
-### Community 15 - "Community 15"
+### Community 16 - "Community 16"
 Cohesion: 0.07
 Nodes (10): arrayDetail(), buildCashControlsDashboardSnapshot(), buildReviewedSaleProjectionEvent(), getCompletedTransactionForRegisterMappingRepair(), normalizeReviewedNonCashOverpaymentPayload(), numberDetail(), recordDetail(), roundCurrencyAmount() (+2 more)
 
-### Community 16 - "Community 16"
+### Community 17 - "Community 17"
 Cohesion: 0.08
 Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
 
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
 Cohesion: 0.14
 Nodes (35): asRecord(), canUploadedRegisterOpenReplaceBlockedDrawer(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta() (+27 more)
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.11
 Nodes (33): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+25 more)
-
-### Community 19 - "Community 19"
-Cohesion: 0.1
-Nodes (31): automationErrorMessage(), automationIdempotencyKey(), configuredEodAutoCompleteStoreDayContext(), configuredOpeningOperatingDate(), eodAutoCompleteDecision(), eodAutoCompletePolicyCronWindow(), eodAutoCompleteTiming(), eodDecision() (+23 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.12
@@ -2218,76 +2218,76 @@ Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
 ### Community 27 - "Community 27"
-Cohesion: 0.12
-Nodes (25): buildDiagnosticEvidence(), buildTerminalOperationalExplanation(), buildTerminalOperationalState(), buildTerminalRecoveryActions(), buildTerminalRecoveryManualReview(), classifySalesReadiness(), classifySupportRecovery(), classifyTerminalHealth() (+17 more)
+Cohesion: 0.15
+Nodes (27): addDays(), addField(), contextWindowsForDate(), dayOfWeek(), exceptionWindowsOverlap(), findNextWindow(), getFormatter(), getMissingStoreScheduleContext() (+19 more)
 
 ### Community 28 - "Community 28"
 Cohesion: 0.12
-Nodes (26): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildInventorySnapshotRowsForProductSkusWithCtx(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle() (+18 more)
+Nodes (25): buildDiagnosticEvidence(), buildTerminalOperationalExplanation(), buildTerminalOperationalState(), buildTerminalRecoveryActions(), buildTerminalRecoveryManualReview(), classifySalesReadiness(), classifySupportRecovery(), classifyTerminalHealth() (+17 more)
 
 ### Community 29 - "Community 29"
+Cohesion: 0.12
+Nodes (26): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildInventorySnapshotRowsForProductSkusWithCtx(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle() (+18 more)
+
+### Community 30 - "Community 30"
 Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.11
 Nodes (24): buildGitProcessEnv(), buildProviderSkip(), collectCommandsForChangedFiles(), commandDisplayName(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs() (+16 more)
 
-### Community 31 - "Community 31"
-Cohesion: 0.16
-Nodes (26): addDays(), addField(), contextWindowsForDate(), dayOfWeek(), exceptionWindowsOverlap(), findNextWindow(), getFormatter(), getMissingStoreScheduleContext() (+18 more)
-
 ### Community 32 - "Community 32"
+Cohesion: 0.13
+Nodes (24): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClearedRegisterSessionCloseoutDatePatch(), buildClosedRegisterSessionPatch(), buildOperatingDateEvidence(), buildRegisterSession(), buildRegisterSessionCloseoutPatch() (+16 more)
+
+### Community 33 - "Community 33"
 Cohesion: 0.14
 Nodes (24): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+16 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.13
 Nodes (24): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), expenseSessionItemHasTrustedAvailabilityHold(), expenseSessionItemSourceKey(), failure() (+16 more)
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.2
 Nodes (28): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftCreatedMessage(), buildCycleCountDraftSavedMessage(), buildCycleCountDraftSubmissionKey(), buildCycleCountDraftSubmittedMessage(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx() (+20 more)
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.13
 Nodes (21): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), formatPendingApprovalsLabel(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate() (+13 more)
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.19
 Nodes (27): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), isExpenseLocalSyncEvent(), isSyncablePosLocalEvent() (+19 more)
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.14
 Nodes (23): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+15 more)
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
-### Community 39 - "Community 39"
+### Community 40 - "Community 40"
 Cohesion: 0.19
 Nodes (23): assertRegisterNumberIsAvailable(), buildRuntimeActiveRegisterSessionDirective(), buildRuntimeDrawerAuthorityDirective(), cleanActiveRegisterSession(), cleanAppSessionRecovery(), cleanAppShell(), cleanAppUpdate(), cleanBrowserInfo() (+15 more)
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.16
 Nodes (25): acknowledgeTerminalRecoveryCommand(), arraysEqualAsSets(), buildExecutionId(), claimTerminalRecoveryCommand(), containsSecretLikeField(), getRuntimeAppUpdateEvidence(), hasRuntimeLocalReviewDetails(), isActiveCommand() (+17 more)
 
-### Community 41 - "Community 41"
+### Community 42 - "Community 42"
 Cohesion: 0.09
 Nodes (6): getConversionRequestId(), handleClick(), handleFinalize(), isSkuReserved(), normalizeCommandMessage(), shouldDisable()
 
-### Community 42 - "Community 42"
+### Community 43 - "Community 43"
 Cohesion: 0.1
 Nodes (15): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+7 more)
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.12
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
-
-### Community 44 - "Community 44"
-Cohesion: 0.15
-Nodes (21): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+13 more)
 
 ### Community 45 - "Community 45"
 Cohesion: 0.16
@@ -2338,40 +2338,40 @@ Cohesion: 0.17
 Nodes (21): buildHomepageSnapshotV1(), hydrateCategory(), hydrateFeaturedItem(), hydrateProduct(), hydrateSubcategory(), hydrateTargetProducts(), isCustomerVisibleProduct(), isCustomerVisibleSku() (+13 more)
 
 ### Community 57 - "Community 57"
+Cohesion: 0.17
+Nodes (19): assertValidEodLocalCompletionWindowMinutes(), assertValidEodThreshold(), assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getEodAutoCompletePolicyConfigWithCtx() (+11 more)
+
+### Community 58 - "Community 58"
 Cohesion: 0.16
 Nodes (17): asRecord(), buildSnapshotHash(), buildStoreInsightsPromptFromContextBundle(), buildStoreInsightsPromptFromContextEvents(), buildUserInsightsPromptFromContextBundle(), buildUserInsightsPromptFromContextEvents(), compactContextEventsForPrompt(), compactEnvironmentForPrompt() (+9 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.15
 Nodes (16): findLatestOpenOperatingDay(), getTodaySummary(), getTransactionById(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile() (+8 more)
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.1
 Nodes (6): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onIssueTerminalRecoveryCommand(), onStartRemoteAssist(), submitUpdateApp()
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.13
 Nodes (11): dateInputToCalendarDate(), formatDateLabel(), formatNextCloseSummaryLabel(), formatNextOpenSummaryLabel(), formatScheduleSummaryLabel(), formatTimeLabel(), getCurrentOpenWindow(), getDayLabel() (+3 more)
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.21
 Nodes (21): detectFormat(), extractJsonRows(), flattenJsonRows(), inferProductName(), isRecord(), looksLikeLabel(), normalizeKey(), normalizeLegacyRow() (+13 more)
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.25
 Nodes (21): asRecord(), errorFor(), getLocalExpenseSessionId(), getOrCreateSession(), isExpenseEvent(), itemSource(), itemSourceKey(), numberField() (+13 more)
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
-
-### Community 65 - "Community 65"
-Cohesion: 0.18
-Nodes (18): assertValidEodLocalCompletionWindowMinutes(), assertValidEodThreshold(), assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getEodAutoCompletePolicyConfigWithCtx() (+10 more)
 
 ### Community 66 - "Community 66"
 Cohesion: 0.11
@@ -2670,88 +2670,88 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 140 - "Community 140"
+Cohesion: 0.29
+Nodes (8): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), resolveStoreOperatingRangeForDateWithCtx(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
+
+### Community 141 - "Community 141"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 142 - "Community 142"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 141 - "Community 141"
+### Community 143 - "Community 143"
+Cohesion: 0.2
+Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
+
+### Community 144 - "Community 144"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 142 - "Community 142"
+### Community 145 - "Community 145"
 Cohesion: 0.2
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 143 - "Community 143"
+### Community 146 - "Community 146"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 144 - "Community 144"
+### Community 147 - "Community 147"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 145 - "Community 145"
+### Community 148 - "Community 148"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 146 - "Community 146"
+### Community 149 - "Community 149"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 147 - "Community 147"
+### Community 150 - "Community 150"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 148 - "Community 148"
+### Community 151 - "Community 151"
 Cohesion: 0.25
 Nodes (5): getRuntimeStatusPublishMaterialSignature(), getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusPublishMaterial(), normalizeRuntimeStatusSignature()
 
-### Community 149 - "Community 149"
+### Community 152 - "Community 152"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 150 - "Community 150"
+### Community 153 - "Community 153"
 Cohesion: 0.25
 Nodes (7): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus()
-
-### Community 151 - "Community 151"
-Cohesion: 0.18
-Nodes (0):
-
-### Community 152 - "Community 152"
-Cohesion: 0.24
-Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
-
-### Community 153 - "Community 153"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 154 - "Community 154"
 Cohesion: 0.18
 Nodes (0):
 
 ### Community 155 - "Community 155"
+Cohesion: 0.24
+Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
+
+### Community 156 - "Community 156"
+Cohesion: 0.18
+Nodes (0):
+
+### Community 157 - "Community 157"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 156 - "Community 156"
+### Community 158 - "Community 158"
 Cohesion: 0.33
 Nodes (7): createAthenaProviderError(), createProviderFailureResult(), getProviderFailureDiagnostic(), invokeStructuredTextProvider(), isJsonObject(), isJsonValue(), sanitizeDiagnostic()
 
-### Community 157 - "Community 157"
+### Community 159 - "Community 159"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 158 - "Community 158"
-Cohesion: 0.22
-Nodes (2): isValidEmail(), validateCustomerInfo()
-
-### Community 159 - "Community 159"
-Cohesion: 0.31
-Nodes (7): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
-
 ### Community 160 - "Community 160"
 Cohesion: 0.22
-Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
+Nodes (2): isValidEmail(), validateCustomerInfo()
 
 ### Community 161 - "Community 161"
 Cohesion: 0.33
@@ -4418,12 +4418,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 577 - "Community 577"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 578 - "Community 578"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 578 - "Community 578"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 579 - "Community 579"
 Cohesion: 0.67
@@ -4446,12 +4446,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 584 - "Community 584"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 585 - "Community 585"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 585 - "Community 585"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 586 - "Community 586"
 Cohesion: 0.67
@@ -4466,16 +4466,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 589 - "Community 589"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 590 - "Community 590"
 Cohesion: 1.0
-Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 591 - "Community 591"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
 
 ### Community 592 - "Community 592"
 Cohesion: 0.67
@@ -4486,28 +4486,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 594 - "Community 594"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 595 - "Community 595"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 596 - "Community 596"
 Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 597 - "Community 597"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 598 - "Community 598"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 599 - "Community 599"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 599 - "Community 599"
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 600 - "Community 600"
 Cohesion: 0.67
@@ -4515,11 +4515,11 @@ Nodes (0):
 
 ### Community 601 - "Community 601"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 602 - "Community 602"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 603 - "Community 603"
 Cohesion: 0.67
@@ -4534,12 +4534,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 606 - "Community 606"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 607 - "Community 607"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 607 - "Community 607"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 608 - "Community 608"
 Cohesion: 0.67
@@ -4558,28 +4558,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 612 - "Community 612"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 613 - "Community 613"
 Cohesion: 1.0
 Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
-### Community 613 - "Community 613"
-Cohesion: 0.67
-Nodes (1): FadeIn()
-
 ### Community 614 - "Community 614"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 615 - "Community 615"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 616 - "Community 616"
-Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
-
-### Community 617 - "Community 617"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 617 - "Community 617"
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 618 - "Community 618"
 Cohesion: 0.67
@@ -4587,15 +4587,15 @@ Nodes (0):
 
 ### Community 619 - "Community 619"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 620 - "Community 620"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
 
 ### Community 621 - "Community 621"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 622 - "Community 622"
 Cohesion: 0.67
@@ -4606,16 +4606,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 624 - "Community 624"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 625 - "Community 625"
 Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 626 - "Community 626"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 627 - "Community 627"
 Cohesion: 0.67
@@ -4650,12 +4650,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 635 - "Community 635"
-Cohesion: 1.0
-Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
-
-### Community 636 - "Community 636"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 636 - "Community 636"
+Cohesion: 1.0
+Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
 
 ### Community 637 - "Community 637"
 Cohesion: 0.67
@@ -4675,79 +4675,79 @@ Nodes (0):
 
 ### Community 641 - "Community 641"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 642 - "Community 642"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 643 - "Community 643"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 644 - "Community 644"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 645 - "Community 645"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 646 - "Community 646"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 647 - "Community 647"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 648 - "Community 648"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 649 - "Community 649"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 649 - "Community 649"
+### Community 650 - "Community 650"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 650 - "Community 650"
+### Community 651 - "Community 651"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 651 - "Community 651"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 652 - "Community 652"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 653 - "Community 653"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 654 - "Community 654"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 655 - "Community 655"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 656 - "Community 656"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 657 - "Community 657"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 658 - "Community 658"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 659 - "Community 659"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 660 - "Community 660"
 Cohesion: 0.67
@@ -4779,11 +4779,11 @@ Nodes (0):
 
 ### Community 667 - "Community 667"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 668 - "Community 668"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 669 - "Community 669"
 Cohesion: 0.67
@@ -4810,44 +4810,44 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 675 - "Community 675"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 676 - "Community 676"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 676 - "Community 676"
+### Community 677 - "Community 677"
 Cohesion: 0.67
 Nodes (1): isInMaintenanceMode()
 
-### Community 677 - "Community 677"
+### Community 678 - "Community 678"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 678 - "Community 678"
+### Community 679 - "Community 679"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 679 - "Community 679"
+### Community 680 - "Community 680"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 680 - "Community 680"
-Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 681 - "Community 681"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 682 - "Community 682"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 683 - "Community 683"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 684 - "Community 684"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 684 - "Community 684"
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 685 - "Community 685"
 Cohesion: 0.67
@@ -4874,76 +4874,76 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 691 - "Community 691"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 692 - "Community 692"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 693 - "Community 693"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 694 - "Community 694"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 695 - "Community 695"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 696 - "Community 696"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 697 - "Community 697"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 698 - "Community 698"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 699 - "Community 699"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 700 - "Community 700"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 701 - "Community 701"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 702 - "Community 702"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 703 - "Community 703"
 Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 704 - "Community 704"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 705 - "Community 705"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 706 - "Community 706"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 707 - "Community 707"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 708 - "Community 708"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 709 - "Community 709"
 Cohesion: 0.67
@@ -4958,12 +4958,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 712 - "Community 712"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 713 - "Community 713"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 713 - "Community 713"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 714 - "Community 714"
 Cohesion: 0.67
@@ -4974,12 +4974,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 716 - "Community 716"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 717 - "Community 717"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 717 - "Community 717"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 718 - "Community 718"
 Cohesion: 0.67
@@ -5046,16 +5046,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 734 - "Community 734"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 735 - "Community 735"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 736 - "Community 736"
+### Community 735 - "Community 735"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 736 - "Community 736"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 737 - "Community 737"
 Cohesion: 1.0
@@ -5070,20 +5070,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 740 - "Community 740"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 741 - "Community 741"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 742 - "Community 742"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 743 - "Community 743"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 744 - "Community 744"
 Cohesion: 1.0
@@ -10400,121 +10400,119 @@ Nodes (0):
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 743`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 744`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 745`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 746`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 747`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 748`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 749`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 750`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 751`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 752`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 753`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 754`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 755`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 756`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 757`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 758`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 759`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 760`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 761`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 762`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 763`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 764`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 765`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 766`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 767`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 768`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 769`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 770`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 771`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 772`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 773`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 774`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 775`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 776`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 777`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 778`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 779`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 780`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 781`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 782`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 783`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 784`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 785`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 786`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 787`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 788`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 789`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 790`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 791`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 792`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 793`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 794`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 795`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 796`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 797`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 798`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 799`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 800`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 801`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -13099,9 +13097,9 @@ _Questions this graph is uniquely positioned to answer:_
 - **What connects `FakeMessageChannel`, `HelpRequested` to the rest of the system?**
   _2 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.06 - nodes in this community are weakly interconnected._
-- **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.05 - nodes in this community are weakly interconnected._
+- **Should `Community 1` be split into smaller, more focused modules?**
+  _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,13 +8,13 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2145
-- Graph nodes: 8281
-- Graph edges: 9853
+- Graph nodes: 8305
+- Graph edges: 9915
 - Communities: 2072
 
 ## Graph Hotspots
-- `harness-inferential-review.ts` (85 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `dailyClose.ts` (84 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (88 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `harness-inferential-review.ts` (85 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `terminalHealthPresentation.ts` (75 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (67 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `DailyCloseView.tsx` (65 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,7 +17,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `dailyClose.ts` (84 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (88 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `terminalHealthPresentation.ts` (75 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (67 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `DailyCloseView.tsx` (65 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -17,9 +17,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - [validation-map.json](../../../packages/storefront-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `storefrontJourneyEvents.ts` (45 edges, Community 10) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `createJourneyEvent()` (40 edges, Community 10) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 64) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storefrontJourneyEvents.ts` (45 edges, Community 11) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 11) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `getStoreConfigV2()` (17 edges, Community 65) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `storefrontContextEvents.ts` (17 edges, Community 83) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
 - `checkoutSession.ts` (14 edges, Community 95) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 

--- a/packages/athena-webapp/convex/automation/runLedger.ts
+++ b/packages/athena-webapp/convex/automation/runLedger.ts
@@ -487,6 +487,36 @@ export async function recordAutomationRunWithCtx(
   return run;
 }
 
+export async function upsertAutomationRunWithCtx(
+  ctx: MutationCtx,
+  args: AutomationRunRecordInput,
+) {
+  const existingRun = await getAutomationRunByIdempotencyKeyWithCtx(ctx, {
+    idempotencyKey: args.idempotencyKey,
+    storeId: args.storeId,
+  });
+
+  if (!existingRun) {
+    return recordAutomationRunWithCtx(ctx, args);
+  }
+
+  await ctx.db.patch("automationRun", existingRun._id, {
+    ...args,
+    appliedAt: args.outcome === "applied" ? existingRun.appliedAt : undefined,
+    error: args.error,
+    eventIds: args.eventIds ?? [],
+    updatedAt: Date.now(),
+  });
+
+  const run = await ctx.db.get("automationRun", existingRun._id);
+
+  if (!run) {
+    throw new Error("Automation run could not be loaded after update.");
+  }
+
+  return run;
+}
+
 export async function patchAutomationRunOutcomeWithCtx(
   ctx: MutationCtx,
   args: {

--- a/packages/athena-webapp/convex/cashControls/closeouts.test.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.test.ts
@@ -228,6 +228,12 @@ describe("cash control closeouts", () => {
         },
         registerSession: {
           _id: "session-1",
+          closeoutOperatingDate: "2026-06-08",
+          closeoutOperatingDateDerivationStatus: "resolved",
+          closeoutOperatingDateEndAt: Date.UTC(2026, 5, 9, 2),
+          closeoutOperatingDateStartAt: Date.UTC(2026, 5, 8, 10),
+          closeoutOwnedAt: Date.UTC(2026, 5, 8, 21),
+          closeoutOwnershipSource: "closed_record",
           status: "closed",
         },
       },
@@ -1578,6 +1584,9 @@ describe("cash control closeouts", () => {
         query: vi.fn(() => ({
           withIndex: vi.fn(() => ({
             collect: vi.fn(async () => []),
+            order: vi.fn(() => ({
+              take: vi.fn(async () => []),
+            })),
             take: vi.fn(async () => []),
           })),
         })),
@@ -1692,6 +1701,9 @@ describe("cash control closeouts", () => {
         query: vi.fn(() => ({
           withIndex: vi.fn(() => ({
             collect: vi.fn(async () => []),
+            order: vi.fn(() => ({
+              take: vi.fn(async () => []),
+            })),
             take: vi.fn(async () => []),
           })),
         })),

--- a/packages/athena-webapp/convex/cashControls/closeouts.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.ts
@@ -10,8 +10,10 @@ import {
 import { consumeApprovalProofWithCtx } from "../operations/approvalProofs";
 import { recordOperationalEventWithCtx } from "../operations/operationalEvents";
 import {
+  buildRegisterSessionDateDerivationPatch,
   rejectRegisterSessionCloseoutWithCtx,
   reopenRejectedRegisterSessionCloseoutWithCtx,
+  resolveRegisterSessionOperatingDateContext,
 } from "../operations/registerSessions";
 import { recordRegisterSessionTraceBestEffort } from "../operations/registerSessionTracing";
 import { authenticateStaffCredentialWithCtx } from "../operations/staffCredentials";
@@ -1254,9 +1256,19 @@ export const submitRegisterSessionCloseout = mutation({
           expectedCash: registerSession.expectedCash,
           registerSession,
         });
+      const approvalRequestCreatedAt = approvalRequest?.createdAt ?? Date.now();
+      const closeoutContext = await resolveRegisterSessionOperatingDateContext(ctx, {
+        at: approvalRequestCreatedAt,
+        storeId: args.storeId,
+      });
 
       await ctx.db.patch("registerSession", registerSession._id, {
         managerApprovalRequestId: approvalRequestId,
+        ...buildRegisterSessionDateDerivationPatch({
+          closeoutContext,
+          closeoutOwnedAt: approvalRequestCreatedAt,
+          closeoutOwnershipSource: "approval_request",
+        }),
       });
 
       await recordOperationalEventWithCtx(ctx, {

--- a/packages/athena-webapp/convex/cashControls/deposits.test.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.test.ts
@@ -137,6 +137,14 @@ function createQueryCtx(seed: Record<string, Array<Record<string, unknown>>>) {
                 );
                 return indexQuery;
               },
+              lte(field: string, value: unknown) {
+                predicateFilters.push(
+                  (row) =>
+                    typeof row[field] === "number" &&
+                    row[field] <= (value as number),
+                );
+                return indexQuery;
+              },
             };
             build(indexQuery);
             return query;

--- a/packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts
+++ b/packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts
@@ -224,11 +224,21 @@ function createMutationCtx(seed?: {
     query: vi.fn((table: string) => ({
       withIndex(indexName: string, apply: (builder: {
         eq(field: string, value: unknown): unknown;
+        lte(field: string, value: unknown): unknown;
       }) => void) {
         const filters: Record<string, unknown> = {};
+        const rangeFilters: Array<(row: Record<string, unknown>) => boolean> = [];
         const builder = {
           eq(field: string, value: unknown) {
             filters[field] = value;
+            return builder;
+          },
+          lte(field: string, value: unknown) {
+            rangeFilters.push(
+              (row) =>
+                typeof row[field] === "number" &&
+                row[field] <= (value as number),
+            );
             return builder;
           },
         };
@@ -268,6 +278,43 @@ function createMutationCtx(seed?: {
                   request.registerSessionId === filters.registerSessionId,
               ),
           };
+        }
+
+        if (
+          table === "storeSchedule" &&
+          indexName === "by_storeId_status_effectiveFrom"
+        ) {
+          const schedules = [
+            {
+              _id: "schedule-1",
+              createdAt: 0,
+              effectiveFrom: 0,
+              organizationId: "org-1",
+              source: "seed",
+              status: "active",
+              storeId: "store-1",
+              timezone: "UTC",
+              updatedAt: 0,
+              weeklyClosedDays: [],
+              weeklyWindows: Array.from({ length: 7 }, (_, dayOfWeek) => ({
+                dayOfWeek,
+                endMinute: 24 * 60,
+                startMinute: 0,
+              })),
+              dateExceptions: [],
+            },
+          ].filter((schedule) =>
+            Object.entries(filters).every(
+              ([field, value]) =>
+                schedule[field as keyof typeof schedule] === value,
+            ) &&
+            rangeFilters.every((matches) => matches(schedule)),
+          );
+          const query = {
+            order: () => query,
+            take: async (limit: number) => schedules.slice(0, limit),
+          };
+          return query;
         }
 
         throw new Error(`Unsupported query ${table}.${indexName}`);

--- a/packages/athena-webapp/convex/cashControls/registerSessions.test.ts
+++ b/packages/athena-webapp/convex/cashControls/registerSessions.test.ts
@@ -6,6 +6,7 @@ import {
   assertValidRegisterSessionTransition,
   buildClosedRegisterSessionPatch,
   buildRegisterSessionDepositPatch,
+  buildRegisterSessionDateDerivationPatch,
   buildRegisterSessionCloseoutPatch,
   buildRegisterSessionOpeningFloatCorrectionPatch,
   buildRejectedRegisterSessionCloseoutPatch,
@@ -18,6 +19,7 @@ import {
   recordRegisterSessionTransaction,
 } from "../operations/registerSessions";
 import { recordRegisterSessionTraceBestEffort } from "../operations/registerSessionTracing";
+import type { StoreScheduleContext } from "../lib/storeScheduleTime";
 
 vi.mock("../operations/registerSessionTracing", () => ({
   recordRegisterSessionTraceBestEffort: vi.fn(() => ({
@@ -44,6 +46,73 @@ describe("cash controls register sessions", () => {
       status: "open",
     });
     expect(session.openedAt).toEqual(expect.any(Number));
+  });
+
+  it("derives register-session operating date evidence from store schedule context", () => {
+    const resolvedContext = {
+      kind: "resolved",
+      timezone: "America/New_York",
+      operatingDate: "2026-06-28",
+      phase: "during_window",
+      isOpen: true,
+      scheduleVersionId: "schedule_1",
+      currentWindow: {
+        localDate: "2026-06-28",
+        startMinute: 600,
+        endMinute: 120,
+        startsAt: 1_800_000,
+        endsAt: 1_860_000,
+        crossesDateBoundary: true,
+        localStartLabel: "10:00",
+        localEndLabel: "02:00",
+      },
+      nextWindow: null,
+    } satisfies StoreScheduleContext;
+
+    expect(
+      buildRegisterSessionDateDerivationPatch({
+        closeoutContext: resolvedContext,
+        closeoutOwnedAt: 1_850_000,
+        closeoutOwnershipSource: "closed_record",
+        openedAt: 1_800_000,
+        openedContext: resolvedContext,
+      }),
+    ).toEqual({
+      closeoutOwnedAt: 1_850_000,
+      closeoutOwnershipSource: "closed_record",
+      closeoutOperatingDate: "2026-06-28",
+      closeoutOperatingDateDerivationStatus: "resolved",
+      closeoutOperatingDateEndAt: 1_860_000,
+      closeoutOperatingDateScheduleVersionId: "schedule_1",
+      closeoutOperatingDateStartAt: 1_800_000,
+      openedOperatingDate: "2026-06-28",
+      openedOperatingDateDerivationStatus: "resolved",
+      openedOperatingDateEndAt: 1_860_000,
+      openedOperatingDateScheduleVersionId: "schedule_1",
+      openedOperatingDateStartAt: 1_800_000,
+    });
+
+    expect(
+      buildRegisterSessionDateDerivationPatch({
+        closeoutContext: {
+          kind: "missing_schedule",
+          timezone: null,
+          operatingDate: "2026-06-28",
+          phase: "unavailable",
+          isOpen: false,
+          scheduleVersionId: null,
+          currentWindow: null,
+          nextWindow: null,
+        },
+        closeoutOwnedAt: 1_850_000,
+        closeoutOwnershipSource: "closeout_submission",
+      }),
+    ).toMatchObject({
+      closeoutOwnedAt: 1_850_000,
+      closeoutOwnershipSource: "closeout_submission",
+      closeoutOperatingDate: undefined,
+      closeoutOperatingDateDerivationStatus: "missing_schedule",
+    });
   });
 
   it("counts only net cash tendered toward expected cash", () => {
@@ -283,9 +352,15 @@ describe("cash controls register sessions", () => {
           return id;
         }),
         patch: vi.fn(),
-        query: vi.fn(() => ({
+        query: vi.fn((tableName: string) => ({
           withIndex: vi.fn((indexName: string) => ({
+            take: vi.fn(async () =>
+              tableName === "storeSchedule" ? [] : existingSessions,
+            ),
             order: vi.fn(() => ({
+              take: vi.fn(async () =>
+                tableName === "storeSchedule" ? [] : existingSessions,
+              ),
               first: vi.fn(async () =>
                 indexName === "by_terminalId"
                   ? existingSessions.shift() ?? null
@@ -357,8 +432,11 @@ describe("cash controls register sessions", () => {
       buildReopenedRegisterSessionPatch({
         status: "closing",
       })
-    ).toEqual({
+    ).toMatchObject({
       countedCash: undefined,
+      closeoutOwnedAt: undefined,
+      closeoutOperatingDate: undefined,
+      closeoutOwnershipSource: undefined,
       managerApprovalRequestId: undefined,
       status: "active",
       variance: undefined,

--- a/packages/athena-webapp/convex/inventory/storeSchedule.test.ts
+++ b/packages/athena-webapp/convex/inventory/storeSchedule.test.ts
@@ -15,6 +15,7 @@ import {
   getStoreDayContext,
   getStoreScheduleSummary,
   listStoreScheduleVersions,
+  resolveStoreOperatingRangeForDateWithCtx,
   upsertStoreScheduleCommand,
   upsertStoreScheduleCommandWithCtx,
 } from "./storeSchedule";
@@ -79,6 +80,18 @@ describe("store schedule resolver", () => {
     ).not.toThrow();
     expect(() =>
       assertConformsToExportedReturns(getStoreDayContext, context),
+    ).not.toThrow();
+    expect(() =>
+      assertConformsToExportedReturns(getStoreDayContext, {
+        kind: "missing_schedule",
+        timezone: null,
+        operatingDate: "2026-06-08",
+        phase: "unavailable",
+        isOpen: false,
+        scheduleVersionId: null,
+        currentWindow: null,
+        nextWindow: null,
+      }),
     ).not.toThrow();
     expect(() =>
       assertConformsToExportedReturns(getStoreScheduleSummary, {
@@ -394,6 +407,100 @@ describe("store schedule schema indexes", () => {
     expect(schema).toContain(
       '.index("by_source_status", ["source", "status"])',
     );
+  });
+});
+
+describe("store schedule version resolution", () => {
+  it("resolves the newest effective schedule before applying the version cap", async () => {
+    const olderSchedules = Array.from({ length: 100 }, (_, index) =>
+      baseSchedule({
+        _id: `old-schedule-${index + 1}` as any,
+        effectiveFrom: Date.UTC(2026, 0, index + 1),
+        weeklyWindows: [
+          { dayOfWeek: 1, startMinute: 9 * 60, endMinute: 10 * 60 },
+        ],
+      }),
+    );
+    const latestSchedule = baseSchedule({
+      _id: "latest-schedule" as any,
+      effectiveFrom: Date.parse("2026-06-01T00:00:00.000Z"),
+      timezone: "UTC",
+      weeklyWindows: [
+        { dayOfWeek: 1, startMinute: 12 * 60, endMinute: 13 * 60 },
+      ],
+    });
+    const schedules = [...olderSchedules, latestSchedule];
+    const ctx = {
+      db: {
+        query: vi.fn(() => {
+          const filters: Array<[string, unknown | { lte: unknown }]> = [];
+          let sortDirection: "asc" | "desc" = "asc";
+          const rows = () =>
+            schedules
+              .filter((schedule) =>
+                filters.every(([field, value]) => {
+                  if (value && typeof value === "object" && "lte" in value) {
+                    return (
+                      Number(schedule[field as keyof typeof schedule]) <=
+                      Number(value.lte)
+                    );
+                  }
+
+                  return schedule[field as keyof typeof schedule] === value;
+                }),
+              )
+              .sort((left, right) =>
+                sortDirection === "desc"
+                  ? right.effectiveFrom - left.effectiveFrom
+                  : left.effectiveFrom - right.effectiveFrom,
+              );
+
+          const chain = {
+            order(direction: "asc" | "desc") {
+              sortDirection = direction;
+              return chain;
+            },
+            take: vi.fn(async (limit: number) => rows().slice(0, limit)),
+            withIndex: vi.fn(
+              (
+                _index: string,
+                applyIndex: (builder: {
+                  eq: (field: string, value: unknown) => typeof builder;
+                  lte: (field: string, value: unknown) => typeof builder;
+                }) => void,
+              ) => {
+                const builder = {
+                  eq(field: string, value: unknown) {
+                    filters.push([field, value]);
+                    return builder;
+                  },
+                  lte(field: string, value: unknown) {
+                    filters.push([field, { lte: value }]);
+                    return builder;
+                  },
+                };
+                applyIndex(builder);
+                return chain;
+              },
+            ),
+          };
+
+          return chain;
+        }),
+      },
+    } as any;
+
+    const result = await resolveStoreOperatingRangeForDateWithCtx(ctx, {
+      operatingDate: "2026-06-08",
+      storeId: "store-1" as any,
+    });
+
+    expect(result.schedule?._id).toBe("latest-schedule");
+    expect(result.range).toMatchObject({
+      kind: "resolved",
+      startAt: Date.parse("2026-06-08T12:00:00.000Z"),
+      endAt: Date.parse("2026-06-08T13:00:00.000Z"),
+    });
   });
 });
 

--- a/packages/athena-webapp/convex/inventory/storeSchedule.ts
+++ b/packages/athena-webapp/convex/inventory/storeSchedule.ts
@@ -5,6 +5,7 @@ import type { Doc, Id } from "../_generated/dataModel";
 import { commandResultValidator } from "../lib/commandResultValidators";
 import {
   getMissingStoreScheduleContext,
+  resolveStoreOperatingRangeForDate,
   resolveStoreScheduleContext,
   validateNoEffectiveRangeOverlap,
   validateStoreScheduleDraft,
@@ -341,6 +342,7 @@ async function findActiveScheduleForStoreAt(
         .eq("status", "active")
         .lte("effectiveFrom", args.at),
     )
+    .order("desc")
     .take(STORE_SCHEDULE_VERSION_READ_LIMIT);
 
   return (
@@ -366,6 +368,27 @@ export async function getStoreScheduleContextForStoreAtWithCtx(
     context: schedule
       ? resolveStoreScheduleContext({ schedule, at: args.at })
       : getMissingStoreScheduleContext({ at: args.at }),
+  };
+}
+
+export async function resolveStoreOperatingRangeForDateWithCtx(
+  ctx: Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">,
+  args: { storeId: Id<"store">; operatingDate: string },
+) {
+  const effectiveAt = Date.parse(`${args.operatingDate}T12:00:00.000Z`);
+  const schedule = Number.isFinite(effectiveAt)
+    ? await findActiveScheduleForStoreAt(ctx, {
+        storeId: args.storeId,
+        at: effectiveAt,
+      })
+    : null;
+
+  return {
+    schedule,
+    range: resolveStoreOperatingRangeForDate({
+      schedule,
+      operatingDate: args.operatingDate,
+    }),
   };
 }
 

--- a/packages/athena-webapp/convex/lib/storeScheduleTime.ts
+++ b/packages/athena-webapp/convex/lib/storeScheduleTime.ts
@@ -80,6 +80,38 @@ export type StoreScheduleContext =
       nextWindow: null;
     };
 
+export type StoreOperatingRangeForDateResult =
+  | {
+      kind: "resolved";
+      timezone: string;
+      operatingDate: string;
+      scheduleVersionId: string | null;
+      startAt: number;
+      endAt: number;
+      windowCount: number;
+    }
+  | {
+      kind: "closed";
+      timezone: string;
+      operatingDate: string;
+      scheduleVersionId: string | null;
+      reason: "closed_day";
+    }
+  | {
+      kind: "missing_schedule";
+      timezone: null;
+      operatingDate: string;
+      scheduleVersionId: null;
+      reason: "missing_schedule";
+    }
+  | {
+      kind: "invalid";
+      timezone: string | null;
+      operatingDate: string;
+      scheduleVersionId: string | null;
+      reason: "invalid_operating_date" | "unresolvable_schedule_window";
+    };
+
 export type StoreScheduleValidationResult =
   | { ok: true; fields: Record<string, never> }
   | { ok: false; fields: Record<string, string[]> };
@@ -665,6 +697,65 @@ export function resolveStoreScheduleContext(args: {
     nextWindow:
       nextWindow ??
       (localMinute < firstWindow.startMinute ? firstWindow : null),
+  };
+}
+
+export function resolveStoreOperatingRangeForDate(args: {
+  schedule: StoreScheduleDraft | null | undefined;
+  operatingDate: string;
+}): StoreOperatingRangeForDateResult {
+  if (!parseLocalDate(args.operatingDate)) {
+    return {
+      kind: "invalid",
+      timezone: args.schedule?.timezone ?? null,
+      operatingDate: args.operatingDate,
+      scheduleVersionId: args.schedule?._id ?? null,
+      reason: "invalid_operating_date",
+    };
+  }
+
+  if (!args.schedule) {
+    return {
+      kind: "missing_schedule",
+      timezone: null,
+      operatingDate: args.operatingDate,
+      scheduleVersionId: null,
+      reason: "missing_schedule",
+    };
+  }
+
+  const windows = contextWindowsForDate(args.schedule, args.operatingDate);
+  if (windows.length === 0) {
+    return {
+      kind: "closed",
+      timezone: args.schedule.timezone,
+      operatingDate: args.operatingDate,
+      scheduleVersionId: args.schedule._id ?? null,
+      reason: "closed_day",
+    };
+  }
+
+  const startAt = Math.min(...windows.map((window) => window.startsAt));
+  const endAt = Math.max(...windows.map((window) => window.endsAt));
+
+  if (!Number.isFinite(startAt) || !Number.isFinite(endAt) || endAt <= startAt) {
+    return {
+      kind: "invalid",
+      timezone: args.schedule.timezone,
+      operatingDate: args.operatingDate,
+      scheduleVersionId: args.schedule._id ?? null,
+      reason: "unresolvable_schedule_window",
+    };
+  }
+
+  return {
+    kind: "resolved",
+    timezone: args.schedule.timezone,
+    operatingDate: args.operatingDate,
+    scheduleVersionId: args.schedule._id ?? null,
+    startAt,
+    endAt,
+    windowCount: windows.length,
   };
 }
 

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -47,6 +47,14 @@ function getHandler<TArgs, TResult>(definition: unknown) {
     ._handler;
 }
 
+function compareIndexedValue(left: unknown, right: unknown) {
+  if (typeof left === "number" && typeof right === "number") {
+    return left - right;
+  }
+
+  return String(left).localeCompare(String(right));
+}
+
 function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
   const tables = new Map<TableName, Map<string, Row>>();
   const inserts: Array<{ table: TableName; value: Row }> = [];
@@ -71,7 +79,7 @@ function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
 
   const query = (table: TableName) => {
     const filters: Array<
-      [string, unknown | { gte?: number; lt?: number; lte?: number }]
+      [string, unknown | { gte?: unknown; lt?: unknown; lte?: unknown }]
     > = [];
     let sortDirection: "asc" | "desc" = "asc";
     const filteredRows = () => {
@@ -80,24 +88,24 @@ function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
           if (value && typeof value === "object" && !Array.isArray(value)) {
             if (
               "gte" in value &&
-              typeof value.gte === "number" &&
-              Number(row[field]) < value.gte
+              value.gte !== undefined &&
+              compareIndexedValue(row[field], value.gte) < 0
             ) {
               return false;
             }
 
             if (
               "lt" in value &&
-              typeof value.lt === "number" &&
-              Number(row[field]) >= value.lt
+              value.lt !== undefined &&
+              compareIndexedValue(row[field], value.lt) >= 0
             ) {
               return false;
             }
 
             if (
               "lte" in value &&
-              typeof value.lte === "number" &&
-              Number(row[field]) > value.lte
+              value.lte !== undefined &&
+              compareIndexedValue(row[field], value.lte) > 0
             ) {
               return false;
             }
@@ -134,9 +142,9 @@ function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
         _index: string,
         applyIndex: (builder: {
           eq: (field: string, value: unknown) => typeof builder;
-          gte: (field: string, value: number) => typeof builder;
-          lt: (field: string, value: number) => typeof builder;
-          lte: (field: string, value: number) => typeof builder;
+          gte: (field: string, value: unknown) => typeof builder;
+          lt: (field: string, value: unknown) => typeof builder;
+          lte: (field: string, value: unknown) => typeof builder;
         }) => unknown,
       ) {
         const builder = {
@@ -144,15 +152,15 @@ function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
             filters.push([field, value]);
             return builder;
           },
-          gte(field: string, value: number) {
+          gte(field: string, value: unknown) {
             filters.push([field, { gte: value }]);
             return builder;
           },
-          lt(field: string, value: number) {
+          lt(field: string, value: unknown) {
             filters.push([field, { lt: value }]);
             return builder;
           },
-          lte(field: string, value: number) {
+          lte(field: string, value: unknown) {
             filters.push([field, { lte: value }]);
             return builder;
           },
@@ -509,6 +517,239 @@ describe("end-of-day review backend foundation", () => {
       policyMode: "enabled",
     });
     expect(snapshot.completedClose).toBeNull();
+  });
+
+  it("includes all closed register sessions for the day and records complete register source evidence", async () => {
+    const registerSessions = Array.from({ length: 205 }, (_, index) => ({
+      _id: `register-closed-${index + 1}`,
+      closedAt: Date.UTC(2026, 4, 7, 18, index % 60),
+      closeoutRecords: [
+        {
+          expectedCash: 10000 + index,
+          occurredAt: Date.UTC(2026, 4, 7, 18, index % 60),
+          type: "closed",
+        },
+      ],
+      countedCash: 10000 + index,
+      expectedCash: 10000 + index,
+      openedAt: Date.UTC(2026, 4, 7, 9, index % 60),
+      openingFloat: 10000,
+      status: "closed",
+      storeId: "store-1",
+    }));
+    const { db } = createDb({
+      registerSession: registerSessions,
+      store: [store],
+    });
+
+    const snapshot = await buildDailyCloseSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      { operatingDate: "2026-05-07", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.summary.closedRegisterSessionCount).toBe(205);
+    expect(snapshot.readyItems).toHaveLength(205);
+    expect(snapshot.sourceCompleteness.complete).toBe(true);
+    expect(snapshot.sourceCompleteness.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          complete: true,
+          readMode: "by_storeId_status_closeoutOperatingDate_missing",
+          recordCount: 205,
+          source: "register_session",
+          statuses: ["closed"],
+        }),
+      ]),
+    );
+  });
+
+  it("finds active register blockers after more than 1000 indexed historic register sessions", async () => {
+    const historicSessions = Array.from({ length: 1000 }, (_, index) => ({
+      _id: `historic-register-${index + 1}`,
+      closedAt: Date.UTC(2026, 4, 6, 18, index % 60),
+      closeoutOperatingDate: "2026-05-06",
+      closeoutRecords: [
+        {
+          closedAt: Date.UTC(2026, 4, 6, 18, index % 60),
+          countedCash: 10000,
+          expectedCash: 10000,
+          occurredAt: Date.UTC(2026, 4, 6, 18, index % 60),
+          type: "closed",
+        },
+      ],
+      countedCash: 10000,
+      expectedCash: 10000,
+      openedAt: Date.UTC(2026, 4, 6, 9, index % 60),
+      openingFloat: 10000,
+      status: "closed",
+      storeId: "store-1",
+    }));
+    const { db } = createDb({
+      registerSession: [
+        ...historicSessions,
+        {
+          _id: "active-register-after-history",
+          openedAt: Date.UTC(2026, 4, 7, 9),
+          openedOperatingDate: "2026-05-07",
+          openingFloat: 10000,
+          status: "active",
+          storeId: "store-1",
+        },
+      ],
+      store: [store],
+    });
+
+    const snapshot = await buildDailyCloseSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      { operatingDate: "2026-05-07", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.sourceCompleteness.complete).toBe(true);
+    expect(snapshot.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "register_session:active-register-after-history:active",
+        }),
+      ]),
+    );
+  });
+
+  it("keeps prior-day active register sessions blocking the target day until resolved", async () => {
+    const { db } = createDb({
+      registerSession: [
+        {
+          _id: "carried-active-register",
+          openedAt: Date.UTC(2026, 4, 6, 20),
+          openedOperatingDate: "2026-05-06",
+          openingFloat: 10000,
+          status: "active",
+          storeId: "store-1",
+        },
+      ],
+      store: [store],
+    });
+
+    const snapshot = await buildDailyCloseSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      { operatingDate: "2026-05-07", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.sourceCompleteness.complete).toBe(true);
+    expect(snapshot.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "register_session:carried-active-register:active",
+        }),
+      ]),
+    );
+  });
+
+  it("does not mark source incomplete for many future active register sessions", async () => {
+    const activeOtherDateSessions = Array.from({ length: 1000 }, (_, index) => ({
+      _id: `active-other-date-${index + 1}`,
+      openedAt: Date.UTC(2026, 4, 8, 9, index % 60),
+      openedOperatingDate: "2026-05-08",
+      openingFloat: 10000,
+      status: "active",
+      storeId: "store-1",
+    }));
+    const { db } = createDb({
+      registerSession: [
+        ...activeOtherDateSessions,
+        {
+          _id: "target-date-closed-register",
+          closedAt: Date.UTC(2026, 4, 7, 18),
+          closeoutOperatingDate: "2026-05-07",
+          closeoutRecords: [
+            {
+              closedAt: Date.UTC(2026, 4, 7, 18),
+              countedCash: 10000,
+              expectedCash: 10000,
+              occurredAt: Date.UTC(2026, 4, 7, 18),
+              type: "closed",
+            },
+          ],
+          countedCash: 10000,
+          expectedCash: 10000,
+          openedAt: Date.UTC(2026, 4, 7, 9),
+          openedOperatingDate: "2026-05-07",
+          openingFloat: 10000,
+          status: "closed",
+          storeId: "store-1",
+        },
+      ],
+      store: [store],
+    });
+
+    const snapshot = await buildDailyCloseSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      { operatingDate: "2026-05-07", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.sourceCompleteness.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          complete: true,
+          readMode: "by_storeId_status_openedOperatingDate",
+          recordCount: 0,
+          statuses: ["active"],
+        }),
+      ]),
+    );
+    expect(snapshot.sourceCompleteness.complete).toBe(true);
+    expect(snapshot.blockers).toEqual([]);
+    expect(snapshot.summary.closedRegisterSessionCount).toBe(1);
+  });
+
+  it("finds review-only closeouts by closeout operating date when the drawer opened on a prior day", async () => {
+    const { db } = createDb({
+      registerSession: [
+        {
+          _id: "carried-rejected-closeout",
+          closedAt: Date.UTC(2026, 4, 7, 18),
+          closeoutOperatingDate: "2026-05-07",
+          closeoutRecords: [
+            {
+              closedAt: Date.UTC(2026, 4, 7, 18),
+              countedCash: 9000,
+              expectedCash: 10000,
+              occurredAt: Date.UTC(2026, 4, 7, 18),
+              type: "closed",
+            },
+          ],
+          countedCash: 9000,
+          expectedCash: 10000,
+          openedAt: Date.UTC(2026, 4, 6, 20),
+          openedOperatingDate: "2026-05-06",
+          openingFloat: 10000,
+          status: "closeout_rejected",
+          storeId: "store-1",
+        },
+      ],
+      store: [store],
+    });
+
+    const snapshot = await buildDailyCloseSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      { operatingDate: "2026-05-07", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "register_session:carried-rejected-closeout:closeout_rejected",
+        }),
+      ]),
+    );
+    expect(snapshot.sourceCompleteness.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          readMode: "by_storeId_status_closeoutOperatingDate",
+          recordCount: 1,
+          statuses: ["closeout_rejected"],
+        }),
+      ]),
+    );
   });
 
   it("classifies blockers, review items, carry-forward items, ready items, and summary totals", async () => {
@@ -2743,6 +2984,253 @@ describe("end-of-day review backend foundation", () => {
     );
   });
 
+  it("keeps default automation completion current and demotes older current closes", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 7, 22));
+    const { db, tables } = createDb({
+      dailyClose: [
+        completedDailyCloseRow({
+          _id: "daily-close-prior-current",
+          completedAt: Date.UTC(2026, 4, 6, 22),
+          createdAt: Date.UTC(2026, 4, 6, 22),
+          operatingDate: "2026-05-06",
+          updatedAt: Date.UTC(2026, 4, 6, 22),
+        }),
+      ],
+      store: [store],
+    });
+
+    const result = await completeDailyCloseForAutomationWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        automationDecisionReason: "EOD Review passed policy checks.",
+        automationPolicyVersion: "daily-close-auto-complete.v1",
+        automationRunId: "automation-run-current" as Id<"automationRun">,
+        eodAutoCompletePolicy,
+        operatingDate: "2026-05-07",
+        policyReviewedItemKeys: [],
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "completed",
+        dailyClose: {
+          isCurrent: true,
+          reportSnapshot: {
+            closeMetadata: {
+              currentnessMode: "mark_current",
+            },
+          },
+        },
+      },
+    });
+    expect(
+      tables.get("dailyClose")?.get("daily-close-prior-current")?.isCurrent,
+    ).toBe(false);
+  });
+
+  it("records historical automation completion without demoting the live current close", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 9, 22));
+    const { db, tables } = createDb({
+      dailyClose: [
+        completedDailyCloseRow({
+          _id: "daily-close-live-current",
+          completedAt: Date.UTC(2026, 4, 8, 22),
+          createdAt: Date.UTC(2026, 4, 8, 22),
+          operatingDate: "2026-05-08",
+          updatedAt: Date.UTC(2026, 4, 8, 22),
+        }),
+      ],
+      store: [store],
+    });
+
+    const result = await completeDailyCloseForAutomationWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        automationDecisionReason: "Historic EOD Review passed policy checks.",
+        automationPolicyVersion: "daily-close-auto-complete.v1",
+        automationRunId: "automation-run-historical" as Id<"automationRun">,
+        currentnessMode: "historical_record",
+        eodAutoCompletePolicy,
+        operatingDate: "2026-05-07",
+        policyReviewedItemKeys: [],
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "completed",
+        dailyClose: {
+          actorType: "automation",
+          isCurrent: false,
+          reportSnapshot: {
+            closeMetadata: {
+              currentnessMode: "historical_record",
+              operatingDate: "2026-05-07",
+            },
+            sourceCompleteness: {
+              complete: true,
+              entries: expect.arrayContaining([
+                expect.objectContaining({
+                  complete: true,
+                  readMode: "by_storeId_status_closeoutOperatingDate_missing",
+                  source: "register_session",
+                }),
+              ]),
+            },
+          },
+        },
+      },
+    });
+    expect(
+      tables.get("dailyClose")?.get("daily-close-live-current")?.isCurrent,
+    ).toBe(true);
+  });
+
+  it("rejects historical automation completion when register source evidence is incomplete", async () => {
+    const registerSessions = Array.from({ length: 1000 }, (_, index) => ({
+      _id: `register-cap-${index + 1}`,
+      closedAt: Date.UTC(2026, 4, 7, 18, index % 60),
+      countedCash: 10000,
+      expectedCash: 10000,
+      openedAt: Date.UTC(2026, 4, 7, 9, index % 60),
+      openingFloat: 10000,
+      status: "closed",
+      storeId: "store-1",
+    }));
+    const { db, inserts } = createDb({
+      registerSession: registerSessions,
+      store: [store],
+    });
+
+    const result = await completeDailyCloseForAutomationWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        automationDecisionReason: "Historic EOD Review passed policy checks.",
+        automationPolicyVersion: "daily-close-auto-complete.v1",
+        automationRunId: "automation-run-incomplete-source" as Id<"automationRun">,
+        currentnessMode: "historical_record",
+        eodAutoCompletePolicy,
+        operatingDate: "2026-05-07",
+        policyReviewedItemKeys: [],
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        metadata: {
+          incompleteSources: [
+            {
+              complete: false,
+              limit: 1000,
+              readMode: "by_storeId_status_closeoutOperatingDate_missing",
+              reason: "register_session_legacy_closed_fallback_cap_reached",
+              source: "register_session",
+            },
+          ],
+        },
+      },
+    });
+    expect(inserts).toEqual([]);
+  });
+
+  it("rejects historical automation completion when completed transaction reads hit the source cap", async () => {
+    const transactions = Array.from({ length: 200 }, (_, index) => ({
+      _id: `txn-cap-${index + 1}`,
+      completedAt: Date.UTC(2026, 4, 7, 15, index % 60),
+      payments: [{ amount: 100, method: "cash", timestamp: 1 }],
+      status: "completed",
+      storeId: "store-1",
+      subtotal: 100,
+      tax: 0,
+      total: 100,
+      totalPaid: 100,
+      transactionNumber: `TXN-CAP-${index + 1}`,
+    }));
+    const { db, inserts } = createDb({
+      posTransaction: transactions,
+      store: [store],
+    });
+
+    const result = await completeDailyCloseForAutomationWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        automationDecisionReason: "Historic EOD Review passed policy checks.",
+        automationPolicyVersion: "daily-close-auto-complete.v1",
+        automationRunId: "automation-run-incomplete-transactions" as Id<"automationRun">,
+        currentnessMode: "historical_record",
+        eodAutoCompletePolicy,
+        operatingDate: "2026-05-07",
+        policyReviewedItemKeys: [],
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        metadata: {
+          incompleteSources: [
+            expect.objectContaining({
+              complete: false,
+              limit: 200,
+              readMode: "by_storeId_status_completedAt",
+              reason: "pos_transaction_source_cap_reached",
+              source: "pos_transaction",
+            }),
+          ],
+        },
+      },
+    });
+    expect(inserts).toEqual([]);
+  });
+
+  it("records incomplete source evidence when pending approval reads hit the cap", async () => {
+    const approvals = Array.from({ length: 200 }, (_, index) => ({
+      _id: `approval-cap-${index + 1}`,
+      createdAt: Date.UTC(2026, 4, 7, 16, index % 60),
+      reason: "Manager review required.",
+      requestType: "variance_review",
+      status: "pending",
+      storeId: "store-1",
+      subjectId: `register-${index + 1}`,
+      subjectType: "register_session",
+    }));
+    const { db } = createDb({
+      approvalRequest: approvals,
+      store: [store],
+    });
+
+    const snapshot = await buildDailyCloseSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      { operatingDate: "2026-05-07", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.sourceCompleteness).toEqual(
+      expect.objectContaining({
+        complete: false,
+        entries: expect.arrayContaining([
+          expect.objectContaining({
+            complete: false,
+            limit: 200,
+            readMode: "by_storeId_status",
+            reason: "approval_request_source_cap_reached",
+            source: "approval_request",
+            statuses: ["pending"],
+          }),
+        ]),
+      }),
+    );
+  });
+
   it("records policy-reviewed item keys when automation completes reviewed items", async () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 7, 22));
     const reviewKey = "pos_transaction:txn-void:void";
@@ -3640,6 +4128,77 @@ describe("end-of-day review backend foundation", () => {
         reason: "Late cash sale was missed.",
         reopenedDailyCloseId: "dailyClose-2",
       },
+    });
+  });
+
+  it("reopens a historical close without demoting the live current close", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 9, 10));
+    const historicalSnapshot = completedDailyCloseSnapshot({
+      closeMetadata: {
+        ...completedDailyCloseSnapshot().closeMetadata,
+        currentnessMode: "historical_record",
+      },
+    });
+    const liveCurrentClose = completedDailyCloseRow({
+      _id: "daily-close-current",
+      completedAt: Date.UTC(2026, 4, 8, 22),
+      createdAt: Date.UTC(2026, 4, 8, 22),
+      isCurrent: true,
+      operatingDate: "2026-05-08",
+      updatedAt: Date.UTC(2026, 4, 8, 22),
+    });
+    const { db, tables } = createDb({
+      approvalProof: [
+        dailyCloseReopenApprovalProof({
+          createdAt: Date.UTC(2026, 4, 9, 9),
+          expiresAt: Date.UTC(2026, 4, 9, 11),
+        }),
+      ],
+      dailyClose: [
+        completedDailyCloseRow({
+          isCurrent: false,
+          reportSnapshot: historicalSnapshot,
+        }),
+        liveCurrentClose,
+      ],
+    });
+
+    const result = await reopenDailyCloseWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        actorUserId: "user-1" as Id<"athenaUser">,
+        approvalProofId: "approval-proof-reopen-1" as Id<"approvalProof">,
+        dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+        reason: "Historic correction.",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        originalDailyClose: {
+          _id: "daily-close-1",
+          isCurrent: false,
+          lifecycleStatus: "reopened",
+        },
+        reopenedDailyClose: {
+          isCurrent: false,
+          lifecycleStatus: "active",
+          reopenedFromDailyCloseId: "daily-close-1",
+          status: "open",
+        },
+      },
+    });
+    expect(tables.get("dailyClose")?.get("daily-close-current")).toMatchObject({
+      isCurrent: true,
+      lifecycleStatus: "active",
+    });
+    expect(tables.get("dailyClose")?.get("daily-close-1")).toMatchObject({
+      isCurrent: false,
+      lifecycleStatus: "reopened",
+      reportSnapshot: historicalSnapshot,
     });
   });
 

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -34,6 +34,7 @@ import { buildPaymentTotals, transactionCashDelta } from "./paymentTotals";
 import type { AutomationDecisionEvidence } from "../automation/runLedger";
 
 const DAILY_CLOSE_QUERY_LIMIT = 200;
+const REGISTER_SESSION_DAILY_CLOSE_SOURCE_LIMIT = 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_OPERATING_DATE_RANGE_MS = 36 * 60 * 60 * 1000;
 const DAILY_CLOSE_SUBJECT_TYPE = "daily_close";
@@ -83,9 +84,11 @@ type DailyCloseRange = { endAt: number; startAt: number };
 type RegisterSessionRangeCandidate = Pick<
   Doc<"registerSession">,
   | "closedAt"
+  | "closeoutOperatingDate"
   | "closeoutRecords"
   | "countedCash"
   | "managerApprovalRequestId"
+  | "openedOperatingDate"
   | "openedAt"
   | "status"
 >;
@@ -143,6 +146,27 @@ type DailyCloseSummary = {
   }>;
 };
 
+type DailyCloseSourceCompletenessEntry = {
+  source: string;
+  complete: boolean;
+  readMode: string;
+  recordCount: number;
+  limit?: number;
+  range?: DailyCloseRange;
+  statuses?: string[];
+  reason?: string;
+};
+
+type DailyCloseSourceCompleteness = {
+  complete: boolean;
+  entries: DailyCloseSourceCompletenessEntry[];
+};
+
+type DailyCloseSourceRead<T> = {
+  rows: T[];
+  completeness: DailyCloseSourceCompletenessEntry;
+};
+
 type DailyCloseSnapshot = {
   operatingDate: string;
   storeId: Id<"store">;
@@ -173,6 +197,7 @@ type DailyCloseSnapshot = {
   readyItems: DailyCloseItem[];
   readiness: DailyCloseReadiness;
   summary: DailyCloseSummary;
+  sourceCompleteness: DailyCloseSourceCompleteness;
   sourceSubjects: Array<{
     type: string;
     id: string;
@@ -209,6 +234,7 @@ type DailyCloseReportSnapshot = {
     automationRunId?: Id<"automationRun">;
     automationPolicyVersion?: string;
     automationDecisionReason?: string;
+    currentnessMode?: "mark_current" | "historical_record";
     policyReviewedItemKeys?: string[];
     notes?: string;
     reviewedItemKeys?: string[];
@@ -219,6 +245,7 @@ type DailyCloseReportSnapshot = {
   reviewedItems: DailyCloseItem[];
   carryForwardItems: DailyCloseItem[];
   readyItems: DailyCloseItem[];
+  sourceCompleteness?: DailyCloseSourceCompleteness;
   sourceSubjects: DailyCloseSnapshot["sourceSubjects"];
 };
 
@@ -279,7 +306,51 @@ function normalizeCompletedDailyCloseSnapshot(args: {
     readiness: reportSnapshot.readiness,
     summary: normalizeDailyCloseSummary(reportSnapshot.summary),
     sourceSubjects: reportSnapshot.sourceSubjects,
+    sourceCompleteness:
+      reportSnapshot.sourceCompleteness ?? completeSourceCompleteness([]),
   };
+}
+
+function completeSourceCompleteness(
+  entries: DailyCloseSourceCompletenessEntry[],
+): DailyCloseSourceCompleteness {
+  return {
+    complete: entries.every((entry) => entry.complete),
+    entries,
+  };
+}
+
+function sourceCompletenessEntry(args: {
+  complete?: boolean;
+  limit?: number;
+  range?: DailyCloseRange;
+  readMode: string;
+  recordCount: number;
+  reason?: string;
+  source: string;
+  statuses?: string[];
+}): DailyCloseSourceCompletenessEntry {
+  const complete =
+    args.complete ?? (args.limit === undefined || args.recordCount < args.limit);
+
+  return {
+    source: args.source,
+    complete,
+    readMode: args.readMode,
+    recordCount: args.recordCount,
+    ...(args.limit === undefined ? {} : { limit: args.limit }),
+    ...(args.range === undefined ? {} : { range: args.range }),
+    ...(args.statuses === undefined ? {} : { statuses: args.statuses }),
+    ...(complete ? {} : { reason: args.reason ?? `${args.source}_source_cap_reached` }),
+  };
+}
+
+function mergeSourceCompleteness(
+  ...sources: Array<DailyCloseSourceCompleteness | DailyCloseSourceCompletenessEntry>
+) {
+  return completeSourceCompleteness(
+    sources.flatMap((source) => ("entries" in source ? source.entries : [source])),
+  );
 }
 
 function normalizeDailyCloseSummary(
@@ -404,6 +475,7 @@ type CompleteDailyCloseForAutomationArgs = {
   policyReviewedItemKeys: string[];
   startAt?: number;
   storeId: Id<"store">;
+  currentnessMode?: "mark_current" | "historical_record";
 };
 
 type CompleteDailyCloseResult = ApprovalCommandResult<{
@@ -877,64 +949,191 @@ async function getPriorCompletedDailyClose(
   );
 }
 
-async function listActiveRegisterSessions(
-  ctx: Pick<QueryCtx, "db">,
-  storeId: Id<"store">,
-) {
-  const sessions = await Promise.all(
-    ACTIVE_REGISTER_STATUSES.map((status) =>
-      ctx.db
-        .query("registerSession")
-        .withIndex("by_storeId_status", (q) =>
-          q.eq("storeId", storeId).eq("status", status),
-        )
-        .take(DAILY_CLOSE_QUERY_LIMIT),
-    ),
-  );
-
-  return sessions.flat();
-}
-
-async function listReviewOnlyRegisterCloseoutSessions(
-  ctx: Pick<QueryCtx, "db">,
-  storeId: Id<"store">,
-) {
-  const sessions = await Promise.all(
-    REVIEW_ONLY_REGISTER_CLOSEOUT_STATUSES.map((status) =>
-      ctx.db
-        .query("registerSession")
-        .withIndex("by_storeId_status", (q) =>
-          q.eq("storeId", storeId).eq("status", status),
-        )
-        .take(DAILY_CLOSE_QUERY_LIMIT),
-    ),
-  );
-
-  return sessions.flat();
-}
-
-async function listClosedRegisterSessionsForDay(
+async function listRegisterSessionsForDailyClose(
   ctx: Pick<QueryCtx, "db">,
   args: {
     endAt: number;
+    operatingDate: string;
     startAt: number;
     storeId: Id<"store">;
   },
 ) {
-  const sessions = await ctx.db
-    .query("registerSession")
-    .withIndex("by_storeId_status", (q) =>
-      q.eq("storeId", args.storeId).eq("status", "closed"),
-    )
-    .take(DAILY_CLOSE_QUERY_LIMIT);
-
-  return sessions.filter((session) =>
-    isInRange(
-      registerSessionCloseoutOperatingAt(session),
-      args.startAt,
-      args.endAt,
+  const range = { startAt: args.startAt, endAt: args.endAt };
+  const activeIndexedSessionPages = await Promise.all(
+    ACTIVE_REGISTER_STATUSES.map((status) =>
+      ctx.db
+        .query("registerSession")
+        .withIndex("by_storeId_status_openedOperatingDate", (q) =>
+          q
+            .eq("storeId", args.storeId)
+            .eq("status", status)
+            .lte("openedOperatingDate", args.operatingDate),
+        )
+        .order("desc")
+        .take(REGISTER_SESSION_DAILY_CLOSE_SOURCE_LIMIT),
     ),
   );
+  const activeMissingDateSessionPages = await Promise.all(
+    ACTIVE_REGISTER_STATUSES.map((status) =>
+      ctx.db
+        .query("registerSession")
+        .withIndex("by_storeId_status_openedOperatingDate", (q) =>
+          q
+            .eq("storeId", args.storeId)
+            .eq("status", status)
+            .eq("openedOperatingDate", undefined),
+        )
+        .take(REGISTER_SESSION_DAILY_CLOSE_SOURCE_LIMIT),
+    ),
+  );
+  const reviewOnlyIndexedSessionPages = await Promise.all(
+    REVIEW_ONLY_REGISTER_CLOSEOUT_STATUSES.map((status) =>
+      ctx.db
+        .query("registerSession")
+        .withIndex("by_storeId_status_closeoutOperatingDate", (q) =>
+          q
+            .eq("storeId", args.storeId)
+            .eq("status", status)
+            .eq("closeoutOperatingDate", args.operatingDate),
+        )
+        .take(REGISTER_SESSION_DAILY_CLOSE_SOURCE_LIMIT),
+    ),
+  );
+  const reviewOnlyMissingDateSessionPages = await Promise.all(
+    REVIEW_ONLY_REGISTER_CLOSEOUT_STATUSES.map((status) =>
+      ctx.db
+        .query("registerSession")
+        .withIndex("by_storeId_status_closeoutOperatingDate", (q) =>
+          q
+            .eq("storeId", args.storeId)
+            .eq("status", status)
+            .eq("closeoutOperatingDate", undefined),
+        )
+        .take(REGISTER_SESSION_DAILY_CLOSE_SOURCE_LIMIT),
+    ),
+  );
+  const indexedClosedSessions = await ctx.db
+    .query("registerSession")
+    .withIndex("by_storeId_status_closeoutOperatingDate", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("status", "closed")
+        .eq("closeoutOperatingDate", args.operatingDate),
+    )
+    .take(REGISTER_SESSION_DAILY_CLOSE_SOURCE_LIMIT);
+  const legacyClosedSessionCandidates = await ctx.db
+    .query("registerSession")
+    .withIndex("by_storeId_status_closeoutOperatingDate", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("status", "closed")
+        .eq("closeoutOperatingDate", undefined),
+    )
+    .take(REGISTER_SESSION_DAILY_CLOSE_SOURCE_LIMIT);
+  const closedSessionsById = new Map<Id<"registerSession">, Doc<"registerSession">>();
+
+  indexedClosedSessions.forEach((session) =>
+    closedSessionsById.set(session._id, session),
+  );
+  legacyClosedSessionCandidates
+    .filter(
+      (session) =>
+        !session.closeoutOperatingDate &&
+        isInRange(
+          registerSessionCloseoutOperatingAt(session),
+          args.startAt,
+          args.endAt,
+        ),
+    )
+    .forEach((session) => closedSessionsById.set(session._id, session));
+  const activeSessionsById = new Map<Id<"registerSession">, Doc<"registerSession">>();
+  const reviewOnlySessionsById = new Map<Id<"registerSession">, Doc<"registerSession">>();
+
+  activeIndexedSessionPages
+    .flat()
+    .filter((session) => registerSessionIntersectsRange(session, range))
+    .forEach((session) => activeSessionsById.set(session._id, session));
+  activeMissingDateSessionPages
+    .flat()
+    .filter((session) => registerSessionBelongsToRange(session, range))
+    .forEach((session) => activeSessionsById.set(session._id, session));
+  reviewOnlyIndexedSessionPages.flat().forEach((session) =>
+    reviewOnlySessionsById.set(session._id, session),
+  );
+  reviewOnlyMissingDateSessionPages
+    .flat()
+    .filter((session) => registerSessionBelongsToRange(session, range))
+    .forEach((session) => reviewOnlySessionsById.set(session._id, session));
+
+  return {
+    activeSessions: Array.from(activeSessionsById.values()),
+    reviewOnlySessions: Array.from(reviewOnlySessionsById.values()),
+    closedSessions: Array.from(closedSessionsById.values()),
+    sourceCompleteness: completeSourceCompleteness([
+      ...ACTIVE_REGISTER_STATUSES.map((status, index) =>
+        sourceCompletenessEntry({
+          source: "register_session",
+          readMode: "by_storeId_status_openedOperatingDate",
+          recordCount: activeIndexedSessionPages[index].length,
+          limit: REGISTER_SESSION_DAILY_CLOSE_SOURCE_LIMIT,
+          range,
+          reason: "register_session_active_opened_date_cap_reached",
+          statuses: [status],
+        }),
+      ),
+      ...ACTIVE_REGISTER_STATUSES.map((status, index) =>
+        sourceCompletenessEntry({
+          source: "register_session",
+          readMode: "by_storeId_status_openedOperatingDate_missing",
+          recordCount: activeMissingDateSessionPages[index].length,
+          limit: REGISTER_SESSION_DAILY_CLOSE_SOURCE_LIMIT,
+          range,
+          reason: "register_session_active_missing_opened_date_cap_reached",
+          statuses: [status],
+        }),
+      ),
+      ...REVIEW_ONLY_REGISTER_CLOSEOUT_STATUSES.map((status, index) =>
+        sourceCompletenessEntry({
+          source: "register_session",
+          readMode: "by_storeId_status_closeoutOperatingDate",
+          recordCount: reviewOnlyIndexedSessionPages[index].length,
+          limit: REGISTER_SESSION_DAILY_CLOSE_SOURCE_LIMIT,
+          range,
+          reason: "register_session_review_closeout_date_cap_reached",
+          statuses: [status],
+        }),
+      ),
+      ...REVIEW_ONLY_REGISTER_CLOSEOUT_STATUSES.map((status, index) =>
+        sourceCompletenessEntry({
+          source: "register_session",
+          readMode: "by_storeId_status_closeoutOperatingDate_missing",
+          recordCount: reviewOnlyMissingDateSessionPages[index].length,
+          limit: REGISTER_SESSION_DAILY_CLOSE_SOURCE_LIMIT,
+          range,
+          reason: "register_session_review_missing_closeout_date_cap_reached",
+          statuses: [status],
+        }),
+      ),
+      sourceCompletenessEntry({
+        source: "register_session",
+        readMode: "by_storeId_status_closeoutOperatingDate",
+        recordCount: indexedClosedSessions.length,
+        limit: REGISTER_SESSION_DAILY_CLOSE_SOURCE_LIMIT,
+        range,
+        reason: "register_session_closed_date_cap_reached",
+        statuses: ["closed"],
+      }),
+      sourceCompletenessEntry({
+        source: "register_session",
+        readMode: "by_storeId_status_closeoutOperatingDate_missing",
+        recordCount: legacyClosedSessionCandidates.length,
+        limit: REGISTER_SESSION_DAILY_CLOSE_SOURCE_LIMIT,
+        range,
+        reason: "register_session_legacy_closed_fallback_cap_reached",
+        statuses: ["closed"],
+      }),
+    ]),
+  };
 }
 
 function registerSessionIntersectsRange(
@@ -1027,7 +1226,8 @@ async function listPendingCloseoutApprovals(
     startAt: number;
     storeId: Id<"store">;
   },
-) {
+): Promise<DailyCloseSourceRead<Doc<"approvalRequest">>> {
+  const range = { startAt: args.startAt, endAt: args.endAt };
   const approvals = await ctx.db
     .query("approvalRequest")
     .withIndex("by_storeId_status", (q) =>
@@ -1049,9 +1249,20 @@ async function listPendingCloseoutApprovals(
     })),
   );
 
-  return scopedApprovals
-    .filter(({ belongsToRange }) => belongsToRange)
-    .map(({ approval }) => approval);
+  return {
+    rows: scopedApprovals
+      .filter(({ belongsToRange }) => belongsToRange)
+      .map(({ approval }) => approval),
+    completeness: sourceCompletenessEntry({
+      source: "approval_request",
+      readMode: "by_storeId_status",
+      recordCount: approvals.length,
+      limit: DAILY_CLOSE_QUERY_LIMIT,
+      range,
+      reason: "approval_request_source_cap_reached",
+      statuses: ["pending"],
+    }),
+  };
 }
 
 async function listOpenPosSessions(
@@ -1061,9 +1272,10 @@ async function listOpenPosSessions(
     startAt: number;
     storeId: Id<"store">;
   },
-) {
+): Promise<DailyCloseSourceRead<Doc<"posSession">>> {
+  const range = { startAt: args.startAt, endAt: args.endAt };
   const now = Date.now();
-  const sessions = await Promise.all(
+  const sessionPages = await Promise.all(
     OPEN_POS_SESSION_STATUSES.map((status) =>
       ctx.db
         .query("posSession")
@@ -1074,18 +1286,28 @@ async function listOpenPosSessions(
     ),
   );
 
-  return sessions
-    .flat()
-    .filter(
+  return {
+    rows: sessionPages.flat().filter(
       (session) =>
         session.expiresAt >= now && posSessionIntersectsRange(session, args),
-    );
+    ),
+    completeness: sourceCompletenessEntry({
+      source: "pos_session",
+      complete: sessionPages.every((page) => page.length < DAILY_CLOSE_QUERY_LIMIT),
+      readMode: "by_storeId_and_status",
+      recordCount: sessionPages.reduce((count, page) => count + page.length, 0),
+      limit: DAILY_CLOSE_QUERY_LIMIT,
+      range,
+      reason: "pos_session_source_cap_reached",
+      statuses: [...OPEN_POS_SESSION_STATUSES],
+    }),
+  };
 }
 
 async function listOpenOperationalWorkItems(
   ctx: Pick<QueryCtx, "db">,
   storeId: Id<"store">,
-) {
+): Promise<DailyCloseSourceRead<Doc<"operationalWorkItem">>> {
   const workItems = await Promise.all(
     OPEN_OPERATIONAL_WORK_ITEM_STATUSES.map((status) =>
       ctx.db
@@ -1097,7 +1319,42 @@ async function listOpenOperationalWorkItems(
     ),
   );
 
-  return workItems.flat();
+  return {
+    rows: workItems.flat(),
+    completeness: sourceCompletenessEntry({
+      source: "operational_work_item",
+      complete: workItems.every((page) => page.length < DAILY_CLOSE_QUERY_LIMIT),
+      readMode: "by_storeId_status",
+      recordCount: workItems.reduce((count, page) => count + page.length, 0),
+      limit: DAILY_CLOSE_QUERY_LIMIT,
+      reason: "operational_work_item_source_cap_reached",
+      statuses: [...OPEN_OPERATIONAL_WORK_ITEM_STATUSES],
+    }),
+  };
+}
+
+async function readCappedSource<T>(args: {
+  limit: number;
+  query: Promise<T[]>;
+  range: DailyCloseRange;
+  readMode: string;
+  source: string;
+  statuses?: string[];
+}): Promise<DailyCloseSourceRead<T>> {
+  const rows = await args.query;
+
+  return {
+    rows,
+    completeness: sourceCompletenessEntry({
+      source: args.source,
+      readMode: args.readMode,
+      recordCount: rows.length,
+      limit: args.limit,
+      range: args.range,
+      reason: `${args.source}_source_cap_reached`,
+      statuses: args.statuses,
+    }),
+  };
 }
 
 async function listTransactionsForDay(
@@ -1108,17 +1365,26 @@ async function listTransactionsForDay(
     status: string;
     storeId: Id<"store">;
   },
-) {
-  return ctx.db
-    .query("posTransaction")
-    .withIndex("by_storeId_status_completedAt", (q) =>
-      q
-        .eq("storeId", args.storeId)
-        .eq("status", args.status)
-        .gte("completedAt", args.startAt)
-        .lt("completedAt", args.endAt),
-    )
-    .take(DAILY_CLOSE_QUERY_LIMIT);
+): Promise<DailyCloseSourceRead<Doc<"posTransaction">>> {
+  const range = { startAt: args.startAt, endAt: args.endAt };
+
+  return readCappedSource({
+    source: "pos_transaction",
+    readMode: "by_storeId_status_completedAt",
+    limit: DAILY_CLOSE_QUERY_LIMIT,
+    range,
+    statuses: [args.status],
+    query: ctx.db
+      .query("posTransaction")
+      .withIndex("by_storeId_status_completedAt", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("status", args.status)
+          .gte("completedAt", args.startAt)
+          .lt("completedAt", args.endAt),
+      )
+      .take(DAILY_CLOSE_QUERY_LIMIT),
+  });
 }
 
 async function listExpensesForDay(
@@ -1128,17 +1394,26 @@ async function listExpensesForDay(
     startAt: number;
     storeId: Id<"store">;
   },
-) {
-  return ctx.db
-    .query("expenseTransaction")
-    .withIndex("by_storeId_status_completedAt", (q) =>
-      q
-        .eq("storeId", args.storeId)
-        .eq("status", "completed")
-        .gte("completedAt", args.startAt)
-        .lt("completedAt", args.endAt),
-    )
-    .take(DAILY_CLOSE_QUERY_LIMIT);
+): Promise<DailyCloseSourceRead<Doc<"expenseTransaction">>> {
+  const range = { startAt: args.startAt, endAt: args.endAt };
+
+  return readCappedSource({
+    source: "expense_transaction",
+    readMode: "by_storeId_status_completedAt",
+    limit: DAILY_CLOSE_QUERY_LIMIT,
+    range,
+    statuses: ["completed"],
+    query: ctx.db
+      .query("expenseTransaction")
+      .withIndex("by_storeId_status_completedAt", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("status", "completed")
+          .gte("completedAt", args.startAt)
+          .lt("completedAt", args.endAt),
+      )
+      .take(DAILY_CLOSE_QUERY_LIMIT),
+  });
 }
 
 async function listDepositsForDay(
@@ -1148,19 +1423,31 @@ async function listDepositsForDay(
     startAt: number;
     storeId: Id<"store">;
   },
-) {
+): Promise<DailyCloseSourceRead<Doc<"paymentAllocation">>> {
+  const range = { startAt: args.startAt, endAt: args.endAt };
   const allocations = await ctx.db
     .query("paymentAllocation")
     .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
     .take(DAILY_CLOSE_QUERY_LIMIT);
 
-  return allocations.filter(
-    (allocation) =>
-      allocation.allocationType === "cash_deposit" &&
-      allocation.direction === "out" &&
-      allocation.status === "recorded" &&
-      isInRange(allocation.recordedAt, args.startAt, args.endAt),
-  );
+  return {
+    rows: allocations.filter(
+      (allocation) =>
+        allocation.allocationType === "cash_deposit" &&
+        allocation.direction === "out" &&
+        allocation.status === "recorded" &&
+        isInRange(allocation.recordedAt, args.startAt, args.endAt),
+    ),
+    completeness: sourceCompletenessEntry({
+      source: "payment_allocation",
+      readMode: "by_storeId",
+      recordCount: allocations.length,
+      limit: DAILY_CLOSE_QUERY_LIMIT,
+      range,
+      reason: "payment_allocation_source_cap_reached",
+      statuses: ["recorded"],
+    }),
+  };
 }
 
 type PosTransactionAdjustmentReportRow = {
@@ -1280,14 +1567,15 @@ function adjustmentSettlementAmount(
   return adjustmentSalesDelta(adjustment);
 }
 
-export async function listAppliedTransactionAdjustmentsForDay(
+async function readAppliedTransactionAdjustmentsForDay(
   ctx: Pick<QueryCtx, "db">,
   args: {
     endAt: number;
     startAt: number;
     storeId: Id<"store">;
   },
-): Promise<AppliedTransactionAdjustment[]> {
+): Promise<DailyCloseSourceRead<AppliedTransactionAdjustment>> {
+  const range = { startAt: args.startAt, endAt: args.endAt };
   const adjustments = (await ctx.db
     .query("posTransactionAdjustment")
     .withIndex("by_storeId_status_appliedAt", (q) =>
@@ -1299,29 +1587,53 @@ export async function listAppliedTransactionAdjustmentsForDay(
     )
     .take(DAILY_CLOSE_QUERY_LIMIT)) as PosTransactionAdjustmentReportRow[];
 
-  return adjustments.flatMap((adjustment) => {
-    const status = adjustment.status ?? "";
-    const appliedAt = adjustmentAppliedAt(adjustment);
-    const transactionId = adjustmentTransactionId(adjustment);
+  return {
+    rows: adjustments.flatMap((adjustment) => {
+      const status = adjustment.status ?? "";
+      const appliedAt = adjustmentAppliedAt(adjustment);
+      const transactionId = adjustmentTransactionId(adjustment);
 
-    if (
-      !APPLIED_TRANSACTION_ADJUSTMENT_STATUSES.has(status) ||
-      appliedAt === null ||
-      !transactionId
-    ) {
-      return [];
-    }
+      if (
+        !APPLIED_TRANSACTION_ADJUSTMENT_STATUSES.has(status) ||
+        appliedAt === null ||
+        !transactionId
+      ) {
+        return [];
+      }
 
-    return [
-      {
-        ...adjustment,
-        appliedAt,
-        signedSalesDelta: adjustmentSalesDelta(adjustment),
-        signedSettlementAmount: adjustmentSettlementAmount(adjustment),
-        transactionId,
-      },
-    ];
-  });
+      return [
+        {
+          ...adjustment,
+          appliedAt,
+          signedSalesDelta: adjustmentSalesDelta(adjustment),
+          signedSettlementAmount: adjustmentSettlementAmount(adjustment),
+          transactionId,
+        },
+      ];
+    }),
+    completeness: sourceCompletenessEntry({
+      source: "pos_transaction_adjustment",
+      readMode: "by_storeId_status_appliedAt",
+      recordCount: adjustments.length,
+      limit: DAILY_CLOSE_QUERY_LIMIT,
+      range,
+      reason: "pos_transaction_adjustment_source_cap_reached",
+      statuses: ["applied"],
+    }),
+  };
+}
+
+export async function listAppliedTransactionAdjustmentsForDay(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    endAt: number;
+    startAt: number;
+    storeId: Id<"store">;
+  },
+): Promise<AppliedTransactionAdjustment[]> {
+  const read = await readAppliedTransactionAdjustmentsForDay(ctx, args);
+
+  return read.rows;
 }
 
 function buildAdjustmentPaymentTotals(
@@ -1480,6 +1792,7 @@ function buildDailyCloseReportSnapshot(args: {
   completedAt: number;
   completedByStaffProfileId?: Id<"staffProfile">;
   completedByUserId?: Id<"athenaUser">;
+  currentnessMode?: "mark_current" | "historical_record";
   notes?: string;
   policyReviewedItemKeys?: string[];
   readiness: DailyCloseReadiness;
@@ -1501,6 +1814,7 @@ function buildDailyCloseReportSnapshot(args: {
       automationRunId: args.automationRunId,
       automationPolicyVersion: args.automationPolicyVersion,
       automationDecisionReason: args.automationDecisionReason,
+      currentnessMode: args.currentnessMode,
       policyReviewedItemKeys: args.policyReviewedItemKeys,
       notes: args.notes,
       reviewedItemKeys: args.reviewedItemKeys,
@@ -1514,6 +1828,7 @@ function buildDailyCloseReportSnapshot(args: {
       ...args.carryForwardWorkItems.map(asCarryForwardItem),
     ]),
     readyItems: args.snapshot.readyItems,
+    sourceCompleteness: args.snapshot.sourceCompleteness,
     sourceSubjects: args.snapshot.sourceSubjects,
   };
 }
@@ -1712,6 +2027,10 @@ function snapshotReviewedItems(
   );
 }
 
+function incompleteSourceCompletenessEntries(snapshot: DailyCloseSnapshot) {
+  return snapshot.sourceCompleteness.entries.filter((entry) => !entry.complete);
+}
+
 function completionAttributionForDailyClose(
   dailyClose: Doc<"dailyClose">,
   completedByStaffProfileId = dailyClose.completedByStaffProfileId,
@@ -1819,6 +2138,7 @@ function redactDailyCloseReportSnapshotForBroadView(
       automationRunId: snapshot.closeMetadata.automationRunId,
       automationPolicyVersion: snapshot.closeMetadata.automationPolicyVersion,
       automationDecisionReason: snapshot.closeMetadata.automationDecisionReason,
+      currentnessMode: snapshot.closeMetadata.currentnessMode,
       notes: snapshot.closeMetadata.notes,
       carryForwardWorkItemIds: [],
     },
@@ -1829,6 +2149,7 @@ function redactDailyCloseReportSnapshotForBroadView(
       redactDailyCloseItemForBroadView,
     ),
     readyItems: snapshot.readyItems.map(redactDailyCloseItemForBroadView),
+    sourceCompleteness: snapshot.sourceCompleteness,
     sourceSubjects: [],
   };
 }
@@ -2014,6 +2335,15 @@ export async function buildDailyCloseSnapshotWithCtx(
         readyCount: 0,
       },
       summary: emptySummary(),
+      sourceCompleteness: completeSourceCompleteness([
+        {
+          source: "operating_date",
+          complete: false,
+          readMode: "validation",
+          recordCount: 0,
+          reason: "invalid_operating_date",
+        },
+      ]),
       sourceSubjects: [blocker.subject],
     };
   }
@@ -2052,22 +2382,22 @@ export async function buildDailyCloseSnapshotWithCtx(
   }
 
   const [
-    activeRegisterSessionsForStore,
-    reviewOnlyRegisterCloseoutSessionsForStore,
-    closedRegisterSessions,
-    pendingApprovals,
-    openPosSessions,
-    openWorkItems,
-    completedTransactions,
-    appliedTransactionAdjustments,
-    voidedTransactions,
-    expenseTransactions,
-    cashDeposits,
+    registerSessionRead,
+    pendingApprovalRead,
+    openPosSessionRead,
+    openWorkItemRead,
+    completedTransactionRead,
+    appliedTransactionAdjustmentRead,
+    voidedTransactionRead,
+    expenseTransactionRead,
+    cashDepositRead,
     priorClose,
   ] = await Promise.all([
-    listActiveRegisterSessions(ctx, args.storeId),
-    listReviewOnlyRegisterCloseoutSessions(ctx, args.storeId),
-    listClosedRegisterSessionsForDay(ctx, { ...range, storeId: args.storeId }),
+    listRegisterSessionsForDailyClose(ctx, {
+      ...range,
+      operatingDate: args.operatingDate,
+      storeId: args.storeId,
+    }),
     listPendingCloseoutApprovals(ctx, { ...range, storeId: args.storeId }),
     listOpenPosSessions(ctx, { ...range, storeId: args.storeId }),
     listOpenOperationalWorkItems(ctx, args.storeId),
@@ -2076,7 +2406,7 @@ export async function buildDailyCloseSnapshotWithCtx(
       status: "completed",
       storeId: args.storeId,
     }),
-    listAppliedTransactionAdjustmentsForDay(ctx, {
+    readAppliedTransactionAdjustmentsForDay(ctx, {
       ...range,
       storeId: args.storeId,
     }),
@@ -2089,19 +2419,39 @@ export async function buildDailyCloseSnapshotWithCtx(
     listDepositsForDay(ctx, { ...range, storeId: args.storeId }),
     getPriorCompletedDailyClose(ctx, args),
   ]);
+  const completedTransactions = completedTransactionRead.rows;
+  const appliedTransactionAdjustments = appliedTransactionAdjustmentRead.rows;
+  const voidedTransactions = voidedTransactionRead.rows;
+  const expenseTransactions = expenseTransactionRead.rows;
+  const cashDeposits = cashDepositRead.rows;
+  const pendingApprovals = pendingApprovalRead.rows;
+  const openPosSessions = openPosSessionRead.rows;
+  const openWorkItems = openWorkItemRead.rows;
+  const sourceCompleteness = mergeSourceCompleteness(
+    registerSessionRead.sourceCompleteness,
+    pendingApprovalRead.completeness,
+    openPosSessionRead.completeness,
+    openWorkItemRead.completeness,
+    completedTransactionRead.completeness,
+    appliedTransactionAdjustmentRead.completeness,
+    voidedTransactionRead.completeness,
+    expenseTransactionRead.completeness,
+    cashDepositRead.completeness,
+  );
 
   const activeRegisterSessionsInRange =
     await filterRegisterSessionsBelongingToRange(
       ctx,
-      activeRegisterSessionsForStore,
+      registerSessionRead.activeSessions,
       range,
     );
   const reviewOnlyRegisterCloseoutSessionsInRange =
     await filterRegisterSessionsBelongingToRange(
       ctx,
-      reviewOnlyRegisterCloseoutSessionsForStore,
+      registerSessionRead.reviewOnlySessions,
       range,
     );
+  const closedRegisterSessions = registerSessionRead.closedSessions;
   const activeRegisterSessionApprovalsById = await buildApprovalRequestsById(
     ctx,
     activeRegisterSessionsInRange.map(
@@ -2910,6 +3260,7 @@ export async function buildDailyCloseSnapshotWithCtx(
       readyItems,
       readiness,
       summary,
+      sourceCompleteness,
       sourceSubjects: uniqueSourceSubjects(allItems),
     },
     includeManagerReviewEvidence,
@@ -3337,6 +3688,7 @@ export async function completeDailyCloseWithCtx(
     isCurrent: true,
     readiness,
     summary,
+    sourceCompleteness: snapshot.sourceCompleteness,
     sourceSubjects: snapshot.sourceSubjects,
     reportSnapshot: buildDailyCloseReportSnapshot({
       carryForwardWorkItemIds,
@@ -3439,6 +3791,8 @@ export async function completeDailyCloseForAutomationWithCtx(
   ctx: MutationCtx,
   args: CompleteDailyCloseForAutomationArgs,
 ): Promise<CompleteDailyCloseResult> {
+  const currentnessMode = args.currentnessMode ?? "mark_current";
+  const markAsCurrent = currentnessMode === "mark_current";
   const store = await getStore(ctx, args.storeId);
 
   if (!store) {
@@ -3531,6 +3885,21 @@ export async function completeDailyCloseForAutomationWithCtx(
     });
   }
 
+  if (currentnessMode === "historical_record") {
+    const incompleteSources = incompleteSourceCompletenessEntries(snapshot);
+
+    if (incompleteSources.length > 0) {
+      return userError({
+        code: "precondition_failed",
+        message:
+          "EOD Review automation cannot complete historic records without complete source evidence.",
+        metadata: {
+          incompleteSources,
+        },
+      });
+    }
+  }
+
   if (snapshot.blockers.length > 0) {
     return userError({
       code: "precondition_failed",
@@ -3612,9 +3981,10 @@ export async function completeDailyCloseForAutomationWithCtx(
     operatingDate: args.operatingDate,
     status: "completed" as const,
     lifecycleStatus: "active" as const,
-    isCurrent: true,
+    isCurrent: markAsCurrent,
     readiness,
     summary,
+    sourceCompleteness: snapshot.sourceCompleteness,
     sourceSubjects: snapshot.sourceSubjects,
     reportSnapshot: buildDailyCloseReportSnapshot({
       actorType: "automation",
@@ -3624,6 +3994,7 @@ export async function completeDailyCloseForAutomationWithCtx(
       carryForwardWorkItemIds,
       carryForwardWorkItems,
       completedAt: now,
+      currentnessMode,
       policyReviewedItemKeys: args.policyReviewedItemKeys,
       readiness,
       reviewedItemKeys: args.policyReviewedItemKeys,
@@ -3652,10 +4023,12 @@ export async function completeDailyCloseForAutomationWithCtx(
     });
   }
 
-  await markOtherDailyClosesNotCurrent(ctx, {
-    currentCloseId: dailyCloseId,
-    storeId: args.storeId,
-  });
+  if (markAsCurrent) {
+    await markOtherDailyClosesNotCurrent(ctx, {
+      currentCloseId: dailyCloseId,
+      storeId: args.storeId,
+    });
+  }
 
   const dailyClose = await ctx.db.get("dailyClose", dailyCloseId);
 
@@ -3667,7 +4040,7 @@ export async function completeDailyCloseForAutomationWithCtx(
     });
   }
 
-  if (dailyClose.supersedesDailyCloseId) {
+  if (markAsCurrent && dailyClose.supersedesDailyCloseId) {
     await ctx.db.patch("dailyClose", dailyClose.supersedesDailyCloseId, {
       lifecycleStatus: "superseded",
       isCurrent: false,
@@ -3809,13 +4182,18 @@ export async function reopenDailyCloseWithCtx(
   }
 
   const now = Date.now();
+  const originalReportSnapshot =
+    originalDailyClose.reportSnapshot as DailyCloseReportSnapshot;
+  const reopenedShouldBeCurrent =
+    originalDailyClose.isCurrent !== false &&
+    originalReportSnapshot.closeMetadata.currentnessMode !== "historical_record";
   const reopenedDailyCloseId = await ctx.db.insert("dailyClose", {
     storeId: originalDailyClose.storeId,
     organizationId: originalDailyClose.organizationId,
     operatingDate: originalDailyClose.operatingDate,
     status: "open",
     lifecycleStatus: "active",
-    isCurrent: true,
+    isCurrent: reopenedShouldBeCurrent,
     readiness: originalDailyClose.readiness,
     summary: originalDailyClose.summary,
     sourceSubjects: originalDailyClose.sourceSubjects,
@@ -3843,10 +4221,12 @@ export async function reopenDailyCloseWithCtx(
     updatedAt: now,
   });
 
-  await markOtherDailyClosesNotCurrent(ctx, {
-    currentCloseId: reopenedDailyCloseId,
-    storeId: args.storeId,
-  });
+  if (reopenedShouldBeCurrent) {
+    await markOtherDailyClosesNotCurrent(ctx, {
+      currentCloseId: reopenedDailyCloseId,
+      storeId: args.storeId,
+    });
+  }
 
   const reopenedDailyClose = await ctx.db.get(
     "dailyClose",
@@ -4140,6 +4520,9 @@ export const completeDailyCloseForAutomation = internalMutation({
       maxVoidedSaleCount: v.number(),
       maxVoidedSaleTotal: v.number(),
     }),
+    currentnessMode: v.optional(
+      v.union(v.literal("mark_current"), v.literal("historical_record")),
+    ),
     endAt: v.optional(v.number()),
     operatingDate: v.string(),
     organizationId: v.optional(v.id("organization")),

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
@@ -9,6 +9,7 @@ import {
   getEodAutoCompletePolicy,
   getOpeningAutoStartPolicy,
   prepareDailyCloseAutomationWithCtx,
+  runHistoricEodAutoCloseBatchWithCtx,
   runDailyCloseAutoCompleteEligibilityWithCtx,
   runConfiguredDailyOperationsAutomationWithCtx,
   runDailyOpeningAutomationWithCtx,
@@ -578,6 +579,14 @@ describe("daily operations automation adapter", () => {
         }),
       ],
       store: [store],
+      storeSchedule: [
+        storeSchedule({
+          weeklyWindows: [
+            { dayOfWeek: 6, startMinute: 9 * 60, endMinute: 17 * 60 },
+            { dayOfWeek: 0, startMinute: 9 * 60, endMinute: 17 * 60 },
+          ],
+        }),
+      ],
     });
 
     const result = await runDailyOpeningAutomationWithCtx(
@@ -606,6 +615,14 @@ describe("daily operations automation adapter", () => {
         }),
       ],
       store: [store],
+      storeSchedule: [
+        storeSchedule({
+          weeklyWindows: [
+            { dayOfWeek: 6, startMinute: 9 * 60, endMinute: 17 * 60 },
+            { dayOfWeek: 0, startMinute: 9 * 60, endMinute: 17 * 60 },
+          ],
+        }),
+      ],
     });
 
     const result = await runDailyOpeningAutomationWithCtx(
@@ -1513,6 +1530,820 @@ describe("daily operations automation adapter", () => {
         carryForwardWorkItemIds: ["work-1"],
       },
     });
+  });
+
+  it("dry-runs bounded historic EOD auto-close dates oldest-first without closing days", async () => {
+    const { db, inserts } = createDb({
+      automationPolicy: [
+        policy("eod.auto_complete", "enabled", {
+          eodCleanDayAutoCompleteEnabled: true,
+          eodLocalCompletionWindowMinutes: 0,
+          operatingTimezoneOffsetMinutes: 0,
+        }),
+      ],
+      posTransaction: [
+        completedTransaction({
+          completedAt: Date.UTC(2026, 5, 6, 14),
+        }),
+        completedTransaction({
+          _id: "txn-2",
+          completedAt: Date.UTC(2026, 5, 7, 14),
+          payments: [{ amount: 12000, method: "cash", timestamp: 1 }],
+          status: "completed",
+          storeId: "store-1",
+          subtotal: 12000,
+          tax: 0,
+          total: 12000,
+          totalPaid: 12000,
+          transactionNumber: "TXN-2",
+        }),
+      ],
+      registerSession: [
+        closedRegisterSession({
+          closedAt: Date.UTC(2026, 5, 6, 21),
+          openedAt: Date.UTC(2026, 5, 6, 8),
+        }),
+        closedRegisterSession({
+          _id: "register-2",
+          closedAt: Date.UTC(2026, 5, 7, 21),
+          countedCash: 25000,
+          expectedCash: 25000,
+          openedAt: Date.UTC(2026, 5, 7, 8),
+          registerNumber: "2",
+          status: "closed",
+          storeId: "store-1",
+        }),
+      ],
+      store: [store],
+      storeSchedule: [
+        storeSchedule({
+          weeklyWindows: [
+            { dayOfWeek: 6, startMinute: 9 * 60, endMinute: 17 * 60 },
+            { dayOfWeek: 0, startMinute: 9 * 60, endMinute: 17 * 60 },
+          ],
+        }),
+      ],
+    });
+
+    const result = await runHistoricEodAutoCloseBatchWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        asOfOperatingDate: "2026-06-10",
+        endOperatingDate: "2026-06-08",
+        maxDays: 2,
+        mode: "dry_run",
+        startOperatingDate: "2026-06-06",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      applied: 0,
+      candidates: 2,
+      failed: 0,
+      mode: "dry_run",
+      nextOperatingDate: "2026-06-08",
+      skipped: 0,
+    });
+    expect(result.results).toEqual([
+      expect.objectContaining({
+        action: "dry_run",
+        classification: "clean_day",
+        operatingDate: "2026-06-06",
+      }),
+      expect.objectContaining({
+        action: "dry_run",
+        classification: "clean_day",
+        operatingDate: "2026-06-07",
+      }),
+    ]);
+    expect(
+      inserts.filter((insert) => insert.table !== "automationRun"),
+    ).toEqual([]);
+    expect(inserts.map((insert) => insert.table)).toEqual([
+      "automationRun",
+      "automationRun",
+    ]);
+    expect(inserts.map((insert) => insert.value)).toEqual([
+        expect.objectContaining({
+          outcome: "dry_run",
+          policyMode: "dry_run",
+          decisionEvidence: expect.objectContaining({
+            classification: "clean_day",
+            observed: expect.objectContaining({
+              scheduleEvidenceSource: "canonical_schedule",
+              storeScheduleId: "storeSchedule-1",
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          outcome: "dry_run",
+          policyMode: "dry_run",
+          decisionEvidence: expect.objectContaining({
+            classification: "clean_day",
+            observed: expect.objectContaining({
+              scheduleEvidenceSource: "canonical_schedule",
+              storeScheduleId: "storeSchedule-1",
+            }),
+          }),
+        }),
+    ]);
+    expect(
+      inserts.map((insert) => insert.value).map((run) => run.idempotencyKey),
+    ).toEqual([
+      "daily_operations:eod.auto_complete:historic:store-1:2026-06-06",
+      "daily_operations:eod.auto_complete:historic:store-1:2026-06-07",
+    ]);
+  });
+
+  it("quarantines current or future historic EOD dates with stable run evidence", async () => {
+    const { db, inserts } = createDb({
+      automationPolicy: [
+        policy("eod.auto_complete", "enabled", {
+          eodCleanDayAutoCompleteEnabled: true,
+          eodLocalCompletionWindowMinutes: 0,
+          operatingTimezoneOffsetMinutes: 0,
+        }),
+      ],
+      store: [store],
+    });
+
+    const result = await runHistoricEodAutoCloseBatchWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        asOfOperatingDate: "2026-06-08",
+        endOperatingDate: "2026-06-08",
+        maxDays: 1,
+        mode: "apply",
+        startOperatingDate: "2026-06-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      applied: 0,
+      candidates: 1,
+      quarantined: 1,
+    });
+    expect(inserts).toContainEqual(
+      expect.objectContaining({
+        table: "automationRun",
+        value: expect.objectContaining({
+          action: "eod.auto_complete",
+          decisionEvidence: expect.objectContaining({
+            classification: "quarantine_current_or_future_date",
+            eligible: false,
+            observed: expect.objectContaining({
+              quarantineReason: "current_or_future_date",
+            }),
+          }),
+          idempotencyKey:
+            "daily_operations:eod.auto_complete:historic:store-1:2026-06-08",
+          outcome: "skipped",
+          triggerType: "support_batch",
+        }),
+      }),
+    );
+  });
+
+  it("quarantines a past UTC date while the store-local operating day is still open", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 5, 9, 0, 30));
+    const { db, inserts } = createDb({
+      automationPolicy: [
+        policy("eod.auto_complete", "enabled", {
+          eodCleanDayAutoCompleteEnabled: true,
+          eodLocalCompletionWindowMinutes: 0,
+          operatingTimezoneOffsetMinutes: -4 * 60,
+        }),
+      ],
+      store: [store],
+      storeSchedule: [
+        storeSchedule({
+          timezone: "America/New_York",
+          weeklyWindows: [
+            { dayOfWeek: 1, startMinute: 10 * 60, endMinute: 22 * 60 },
+          ],
+        }),
+      ],
+    });
+
+    const result = await runHistoricEodAutoCloseBatchWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        asOfOperatingDate: "2026-06-09",
+        endOperatingDate: "2026-06-08",
+        maxDays: 1,
+        mode: "apply",
+        startOperatingDate: "2026-06-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      applied: 0,
+      candidates: 1,
+      quarantined: 1,
+    });
+    expect(inserts.map((insert) => insert.table)).toEqual(["automationRun"]);
+    expect(inserts[0].value).toMatchObject({
+      decisionEvidence: {
+        classification: "quarantine_store_day_still_open",
+        eligible: false,
+        observed: {
+          quarantineReason: "store_day_still_open",
+          scheduleEvidenceSource: "canonical_schedule",
+          storeScheduleId: "storeSchedule-1",
+        },
+      },
+      outcome: "skipped",
+      triggerType: "support_batch",
+    });
+  });
+
+  it("quarantines historic apply dates when Store Schedule evidence is missing", async () => {
+    const { db, inserts } = createDb({
+      automationPolicy: [
+        policy("eod.auto_complete", "enabled", {
+          eodCleanDayAutoCompleteEnabled: true,
+          eodLocalCompletionWindowMinutes: 0,
+          operatingTimezoneOffsetMinutes: 0,
+        }),
+      ],
+      store: [store],
+    });
+
+    const result = await runHistoricEodAutoCloseBatchWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        asOfOperatingDate: "2026-06-10",
+        endOperatingDate: "2026-06-08",
+        maxDays: 1,
+        mode: "apply",
+        startOperatingDate: "2026-06-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      applied: 0,
+      candidates: 1,
+      quarantined: 1,
+      results: [
+        expect.objectContaining({
+          action: "quarantined",
+          classification: "quarantine_missing_store_schedule",
+          operatingDate: "2026-06-08",
+        }),
+      ],
+    });
+    expect(inserts.map((insert) => insert.table)).toEqual(["automationRun"]);
+    expect(inserts[0].value).toMatchObject({
+      decisionEvidence: {
+        classification: "quarantine_missing_store_schedule",
+        eligible: false,
+        observed: expect.objectContaining({
+          quarantineReason: "missing_store_schedule",
+        }),
+      },
+      outcome: "skipped",
+      policyMode: "enabled",
+      triggerType: "support_batch",
+    });
+  });
+
+  it("applies historic EOD auto-close with full canonical Store Schedule range evidence", async () => {
+    const { db, inserts } = createDb({
+      automationPolicy: [
+        policy("eod.auto_complete", "enabled", {
+          eodCleanDayAutoCompleteEnabled: true,
+          eodLocalCompletionWindowMinutes: 0,
+          operatingTimezoneOffsetMinutes: 0,
+        }),
+      ],
+      posTransaction: [
+        completedTransaction({
+          _id: "txn-morning",
+          completedAt: Date.UTC(2026, 5, 8, 10),
+          transactionNumber: "TXN-MORNING",
+        }),
+        completedTransaction({
+          _id: "txn-evening",
+          completedAt: Date.UTC(2026, 5, 8, 18),
+          transactionNumber: "TXN-EVENING",
+        }),
+      ],
+      registerSession: [
+        closedRegisterSession({
+          _id: "register-morning",
+          closedAt: Date.UTC(2026, 5, 8, 11),
+          closeoutOperatingDate: "2026-06-08",
+          openedAt: Date.UTC(2026, 5, 8, 9),
+        }),
+        closedRegisterSession({
+          _id: "register-evening",
+          closedAt: Date.UTC(2026, 5, 8, 19),
+          closeoutOperatingDate: "2026-06-08",
+          openedAt: Date.UTC(2026, 5, 8, 16),
+        }),
+      ],
+      store: [store],
+      storeSchedule: [
+        storeSchedule({
+          weeklyWindows: [
+            { dayOfWeek: 1, startMinute: 9 * 60, endMinute: 12 * 60 },
+            { dayOfWeek: 1, startMinute: 16 * 60, endMinute: 20 * 60 },
+          ],
+        }),
+      ],
+    });
+
+    const result = await runHistoricEodAutoCloseBatchWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        asOfOperatingDate: "2026-06-10",
+        endOperatingDate: "2026-06-08",
+        maxDays: 1,
+        mode: "apply",
+        startOperatingDate: "2026-06-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      applied: 1,
+      candidates: 1,
+      failed: 0,
+      quarantined: 0,
+    });
+    expect(inserts.map((insert) => insert.table)).toEqual([
+      "automationRun",
+      "dailyClose",
+      "operationalEvent",
+    ]);
+    expect(
+      inserts.find((insert) => insert.table === "dailyClose")?.value,
+    ).toMatchObject({
+      actorType: "automation",
+      automationRunId: "automationRun-1",
+      isCurrent: false,
+      operatingDate: "2026-06-08",
+      reportSnapshot: {
+        closeMetadata: {
+          endAt: Date.UTC(2026, 5, 8, 20),
+          startAt: Date.UTC(2026, 5, 8, 9),
+        },
+      },
+      summary: {
+        salesTotal: 24000,
+        transactionCount: 2,
+      },
+    });
+    expect(inserts[0].value).toMatchObject({
+      decisionEvidence: {
+        observed: {
+          scheduleEvidenceSource: "canonical_schedule",
+          storeScheduleId: "storeSchedule-1",
+        },
+      },
+      triggerType: "support_batch",
+    });
+  });
+
+  it("quarantines historic apply dates when Store Schedule marks the date closed", async () => {
+    const { db, inserts } = createDb({
+      automationPolicy: [
+        policy("eod.auto_complete", "enabled", {
+          eodCleanDayAutoCompleteEnabled: true,
+          eodLocalCompletionWindowMinutes: 0,
+          operatingTimezoneOffsetMinutes: 0,
+        }),
+      ],
+      store: [store],
+      storeSchedule: [
+        storeSchedule({
+          weeklyClosedDays: [1],
+          weeklyWindows: [],
+        }),
+      ],
+    });
+
+    const result = await runHistoricEodAutoCloseBatchWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        asOfOperatingDate: "2026-06-10",
+        endOperatingDate: "2026-06-08",
+        maxDays: 1,
+        mode: "apply",
+        startOperatingDate: "2026-06-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      applied: 0,
+      quarantined: 1,
+    });
+    expect(inserts).toContainEqual(
+      expect.objectContaining({
+        table: "automationRun",
+        value: expect.objectContaining({
+          decisionEvidence: expect.objectContaining({
+            classification: "quarantine_store_schedule_closed",
+            observed: expect.objectContaining({
+              quarantineReason: "store_schedule_closed",
+              scheduleEvidenceSource: "canonical_schedule",
+              storeScheduleId: "storeSchedule-1",
+            }),
+          }),
+          outcome: "skipped",
+        }),
+      }),
+    );
+  });
+
+  it("quarantines historic apply when Daily Close source reads are incomplete", async () => {
+    const cappedTransactions = Array.from({ length: 200 }, (_, index) =>
+      completedTransaction({
+        _id: `txn-cap-${index + 1}`,
+        completedAt: Date.UTC(2026, 5, 8, 14, index % 60),
+        transactionNumber: `TXN-CAP-${index + 1}`,
+      }),
+    );
+    const { db, inserts } = createDb({
+      automationPolicy: [
+        policy("eod.auto_complete", "enabled", {
+          eodCleanDayAutoCompleteEnabled: true,
+          eodLocalCompletionWindowMinutes: 0,
+          operatingTimezoneOffsetMinutes: 0,
+        }),
+      ],
+      posTransaction: cappedTransactions,
+      store: [store],
+      storeSchedule: [storeSchedule()],
+    });
+    const dryRunDb = createDb({
+      automationPolicy: [
+        policy("eod.auto_complete", "enabled", {
+          eodCleanDayAutoCompleteEnabled: true,
+          eodLocalCompletionWindowMinutes: 0,
+          operatingTimezoneOffsetMinutes: 0,
+        }),
+      ],
+      posTransaction: cappedTransactions,
+      store: [store],
+      storeSchedule: [storeSchedule()],
+    });
+
+    const result = await runHistoricEodAutoCloseBatchWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        asOfOperatingDate: "2026-06-10",
+        endOperatingDate: "2026-06-08",
+        maxDays: 1,
+        mode: "apply",
+        startOperatingDate: "2026-06-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+    const dryRunResult = await runHistoricEodAutoCloseBatchWithCtx(
+      { db: dryRunDb.db } as unknown as MutationCtx,
+      {
+        asOfOperatingDate: "2026-06-10",
+        endOperatingDate: "2026-06-08",
+        maxDays: 1,
+        mode: "dry_run",
+        startOperatingDate: "2026-06-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      applied: 0,
+      candidates: 1,
+      quarantined: 1,
+    });
+    expect(inserts.map((insert) => insert.table)).toEqual(["automationRun"]);
+    expect(inserts[0].value).toMatchObject({
+      decisionEvidence: {
+        classification: "quarantine_incomplete_source_reads",
+        eligible: false,
+        observed: expect.objectContaining({
+          quarantineReason: "incomplete_source_reads",
+          scheduleEvidenceSource: "canonical_schedule",
+          storeScheduleId: "storeSchedule-1",
+        }),
+      },
+      outcome: "skipped",
+      triggerType: "support_batch",
+    });
+    expect(dryRunResult).toMatchObject({
+      applied: 0,
+      candidates: 1,
+      quarantined: 1,
+      results: [
+        {
+          action: "quarantined",
+          classification: "quarantine_incomplete_source_reads",
+        },
+      ],
+    });
+    expect(dryRunDb.inserts.map((insert) => insert.table)).toEqual([
+      "automationRun",
+    ]);
+    expect(dryRunDb.inserts[0].value).toMatchObject({
+      decisionEvidence: {
+        classification: "quarantine_incomplete_source_reads",
+        observed: expect.objectContaining({
+          quarantineReason: "incomplete_source_reads",
+        }),
+      },
+    });
+  });
+
+  it("preserves applied historic automation run evidence on apply and dry-run reruns", async () => {
+    const appliedRun = {
+      _id: "automation-run-applied",
+      action: "eod.auto_complete",
+      appliedAt: Date.UTC(2026, 5, 8, 22),
+      createdAt: Date.UTC(2026, 5, 8, 22),
+      decisionEvidence: {
+        classification: "clean_day",
+        eligible: true,
+        observed: {},
+      },
+      decisionReason: "Historic EOD Review completed by automation policy.",
+      domain: "daily_operations",
+      eventIds: ["event-applied"],
+      idempotencyKey:
+        "daily_operations:eod.auto_complete:historic:store-1:2026-06-08",
+      mutationBoundary: "Daily Close completion record and audit event only",
+      operatingDate: "2026-06-08",
+      outcome: "applied",
+      policyMode: "enabled",
+      policyVersion: "daily-operations.v1",
+      snapshotCounts: {},
+      sourceSubjects: [],
+      storeId: "store-1",
+      triggerType: "support_batch",
+      updatedAt: Date.UTC(2026, 5, 8, 22),
+    };
+    const { db, inserts, patches } = createDb({
+      automationPolicy: [
+        policy("eod.auto_complete", "enabled", {
+          eodCleanDayAutoCompleteEnabled: true,
+          eodLocalCompletionWindowMinutes: 0,
+          operatingTimezoneOffsetMinutes: 0,
+        }),
+      ],
+      automationRun: [appliedRun],
+      dailyClose: [
+        completedDailyClose({
+          _id: "daily-close-applied",
+          automationRunId: "automation-run-applied",
+          completedAt: Date.UTC(2026, 5, 8, 22),
+          operatingDate: "2026-06-08",
+          updatedAt: Date.UTC(2026, 5, 8, 22),
+        }),
+      ],
+      store: [store],
+      storeSchedule: [storeSchedule()],
+    });
+
+    const applyResult = await runHistoricEodAutoCloseBatchWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        asOfOperatingDate: "2026-06-10",
+        endOperatingDate: "2026-06-08",
+        maxDays: 1,
+        mode: "apply",
+        startOperatingDate: "2026-06-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+    const dryRunResult = await runHistoricEodAutoCloseBatchWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        asOfOperatingDate: "2026-06-10",
+        endOperatingDate: "2026-06-08",
+        maxDays: 1,
+        mode: "dry_run",
+        startOperatingDate: "2026-06-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+    const currentDateResult = await runHistoricEodAutoCloseBatchWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        asOfOperatingDate: "2026-06-08",
+        endOperatingDate: "2026-06-08",
+        maxDays: 1,
+        mode: "apply",
+        startOperatingDate: "2026-06-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(applyResult.results[0]).toMatchObject({
+      action: "already_completed",
+      runId: "automation-run-applied",
+    });
+    expect(dryRunResult.results[0]).toMatchObject({
+      action: "already_completed",
+      runId: "automation-run-applied",
+    });
+    expect(currentDateResult.results[0]).toMatchObject({
+      action: "already_completed",
+      runId: "automation-run-applied",
+    });
+    expect(inserts).toEqual([]);
+    expect(patches).toEqual([]);
+  });
+
+  it("does not report an applied historic run as completed after the linked close is reopened", async () => {
+    const appliedRun = {
+      _id: "automation-run-applied",
+      action: "eod.auto_complete",
+      appliedAt: Date.UTC(2026, 5, 8, 22),
+      createdAt: Date.UTC(2026, 5, 8, 22),
+      decisionEvidence: {
+        classification: "completed",
+        eligible: true,
+        observed: {},
+      },
+      decisionReason: "Historic EOD Review completed by automation policy.",
+      domain: "daily_operations",
+      eventIds: ["event-applied"],
+      idempotencyKey:
+        "daily_operations:eod.auto_complete:historic:store-1:2026-06-08",
+      mutationBoundary: "Daily Close completion record and audit event only",
+      operatingDate: "2026-06-08",
+      outcome: "applied",
+      policyMode: "enabled",
+      policyVersion: "daily-operations.v1",
+      snapshotCounts: {},
+      sourceSubjects: [],
+      storeId: "store-1",
+      triggerType: "support_batch",
+      updatedAt: Date.UTC(2026, 5, 8, 22),
+    };
+    const { db, patches } = createDb({
+      automationPolicy: [
+        policy("eod.auto_complete", "enabled", {
+          eodCleanDayAutoCompleteEnabled: true,
+          eodLocalCompletionWindowMinutes: 0,
+          operatingTimezoneOffsetMinutes: 0,
+        }),
+      ],
+      automationRun: [appliedRun],
+      dailyClose: [
+        completedDailyClose({
+          _id: "daily-close-applied",
+          automationRunId: "automation-run-applied",
+          completedAt: Date.UTC(2026, 5, 8, 22),
+          lifecycleStatus: "reopened",
+          operatingDate: "2026-06-08",
+          supersededByDailyCloseId: "daily-close-reopened",
+          updatedAt: Date.UTC(2026, 5, 9, 10),
+        }),
+        completedDailyClose({
+          _id: "daily-close-reopened",
+          automationRunId: undefined,
+          completedAt: undefined,
+          lifecycleStatus: "active",
+          operatingDate: "2026-06-08",
+          reopenedFromDailyCloseId: "daily-close-applied",
+          status: "open",
+          updatedAt: Date.UTC(2026, 5, 9, 10),
+        }),
+      ],
+      store: [store],
+      storeSchedule: [storeSchedule()],
+    });
+
+    const rerunResult = await runHistoricEodAutoCloseBatchWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        asOfOperatingDate: "2026-06-10",
+        endOperatingDate: "2026-06-08",
+        maxDays: 1,
+        mode: "apply",
+        startOperatingDate: "2026-06-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(rerunResult.results[0]).toMatchObject({
+      action: "skipped",
+      runId: "automation-run-applied",
+    });
+    expect(rerunResult.results[0]).not.toMatchObject({
+      action: "already_completed",
+    });
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "automation-run-applied",
+          table: "automationRun",
+          value: expect.objectContaining({
+            outcome: "skipped",
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("clears applied evidence when an invalidated historic run is downgraded by a replacement close", async () => {
+    const appliedRun = {
+      _id: "automation-run-applied",
+      action: "eod.auto_complete",
+      appliedAt: Date.UTC(2026, 5, 8, 22),
+      createdAt: Date.UTC(2026, 5, 8, 22),
+      decisionEvidence: {
+        classification: "completed",
+        eligible: true,
+        observed: {},
+      },
+      decisionReason: "Historic EOD Review completed by automation policy.",
+      domain: "daily_operations",
+      error: {
+        code: "stale-error",
+        message: "Previous stale error evidence.",
+      },
+      eventIds: ["event-applied"],
+      idempotencyKey:
+        "daily_operations:eod.auto_complete:historic:store-1:2026-06-08",
+      mutationBoundary: "Daily Close completion record and audit event only",
+      operatingDate: "2026-06-08",
+      outcome: "applied",
+      policyMode: "enabled",
+      policyVersion: "daily-operations.v1",
+      snapshotCounts: {},
+      sourceSubjects: [],
+      storeId: "store-1",
+      triggerType: "support_batch",
+      updatedAt: Date.UTC(2026, 5, 8, 22),
+    };
+    const { db, patches } = createDb({
+      automationPolicy: [
+        policy("eod.auto_complete", "enabled", {
+          eodCleanDayAutoCompleteEnabled: true,
+          eodLocalCompletionWindowMinutes: 0,
+          operatingTimezoneOffsetMinutes: 0,
+        }),
+      ],
+      automationRun: [appliedRun],
+      dailyClose: [
+        completedDailyClose({
+          _id: "daily-close-applied",
+          automationRunId: "automation-run-applied",
+          completedAt: Date.UTC(2026, 5, 8, 22),
+          lifecycleStatus: "reopened",
+          operatingDate: "2026-06-08",
+          supersededByDailyCloseId: "daily-close-replacement",
+          updatedAt: Date.UTC(2026, 5, 9, 10),
+        }),
+        completedDailyClose({
+          _id: "daily-close-replacement",
+          automationRunId: undefined,
+          completedAt: Date.UTC(2026, 5, 9, 11),
+          lifecycleStatus: "active",
+          operatingDate: "2026-06-08",
+          reopenedFromDailyCloseId: "daily-close-applied",
+          status: "completed",
+          updatedAt: Date.UTC(2026, 5, 9, 11),
+        }),
+      ],
+      store: [store],
+      storeSchedule: [storeSchedule()],
+    });
+
+    const rerunResult = await runHistoricEodAutoCloseBatchWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        asOfOperatingDate: "2026-06-10",
+        endOperatingDate: "2026-06-08",
+        maxDays: 1,
+        mode: "apply",
+        startOperatingDate: "2026-06-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(rerunResult.results[0]).toMatchObject({
+      action: "already_completed",
+      runId: "automation-run-applied",
+    });
+
+    const runPatch = patches.find(
+      (patch) =>
+        patch.table === "automationRun" && patch.id === "automation-run-applied",
+    )?.value;
+
+    expect(runPatch).toMatchObject({
+      outcome: "skipped",
+    });
+    expect(runPatch).toHaveProperty("appliedAt", undefined);
+    expect(runPatch).toHaveProperty("error", undefined);
   });
 
   it("skips EOD auto-complete for review categories outside the low-risk policy", async () => {

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
@@ -1,6 +1,12 @@
 import type { Doc, Id } from "../_generated/dataModel";
-import type { MutationCtx, QueryCtx } from "../_generated/server";
-import { internalMutation, mutation, query } from "../_generated/server";
+import { internal } from "../_generated/api";
+import type { ActionCtx, MutationCtx, QueryCtx } from "../_generated/server";
+import {
+  internalAction,
+  internalMutation,
+  mutation,
+  query,
+} from "../_generated/server";
 import { v } from "convex/values";
 import { defineAutomationAction } from "../automation/actionRegistry";
 import { evaluateAutomationActionWithCtx } from "../automation/automationFoundation";
@@ -9,13 +15,16 @@ import {
   DEFAULT_OPENING_BLOCKER_HANDLING,
   DEFAULT_OPENING_LOCAL_START_MINUTES,
   EOD_AUTO_COMPLETE_POLICY_ACTION,
+  getAutomationRunByIdempotencyKeyWithCtx,
   getEodAutoCompletePolicyConfigWithCtx,
   getOpeningAutoStartPolicyConfigWithCtx,
   listAutomationRunsForStoreDayActionWithCtx,
+  patchAutomationRunOutcomeWithCtx,
   recordAutomationRunWithCtx,
   type AutomationDecisionEvidence,
   type EodAutoCompletePolicyConfig,
   upsertEodAutoCompletePolicyConfigWithCtx,
+  upsertAutomationRunWithCtx,
   upsertOpeningAutoStartPolicyConfigWithCtx,
   type OpeningAutoStartBlockerHandling,
 } from "../automation/runLedger";
@@ -28,7 +37,10 @@ import {
   completeDailyCloseForAutomationWithCtx,
 } from "./dailyClose";
 import { requireStoreFullAdminAccess } from "../stockOps/access";
-import { getStoreScheduleContextForStoreAtWithCtx } from "../inventory/storeSchedule";
+import {
+  getStoreScheduleContextForStoreAtWithCtx,
+  resolveStoreOperatingRangeForDateWithCtx,
+} from "../inventory/storeSchedule";
 
 export const DAILY_OPERATIONS_AUTOMATION_DOMAIN = "daily_operations";
 const OPENING_AUTO_START_ACTION = "opening.auto_start";
@@ -37,6 +49,8 @@ const EOD_AUTO_COMPLETE_ACTION = EOD_AUTO_COMPLETE_POLICY_ACTION;
 const AUTOMATION_POLICY_CRON_LIMIT = 500;
 const DAILY_OPERATIONS_POLICY_VERSION = "daily-operations.v1";
 const CONFIGURED_AUTOMATION_LOOKBACK_MS = 2 * 60 * 60 * 1000;
+const HISTORIC_EOD_AUTO_CLOSE_TRIGGER_TYPE = "support_batch";
+const HISTORIC_EOD_AUTO_CLOSE_MAX_DAYS_LIMIT = 100;
 const EOD_AUTO_COMPLETE_LOW_RISK_REVIEW_CATEGORIES = new Set([
   "cash_variance",
   "voided_sale",
@@ -133,6 +147,46 @@ type ConfiguredStoreScheduleContext = {
     | "closed"
     | "unavailable";
   storeDayContext?: DailyOperationsAutomationStoreDayContext;
+};
+
+type HistoricEodAutoCloseMode = "dry_run" | "apply";
+
+type HistoricEodStoreRangeResolution =
+  | {
+      kind: "resolved";
+      endAt: number;
+      scheduleEvidence: DailyOperationsAutomationTimingEvidence;
+      startAt: number;
+      storeDayContext: DailyOperationsAutomationStoreDayContext;
+    }
+  | {
+      kind: "unavailable";
+    }
+  | {
+      kind: "quarantine";
+      classification:
+        | "quarantine_store_schedule_ambiguous"
+        | "quarantine_store_schedule_closed"
+        | "quarantine_missing_store_schedule";
+      reason:
+        | "missing_store_schedule"
+        | "store_schedule_ambiguous"
+        | "store_schedule_closed";
+      scheduleEvidence?: DailyOperationsAutomationTimingEvidence;
+      storeScheduleId?: string;
+    };
+
+type HistoricEodDateResult = {
+  action:
+    | "applied"
+    | "already_completed"
+    | "dry_run"
+    | "failed"
+    | "quarantined"
+    | "skipped";
+  classification?: string;
+  operatingDate: string;
+  runId?: Id<"automationRun">;
 };
 
 function toApiOpeningBlockerHandling(
@@ -775,6 +829,567 @@ export async function runDailyCloseAutoCompleteEligibilityWithCtx(
     organizationId: snapshot.organizationId ?? undefined,
     storeId: args.storeId,
   });
+}
+
+function isValidOperatingDate(value: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+
+  const parsed = Date.parse(`${value}T00:00:00.000Z`);
+
+  return (
+    Number.isFinite(parsed) &&
+    new Date(parsed).toISOString().slice(0, 10) === value
+  );
+}
+
+function addDaysToOperatingDate(operatingDate: string, days: number) {
+  return new Date(
+    Date.parse(`${operatingDate}T00:00:00.000Z`) + days * 24 * 60 * 60_000,
+  )
+    .toISOString()
+    .slice(0, 10);
+}
+
+function historicEodAutoCloseIdempotencyKey(args: {
+  operatingDate: string;
+  storeId: Id<"store">;
+}) {
+  return `${DAILY_OPERATIONS_AUTOMATION_DOMAIN}:${EOD_AUTO_COMPLETE_ACTION}:historic:${args.storeId}:${args.operatingDate}`;
+}
+
+function policyEvidenceForHistoricRun(policyConfig: EodAutoCompletePolicyConfig) {
+  return {
+    cleanDayAutoCompleteEnabled: policyConfig.cleanDayAutoCompleteEnabled,
+    localCompletionWindowMinutes: policyConfig.localCompletionWindowMinutes,
+    maxAbsoluteCashVariance: policyConfig.maxAbsoluteCashVariance,
+    maxVoidedSaleCount: policyConfig.maxVoidedSaleCount,
+    maxVoidedSaleTotal: policyConfig.maxVoidedSaleTotal,
+    mode: policyConfig.paused ? "disabled" : policyConfig.mode,
+  };
+}
+
+function historicQuarantineEvidence(args: {
+  classification: string;
+  operatingDate: string;
+  policyConfig: EodAutoCompletePolicyConfig;
+  quarantineReason: string;
+  scheduleEvidence?: DailyOperationsAutomationTimingEvidence;
+}): AutomationDecisionEvidence {
+  return {
+    kind: "eod_auto_complete",
+    classification: args.classification,
+    eligible: false,
+    observed: {
+      operatingDate: args.operatingDate,
+      quarantineReason: args.quarantineReason,
+      ...(args.scheduleEvidence
+        ? {
+            scheduleEvidenceSource: args.scheduleEvidence.source,
+            ...(args.scheduleEvidence.storeScheduleId
+              ? { storeScheduleId: args.scheduleEvidence.storeScheduleId }
+              : {}),
+            ...(args.scheduleEvidence.scheduleVersion
+              ? { scheduleVersion: args.scheduleEvidence.scheduleVersion }
+              : {}),
+            ...(typeof args.scheduleEvidence.openedAt === "number"
+              ? { scheduleOpenedAt: args.scheduleEvidence.openedAt }
+              : {}),
+            ...(typeof args.scheduleEvidence.closedAt === "number"
+              ? { scheduleClosedAt: args.scheduleEvidence.closedAt }
+              : {}),
+            ...(typeof args.scheduleEvidence.evaluationAt === "number"
+              ? { scheduleEvaluationAt: args.scheduleEvidence.evaluationAt }
+              : {}),
+          }
+        : {}),
+    },
+    policy: policyEvidenceForHistoricRun(args.policyConfig),
+  };
+}
+
+async function recordHistoricEodQuarantineWithCtx(
+  ctx: MutationCtx,
+  args: {
+    classification: string;
+    decisionReason: string;
+    operatingDate: string;
+    policyConfig: EodAutoCompletePolicyConfig;
+    quarantineReason: string;
+    scheduleEvidence?: DailyOperationsAutomationTimingEvidence;
+    storeId: Id<"store">;
+  },
+): Promise<HistoricEodDateResult> {
+  const run = await upsertAutomationRunWithCtx(ctx, {
+    action: EOD_AUTO_COMPLETE_ACTION,
+    decisionEvidence: historicQuarantineEvidence({
+      classification: args.classification,
+      operatingDate: args.operatingDate,
+      policyConfig: args.policyConfig,
+      quarantineReason: args.quarantineReason,
+      scheduleEvidence: args.scheduleEvidence,
+    }),
+    decisionReason: args.decisionReason,
+    domain: DAILY_OPERATIONS_AUTOMATION_DOMAIN,
+    eventIds: [],
+    idempotencyKey: historicEodAutoCloseIdempotencyKey(args),
+    mutationBoundary: dailyOperationsEodAutoCompleteAction.mutationBoundary,
+    operatingDate: args.operatingDate,
+    organizationId: args.policyConfig.policy?.organizationId,
+    outcome: "skipped",
+    policyMode: args.policyConfig.paused
+      ? "disabled"
+      : args.policyConfig.mode,
+    policyVersion:
+      args.policyConfig.policy?.policyVersion ?? DAILY_OPERATIONS_POLICY_VERSION,
+    snapshotCounts: {},
+    sourceSubjects: [
+      {
+        id: args.operatingDate,
+        label: args.operatingDate,
+        type: "daily_close",
+      },
+    ],
+    storeId: args.storeId,
+    triggerType: HISTORIC_EOD_AUTO_CLOSE_TRIGGER_TYPE,
+  });
+
+  return {
+    action: "quarantined",
+    classification: args.classification,
+    operatingDate: args.operatingDate,
+    runId: run._id,
+  };
+}
+
+async function resolveHistoricEodStoreRangeForDateWithCtx(
+  ctx: MutationCtx,
+  args: {
+    operatingDate: string;
+    storeId: Id<"store">;
+  },
+): Promise<HistoricEodStoreRangeResolution> {
+  const { range } = await resolveStoreOperatingRangeForDateWithCtx(ctx, {
+    operatingDate: args.operatingDate,
+    storeId: args.storeId,
+  });
+
+  const scheduleEvidence = {
+    closedAt: range.kind === "resolved" ? range.endAt : undefined,
+    evaluationAt: range.kind === "resolved" ? range.endAt : undefined,
+    openedAt: range.kind === "resolved" ? range.startAt : undefined,
+    scheduleVersion: range.scheduleVersionId ?? undefined,
+    source: "canonical_schedule" as const,
+    storeScheduleId: range.scheduleVersionId ?? undefined,
+  };
+
+  if (range.kind === "invalid") {
+    return {
+      kind: "quarantine",
+      classification: "quarantine_store_schedule_ambiguous",
+      reason: "store_schedule_ambiguous",
+      scheduleEvidence,
+      storeScheduleId: range.scheduleVersionId ?? undefined,
+    };
+  }
+
+  if (range.kind === "missing_schedule") {
+    return {
+      kind: "quarantine",
+      classification: "quarantine_missing_store_schedule",
+      reason: "missing_store_schedule",
+      scheduleEvidence,
+      storeScheduleId: range.scheduleVersionId ?? undefined,
+    };
+  }
+
+  if (range.kind === "closed") {
+    return {
+      kind: "quarantine",
+      classification: "quarantine_store_schedule_closed",
+      reason: "store_schedule_closed",
+      scheduleEvidence,
+      storeScheduleId: range.scheduleVersionId ?? undefined,
+    };
+  }
+
+  if (!range.scheduleVersionId) {
+    return {
+      kind: "quarantine",
+      classification: "quarantine_store_schedule_ambiguous",
+      reason: "store_schedule_ambiguous",
+      scheduleEvidence,
+    };
+  }
+
+  const storeDayContext: DailyOperationsAutomationStoreDayContext = {
+    closedAt: range.endAt,
+    eodEvaluationAt: range.endAt,
+    openedAt: range.startAt,
+    openingEvaluationAt: range.startAt,
+    operatingDate: args.operatingDate,
+    scheduleVersion: range.scheduleVersionId,
+    source: "canonical_schedule",
+    storeScheduleId: range.scheduleVersionId,
+  };
+
+  return {
+    kind: "resolved",
+    endAt: range.endAt,
+    scheduleEvidence,
+    startAt: range.startAt,
+    storeDayContext,
+  };
+}
+
+export async function runHistoricEodAutoCloseForDateWithCtx(
+  ctx: MutationCtx,
+  args: {
+    asOfOperatingDate: string;
+    mode: HistoricEodAutoCloseMode;
+    operatingDate: string;
+    storeId: Id<"store">;
+  },
+): Promise<HistoricEodDateResult> {
+  const policyConfig = await getEodAutoCompletePolicyConfigWithCtx(ctx, {
+    storeId: args.storeId,
+  });
+  const idempotencyKey = historicEodAutoCloseIdempotencyKey(args);
+  const existingRun = await getAutomationRunByIdempotencyKeyWithCtx(ctx, {
+    idempotencyKey,
+    storeId: args.storeId,
+  });
+
+  if (existingRun?.outcome === "applied") {
+    const activeCompletedClose = await ctx.db
+      .query("dailyClose")
+      .withIndex("by_storeId_operatingDate_lifecycleStatus", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("operatingDate", args.operatingDate)
+          .eq("lifecycleStatus", "active"),
+      )
+      .first();
+
+    if (
+      activeCompletedClose?.status === "completed" &&
+      activeCompletedClose.automationRunId === existingRun._id
+    ) {
+      return {
+        action: "already_completed",
+        classification:
+          typeof existingRun.decisionEvidence?.classification === "string"
+            ? existingRun.decisionEvidence.classification
+            : "completed",
+        operatingDate: args.operatingDate,
+        runId: existingRun._id,
+      };
+    }
+  }
+
+  if (!isValidOperatingDate(args.operatingDate)) {
+    return recordHistoricEodQuarantineWithCtx(ctx, {
+      classification: "quarantine_invalid_operating_date",
+      decisionReason:
+        "Historic EOD auto-close requires an operating date in YYYY-MM-DD format.",
+      operatingDate: args.operatingDate,
+      policyConfig,
+      quarantineReason: "invalid_operating_date",
+      storeId: args.storeId,
+    });
+  }
+
+  if (args.operatingDate >= args.asOfOperatingDate) {
+    return recordHistoricEodQuarantineWithCtx(ctx, {
+      classification: "quarantine_current_or_future_date",
+      decisionReason:
+        "Historic EOD auto-close is support-owned and only processes past operating dates.",
+      operatingDate: args.operatingDate,
+      policyConfig,
+      quarantineReason: "current_or_future_date",
+      storeId: args.storeId,
+    });
+  }
+
+  const scheduleRange = await resolveHistoricEodStoreRangeForDateWithCtx(ctx, {
+    operatingDate: args.operatingDate,
+    storeId: args.storeId,
+  });
+
+  if (scheduleRange.kind === "quarantine") {
+    return recordHistoricEodQuarantineWithCtx(ctx, {
+      classification: scheduleRange.classification,
+      decisionReason:
+        "Historic EOD auto-close quarantined this date for Store Schedule review.",
+      operatingDate: args.operatingDate,
+      policyConfig,
+      quarantineReason: scheduleRange.reason,
+      scheduleEvidence: scheduleRange.scheduleEvidence,
+      storeId: args.storeId,
+    });
+  }
+
+  if (scheduleRange.kind === "unavailable" && args.mode === "apply") {
+    return recordHistoricEodQuarantineWithCtx(ctx, {
+      classification: "quarantine_missing_store_schedule",
+      decisionReason:
+        "Historic EOD auto-close apply mode requires Store Schedule range evidence.",
+      operatingDate: args.operatingDate,
+      policyConfig,
+      quarantineReason: "missing_store_schedule",
+      storeId: args.storeId,
+    });
+  }
+
+  if (scheduleRange.kind === "resolved" && scheduleRange.endAt > Date.now()) {
+    return recordHistoricEodQuarantineWithCtx(ctx, {
+      classification: "quarantine_store_day_still_open",
+      decisionReason:
+        "Historic EOD auto-close waits until the resolved store-local operating day has ended.",
+      operatingDate: args.operatingDate,
+      policyConfig,
+      quarantineReason: "store_day_still_open",
+      scheduleEvidence: scheduleRange.scheduleEvidence,
+      storeId: args.storeId,
+    });
+  }
+
+  const snapshot = await buildDailyCloseSnapshotWithCtx(ctx, {
+    endAt: scheduleRange.kind === "resolved" ? scheduleRange.endAt : undefined,
+    operatingDate: args.operatingDate,
+    startAt:
+      scheduleRange.kind === "resolved" ? scheduleRange.startAt : undefined,
+    storeId: args.storeId,
+  });
+
+  if (!snapshot.sourceCompleteness.complete) {
+    return recordHistoricEodQuarantineWithCtx(ctx, {
+      classification: "quarantine_incomplete_source_reads",
+      decisionReason:
+        "Historic EOD auto-close requires complete Daily Close source reads.",
+      operatingDate: args.operatingDate,
+      policyConfig,
+      quarantineReason: "incomplete_source_reads",
+      scheduleEvidence:
+        scheduleRange.kind === "resolved"
+          ? scheduleRange.scheduleEvidence
+          : undefined,
+      storeId: args.storeId,
+    });
+  }
+
+  const adapterDecision = eodAutoCompleteDecision(snapshot, policyConfig, {
+    insideCompletionWindow: true,
+    localCompletionWindowMinutes: policyConfig.localCompletionWindowMinutes,
+    localMinuteOfDay: policyConfig.localCompletionWindowMinutes,
+    scheduleEvidence:
+      scheduleRange.kind === "resolved"
+        ? scheduleRange.scheduleEvidence
+        : undefined,
+  });
+  const policyReviewedItemKeys =
+    adapterDecision.decisionEvidence.classification === "low_risk_review"
+      ? snapshot.reviewItems.map((item) => item.key)
+      : [];
+  const supportPolicyMode =
+    args.mode === "dry_run"
+      ? "dry_run"
+      : policyConfig.paused
+        ? "disabled"
+        : policyConfig.mode;
+  const initialOutcome =
+    args.mode === "dry_run"
+      ? "dry_run"
+      : supportPolicyMode === "enabled"
+        ? adapterDecision.outcome
+        : supportPolicyMode;
+  const run = await upsertAutomationRunWithCtx(ctx, {
+    action: EOD_AUTO_COMPLETE_ACTION,
+    decisionEvidence: adapterDecision.decisionEvidence,
+    decisionReason: adapterDecision.decisionReason,
+    domain: DAILY_OPERATIONS_AUTOMATION_DOMAIN,
+    eventIds: [],
+    idempotencyKey,
+    mutationBoundary: dailyOperationsEodAutoCompleteAction.mutationBoundary,
+    operatingDate: args.operatingDate,
+    organizationId:
+      snapshot.organizationId ?? policyConfig.policy?.organizationId,
+    outcome: initialOutcome,
+    policyMode: supportPolicyMode,
+    policyVersion:
+      policyConfig.policy?.policyVersion ?? DAILY_OPERATIONS_POLICY_VERSION,
+    snapshotCounts: adapterDecision.snapshotCounts,
+    sourceSubjects: adapterDecision.sourceSubjects,
+    storeId: args.storeId,
+    triggerType: HISTORIC_EOD_AUTO_CLOSE_TRIGGER_TYPE,
+  });
+
+  if (args.mode === "dry_run") {
+    return {
+      action: "dry_run",
+      classification: adapterDecision.decisionEvidence.classification,
+      operatingDate: args.operatingDate,
+      runId: run._id,
+    };
+  }
+
+  if (supportPolicyMode !== "enabled" || adapterDecision.outcome !== "eligible") {
+    return {
+      action:
+        adapterDecision.decisionEvidence.classification === "completed"
+          ? "already_completed"
+          : "skipped",
+      classification: adapterDecision.decisionEvidence.classification,
+      operatingDate: args.operatingDate,
+      runId: run._id,
+    };
+  }
+
+  const result = await completeDailyCloseForAutomationWithCtx(ctx, {
+    automationDecisionReason:
+      run.decisionReason ?? "Historic EOD Review completed by automation policy.",
+    automationPolicyVersion: run.policyVersion,
+    automationRunId: run._id,
+    automationScheduleEvidence:
+      scheduleRange.kind === "resolved"
+        ? scheduleRange.scheduleEvidence
+        : undefined,
+    currentnessMode: "historical_record",
+    eodAutoCompletePolicy: {
+      cleanDayAutoCompleteEnabled: policyConfig.cleanDayAutoCompleteEnabled,
+      maxAbsoluteCashVariance: policyConfig.maxAbsoluteCashVariance,
+      maxVoidedSaleCount: policyConfig.maxVoidedSaleCount,
+      maxVoidedSaleTotal: policyConfig.maxVoidedSaleTotal,
+    },
+    endAt: scheduleRange.kind === "resolved" ? scheduleRange.endAt : undefined,
+    operatingDate: args.operatingDate,
+    organizationId: snapshot.organizationId ?? undefined,
+    policyReviewedItemKeys,
+    startAt:
+      scheduleRange.kind === "resolved" ? scheduleRange.startAt : undefined,
+    storeId: args.storeId,
+  });
+
+  if (result.kind !== "ok") {
+    await patchAutomationRunOutcomeWithCtx(ctx, {
+      error:
+        result.kind === "user_error"
+          ? {
+              code: result.error.code,
+              message: result.error.message,
+            }
+          : {
+              code: "historic_eod_auto_close_failed",
+              message: "Historic EOD auto-close could not complete.",
+            },
+      outcome: result.kind === "user_error" ? "skipped" : "failed",
+      runId: run._id,
+    });
+
+    return {
+      action: result.kind === "user_error" ? "skipped" : "failed",
+      classification: adapterDecision.decisionEvidence.classification,
+      operatingDate: args.operatingDate,
+      runId: run._id,
+    };
+  }
+
+  await patchAutomationRunOutcomeWithCtx(ctx, {
+    appliedAt: result.data.action === "completed" ? Date.now() : undefined,
+    decisionEvidence: result.data.automationDecisionEvidence,
+    eventIds: result.data.operationalEventId
+      ? [result.data.operationalEventId]
+      : [],
+    outcome: result.data.action === "completed" ? "applied" : "skipped",
+    runId: run._id,
+  });
+
+  return {
+    action:
+      result.data.action === "completed" ? "applied" : "already_completed",
+    classification: adapterDecision.decisionEvidence.classification,
+    operatingDate: args.operatingDate,
+    runId: run._id,
+  };
+}
+
+export async function runHistoricEodAutoCloseBatchWithCtx(
+  ctx: MutationCtx,
+  args: {
+    asOfOperatingDate?: string;
+    endOperatingDate: string;
+    maxDays: number;
+    mode: HistoricEodAutoCloseMode;
+    startOperatingDate: string;
+    storeId: Id<"store">;
+  },
+) {
+  if (
+    !isValidOperatingDate(args.startOperatingDate) ||
+    !isValidOperatingDate(args.endOperatingDate)
+  ) {
+    throw new Error("Historic EOD auto-close requires valid date range bounds.");
+  }
+
+  if (
+    !Number.isInteger(args.maxDays) ||
+    args.maxDays < 1 ||
+    args.maxDays > HISTORIC_EOD_AUTO_CLOSE_MAX_DAYS_LIMIT
+  ) {
+    throw new Error("Historic EOD auto-close maxDays is out of range.");
+  }
+
+  const asOfOperatingDate =
+    args.asOfOperatingDate ?? new Date(Date.now()).toISOString().slice(0, 10);
+  if (!isValidOperatingDate(asOfOperatingDate)) {
+    throw new Error("Historic EOD auto-close as-of date is invalid.");
+  }
+
+  const results: HistoricEodDateResult[] = [];
+  let operatingDate = args.startOperatingDate;
+
+  while (operatingDate <= args.endOperatingDate && results.length < args.maxDays) {
+    const result = await runHistoricEodAutoCloseForDateWithCtx(ctx, {
+      asOfOperatingDate,
+      mode: args.mode,
+      operatingDate,
+      storeId: args.storeId,
+    });
+
+    results.push(result);
+    operatingDate = addDaysToOperatingDate(operatingDate, 1);
+  }
+
+  return summarizeHistoricEodAutoCloseBatch(args.mode, results, {
+    endOperatingDate: args.endOperatingDate,
+    nextOperatingDate: operatingDate,
+  });
+}
+
+function summarizeHistoricEodAutoCloseBatch(
+  mode: HistoricEodAutoCloseMode,
+  results: HistoricEodDateResult[],
+  args: {
+    endOperatingDate: string;
+    nextOperatingDate: string;
+  },
+) {
+  return {
+    alreadyCompleted: results.filter(
+      (result) => result.action === "already_completed",
+    ).length,
+    applied: results.filter((result) => result.action === "applied").length,
+    candidates: results.length,
+    failed: results.filter((result) => result.action === "failed").length,
+    mode,
+    nextOperatingDate:
+      args.nextOperatingDate <= args.endOperatingDate
+        ? args.nextOperatingDate
+        : null,
+    quarantined: results.filter((result) => result.action === "quarantined")
+      .length,
+    results,
+    skipped: results.filter((result) => result.action === "skipped").length,
+  };
 }
 
 function operatingDateForPolicy(args: {
@@ -1445,6 +2060,84 @@ export const runScheduledDailyOperationsAutomation = internalMutation({
 export const runConfiguredDailyOperationsAutomation = internalMutation({
   args: {},
   handler: (ctx) => runConfiguredDailyOperationsAutomationWithCtx(ctx),
+});
+
+export const runHistoricEodAutoCloseForDate = internalMutation({
+  args: {
+    asOfOperatingDate: v.string(),
+    mode: v.union(v.literal("dry_run"), v.literal("apply")),
+    operatingDate: v.string(),
+    storeId: v.id("store"),
+  },
+  handler: (ctx, args) => runHistoricEodAutoCloseForDateWithCtx(ctx, args),
+});
+
+async function runHistoricEodAutoCloseBatchActionWithCtx(
+  ctx: Pick<ActionCtx, "runMutation">,
+  args: {
+    asOfOperatingDate?: string;
+    endOperatingDate: string;
+    maxDays: number;
+    mode: HistoricEodAutoCloseMode;
+    startOperatingDate: string;
+    storeId: Id<"store">;
+  },
+) {
+  if (
+    !isValidOperatingDate(args.startOperatingDate) ||
+    !isValidOperatingDate(args.endOperatingDate)
+  ) {
+    throw new Error("Historic EOD auto-close requires valid date range bounds.");
+  }
+
+  if (
+    !Number.isInteger(args.maxDays) ||
+    args.maxDays < 1 ||
+    args.maxDays > HISTORIC_EOD_AUTO_CLOSE_MAX_DAYS_LIMIT
+  ) {
+    throw new Error("Historic EOD auto-close maxDays is out of range.");
+  }
+
+  const asOfOperatingDate =
+    args.asOfOperatingDate ?? new Date(Date.now()).toISOString().slice(0, 10);
+  if (!isValidOperatingDate(asOfOperatingDate)) {
+    throw new Error("Historic EOD auto-close as-of date is invalid.");
+  }
+
+  const results: HistoricEodDateResult[] = [];
+  let operatingDate = args.startOperatingDate;
+
+  while (operatingDate <= args.endOperatingDate && results.length < args.maxDays) {
+    const result = await ctx.runMutation(
+      internal.operations.dailyOperationsAutomation.runHistoricEodAutoCloseForDate,
+      {
+        asOfOperatingDate,
+        mode: args.mode,
+        operatingDate,
+        storeId: args.storeId,
+      },
+    );
+
+    results.push(result as HistoricEodDateResult);
+    operatingDate = addDaysToOperatingDate(operatingDate, 1);
+  }
+
+  return summarizeHistoricEodAutoCloseBatch(args.mode, results, {
+    endOperatingDate: args.endOperatingDate,
+    nextOperatingDate: operatingDate,
+  });
+}
+
+export const runHistoricEodAutoCloseBatch = internalAction({
+  args: {
+    asOfOperatingDate: v.optional(v.string()),
+    endOperatingDate: v.string(),
+    maxDays: v.number(),
+    mode: v.union(v.literal("dry_run"), v.literal("apply")),
+    startOperatingDate: v.string(),
+    storeId: v.id("store"),
+  },
+  handler: (ctx, args) => runHistoricEodAutoCloseBatchActionWithCtx(ctx, args),
 });
 
 export const getOpeningAutoStartPolicy = query({

--- a/packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts
+++ b/packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts
@@ -201,6 +201,21 @@ describe("operations query indexing", () => {
       },
       {
         table: "registerSession",
+        descriptor: "by_storeId_status_openedOperatingDate",
+        fields: ["storeId", "status", "openedOperatingDate"],
+      },
+      {
+        table: "registerSession",
+        descriptor: "by_storeId_status_closeoutOperatingDate",
+        fields: ["storeId", "status", "closeoutOperatingDate"],
+      },
+      {
+        table: "registerSession",
+        descriptor: "by_storeId_closeoutOperatingDate",
+        fields: ["storeId", "closeoutOperatingDate"],
+      },
+      {
+        table: "registerSession",
         descriptor: "by_storeId_registerNumber",
         fields: ["storeId", "registerNumber"],
       },

--- a/packages/athena-webapp/convex/operations/registerSessions.trace.test.ts
+++ b/packages/athena-webapp/convex/operations/registerSessions.trace.test.ts
@@ -95,8 +95,13 @@ function createMutationCtx(seed?: {
     query: vi.fn((table: string) => ({
       withIndex(indexName: string, buildQuery?: (q: {
         eq: (field: string, value: string) => unknown;
+        lte: (field: string, value: number) => unknown;
       }) => unknown) {
-        if (table !== "registerSession" && table !== "workflowTrace") {
+        if (
+          table !== "registerSession" &&
+          table !== "workflowTrace" &&
+          table !== "storeSchedule"
+        ) {
           throw new Error(`Unsupported query table ${table}`);
         }
 
@@ -108,15 +113,63 @@ function createMutationCtx(seed?: {
         if (table === "workflowTrace" && indexName !== "by_storeId_traceId") {
           throw new Error(`Unsupported workflowTrace index ${indexName}`);
         }
+        if (
+          table === "storeSchedule" &&
+          indexName !== "by_storeId_status_effectiveFrom"
+        ) {
+          throw new Error(`Unsupported storeSchedule index ${indexName}`);
+        }
 
         const filters = new Map<string, string>();
+        const rangeFilters: Array<(row: Record<string, unknown>) => boolean> = [];
         const queryBuilder = {
           eq(field: string, value: string) {
             filters.set(field, value);
             return queryBuilder;
           },
+          lte(field: string, value: number) {
+            rangeFilters.push(
+              (row) =>
+                typeof row[field] === "number" && row[field] <= value,
+            );
+            return queryBuilder;
+          },
         };
         buildQuery?.(queryBuilder);
+
+        if (table === "storeSchedule") {
+          const schedules = [
+            {
+              _id: "schedule-1",
+              createdAt: 0,
+              dateExceptions: [],
+              effectiveFrom: 0,
+              organizationId: "org-1",
+              source: "seed",
+              status: "active",
+              storeId: "store-1",
+              timezone: "UTC",
+              updatedAt: 0,
+              weeklyClosedDays: [],
+              weeklyWindows: Array.from({ length: 7 }, (_, dayOfWeek) => ({
+                dayOfWeek,
+                endMinute: 24 * 60,
+                startMinute: 0,
+              })),
+            },
+          ].filter((schedule) =>
+            [...filters].every(
+              ([field, value]) =>
+                schedule[field as keyof typeof schedule] === value,
+            ) &&
+            rangeFilters.every((matches) => matches(schedule)),
+          );
+          const query = {
+            order: () => query,
+            take: async (limit: number) => schedules.slice(0, limit),
+          };
+          return query;
+        }
 
         return {
           first: async () => {

--- a/packages/athena-webapp/convex/operations/registerSessions.ts
+++ b/packages/athena-webapp/convex/operations/registerSessions.ts
@@ -8,6 +8,8 @@ import {
   type RegisterSessionStatus,
 } from "../../shared/registerSessionStatus";
 import { isRegisterSessionReplacementBlocking } from "../../shared/registerSessionLifecyclePolicy";
+import { getStoreScheduleContextForStoreAtWithCtx } from "../inventory/storeSchedule";
+import type { StoreScheduleContext } from "../lib/storeScheduleTime";
 import { recordRegisterSessionTraceBestEffort } from "./registerSessionTracing";
 
 const registerSessionStatusSet = (
@@ -26,6 +28,12 @@ type RegisterSessionIdentity = {
   terminalId?: Id<"posTerminal"> | null;
 };
 type RegisterSessionCashAdjustmentKind = "sale" | "void";
+type RegisterSessionOperatingDateDerivationStatus = "resolved" | "missing_schedule";
+type RegisterSessionCloseoutOwnershipSource =
+  | "closed_record"
+  | "approval_request"
+  | "closeout_submission"
+  | "closed_at";
 type RegisterSessionCloseoutRecord = {
   actorStaffProfileId?: Id<"staffProfile">;
   actorUserId?: Id<"athenaUser">;
@@ -50,6 +58,106 @@ function omitUndefined<T extends Record<string, unknown>>(value: T) {
   return Object.fromEntries(
     Object.entries(value).filter(([, entryValue]) => entryValue !== undefined)
   ) as T;
+}
+
+function buildOperatingDateEvidence(context: StoreScheduleContext) {
+  if (context.kind !== "resolved") {
+    return {
+      derivationStatus: "missing_schedule" as const,
+      operatingDate: undefined,
+      operatingDateEndAt: undefined,
+      operatingDateScheduleVersionId: undefined,
+      operatingDateStartAt: undefined,
+    };
+  }
+
+  return {
+    derivationStatus: "resolved" as const,
+    operatingDate: context.operatingDate,
+    operatingDateEndAt: context.currentWindow?.endsAt,
+    operatingDateScheduleVersionId: context.scheduleVersionId
+      ? (context.scheduleVersionId as Id<"storeSchedule">)
+      : undefined,
+    operatingDateStartAt: context.currentWindow?.startsAt,
+  };
+}
+
+export async function resolveRegisterSessionOperatingDateContext(
+  ctx: MutationCtx,
+  args: {
+    at: number;
+    storeId: Id<"store">;
+  }
+) {
+  return (
+    await getStoreScheduleContextForStoreAtWithCtx(ctx, {
+      at: args.at,
+      storeId: args.storeId,
+    })
+  ).context;
+}
+
+export function buildRegisterSessionDateDerivationPatch(args: {
+  closeoutContext?: StoreScheduleContext;
+  closeoutOwnedAt?: number;
+  closeoutOwnershipSource?: RegisterSessionCloseoutOwnershipSource;
+  openedAt?: number;
+  openedContext?: StoreScheduleContext;
+}) {
+  const patch: {
+    closeoutOperatingDate?: string;
+    closeoutOperatingDateDerivationStatus?: RegisterSessionOperatingDateDerivationStatus;
+    closeoutOperatingDateEndAt?: number;
+    closeoutOperatingDateScheduleVersionId?: Id<"storeSchedule">;
+    closeoutOperatingDateStartAt?: number;
+    closeoutOwnedAt?: number;
+    closeoutOwnershipSource?: RegisterSessionCloseoutOwnershipSource;
+    openedOperatingDate?: string;
+    openedOperatingDateDerivationStatus?: RegisterSessionOperatingDateDerivationStatus;
+    openedOperatingDateEndAt?: number;
+    openedOperatingDateScheduleVersionId?: Id<"storeSchedule">;
+    openedOperatingDateStartAt?: number;
+  } = {};
+
+  if (args.openedAt !== undefined && args.openedContext) {
+    const evidence = buildOperatingDateEvidence(args.openedContext);
+    patch.openedOperatingDate = evidence.operatingDate;
+    patch.openedOperatingDateDerivationStatus = evidence.derivationStatus;
+    patch.openedOperatingDateEndAt = evidence.operatingDateEndAt;
+    patch.openedOperatingDateScheduleVersionId =
+      evidence.operatingDateScheduleVersionId;
+    patch.openedOperatingDateStartAt = evidence.operatingDateStartAt;
+  }
+
+  if (
+    args.closeoutOwnedAt !== undefined &&
+    args.closeoutOwnershipSource &&
+    args.closeoutContext
+  ) {
+    const evidence = buildOperatingDateEvidence(args.closeoutContext);
+    patch.closeoutOwnedAt = args.closeoutOwnedAt;
+    patch.closeoutOwnershipSource = args.closeoutOwnershipSource;
+    patch.closeoutOperatingDate = evidence.operatingDate;
+    patch.closeoutOperatingDateDerivationStatus = evidence.derivationStatus;
+    patch.closeoutOperatingDateEndAt = evidence.operatingDateEndAt;
+    patch.closeoutOperatingDateScheduleVersionId =
+      evidence.operatingDateScheduleVersionId;
+    patch.closeoutOperatingDateStartAt = evidence.operatingDateStartAt;
+  }
+
+  return patch;
+}
+
+export function buildClearedRegisterSessionCloseoutDatePatch() {
+  return {
+    closeoutOwnedAt: undefined,
+    closeoutOwnershipSource: undefined,
+    closeoutOperatingDate: undefined,
+    closeoutOperatingDateDerivationStatus: undefined,
+    closeoutOperatingDateEndAt: undefined,
+    closeoutOperatingDateScheduleVersionId: undefined,
+    closeoutOperatingDateStartAt: undefined,
+  };
 }
 
 async function persistRegisterSessionWorkflowTraceIdBestEffort(
@@ -240,6 +348,7 @@ export function buildReopenedRegisterSessionPatch(session: {
   assertValidRegisterSessionTransition(session.status, "active");
 
   return {
+    ...buildClearedRegisterSessionCloseoutDatePatch(),
     countedCash: undefined,
     managerApprovalRequestId: undefined,
     status: "active" as const,
@@ -269,6 +378,7 @@ export function buildReopenedRejectedRegisterSessionCloseoutPatch(
     "Rejected register closeout reopened for correction.";
 
   return {
+    ...buildClearedRegisterSessionCloseoutDatePatch(),
     closeoutRecords: [
       ...(session.closeoutRecords ?? []),
       omitUndefined({
@@ -388,6 +498,7 @@ export function buildReopenedClosedRegisterSessionPatch(
     "Closed register closeout reopened for correction.";
 
   return {
+    ...buildClearedRegisterSessionCloseoutDatePatch(),
     closedAt: undefined,
     closedByStaffProfileId: undefined,
     closedByUserId: undefined,
@@ -600,11 +711,22 @@ export const openRegisterSession = internalMutation({
       ...args,
       ...identity,
     });
+    const sessionInput = buildRegisterSession({
+      ...args,
+      ...identity,
+    });
+    const openedContext = await resolveRegisterSessionOperatingDateContext(ctx, {
+      at: sessionInput.openedAt,
+      storeId: args.storeId,
+    });
     const sessionId = await ctx.db.insert(
       "registerSession",
-      buildRegisterSession({
-        ...args,
-        ...identity,
+      omitUndefined({
+        ...sessionInput,
+        ...buildRegisterSessionDateDerivationPatch({
+          openedAt: sessionInput.openedAt,
+          openedContext,
+        }),
       })
     );
     const session = await ctx.db.get("registerSession", sessionId);
@@ -854,10 +976,23 @@ export const beginRegisterSessionCloseout = internalMutation({
       throw new Error("Register session not found.");
     }
 
+    const closeoutSubmittedAt = Date.now();
+    const closeoutContext = await resolveRegisterSessionOperatingDateContext(ctx, {
+      at: closeoutSubmittedAt,
+      storeId: session.storeId,
+    });
+    const closeoutPatch = buildRegisterSessionCloseoutPatch(session, args);
     await ctx.db.patch(
       "registerSession",
       args.registerSessionId,
-      buildRegisterSessionCloseoutPatch(session, args)
+      {
+        ...closeoutPatch,
+        ...buildRegisterSessionDateDerivationPatch({
+          closeoutContext,
+          closeoutOwnedAt: closeoutSubmittedAt,
+          closeoutOwnershipSource: "closeout_submission",
+        }),
+      }
     );
 
     return ctx.db.get("registerSession", args.registerSessionId);
@@ -1046,10 +1181,22 @@ export const closeRegisterSession = internalMutation({
       throw new Error("Register session not found.");
     }
 
+    const closeoutPatch = buildClosedRegisterSessionPatch(session, args);
+    const closeoutContext = await resolveRegisterSessionOperatingDateContext(ctx, {
+      at: closeoutPatch.closedAt,
+      storeId: session.storeId,
+    });
     await ctx.db.patch(
       "registerSession",
       args.registerSessionId,
-      buildClosedRegisterSessionPatch(session, args)
+      {
+        ...closeoutPatch,
+        ...buildRegisterSessionDateDerivationPatch({
+          closeoutContext,
+          closeoutOwnedAt: closeoutPatch.closedAt,
+          closeoutOwnershipSource: "closed_record",
+        }),
+      }
     );
 
     return ctx.db.get("registerSession", args.registerSessionId);

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/resolveTerminalCloudRepair.test.ts
@@ -521,6 +521,7 @@ function buildQuery(rows: Array<Record<string, unknown>>) {
     withIndex: vi.fn((_indexName: string, build: (q: {
       eq: (field: string, value: unknown) => unknown;
       gt: (field: string, value: unknown) => unknown;
+      lte: (field: string, value: unknown) => unknown;
     }) => unknown) => {
       const q = {
         eq: vi.fn((field: string, value: unknown) => {
@@ -529,6 +530,12 @@ function buildQuery(rows: Array<Record<string, unknown>>) {
         }),
         gt: vi.fn((field: string, value: unknown) => {
           currentRows = currentRows.filter((row) => Number(row[field]) > Number(value));
+          return q;
+        }),
+        lte: vi.fn((field: string, value: unknown) => {
+          currentRows = currentRows.filter(
+            (row) => Number(row[field]) <= Number(value),
+          );
           return q;
         }),
       };

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
@@ -2,6 +2,10 @@ import type { Id, TableNames } from "../../../_generated/dataModel";
 import type { MutationCtx } from "../../../_generated/server";
 import { isRegisterSessionConflictBlockingStatus } from "../../../../shared/registerSessionStatus";
 import { recordRegisterSessionTraceBestEffort } from "../../../operations/registerSessionTracing";
+import {
+  buildRegisterSessionDateDerivationPatch,
+  resolveRegisterSessionOperatingDateContext,
+} from "../../../operations/registerSessions";
 import { buildOperationalWorkItem } from "../../../operations/operationalWorkItems";
 import { normalizeOperationalEventTraceFields } from "../../../operations/operationalEvents";
 import {
@@ -29,6 +33,12 @@ import type {
 } from "../../application/sync/types";
 import { listRegisterSessionCloseoutHolds } from "../../application/sync/registerSessionCloseoutHolds";
 import { validatePosLocalStaffProofWithCtx } from "../../application/sync/staffProofValidation";
+
+function omitUndefined<T extends Record<string, unknown>>(value: T) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as T;
+}
 
 export function createConvexLocalSyncRepository(
   ctx: MutationCtx,
@@ -380,7 +390,11 @@ export function createConvexLocalSyncRepository(
         .take(100);
     },
     async createRegisterSession(input) {
-      return ctx.db.insert("registerSession", {
+      const openedContext = await resolveRegisterSessionOperatingDateContext(ctx, {
+        at: input.openedAt,
+        storeId: input.storeId,
+      });
+      return ctx.db.insert("registerSession", omitUndefined({
         storeId: input.storeId,
         organizationId: input.organizationId,
         terminalId: input.terminalId,
@@ -388,10 +402,14 @@ export function createConvexLocalSyncRepository(
         status: "active",
         openedByStaffProfileId: input.openedByStaffProfileId,
         openedAt: input.openedAt,
+        ...buildRegisterSessionDateDerivationPatch({
+          openedAt: input.openedAt,
+          openedContext,
+        }),
         openingFloat: input.openingFloat,
         expectedCash: input.expectedCash,
         notes: input.notes,
-      });
+      }));
     },
     async findBlockingRegisterSession(args) {
       const latestByTerminal = await ctx.db
@@ -577,7 +595,28 @@ export function createConvexLocalSyncRepository(
         : null;
     },
     async patchRegisterSession(registerSessionId, patch) {
-      await ctx.db.patch("registerSession", registerSessionId, patch);
+      let datePatch = {};
+
+      if (patch.status === "closed" && typeof patch.closedAt === "number") {
+        const storeId =
+          patch.storeId ?? (await ctx.db.get("registerSession", registerSessionId))?.storeId;
+
+        if (storeId) {
+          datePatch = buildRegisterSessionDateDerivationPatch({
+            closeoutContext: await resolveRegisterSessionOperatingDateContext(ctx, {
+              at: patch.closedAt,
+              storeId,
+            }),
+            closeoutOwnedAt: patch.closedAt,
+            closeoutOwnershipSource: "closed_record",
+          });
+        }
+      }
+
+      await ctx.db.patch("registerSession", registerSessionId, {
+        ...patch,
+        ...datePatch,
+      });
     },
     async createPosSession(input) {
       return ctx.db.insert("posSession", {

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -880,6 +880,20 @@ const schema = defineSchema({
   registerSession: defineTable(registerSessionSchema)
     .index("by_storeId", ["storeId"])
     .index("by_storeId_status", ["storeId", "status"])
+    .index("by_storeId_status_openedOperatingDate", [
+      "storeId",
+      "status",
+      "openedOperatingDate",
+    ])
+    .index("by_storeId_status_closeoutOperatingDate", [
+      "storeId",
+      "status",
+      "closeoutOperatingDate",
+    ])
+    .index("by_storeId_closeoutOperatingDate", [
+      "storeId",
+      "closeoutOperatingDate",
+    ])
     .index("by_storeId_registerNumber", ["storeId", "registerNumber"])
     .index("by_terminalId", ["terminalId"])
     .index("by_managerApprovalRequestId", ["managerApprovalRequestId"]),

--- a/packages/athena-webapp/convex/schemas/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/schemas/operations/dailyClose.ts
@@ -12,6 +12,27 @@ const dailyCloseSourceSubjectValidator = v.object({
   label: v.optional(v.string()),
 });
 
+const dailyCloseSourceCompletenessValidator = v.object({
+  complete: v.boolean(),
+  entries: v.array(
+    v.object({
+      source: v.string(),
+      complete: v.boolean(),
+      readMode: v.string(),
+      recordCount: v.number(),
+      limit: v.optional(v.number()),
+      range: v.optional(
+        v.object({
+          startAt: v.number(),
+          endAt: v.number(),
+        }),
+      ),
+      statuses: v.optional(v.array(v.string())),
+      reason: v.optional(v.string()),
+    }),
+  ),
+});
+
 const dailyCloseReportItemValidator = v.object({
   key: v.string(),
   severity: v.union(
@@ -52,6 +73,9 @@ const dailyCloseReportSnapshotValidator = v.object({
     automationRunId: v.optional(v.id("automationRun")),
     automationPolicyVersion: v.optional(v.string()),
     automationDecisionReason: v.optional(v.string()),
+    currentnessMode: v.optional(
+      v.union(v.literal("mark_current"), v.literal("historical_record")),
+    ),
     policyReviewedItemKeys: v.optional(v.array(v.string())),
     notes: v.optional(v.string()),
     reviewedItemKeys: v.optional(v.array(v.string())),
@@ -68,6 +92,7 @@ const dailyCloseReportSnapshotValidator = v.object({
   reviewedItems: v.array(dailyCloseReportItemValidator),
   carryForwardItems: v.array(dailyCloseReportItemValidator),
   readyItems: v.array(dailyCloseReportItemValidator),
+  sourceCompleteness: v.optional(dailyCloseSourceCompletenessValidator),
   sourceSubjects: v.array(dailyCloseSourceSubjectValidator),
 });
 
@@ -92,6 +117,7 @@ export const dailyCloseSchema = v.object({
     readyCount: v.number(),
   }),
   summary: v.record(v.string(), v.any()),
+  sourceCompleteness: v.optional(dailyCloseSourceCompletenessValidator),
   sourceSubjects: v.array(dailyCloseSourceSubjectValidator),
   reportSnapshot: v.optional(dailyCloseReportSnapshotValidator),
   carryForwardWorkItemIds: v.array(v.id("operationalWorkItem")),

--- a/packages/athena-webapp/convex/schemas/operations/registerSession.ts
+++ b/packages/athena-webapp/convex/schemas/operations/registerSession.ts
@@ -17,6 +17,29 @@ export const registerSessionSchema = v.object({
   openedByUserId: v.optional(v.id("athenaUser")),
   openedByStaffProfileId: v.optional(v.id("staffProfile")),
   openedAt: v.number(),
+  openedOperatingDate: v.optional(v.string()),
+  openedOperatingDateStartAt: v.optional(v.number()),
+  openedOperatingDateEndAt: v.optional(v.number()),
+  openedOperatingDateScheduleVersionId: v.optional(v.id("storeSchedule")),
+  openedOperatingDateDerivationStatus: v.optional(
+    v.union(v.literal("resolved"), v.literal("missing_schedule"))
+  ),
+  closeoutOwnedAt: v.optional(v.number()),
+  closeoutOwnershipSource: v.optional(
+    v.union(
+      v.literal("closed_record"),
+      v.literal("approval_request"),
+      v.literal("closeout_submission"),
+      v.literal("closed_at")
+    )
+  ),
+  closeoutOperatingDate: v.optional(v.string()),
+  closeoutOperatingDateStartAt: v.optional(v.number()),
+  closeoutOperatingDateEndAt: v.optional(v.number()),
+  closeoutOperatingDateScheduleVersionId: v.optional(v.id("storeSchedule")),
+  closeoutOperatingDateDerivationStatus: v.optional(
+    v.union(v.literal("resolved"), v.literal("missing_schedule"))
+  ),
   openingFloat: v.number(),
   expectedCash: v.number(),
   countedCash: v.optional(v.number()),


### PR DESCRIPTION
## Summary
- add register-session operating-date evidence fields plus date indexes for opened and closeout-day lookup paths
- make Daily Close source completeness/currentness safe for historical auto-completion
- add bounded support-owned historic EOD auto-close automation with Store Schedule currentness guards and audit evidence
- document the plan and durable architecture learning

## Linear
- V26-898
- V26-899
- V26-900
- V26-901
- V26-902
- V26-903
- V26-904

## Validation
- unanimous subagent reviewer approval: correctness, adversarial, data integrity, testing, performance, project standards
- bun run test -- convex/operations/dailyOperationsAutomation.test.ts
- focused suite: 293 tests across Daily Close, automation, register sessions, closeouts, POS sync projection, operation indexes, Store Schedule
- failed coverage slice regression rerun: 101 tests across deposits, register trace lifecycle, registerSessions trace, terminal recovery
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- bun run --filter @athena/webapp lint:convex:changed
- bun run --filter @athena/webapp audit:convex
- bun run --filter @athena/webapp build
- bun run pr:athena (passed; proof recorded; scorecard only notes missing runtime trend artifact)
