### PR TITLE
fix(operations): stabilize daily analytics hydration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,13 @@ Keep operator-facing language calm, clear, restrained, and operational, and norm
 
 This project uses [Convex](https://convex.dev) as its backend.
 
-When working on Convex code, **always read the repo-root file
-`convex/_generated/ai/guidelines.md` first** for important guidelines on
-how to correctly use Convex APIs and patterns. The file contains rules that
-override what you may have learned about Convex from training data.
+When working on Convex code, **always read the Convex AI guidelines first** for
+important guidance on how to correctly use Convex APIs and patterns. The
+canonical file lives at `convex/_generated/ai/guidelines.md`, and Athena also
+keeps a package-local mirror at
+`packages/athena-webapp/convex/_generated/ai/guidelines.md` for agents working
+from inside the webapp package. These files contain rules that override what you
+may have learned about Convex from training data.
 
 Convex agent skills for common tasks can be installed by running
 `npx convex ai-files install`.

--- a/docs/solutions/harness/daily-operations-hydration-and-hook-env-2026-06-30.md
+++ b/docs/solutions/harness/daily-operations-hydration-and-hook-env-2026-06-30.md
@@ -1,0 +1,70 @@
+---
+title: Daily Operations Hydration Should Be Split From Hook-Safe Delivery Checks
+date: 2026-06-30
+category: harness
+module: athena-webapp
+problem_type: performance_regression
+component: daily-operations
+symptoms:
+  - "Daily Operations analytics loaded too much data through one snapshot"
+  - "Compact UI panes either felt empty or re-rendered unrelated analytics"
+  - "Pre-push fixture repositories failed or flipped assertions when Git hook environment leaked into nested Git commands"
+root_cause: boundary_mismatch
+resolution_type: architecture
+severity: medium
+tags:
+  - daily-operations
+  - store-pulse
+  - convex
+  - hydration
+  - git-hooks
+---
+
+# Daily Operations Hydration Should Be Split From Hook-Safe Delivery Checks
+
+## Problem
+
+Daily Operations had two related boundary problems. The UI wanted the week strip
+and sales trend to feel immediately useful, while heavier store-pulse detail
+data needed a separate hydration path. Folding every pane into the same snapshot
+made the Convex read path expensive and made later UI hydration redraw unrelated
+surfaces.
+
+The delivery harness then exposed a second boundary issue. Some validation code
+spawns nested fixture repositories during Git hooks. Those subprocesses inherit
+hook-provided `GIT_*` variables unless the harness clears them, so a fixture Git
+command can accidentally operate against the outer repository/index instead of
+the fixture work tree.
+
+## Solution
+
+Keep Daily Operations data reads split by operator intent:
+
+- The base daily snapshot should carry the immediately visible store-day
+  metrics and lightweight weekly summary.
+- Week-level analytics can be cached and reused for the week strip and selected
+  day sales trend.
+- Store pulse detail should hydrate through its own request boundary so top
+  items, payment mix, and timeline detail can load without invalidating the
+  chart or forcing another broad snapshot read.
+- Timeline preview should also be its own compact query when the UI only needs
+  the latest entries.
+
+For harness and delivery scripts, every Git subprocess that may run inside a
+Git hook should use a sanitized environment that removes inherited `GIT_*`
+variables. This is production harness behavior, not only test fixture behavior,
+because pre-push and pre-commit hooks routinely execute nested Git commands.
+
+## Prevention
+
+- Do not add heavyweight analytics to `getDailyOperationsSnapshot` just because
+  a Daily Operations subcomponent needs them. Prefer a separately cached query
+  with a stable shell in the UI.
+- When a hydrated pane updates, keep unrelated chart and week-strip inputs
+  referentially stable so animations do not replay from unrelated data changes.
+- For nested fixture repos or provider-evidence writers, sanitize `GIT_*` before
+  invoking Git. This includes `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE`,
+  plus any future hook-scoped Git variables.
+- Validate hook-safe changes with both focused tests and the full root harness:
+  `bun test scripts/harness-inferential-review.test.ts scripts/pr-athena-delivery-run.test.ts`
+  and `bun run harness:test`.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2146 files · ~0 words
+- 2147 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8310 nodes · 9922 edges · 2073 communities detected
+- 8316 nodes · 9930 edges · 2074 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2083,6 +2083,7 @@
 - [[_COMMUNITY_Community 2070|Community 2070]]
 - [[_COMMUNITY_Community 2071|Community 2071]]
 - [[_COMMUNITY_Community 2072|Community 2072]]
+- [[_COMMUNITY_Community 2073|Community 2073]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2116,7 +2117,7 @@ Nodes (75): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelong
 
 ### Community 1 - "Community 1"
 Cohesion: 0.06
-Nodes (84): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectConvexQueryWriteBoundaryFindings(), collectConvexReturnValidatorContractFindings(), collectHandlerDbAliases() (+76 more)
+Nodes (85): buildFinding(), buildGitProcessEnv(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectConvexQueryWriteBoundaryFindings(), collectConvexReturnValidatorContractFindings() (+77 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.06
@@ -2124,7 +2125,7 @@ Nodes (68): buildLegacyOperationalExplanation(), buildRecoveryBlockers(), buildR
 
 ### Community 3 - "Community 3"
 Cohesion: 0.06
-Nodes (63): attentionSeverity(), automationRunClassification(), automationStatusBucketForRun(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildRegisterCloseoutTimelineMessage() (+55 more)
+Nodes (62): attentionSeverity(), automationRunClassification(), automationStatusBucketForRun(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildRegisterCloseoutTimelineMessage() (+54 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.09
@@ -2191,16 +2192,16 @@ Cohesion: 0.11
 Nodes (33): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+25 more)
 
 ### Community 20 - "Community 20"
-Cohesion: 0.12
-Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
-
-### Community 21 - "Community 21"
 Cohesion: 0.08
 Nodes (21): buildDisplaySafeConflictSummary(), buildTerminalSyncReviewSummary(), classifyTerminalSyncReviewConflict(), dedupeConflictsById(), emptyTerminalSyncReviewSummary(), getConflictBusinessKey(), getCurrentConflictKey(), getLatestRuntimeStatusForTerminal() (+13 more)
 
-### Community 22 - "Community 22"
+### Community 21 - "Community 21"
 Cohesion: 0.07
 Nodes (15): buildMissingDraftResult(), formatQueueWorkItemValue(), formatWorkItemTitle(), getQueueWorkItemArrayMetadataCount(), getQueueWorkItemInventoryReviewLineCount(), getQueueWorkItemStockAdjustmentSkuId(), getQueueWorkItemStringMetadata(), getQueueWorkItemTransactionId() (+7 more)
+
+### Community 22 - "Community 22"
+Cohesion: 0.12
+Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
 ### Community 23 - "Community 23"
 Cohesion: 0.07
@@ -2239,24 +2240,24 @@ Cohesion: 0.11
 Nodes (24): buildGitProcessEnv(), buildProviderSkip(), collectCommandsForChangedFiles(), commandDisplayName(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs() (+16 more)
 
 ### Community 32 - "Community 32"
+Cohesion: 0.12
+Nodes (21): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), formatPendingApprovalsLabel(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate() (+13 more)
+
+### Community 33 - "Community 33"
 Cohesion: 0.13
 Nodes (24): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClearedRegisterSessionCloseoutDatePatch(), buildClosedRegisterSessionPatch(), buildOperatingDateEvidence(), buildRegisterSession(), buildRegisterSessionCloseoutPatch() (+16 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.14
 Nodes (24): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+16 more)
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.13
 Nodes (24): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), expenseSessionItemHasTrustedAvailabilityHold(), expenseSessionItemSourceKey(), failure() (+16 more)
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.2
 Nodes (28): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftCreatedMessage(), buildCycleCountDraftSavedMessage(), buildCycleCountDraftSubmissionKey(), buildCycleCountDraftSubmittedMessage(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx() (+20 more)
-
-### Community 36 - "Community 36"
-Cohesion: 0.13
-Nodes (21): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), formatPendingApprovalsLabel(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate() (+13 more)
 
 ### Community 37 - "Community 37"
 Cohesion: 0.19
@@ -2479,48 +2480,48 @@ Cohesion: 0.19
 Nodes (10): buildLatestRunDebugPayload(), getBoundedDebugRunsByCapability(), getLatestDebugRunByCapability(), getLatestDebugRunBySubject(), isActiveRunStale(), isActiveRunStatus(), selectLatestDebugRunFromCandidates(), shouldRecoverActiveRun() (+2 more)
 
 ### Community 92 - "Community 92"
+Cohesion: 0.3
+Nodes (15): buildPosOperatorSnapshot(), buildRecentDayBuckets(), buildSummaryTrendBucket(), buildTransactionDateBuckets(), calculateDeltaPercent(), formatHourLabel(), formatPaymentMethodLabel(), formatShortDate() (+7 more)
+
+### Community 93 - "Community 93"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.13
 Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.17
 Nodes (8): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterCatalogState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.24
 Nodes (15): buildGeneratedControlId(), captureRemoteAssistCoBrowseFrame(), collectSanitizedSurface(), collectSensitiveRegions(), collectVisibleText(), getControlId(), getControlPriority(), getElementLabel() (+7 more)
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.22
 Nodes (11): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), getInvalidationNodes(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline() (+3 more)
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.23
 Nodes (13): collectConvexReturnValidatorContractFindings(), escapeRegExp(), extractConvexPublicFunctionsWithReturns(), fileExists(), findMatchingDefinitionEnd(), hasConvexReturnContractProofForExport(), isConvexReturnContractSourcePath(), isRelevantConvexContractProofPath() (+5 more)
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.22
 Nodes (9): buildHistoricalContextEventAppendArgs(), buildHistoricalImportIdempotencyKey(), buildPrimarySubject(), buildStoppedReport(), countOmittedFields(), createEmptyReport(), increment(), planHistoricalStorefrontContextImport() (+1 more)
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
-
-### Community 102 - "Community 102"
-Cohesion: 0.32
-Nodes (14): buildPosOperatorSnapshot(), buildRecentDayBuckets(), buildSummaryTrendBucket(), buildTransactionDateBuckets(), calculateDeltaPercent(), formatHourLabel(), formatPaymentMethodLabel(), formatShortDate() (+6 more)
 
 ### Community 103 - "Community 103"
 Cohesion: 0.17
@@ -2743,68 +2744,68 @@ Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
 ### Community 158 - "Community 158"
+Cohesion: 0.25
+Nodes (6): buildGitProcessEnv(), clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), runProcess(), writePrAthenaProviderEvidence()
+
+### Community 159 - "Community 159"
 Cohesion: 0.33
 Nodes (7): createAthenaProviderError(), createProviderFailureResult(), getProviderFailureDiagnostic(), invokeStructuredTextProvider(), isJsonObject(), isJsonValue(), sanitizeDiagnostic()
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
-
-### Community 173 - "Community 173"
-Cohesion: 0.27
-Nodes (5): clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), runProcess(), writePrAthenaProviderEvidence()
 
 ### Community 174 - "Community 174"
 Cohesion: 0.39
@@ -2883,24 +2884,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 193 - "Community 193"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 194 - "Community 194"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 195 - "Community 195"
+### Community 194 - "Community 194"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 196 - "Community 196"
+### Community 195 - "Community 195"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 197 - "Community 197"
+### Community 196 - "Community 196"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 197 - "Community 197"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 198 - "Community 198"
 Cohesion: 0.39
@@ -3355,8 +3356,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 311 - "Community 311"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 312 - "Community 312"
 Cohesion: 0.33
@@ -3371,80 +3372,80 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 315 - "Community 315"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 316 - "Community 316"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 317 - "Community 317"
+### Community 316 - "Community 316"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
-### Community 318 - "Community 318"
+### Community 317 - "Community 317"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 319 - "Community 319"
+### Community 318 - "Community 318"
 Cohesion: 0.53
 Nodes (5): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
-### Community 320 - "Community 320"
+### Community 319 - "Community 319"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 321 - "Community 321"
+### Community 320 - "Community 320"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 322 - "Community 322"
+### Community 321 - "Community 321"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 323 - "Community 323"
+### Community 322 - "Community 322"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 324 - "Community 324"
+### Community 323 - "Community 323"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 324 - "Community 324"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 325 - "Community 325"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 326 - "Community 326"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 327 - "Community 327"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 328 - "Community 328"
+### Community 327 - "Community 327"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 329 - "Community 329"
+### Community 328 - "Community 328"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 329 - "Community 329"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 330 - "Community 330"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 331 - "Community 331"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 332 - "Community 332"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 333 - "Community 333"
+### Community 332 - "Community 332"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 333 - "Community 333"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 334 - "Community 334"
 Cohesion: 0.53
@@ -3463,124 +3464,124 @@ Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
 ### Community 338 - "Community 338"
+Cohesion: 0.53
+Nodes (5): commitFixtureRepo(), createFixtureRepo(), gitFixtureEnv(), runFixtureCommand(), write()
+
+### Community 339 - "Community 339"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 339 - "Community 339"
+### Community 340 - "Community 340"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 340 - "Community 340"
+### Community 341 - "Community 341"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 341 - "Community 341"
+### Community 342 - "Community 342"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
-### Community 342 - "Community 342"
+### Community 343 - "Community 343"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 343 - "Community 343"
+### Community 344 - "Community 344"
 Cohesion: 0.6
 Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
-### Community 344 - "Community 344"
+### Community 345 - "Community 345"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 345 - "Community 345"
-Cohesion: 0.5
-Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 346 - "Community 346"
 Cohesion: 0.5
-Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
+Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 347 - "Community 347"
+Cohesion: 0.5
+Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
+
+### Community 348 - "Community 348"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 348 - "Community 348"
+### Community 349 - "Community 349"
 Cohesion: 0.5
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 349 - "Community 349"
+### Community 350 - "Community 350"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 350 - "Community 350"
+### Community 351 - "Community 351"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 351 - "Community 351"
+### Community 352 - "Community 352"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 352 - "Community 352"
+### Community 353 - "Community 353"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 353 - "Community 353"
+### Community 354 - "Community 354"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
-
-### Community 354 - "Community 354"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 355 - "Community 355"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 356 - "Community 356"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 357 - "Community 357"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 357 - "Community 357"
+### Community 358 - "Community 358"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
 
-### Community 358 - "Community 358"
+### Community 359 - "Community 359"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 359 - "Community 359"
+### Community 360 - "Community 360"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 360 - "Community 360"
+### Community 361 - "Community 361"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 361 - "Community 361"
+### Community 362 - "Community 362"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 362 - "Community 362"
+### Community 363 - "Community 363"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 363 - "Community 363"
+### Community 364 - "Community 364"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 364 - "Community 364"
+### Community 365 - "Community 365"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 365 - "Community 365"
+### Community 366 - "Community 366"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 366 - "Community 366"
+### Community 367 - "Community 367"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
-
-### Community 367 - "Community 367"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 368 - "Community 368"
 Cohesion: 0.4
@@ -3591,12 +3592,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 370 - "Community 370"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 371 - "Community 371"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 371 - "Community 371"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 372 - "Community 372"
 Cohesion: 0.4
@@ -3779,80 +3780,80 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 417 - "Community 417"
-Cohesion: 0.6
-Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
-
-### Community 418 - "Community 418"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 419 - "Community 419"
+### Community 418 - "Community 418"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 420 - "Community 420"
+### Community 419 - "Community 419"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 421 - "Community 421"
+### Community 420 - "Community 420"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 422 - "Community 422"
+### Community 421 - "Community 421"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 423 - "Community 423"
+### Community 422 - "Community 422"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 424 - "Community 424"
+### Community 423 - "Community 423"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 425 - "Community 425"
+### Community 424 - "Community 424"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 426 - "Community 426"
+### Community 425 - "Community 425"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 427 - "Community 427"
+### Community 426 - "Community 426"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
+
+### Community 427 - "Community 427"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 428 - "Community 428"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 429 - "Community 429"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 430 - "Community 430"
 Cohesion: 0.67
 Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
+
+### Community 430 - "Community 430"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 431 - "Community 431"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 432 - "Community 432"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 433 - "Community 433"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 434 - "Community 434"
+### Community 433 - "Community 433"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 435 - "Community 435"
+### Community 434 - "Community 434"
 Cohesion: 0.67
 Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
+
+### Community 435 - "Community 435"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 436 - "Community 436"
 Cohesion: 0.5
@@ -3871,64 +3872,64 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 440 - "Community 440"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 441 - "Community 441"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 442 - "Community 442"
+### Community 441 - "Community 441"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 443 - "Community 443"
+### Community 442 - "Community 442"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 444 - "Community 444"
+### Community 443 - "Community 443"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 445 - "Community 445"
+### Community 444 - "Community 444"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 445 - "Community 445"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 446 - "Community 446"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 447 - "Community 447"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 448 - "Community 448"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 449 - "Community 449"
+### Community 448 - "Community 448"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 450 - "Community 450"
+### Community 449 - "Community 449"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 451 - "Community 451"
+### Community 450 - "Community 450"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 452 - "Community 452"
+### Community 451 - "Community 451"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 453 - "Community 453"
+### Community 452 - "Community 452"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 454 - "Community 454"
+### Community 453 - "Community 453"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 454 - "Community 454"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 455 - "Community 455"
 Cohesion: 0.83
@@ -5079,16 +5080,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 742 - "Community 742"
+Cohesion: 1.0
+Nodes (2): gitFixtureEnv(), runGit()
+
+### Community 743 - "Community 743"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 743 - "Community 743"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
-
 ### Community 744 - "Community 744"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 745 - "Community 745"
 Cohesion: 1.0
@@ -6208,11 +6209,11 @@ Nodes (0):
 
 ### Community 1024 - "Community 1024"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1025 - "Community 1025"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1026 - "Community 1026"
 Cohesion: 1.0
@@ -10402,368 +10403,372 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2073 - "Community 2073"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 744`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 745`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 746`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 747`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 748`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 749`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 750`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 751`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 752`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 753`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 754`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 755`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 756`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 757`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 758`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 759`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 760`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 761`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 762`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 763`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 764`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 765`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 766`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 767`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 768`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 769`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 770`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 771`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 772`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 773`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 774`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 775`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 776`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 777`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 778`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 779`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 780`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 781`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 782`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 783`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 784`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 785`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 786`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 787`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 788`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 789`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 790`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 791`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 792`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 793`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 794`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 795`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 796`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 797`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 798`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 799`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 800`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 801`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
+- **Thin community `Community 802`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 803`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 804`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 805`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 806`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 807`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 808`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 809`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 810`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 811`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 812`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 813`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 814`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 815`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 816`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 817`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 818`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 819`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 820`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 821`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 822`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 823`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 824`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 825`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 826`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 827`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 828`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 829`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 830`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 831`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 832`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 833`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 834`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 835`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 836`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 837`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 838`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 839`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 840`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 841`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 842`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 843`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 844`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 845`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 846`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 847`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 848`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 849`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 850`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 851`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 852`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 853`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 854`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 855`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 856`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 857`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 858`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 859`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 860`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 861`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 862`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 863`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 864`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 865`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 866`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 867`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 868`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 869`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 870`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 871`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 872`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 873`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 874`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 875`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 876`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 877`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 878`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 879`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 880`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 881`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 882`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 883`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 884`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 885`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 886`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 887`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 888`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 889`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 890`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 891`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 892`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 893`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 894`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 895`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 896`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 897`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 898`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 899`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 900`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 901`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 902`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 903`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 904`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 905`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 906`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 907`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 908`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
+- **Thin community `Community 909`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 910`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 911`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 912`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 913`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 914`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 915`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 916`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 917`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 918`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 919`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 920`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 921`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 922`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 923`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 924`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -10799,591 +10804,589 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 925`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 926`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 927`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 928`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 929`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 930`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 931`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 932`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 933`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 934`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
+- **Thin community `Community 935`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 936`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 937`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 938`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 939`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 940`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 941`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 942`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 943`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 944`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 945`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 946`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 947`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 948`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 949`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 950`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 951`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 952`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 953`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 954`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 955`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 956`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 957`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 958`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 959`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 960`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 961`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 962`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 963`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 964`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 965`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 966`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 967`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 968`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 969`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 970`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 971`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 972`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 973`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 974`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 975`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 976`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 977`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 978`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 979`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 980`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 981`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 982`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 983`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 984`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 985`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 986`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 987`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 988`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 989`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 990`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 991`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 992`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 993`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 994`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 995`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 996`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 997`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 998`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 999`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1000`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1001`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1002`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1003`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1004`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1005`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1006`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1007`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1008`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1009`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1010`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1011`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1012`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1013`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1014`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1015`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1016`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1017`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1018`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1019`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1020`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1021`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1022`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1023`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1024`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1025`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1026`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1027`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1028`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1029`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1030`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1031`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1032`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 1033`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1034`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1035`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1036`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1037`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1038`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1039`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1040`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1041`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1042`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1043`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1044`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
+- **Thin community `Community 1045`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1046`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1047`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1048`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1049`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
+- **Thin community `Community 1050`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1051`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1052`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1053`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1054`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1055`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1056`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1057`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1058`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1059`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1060`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1061`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1062`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `Index()`, `-index-route-view.tsx`
+- **Thin community `Community 1063`** (2 nodes): `Index()`, `-index-route-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1064`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1065`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1066`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1067`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1068`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1069`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1070`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1071`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1072`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
+- **Thin community `Community 1073`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1074`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1075`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1076`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1077`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1078`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1079`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1080`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1081`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1082`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1083`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1084`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1085`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1086`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1087`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1088`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1089`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1090`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1091`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1092`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1093`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1094`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1095`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1096`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1097`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1098`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1099`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1100`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1101`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1102`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1103`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1104`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1105`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1106`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1107`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1108`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1109`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1110`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1111`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1112`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1113`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1114`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1115`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1116`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1117`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1118`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1119`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1120`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1121`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1122`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1123`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1124`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1125`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1126`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1127`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1128`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1129`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1130`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1131`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1132`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1133`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1134`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1135`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1136`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1137`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1138`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1139`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1140`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1141`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1142`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1143`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1144`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1145`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1146`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1147`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1148`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1149`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1150`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1151`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1152`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1153`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1154`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1155`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1156`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1157`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1158`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1159`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1160`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1161`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1162`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1163`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1164`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1165`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1166`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1167`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1168`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1169`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1170`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1171`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1172`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1173`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1174`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1175`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1176`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1177`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1178`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1179`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1180`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1181`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1182`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1183`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1184`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1185`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1186`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1187`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1188`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1189`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1190`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1191`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1192`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1193`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1194`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1195`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1196`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1197`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1198`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1199`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1200`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1201`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1202`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1203`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1204`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1205`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1206`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1207`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1208`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1209`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1210`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1211`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1212`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1213`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1214`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1215`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `runGit()`, `pr-athena-delivery-run.test.ts`
+- **Thin community `Community 1216`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1217`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -12127,975 +12130,977 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1587`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `OperationReviewItemCard.tsx`
+- **Thin community `Community 1588`** (1 nodes): `DailyOperationsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1589`** (1 nodes): `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1590`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1591`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1592`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1593`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1594`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1595`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1596`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1597`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1598`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1599`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `constants.ts`
+- **Thin community `Community 1600`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1601`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1602`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1603`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `data.ts`
+- **Thin community `Community 1604`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1605`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1606`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `constants.ts`
+- **Thin community `Community 1607`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1608`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1609`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1610`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1611`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `data.ts`
+- **Thin community `Community 1612`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1613`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `constants.ts`
+- **Thin community `Community 1614`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1615`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1616`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1617`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1618`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `data.ts`
+- **Thin community `Community 1619`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1620`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1621`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1622`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1623`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1624`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1625`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1626`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1627`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1628`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1629`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1630`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1631`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1632`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1633`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1634`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1635`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1636`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1637`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1638`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1639`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1640`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1641`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1642`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1643`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1644`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1645`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1646`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1647`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `types.ts`
+- **Thin community `Community 1648`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1649`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1650`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1651`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1652`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1653`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1654`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1655`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1656`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 1657`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1658`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1659`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1660`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1661`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1662`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1663`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1664`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1665`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1666`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `data.ts`
+- **Thin community `Community 1667`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1668`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1669`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1670`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1671`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1672`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1673`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1674`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1675`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1676`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1677`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1678`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1679`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `constants.ts`
+- **Thin community `Community 1680`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1681`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1682`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1683`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `data.ts`
+- **Thin community `Community 1684`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `types.ts`
+- **Thin community `Community 1685`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1686`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1687`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1688`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1689`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1690`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `index.ts`
+- **Thin community `Community 1691`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1692`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1693`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1694`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1695`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `index.tsx`
+- **Thin community `Community 1696`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1697`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1698`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1699`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1700`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1701`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1702`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1703`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `StoreHoursView.test.tsx`
+- **Thin community `Community 1704`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1705`** (1 nodes): `StoreHoursView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 1706`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `index.tsx`
+- **Thin community `Community 1707`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1708`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1709`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1710`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `button.tsx`
+- **Thin community `Community 1711`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1712`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `card.tsx`
+- **Thin community `Community 1713`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1714`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1715`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `command.tsx`
+- **Thin community `Community 1716`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1717`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1718`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1719`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `form.tsx`
+- **Thin community `Community 1720`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1721`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1722`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `input.tsx`
+- **Thin community `Community 1723`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1724`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1725`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1726`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1727`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1728`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1729`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `select.tsx`
+- **Thin community `Community 1730`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1731`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1732`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1733`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1734`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `table.tsx`
+- **Thin community `Community 1735`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1736`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1737`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1738`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1739`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1740`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1741`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1742`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1743`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `constants.ts`
+- **Thin community `Community 1744`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1745`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1746`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1747`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `data.ts`
+- **Thin community `Community 1748`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1749`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1750`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1751`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1752`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1753`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1754`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1755`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1756`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1757`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1758`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `index.ts`
+- **Thin community `Community 1759`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1760`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1761`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1762`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 1763`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1764`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1765`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1766`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1767`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1768`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1769`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 1770`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1771`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1772`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 1773`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 1774`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `index.ts`
+- **Thin community `Community 1775`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 1776`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `index.ts`
+- **Thin community `Community 1777`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 1778`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 1779`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `aws.ts`
+- **Thin community `Community 1780`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `constants.ts`
+- **Thin community `Community 1781`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `countries.ts`
+- **Thin community `Community 1782`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1783`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1784`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1785`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1786`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1787`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1788`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1789`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 1790`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `dto.ts`
+- **Thin community `Community 1791`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `ports.ts`
+- **Thin community `Community 1792`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `constants.ts`
+- **Thin community `Community 1793`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1794`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1795`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `index.ts`
+- **Thin community `Community 1796`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1797`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `types.ts`
+- **Thin community `Community 1798`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1799`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1800`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1801`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1802`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1803`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1804`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1805`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1806`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1807`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 1808`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 1809`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 1810`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 1811`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 1812`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1813`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1814`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1815`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1816`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `index.ts`
+- **Thin community `Community 1817`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1818`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `category.ts`
+- **Thin community `Community 1819`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `product.ts`
+- **Thin community `Community 1820`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `store.ts`
+- **Thin community `Community 1821`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1822`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `user.ts`
+- **Thin community `Community 1823`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1824`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1825`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1826`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1827`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1828`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `main.tsx`
+- **Thin community `Community 1829`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 1830`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1831`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1832`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1833`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1834`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1835`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `index.tsx`
+- **Thin community `Community 1836`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1837`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1838`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1839`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1840`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1841`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1842`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1843`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `index.tsx`
+- **Thin community `Community 1844`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1845`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1846`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1847`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `home.tsx`
+- **Thin community `Community 1848`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1849`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1850`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1851`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `index.tsx`
+- **Thin community `Community 1852`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `review.tsx`
+- **Thin community `Community 1853`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1854`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1855`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `index.tsx`
+- **Thin community `Community 1856`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1857`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1858`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1859`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `index.tsx`
+- **Thin community `Community 1860`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1861`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1862`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1863`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1864`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1865`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1866`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 1867`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `index.tsx`
+- **Thin community `Community 1868`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1869`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1870`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1871`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1872`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1873`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1874`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1875`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1876`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1877`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `index.tsx`
+- **Thin community `Community 1878`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1879`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `index.tsx`
+- **Thin community `Community 1880`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `new.tsx`
+- **Thin community `Community 1881`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `index.tsx`
+- **Thin community `Community 1882`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `new.tsx`
+- **Thin community `Community 1883`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1884`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1885`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `index.tsx`
+- **Thin community `Community 1886`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `new.tsx`
+- **Thin community `Community 1887`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `index.tsx`
+- **Thin community `Community 1888`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1889`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1890`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1891`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1892`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `index.tsx`
+- **Thin community `Community 1893`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1894`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1895`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1896`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `index.tsx`
+- **Thin community `Community 1897`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1898`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `_authed.tsx`
+- **Thin community `Community 1899`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1900`** (1 nodes): `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `index.tsx`
+- **Thin community `Community 1901`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1902`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1903`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1904`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 1905`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1906`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 1907`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1908`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 1909`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1910`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1911`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1912`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1913`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1914`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1915`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1916`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1917`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1918`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1919`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1920`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1921`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1922`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1923`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1924`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1925`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `setup.ts`
+- **Thin community `Community 1926`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1927`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `types.ts`
+- **Thin community `Community 1928`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1929`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1930`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1931`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1932`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1933`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1934`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1935`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `types.ts`
+- **Thin community `Community 1936`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1937`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1938`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1939`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1940`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1941`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1942`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1943`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1944`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `schema.ts`
+- **Thin community `Community 1945`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1946`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1947`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1948`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1949`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1950`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1951`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1952`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1953`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1954`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `types.ts`
+- **Thin community `Community 1955`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1956`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1957`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1958`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1959`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1960`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1961`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1962`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `constants.ts`
+- **Thin community `Community 1963`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1964`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `About.tsx`
+- **Thin community `Community 1965`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1966`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1967`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1968`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1969`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1970`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1971`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1972`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1973`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1974`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1975`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `types.ts`
+- **Thin community `Community 1976`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1977`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1978`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1979`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1980`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1981`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1982`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1983`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1984`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1985`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1986`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1987`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `button.tsx`
+- **Thin community `Community 1988`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `card.tsx`
+- **Thin community `Community 1989`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1990`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `command.tsx`
+- **Thin community `Community 1991`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1992`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1993`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1994`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `form.tsx`
+- **Thin community `Community 1995`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1996`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1997`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1998`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1999`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `input.tsx`
+- **Thin community `Community 2000`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `label.tsx`
+- **Thin community `Community 2001`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2002`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2003`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2004`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `index.ts`
+- **Thin community `Community 2005`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `types.ts`
+- **Thin community `Community 2006`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2007`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2008`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2009`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2010`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `select.tsx`
+- **Thin community `Community 2011`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2012`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2013`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `table.tsx`
+- **Thin community `Community 2014`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2015`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2016`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2017`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2018`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2019`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `config.ts`
+- **Thin community `Community 2020`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2021`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2022`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2023`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2024`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2025`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `constants.ts`
+- **Thin community `Community 2026`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `countries.ts`
+- **Thin community `Community 2027`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2028`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2029`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2030`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2031`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `index.ts`
+- **Thin community `Community 2032`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2033`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `store.ts`
+- **Thin community `Community 2034`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `bag.ts`
+- **Thin community `Community 2035`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2036`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `category.ts`
+- **Thin community `Community 2037`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `organization.ts`
+- **Thin community `Community 2038`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `product.ts`
+- **Thin community `Community 2039`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `store.ts`
+- **Thin community `Community 2040`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2041`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `user.ts`
+- **Thin community `Community 2042`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `states.ts`
+- **Thin community `Community 2043`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2044`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2045`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2046`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2047`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2048`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2049`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2050`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2051`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `index.tsx`
+- **Thin community `Community 2052`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2053`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `index.tsx`
+- **Thin community `Community 2054`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2055`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2056`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2056`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2057`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2057`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2058`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2058`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2059`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2059`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2060`** (1 nodes): `index.tsx`
+- **Thin community `Community 2060`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2061`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2061`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2062`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2062`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2063`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2063`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2064`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2064`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2065`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2065`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2066`** (1 nodes): `index.js`
+- **Thin community `Community 2066`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2067`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2067`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2068`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2068`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2069`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2069`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2070`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2070`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2071`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2071`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2072`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2072`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2073`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,14 +7,14 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2146
-- Graph nodes: 8310
-- Graph edges: 9922
-- Communities: 2073
+- Code files discovered: 2147
+- Graph nodes: 8316
+- Graph edges: 9930
+- Communities: 2074
 
 ## Graph Hotspots
 - `dailyClose.ts` (88 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `harness-inferential-review.ts` (85 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
+- `harness-inferential-review.ts` (86 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `terminalHealthPresentation.ts` (75 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (67 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `DailyCloseView.tsx` (65 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -21,7 +21,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `createJourneyEvent()` (40 edges, Community 11) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 65) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `storefrontContextEvents.ts` (17 edges, Community 83) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
-- `checkoutSession.ts` (14 edges, Community 96) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 97) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (15 edges, Community 97) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (15 edges, Community 98) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `app.test.js` (6 edges, Community 199) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 97) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossCluster()` (4 edges, Community 97) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossClusterWithPipeline()` (4 edges, Community 97) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisClient()` (4 edges, Community 98) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossCluster()` (4 edges, Community 98) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossClusterWithPipeline()` (4 edges, Community 98) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/AGENTS.md
+++ b/packages/athena-webapp/AGENTS.md
@@ -6,6 +6,6 @@
 - Read [docs/agent/design.md](./docs/agent/design.md) before changing Athena UI, Storybook stories, design tokens, or visual component patterns.
 - Use [docs/agent/testing.md](./docs/agent/testing.md) to choose the smallest honest validation set.
 - Use [docs/agent/code-map.md](./docs/agent/code-map.md) when tracing ownership across `src/` and `convex/`.
-- Before changing Convex code in this package, read the repo-root Convex AI guide at [../../convex/_generated/ai/guidelines.md](../../convex/_generated/ai/guidelines.md). Do not look for a package-local `convex/_generated/ai/guidelines.md`; Athena's Convex guide lives at the repository root.
+- Before changing Convex code in this package, read the Convex AI guide. The canonical guide lives at [../../convex/_generated/ai/guidelines.md](../../convex/_generated/ai/guidelines.md), and this package also keeps an approved local mirror at [convex/_generated/ai/guidelines.md](./convex/_generated/ai/guidelines.md) for package-scoped agents.
 - For product-copy changes, follow the repo guide at [../../docs/product-copy-tone.md](../../docs/product-copy-tone.md) and normalize operator-facing system text instead of surfacing raw backend phrasing.
 - When generated Convex client artifacts need to refresh, run `bunx convex dev --once` from `packages/athena-webapp`. Plain `bunx convex dev` enters watch mode. Do not use `bunx convex codegen` in this repo's normal agent flow because local workspaces may not have `CONVEX_DEPLOYMENT` configured.

--- a/packages/athena-webapp/convex/_generated/ai/guidelines.md
+++ b/packages/athena-webapp/convex/_generated/ai/guidelines.md
@@ -1,0 +1,368 @@
+# Convex guidelines
+
+These guidelines target Convex `^1.41.0`.
+
+## Function guidelines
+
+### Http endpoint syntax
+
+- HTTP endpoints are defined in `convex/http.ts` and require an `httpAction` decorator. For example:
+
+```typescript
+import { httpRouter } from "convex/server";
+import { httpAction } from "./_generated/server";
+const http = httpRouter();
+http.route({
+  path: "/echo",
+  method: "POST",
+  handler: httpAction(async (ctx, req) => {
+    const body = await req.bytes();
+    return new Response(body, { status: 200 });
+  }),
+});
+```
+
+- HTTP endpoints are always registered at the exact path you specify in the `path` field. For example, if you specify `/api/someRoute`, the endpoint will be registered at `/api/someRoute`.
+
+### Validators
+
+- Below is an example of an array validator:
+
+```typescript
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+export default mutation({
+  args: {
+    simpleArray: v.array(v.union(v.string(), v.number())),
+  },
+  handler: async (ctx, args) => {
+    //...
+  },
+});
+```
+
+- Below is an example of a schema with validators that codify a discriminated union type:
+
+```typescript
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  results: defineTable(
+    v.union(
+      v.object({
+        kind: v.literal("error"),
+        errorMessage: v.string(),
+      }),
+      v.object({
+        kind: v.literal("success"),
+        value: v.number(),
+      }),
+    ),
+  ),
+});
+```
+
+- Here are the valid Convex types along with their respective validators:
+  Convex Type | TS/JS type | Example Usage | Validator for argument validation and schemas | Notes |
+  | ----------- | ------------| -----------------------| -----------------------------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+  | Id | string | `doc._id` | `v.id(tableName)` | |
+  | Null | null | `null` | `v.null()` | JavaScript's `undefined` is not a valid Convex value. Functions the return `undefined` or do not return will return `null` when called from a client. Use `null` instead. |
+  | Int64 | bigint | `3n` | `v.int64()` | Int64s only support BigInts between -2^63 and 2^63-1. Convex supports `bigint`s in most modern browsers. |
+  | Float64 | number | `3.1` | `v.number()` | Convex supports all IEEE-754 double-precision floating point numbers (such as NaNs). Inf and NaN are JSON serialized as strings. |
+  | Boolean | boolean | `true` | `v.boolean()` |
+  | String | string | `"abc"` | `v.string()` | Strings are stored as UTF-8 and must be valid Unicode sequences. Strings must be smaller than the 1MB total size limit when encoded as UTF-8. |
+  | Bytes | ArrayBuffer | `new ArrayBuffer(8)` | `v.bytes()` | Convex supports first class bytestrings, passed in as `ArrayBuffer`s. Bytestrings must be smaller than the 1MB total size limit for Convex types. |
+  | Array | Array | `[1, 3.2, "abc"]` | `v.array(values)` | Arrays can have at most 8192 values. |
+  | Object | Object | `{a: "abc"}` | `v.object({property: value})` | Convex only supports "plain old JavaScript objects" (objects that do not have a custom prototype). Objects can have at most 1024 entries. Field names must be nonempty and not start with "$" or "_". |
+| Record      | Record      | `{"a": "1", "b": "2"}` | `v.record(keys, values)`                       | Records are objects at runtime, but can have dynamic keys. Keys must be only ASCII characters, nonempty, and not start with "$" or "\_". |
+
+### Function registration
+
+- Use `internalQuery`, `internalMutation`, and `internalAction` to register internal functions. These functions are private and aren't part of an app's API. They can only be called by other Convex functions. These functions are always imported from `./_generated/server`.
+- Use `query`, `mutation`, and `action` to register public functions. These functions are part of the public API and are exposed to the public Internet. Do NOT use `query`, `mutation`, or `action` to register sensitive internal functions that should be kept private.
+- You CANNOT register a function through the `api` or `internal` objects.
+- ALWAYS include argument validators for all Convex functions. This includes all of `query`, `internalQuery`, `mutation`, `internalMutation`, `action`, and `internalAction`.
+
+### Function calling
+
+- Use `ctx.runQuery` to call a query from a query, mutation, or action.
+- Use `ctx.runMutation` to call a mutation from a mutation or action.
+- Use `ctx.runAction` to call an action from an action.
+- ONLY call an action from another action if you need to cross runtimes (e.g. from V8 to Node). Otherwise, pull out the shared code into a helper async function and call that directly instead.
+- Try to use as few calls from actions to queries and mutations as possible. Queries and mutations are transactions, so splitting logic up into multiple calls introduces the risk of race conditions.
+- All of these calls take in a `FunctionReference`. Do NOT try to pass the callee function directly into one of these calls.
+- When using `ctx.runQuery`, `ctx.runMutation`, or `ctx.runAction` to call a function in the same file, specify a type annotation on the return value to work around TypeScript circularity limitations. For example,
+
+```
+export const f = query({
+  args: { name: v.string() },
+  handler: async (ctx, args) => {
+    return "Hello " + args.name;
+  },
+});
+
+export const g = query({
+  args: {},
+  handler: async (ctx, args) => {
+    const result: string = await ctx.runQuery(api.example.f, { name: "Bob" });
+    return null;
+  },
+});
+```
+
+### Function references
+
+- Use the `api` object defined by the framework in `convex/_generated/api.ts` to call public functions registered with `query`, `mutation`, or `action`.
+- Use the `internal` object defined by the framework in `convex/_generated/api.ts` to call internal (or private) functions registered with `internalQuery`, `internalMutation`, or `internalAction`.
+- Convex uses file-based routing, so a public function defined in `convex/example.ts` named `f` has a function reference of `api.example.f`.
+- A private function defined in `convex/example.ts` named `g` has a function reference of `internal.example.g`.
+- Functions can also registered within directories nested within the `convex/` folder. For example, a public function `h` defined in `convex/messages/access.ts` has a function reference of `api.messages.access.h`.
+
+### Pagination
+
+- Define pagination using the following syntax:
+
+```ts
+import { v } from "convex/values";
+import { query, mutation } from "./_generated/server";
+import { paginationOptsValidator } from "convex/server";
+export const listWithExtraArg = query({
+  args: { paginationOpts: paginationOptsValidator, author: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("messages")
+      .withIndex("by_author", (q) => q.eq("author", args.author))
+      .order("desc")
+      .paginate(args.paginationOpts);
+  },
+});
+```
+
+Note: `paginationOpts` is an object with the following properties:
+
+- `numItems`: the maximum number of documents to return (the validator is `v.number()`)
+- `cursor`: the cursor to use to fetch the next page of documents (the validator is `v.union(v.string(), v.null())`)
+- A query that ends in `.paginate()` returns an object that has the following properties:
+- page (contains an array of documents that you fetches)
+- isDone (a boolean that represents whether or not this is the last page of documents)
+- continueCursor (a string that represents the cursor to use to fetch the next page of documents)
+
+## Schema guidelines
+
+- Always define your schema in `convex/schema.ts`.
+- Always import the schema definition functions from `convex/server`.
+- System fields are automatically added to all documents and are prefixed with an underscore. The two system fields that are automatically added to all documents are `_creationTime` which has the validator `v.number()` and `_id` which has the validator `v.id(tableName)`.
+- Always include all index fields in the index name. For example, if an index is defined as `["field1", "field2"]`, the index name should be "by_field1_and_field2".
+- Index fields must be queried in the same order they are defined. If you want to be able to query by "field1" then "field2" and by "field2" then "field1", you must create separate indexes.
+- Do not store unbounded lists as an array field inside a document (e.g. `v.array(v.object({...}))`). As the array grows it will hit the 1MB document size limit, and every update rewrites the entire document. Instead, create a separate table for the child items with a foreign key back to the parent.
+- Separate high-churn operational data (e.g. heartbeats, online status, typing indicators) from stable profile data. Storing frequently updated fields on a shared document forces every write to contend with reads of the entire document. Instead, create a dedicated table for the high-churn data with a foreign key back to the parent record.
+
+## Authentication guidelines
+
+- Convex supports JWT-based authentication through `convex/auth.config.ts`. ALWAYS create this file when using authentication. Without it, `ctx.auth.getUserIdentity()` will always return `null`.
+- Example `convex/auth.config.ts`:
+
+```typescript
+export default {
+  providers: [
+    {
+      domain: "https://your-auth-provider.com",
+      applicationID: "convex",
+    },
+  ],
+};
+```
+
+The `domain` must be the issuer URL of the JWT provider. Convex fetches `{domain}/.well-known/openid-configuration` to discover the JWKS endpoint. The `applicationID` is checked against the JWT `aud` (audience) claim.
+
+- Use `ctx.auth.getUserIdentity()` to get the authenticated user's identity in any query, mutation, or action. This returns `null` if the user is not authenticated, or a `UserIdentity` object with fields like `subject`, `issuer`, `name`, `email`, etc. The `subject` field is the unique user identifier.
+- In Convex `UserIdentity`, `tokenIdentifier` is guaranteed and is the canonical stable identifier for the authenticated identity. For any auth-linked database lookup or ownership check, prefer `identity.tokenIdentifier` over `identity.subject`. Do NOT use `identity.subject` alone as a global identity key.
+- NEVER accept a `userId` or any user identifier as a function argument for authorization purposes. Always derive the user identity server-side via `ctx.auth.getUserIdentity()`.
+- When using an external auth provider with Convex on the client, use `ConvexProviderWithAuth` instead of `ConvexProvider`:
+
+```tsx
+import { ConvexProviderWithAuth, ConvexReactClient } from "convex/react";
+
+const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+
+function App({ children }: { children: React.ReactNode }) {
+  return (
+    <ConvexProviderWithAuth client={convex} useAuth={useYourAuthHook}>
+      {children}
+    </ConvexProviderWithAuth>
+  );
+}
+```
+
+The `useAuth` prop must return `{ isLoading, isAuthenticated, fetchAccessToken }`. Do NOT use plain `ConvexProvider` when authentication is needed — it will not send tokens with requests.
+
+## Typescript guidelines
+
+- You can use the helper typescript type `Id` imported from './\_generated/dataModel' to get the type of the id for a given table. For example if there is a table called 'users' you can use `Id<'users'>` to get the type of the id for that table.
+- Use `Doc<"tableName">` from `./_generated/dataModel` to get the full document type for a table.
+- Use `QueryCtx`, `MutationCtx`, `ActionCtx` from `./_generated/server` for typing function contexts. NEVER use `any` for ctx parameters — always use the proper context type.
+- If you need to define a `Record` make sure that you correctly provide the type of the key and value in the type. For example a validator `v.record(v.id('users'), v.string())` would have the type `Record<Id<'users'>, string>`. Below is an example of using `Record` with an `Id` type in a query:
+
+```ts
+import { query } from "./_generated/server";
+import { Doc, Id } from "./_generated/dataModel";
+
+export const exampleQuery = query({
+  args: { userIds: v.array(v.id("users")) },
+  handler: async (ctx, args) => {
+    const idToUsername: Record<Id<"users">, string> = {};
+    for (const userId of args.userIds) {
+      const user = await ctx.db.get("users", userId);
+      if (user) {
+        idToUsername[user._id] = user.username;
+      }
+    }
+
+    return idToUsername;
+  },
+});
+```
+
+- Be strict with types, particularly around id's of documents. For example, if a function takes in an id for a document in the 'users' table, take in `Id<'users'>` rather than `string`.
+- For typed app environment variables, declare them in `convex/convex.config.ts` with `defineApp({ env: { MY_KEY: v.optional(v.string()) } })` and read them with `env` from `./_generated/server` instead of `process.env`.
+
+## Full text search guidelines
+
+- A query for "10 messages in channel '#general' that best match the query 'hello hi' in their body" would look like:
+
+const messages = await ctx.db
+.query("messages")
+.withSearchIndex("search_body", (q) =>
+q.search("body", "hello hi").eq("channel", "#general"),
+)
+.take(10);
+
+## Query guidelines
+
+- Do NOT use `filter` in queries. Instead, define an index in the schema and use `withIndex` instead.
+- If the user does not explicitly tell you to return all results from a query you should ALWAYS return a bounded collection instead. So that is instead of using `.collect()` you should use `.take()` or paginate on database queries. This prevents future performance issues when tables grow in an unbounded way.
+- Never use `.collect().length` to count rows. Convex has no built-in count operator, so if you need a count that stays efficient at scale, maintain a denormalized counter in a separate document and update it in your mutations.
+- Convex queries do NOT support `.delete()`. If you need to delete all documents matching a query, use `.take(n)` to read them in batches, iterate over each batch calling `ctx.db.delete("tasks", row._id)`, and repeat until no more results are returned.
+- Convex mutations are transactions with limits on the number of documents read and written. If a mutation needs to process more documents than fit in a single transaction (e.g. bulk deletion on a large table), process a batch with `.take(n)` and then call `ctx.scheduler.runAfter(0, api.myModule.myMutation, args)` to schedule itself to continue. This way each invocation stays within transaction limits.
+- Use `.unique()` to get a single document from a query. This method will throw an error if there are multiple documents that match the query.
+- When using async iteration, don't use `.collect()` or `.take(n)` on the result of a query. Instead, use the `for await (const row of query)` syntax.
+
+### Ordering
+
+- By default Convex always returns documents in ascending `_creationTime` order.
+- You can use `.order('asc')` or `.order('desc')` to pick whether a query is in ascending or descending order. If the order isn't specified, it defaults to ascending.
+- Document queries that use indexes will be ordered based on the columns in the index and can avoid slow table scans.
+
+## Mutation guidelines
+
+- Use `ctx.db.replace` to fully replace an existing document. This method will throw an error if the document does not exist. Syntax: `await ctx.db.replace("tasks", taskId, { name: "Buy milk", completed: false })`
+- Use `ctx.db.patch` to shallow merge updates into an existing document. This method will throw an error if the document does not exist. Syntax: `await ctx.db.patch("tasks", taskId, { completed: true })`
+
+## Action guidelines
+
+- Always add `"use node";` to the top of files containing actions that use Node.js built-in modules.
+- Never add `"use node";` to a file that also exports queries or mutations. Only actions can run in the Node.js runtime; queries and mutations must stay in the default Convex runtime. If you need Node.js built-ins alongside queries or mutations, put the action in a separate file.
+- `fetch()` is available in the default Convex runtime. You do NOT need `"use node";` just to use `fetch()`.
+- Never use `ctx.db` inside of an action. Actions don't have access to the database.
+- Below is an example of the syntax for an action:
+
+```ts
+import { action } from "./_generated/server";
+
+export const exampleAction = action({
+  args: {},
+  handler: async (ctx, args) => {
+    console.log("This action does not return anything");
+    return null;
+  },
+});
+```
+
+## Scheduling guidelines
+
+### Cron guidelines
+
+- Only use the `crons.interval` or `crons.cron` methods to schedule cron jobs. Do NOT use the `crons.hourly`, `crons.daily`, or `crons.weekly` helpers.
+- Both cron methods take in a FunctionReference. Do NOT try to pass the function directly into one of these methods.
+- Define crons by declaring the top-level `crons` object, calling some methods on it, and then exporting it as default. For example,
+
+```ts
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+import { internalAction } from "./_generated/server";
+
+const empty = internalAction({
+  args: {},
+  handler: async (ctx, args) => {
+    console.log("empty");
+  },
+});
+
+const crons = cronJobs();
+
+// Run `internal.crons.empty` every two hours.
+crons.interval("delete inactive users", { hours: 2 }, internal.crons.empty, {});
+
+export default crons;
+```
+
+- You can register Convex functions within `crons.ts` just like any other file.
+- If a cron calls an internal function, always import the `internal` object from '\_generated/api', even if the internal function is registered in the same file.
+
+## Testing guidelines
+
+- Use `convex-test` with `vitest` and `@edge-runtime/vm` to test Convex functions. Always install the latest versions of these packages. Configure vitest with `environment: "edge-runtime"` in `vitest.config.ts`.
+
+Test files go inside the `convex/` directory. You must pass a module map from `import.meta.glob` to `convexTest`:
+
+```typescript
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+test("some behavior", async () => {
+  const t = convexTest(schema, modules);
+  await t.mutation(api.messages.send, { body: "Hi!", author: "Sarah" });
+  const messages = await t.query(api.messages.list);
+  expect(messages).toMatchObject([{ body: "Hi!", author: "Sarah" }]);
+});
+```
+
+The `modules` argument is required so convex-test can discover and load function files. The `/// <reference types="vite/client" />` directive is needed for TypeScript to recognize `import.meta.glob`.
+
+## File storage guidelines
+
+- The `ctx.storage.getUrl()` method returns a signed URL for a given file. It returns `null` if the file doesn't exist.
+- Do NOT use the deprecated `ctx.storage.getMetadata` call for loading a file's metadata.
+
+Instead, query the `_storage` system table. For example, you can use `ctx.db.system.get` to get an `Id<"_storage">`.
+
+```
+import { query } from "./_generated/server";
+import { Id } from "./_generated/dataModel";
+
+type FileMetadata = {
+    _id: Id<"_storage">;
+    _creationTime: number;
+    contentType?: string;
+    sha256: string;
+    size: number;
+}
+
+export const exampleQuery = query({
+    args: { fileId: v.id("_storage") },
+    handler: async (ctx, args) => {
+        const metadata: FileMetadata | null = await ctx.db.system.get("_storage", args.fileId);
+        console.log(metadata);
+        return null;
+    },
+});
+```
+
+- Convex storage stores items as `Blob` objects. You must convert all items to/from a `Blob` when using Convex storage.

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -6,6 +6,9 @@ import {
   buildDailyOperationsSnapshotWithCtx,
   getDailyOperationsDetailSnapshot,
   getDailyOperationsSnapshot,
+  getDailyOperationsStorePulseSnapshot,
+  getDailyOperationsTimelinePreviewSnapshot,
+  getDailyOperationsTimelineSnapshot,
 } from "./dailyOperations";
 
 vi.mock("../lib/athenaUserAuth", () => ({
@@ -1954,9 +1957,8 @@ describe("daily operations overview read model", () => {
     });
     expect(snapshot.priorDayMetric).toBeUndefined();
     expect(snapshot.storePulse).toBeUndefined();
-    expect(snapshot.timeline).toEqual([
-      expect.objectContaining({ id: "event-register-opened" }),
-    ]);
+    expect(snapshot.timeline).toEqual([]);
+    expect(snapshot.timelineHasMore).toBe(false);
     expect(snapshot.weekMetrics).toEqual([]);
   });
 
@@ -2030,14 +2032,8 @@ describe("daily operations overview read model", () => {
     expect(snapshot.primaryAction).toMatchObject({
       label: "Start EOD Review",
     });
-    expect(snapshot.timeline).toHaveLength(5);
-    expect(snapshot.timeline[0].id).toBe("event-19");
-    expect(
-      snapshot.timeline.map(
-        (event: (typeof snapshot.timeline)[number]) => event.id,
-      ),
-    ).not.toContain("event-14");
-    expect(snapshot.timelineHasMore).toBe(true);
+    expect(snapshot.timeline).toEqual([]);
+    expect(snapshot.timelineHasMore).toBe(false);
     expect(snapshot.scheduledRunSummaries).toEqual([
       expect.objectContaining({ id: "run-applied" }),
     ]);
@@ -2046,7 +2042,7 @@ describe("daily operations overview read model", () => {
     expect(snapshot.weekMetrics).toEqual([]);
   });
 
-  it("returns analytics and full bounded history from the explicit detail query", async () => {
+  it("returns week analytics without timeline or store pulse detail from the explicit detail query", async () => {
     vi.mocked(
       athenaUserAuth.requireAuthenticatedAthenaUserWithCtx,
     ).mockResolvedValue({
@@ -2103,10 +2099,33 @@ describe("daily operations overview read model", () => {
       },
     );
 
-    expect(snapshot.timeline).toHaveLength(20);
-    expect(snapshot.timeline[0].id).toBe("event-19");
-    expect(snapshot.storePulse).toBeDefined();
+    expect(snapshot.timeline).toEqual([]);
+    expect(snapshot.timelineHasMore).toBe(false);
+    expect(snapshot.scheduledRunSummaries).toEqual([]);
+    expect(snapshot.storePulse).toBeUndefined();
     expect(snapshot.weekMetrics).toHaveLength(7);
+    expect(snapshot.weekStorePulses).toBeUndefined();
+    expect(snapshot.weekSnapshots).toHaveLength(7);
+    expect(
+      snapshot.weekSnapshots.find(
+        (weekSnapshot: (typeof snapshot.weekSnapshots)[number]) =>
+          weekSnapshot.operatingDate === "2026-05-08",
+      ),
+    ).toMatchObject({
+      operatingDate: "2026-05-08",
+      scheduledRunSummaries: [],
+      timeline: [],
+      timelineHasMore: false,
+    });
+    expect(
+      snapshot.weekSnapshots.find(
+        (weekSnapshot: (typeof snapshot.weekSnapshots)[number]) =>
+          weekSnapshot.operatingDate === "2026-05-07",
+      ),
+    ).toMatchObject({
+      operatingDate: "2026-05-07",
+      weekMetrics: [],
+    });
     expect(
       snapshot.weekMetrics.find(
         (metric: (typeof snapshot.weekMetrics)[number]) =>
@@ -2115,6 +2134,187 @@ describe("daily operations overview read model", () => {
     ).toMatchObject({
       salesTotal: 821500,
       transactionCount: 1,
+    });
+  });
+
+  it("returns selected-day store pulse detail from the explicit store pulse query", async () => {
+    vi.mocked(
+      athenaUserAuth.requireAuthenticatedAthenaUserWithCtx,
+    ).mockResolvedValue({
+      _creationTime: 0,
+      _id: "user-1" as Id<"athenaUser">,
+      email: "admin@wigclub.store",
+    });
+    vi.mocked(
+      athenaUserAuth.requireOrganizationMemberRoleWithCtx,
+    ).mockResolvedValue({
+      _creationTime: 0,
+      _id: "member-admin" as Id<"organizationMember">,
+      organizationId: "org-1" as Id<"organization">,
+      role: "full_admin",
+      userId: "user-1" as Id<"athenaUser">,
+    });
+
+    const snapshot = await getHandler(getDailyOperationsStorePulseSnapshot)(
+      buildCtx({
+        posTransaction: [
+          {
+            _id: "txn-current",
+            changeGiven: 0,
+            completedAt: Date.UTC(2026, 4, 8, 16),
+            paymentMethod: "cash",
+            paymentAllocations: [],
+            payments: [{ amount: 821500, method: "cash" }],
+            status: "completed",
+            storeId: "store-1",
+            terminalId: "terminal-1",
+            total: 821500,
+            totalPaid: 821500,
+            transactionNumber: "TXN-CURRENT",
+          },
+        ],
+        posTransactionItem: [
+          {
+            _id: "txn-item-current",
+            productId: "product-1",
+            productName: "Braiding Hair",
+            productSku: "BRAID-1",
+            productSkuId: "sku-1",
+            quantity: 2,
+            totalPrice: 821500,
+            transactionId: "txn-current",
+            unitPrice: 410750,
+          },
+        ],
+        store: [store],
+      }) as never,
+      {
+        operatingDate: "2026-05-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(snapshot).toMatchObject({
+      operatingDate: "2026-05-08",
+      storePulse: {
+        operatorSnapshot: {
+          paymentMix: [
+            expect.objectContaining({
+              count: 1,
+              label: "Cash",
+              total: 821500,
+            }),
+          ],
+          topItems: [
+            expect.objectContaining({
+              name: "Braiding Hair",
+              quantity: 2,
+              totalSales: 821500,
+            }),
+          ],
+        },
+      },
+    });
+  });
+
+  it("returns full bounded timeline history from the explicit timeline query", async () => {
+    vi.mocked(
+      athenaUserAuth.requireAuthenticatedAthenaUserWithCtx,
+    ).mockResolvedValue({
+      _creationTime: 0,
+      _id: "user-1" as Id<"athenaUser">,
+      email: "admin@wigclub.store",
+    });
+    vi.mocked(
+      athenaUserAuth.requireOrganizationMemberRoleWithCtx,
+    ).mockResolvedValue({
+      _creationTime: 0,
+      _id: "member-admin" as Id<"organizationMember">,
+      organizationId: "org-1" as Id<"organization">,
+      role: "full_admin",
+      userId: "user-1" as Id<"athenaUser">,
+    });
+    const events = Array.from({ length: 8 }, (_, index) => ({
+      _id: `timeline-event-${index}`,
+      createdAt: Date.UTC(2026, 4, 8, 9, index),
+      eventType: "operations.event",
+      message: `Timeline event ${index}`,
+      storeId: "store-1",
+      subjectId: `subject-${index}`,
+      subjectType: "operations",
+    }));
+
+    const snapshot = await getHandler(getDailyOperationsTimelineSnapshot)(
+      buildCtx({
+        dailyOpening: [startedOpening],
+        operationalEvent: events,
+        store: [store],
+      }) as never,
+      {
+        operatingDate: "2026-05-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(snapshot).toEqual({
+      operatingDate: "2026-05-08",
+      timeline: expect.arrayContaining([
+        expect.objectContaining({ id: "timeline-event-7" }),
+        expect.objectContaining({ id: "timeline-event-0" }),
+      ]),
+    });
+    expect(snapshot.timeline).toHaveLength(8);
+    expect(snapshot).not.toHaveProperty("storePulse");
+    expect(snapshot).not.toHaveProperty("weekMetrics");
+  });
+
+  it("returns the same first five events from the timeline preview query", async () => {
+    vi.mocked(
+      athenaUserAuth.requireAuthenticatedAthenaUserWithCtx,
+    ).mockResolvedValue({
+      _creationTime: 0,
+      _id: "user-1" as Id<"athenaUser">,
+      email: "admin@wigclub.store",
+    });
+    vi.mocked(
+      athenaUserAuth.requireOrganizationMemberRoleWithCtx,
+    ).mockResolvedValue({
+      _creationTime: 0,
+      _id: "member-admin" as Id<"organizationMember">,
+      organizationId: "org-1" as Id<"organization">,
+      role: "full_admin",
+      userId: "user-1" as Id<"athenaUser">,
+    });
+    const seed = {
+      dailyOpening: [startedOpening],
+      operationalEvent: Array.from({ length: 8 }, (_, index) => ({
+        _id: `timeline-event-${index}`,
+        createdAt: Date.UTC(2026, 4, 8, 9, index),
+        eventType: "operations.event",
+        message: `Timeline event ${index}`,
+        storeId: "store-1",
+        subjectId: `subject-${index}`,
+        subjectType: "operations",
+      })),
+      store: [store],
+    };
+    const args = {
+      operatingDate: "2026-05-08",
+      storeId: "store-1" as Id<"store">,
+    };
+
+    const previewSnapshot = await getHandler(
+      getDailyOperationsTimelinePreviewSnapshot,
+    )(buildCtx(seed) as never, args);
+    const fullSnapshot = await getHandler(getDailyOperationsTimelineSnapshot)(
+      buildCtx(seed) as never,
+      args,
+    );
+
+    expect(previewSnapshot).toEqual({
+      operatingDate: "2026-05-08",
+      timeline: fullSnapshot.timeline.slice(0, 5),
+      timelineHasMore: true,
     });
   });
 
@@ -2800,6 +3000,141 @@ describe("daily operations overview read model", () => {
     });
   });
 
+  it("selects the most recent compact timeline events after merging fallback sources", async () => {
+    const operationalEvents = Array.from({ length: 6 }, (_, index) => ({
+      _id: `older-event-${index}`,
+      createdAt: Date.UTC(2026, 4, 8, 10, index),
+      eventType: "operations.event",
+      message: `Older event ${index}`,
+      storeId: "store-1",
+      subjectId: `subject-${index}`,
+      subjectType: "operations",
+    }));
+    const snapshot = await buildDailyOperationsSnapshotWithCtx(
+      buildCtx({
+        dailyClose: [priorClose],
+        dailyOpening: [startedOpening],
+        operationalEvent: operationalEvents,
+        registerSession: [
+          {
+            _id: "register-latest",
+            closeoutRecords: [
+              {
+                actorStaffProfileId: "staff-1",
+                countedCash: 450,
+                expectedCash: 450,
+                occurredAt: Date.UTC(2026, 4, 8, 20, 45),
+                type: "closed",
+                variance: 0,
+              },
+            ],
+            expectedCash: 450,
+            openedAt: Date.UTC(2026, 4, 8, 8),
+            openingFloat: 100,
+            organizationId: "org-1",
+            registerNumber: "Register 9",
+            status: "closed",
+            storeId: "store-1",
+          },
+        ],
+        store: [store],
+      }),
+      {
+        operatingDate: "2026-05-08",
+        storeId: "store-1" as Id<"store">,
+        timelineLimit: 5,
+        timelinePreviewLimit: 5,
+      },
+    );
+
+    expect(snapshot.timeline).toHaveLength(5);
+    expect(snapshot.timeline[0]).toMatchObject({
+      id: "register_closeout:register-latest:closed:1778273100000",
+      message: "Register 9 closeout recorded with an exact cash match.",
+    });
+    expect(snapshot.timeline.map((event) => event.id)).not.toContain(
+      "older-event-0",
+    );
+  });
+
+  it("matches the compact timeline preview to the full timeline first rows", async () => {
+    vi.mocked(
+      athenaUserAuth.requireAuthenticatedAthenaUserWithCtx,
+    ).mockResolvedValue({
+      _creationTime: 0,
+      _id: "user-1" as Id<"athenaUser">,
+      email: "admin@wigclub.store",
+    });
+    vi.mocked(
+      athenaUserAuth.requireOrganizationMemberRoleWithCtx,
+    ).mockResolvedValue({
+      _creationTime: 0,
+      _id: "member-admin" as Id<"organizationMember">,
+      organizationId: "org-1" as Id<"organization">,
+      role: "full_admin",
+      userId: "user-1" as Id<"athenaUser">,
+    });
+    const seed = {
+      dailyClose: [priorClose],
+      dailyOpening: [startedOpening],
+      operationalEvent: Array.from({ length: 8 }, (_, index) => ({
+        _id: `timeline-event-${index}`,
+        createdAt: Date.UTC(2026, 4, 8, 10, index),
+        eventType: "operations.event",
+        message: `Timeline event ${index}`,
+        storeId: "store-1",
+        subjectId: `subject-${index}`,
+        subjectType: "operations",
+      })),
+      registerSession: [
+        {
+          _id: "register-latest",
+          closeoutRecords: [
+            {
+              actorStaffProfileId: "staff-1",
+              countedCash: 450,
+              expectedCash: 450,
+              occurredAt: Date.UTC(2026, 4, 8, 20, 45),
+              type: "closed",
+              variance: 0,
+            },
+          ],
+          expectedCash: 450,
+          openedAt: Date.UTC(2026, 4, 8, 8),
+          openingFloat: 100,
+          organizationId: "org-1",
+          registerNumber: "Register 9",
+          status: "closed",
+          storeId: "store-1",
+        },
+      ],
+      store: [store],
+    };
+    const args = {
+      operatingDate: "2026-05-08",
+      storeId: "store-1" as Id<"store">,
+    };
+    const compactSnapshot = await buildDailyOperationsSnapshotWithCtx(
+      buildCtx(seed),
+      {
+        ...args,
+        timelineLimit: 5,
+        timelinePreviewLimit: 5,
+      },
+    );
+    const fullTimelineSnapshot = await getHandler(
+      getDailyOperationsTimelineSnapshot,
+    )(buildCtx(seed) as never, args);
+
+    expect(compactSnapshot.timeline.map((event) => event.id)).toEqual(
+      fullTimelineSnapshot.timeline
+        .slice(0, 5)
+        .map(
+          (event: (typeof fullTimelineSnapshot.timeline)[number]) => event.id,
+        ),
+    );
+  });
+
   it("formats fallback register closeout variance records for the timeline", async () => {
     const snapshot = await buildDailyOperationsSnapshotWithCtx(
       buildCtx({
@@ -3425,7 +3760,7 @@ describe("daily operations overview read model", () => {
     expect(snapshot.timeline.map((event) => event.id)).not.toContain("event-0");
   });
 
-  it("orders same-minute cycle count lifecycle events by operator relevance", async () => {
+  it("orders same-minute timeline events by exact recency", async () => {
     const snapshot = await buildDailyOperationsSnapshotWithCtx(
       buildCtx({
         dailyClose: [priorClose],
@@ -3492,10 +3827,10 @@ describe("daily operations overview read model", () => {
     );
 
     expect(snapshot.timeline.map((event) => event.id)).toEqual([
+      "event-draft-started",
       "event-draft-submitted",
       "event-adjustment-applied",
       "event-draft-updated",
-      "event-draft-started",
     ]);
     expect(
       snapshot.timeline.find((event) => event.id === "event-draft-updated")

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -590,6 +590,10 @@ async function listTimelineEvents(
 
   if (limit === 0) return [];
 
+  const operationalEventLimit =
+    limit >= MAX_OPERATIONS_QUERY_LIMIT
+      ? MAX_OPERATIONS_QUERY_LIMIT
+      : MAX_OPERATIONS_LOOKAHEAD_LIMIT;
   const eventsPromise = ctx.db
     .query("operationalEvent")
     .withIndex("by_storeId_createdAt", (q) =>
@@ -599,7 +603,7 @@ async function listTimelineEvents(
         .lt("createdAt", args.endAt),
     )
     .order("desc")
-    .take(limit);
+    .take(operationalEventLimit);
   const storePromise = ctx.db.get("store", args.storeId);
   const registerSessionsPromise = listTimelineRegisterSessions(ctx, args.storeId);
   const pendingRegisterCountsPromise = args.includeManagerReviewEvidence
@@ -1444,44 +1448,16 @@ function getTimelineMinuteBucket(createdAt: number) {
   return Math.floor(createdAt / 60_000);
 }
 
-function getTimelineEventPriority(event: {
-  eventType: string;
-  metadata?: Record<string, unknown>;
-}) {
-  if (event.eventType === "cycle_count_draft_submitted") return 40;
-  if (
-    event.eventType === "stock_adjustment_applied" &&
-    event.metadata?.adjustmentType === "cycle_count"
-  ) {
-    return 30;
-  }
-  if (event.eventType === "cycle_count_draft_updated") return 20;
-  if (event.eventType === "cycle_count_draft_created") return 10;
-  return 25;
-}
-
 function compareTimelineEvents(
   left: {
     _id: Id<"operationalEvent">;
     createdAt: number;
-    eventType: string;
-    metadata?: Record<string, unknown>;
   },
   right: {
     _id: Id<"operationalEvent">;
     createdAt: number;
-    eventType: string;
-    metadata?: Record<string, unknown>;
   },
 ) {
-  const leftMinute = getTimelineMinuteBucket(left.createdAt);
-  const rightMinute = getTimelineMinuteBucket(right.createdAt);
-  if (leftMinute !== rightMinute) return rightMinute - leftMinute;
-
-  const priorityDelta =
-    getTimelineEventPriority(right) - getTimelineEventPriority(left);
-  if (priorityDelta !== 0) return priorityDelta;
-
   if (left.createdAt !== right.createdAt) return right.createdAt - left.createdAt;
   return String(right._id).localeCompare(String(left._id));
 }
@@ -1494,12 +1470,10 @@ function compareDailyOperationsTimelineEvents(
     {
       _id: left.id as Id<"operationalEvent">,
       createdAt: left.createdAt,
-      eventType: left.type,
     },
     {
       _id: right.id as Id<"operationalEvent">,
       createdAt: right.createdAt,
-      eventType: right.type,
     },
   );
 }
@@ -2108,6 +2082,7 @@ export async function buildDailyOperationsSnapshotWithCtx(
     includeFinancialDetails?: boolean;
     includeManagerReviewEvidence?: boolean;
     includeScheduledRunSummaries?: boolean;
+    includeStorePulseDetails?: boolean;
     scheduledRunSummariesLimit?: number;
     operatingDate: string;
     operatingTimezoneOffsetMinutes?: number;
@@ -2122,6 +2097,8 @@ export async function buildDailyOperationsSnapshotWithCtx(
   const includeFinancialDetails = args.includeFinancialDetails ?? true;
   const includeAnalyticsDetails =
     args.includeAnalyticsDetails ?? includeFinancialDetails;
+  const includeStorePulseDetails =
+    args.includeStorePulseDetails ?? includeAnalyticsDetails;
   const range = resolveRange(args);
   const [
     openingSnapshot,
@@ -2158,7 +2135,7 @@ export async function buildDailyOperationsSnapshotWithCtx(
         storeId: args.storeId,
       }),
       ctx.db.get("store", args.storeId),
-      includeAnalyticsDetails
+      includeStorePulseDetails
         ? getStorePulseSummaryForWindow(ctx as QueryCtx, {
             currentDayEnd: range.endAt - 1,
             currentDayStart: range.startAt,
@@ -2337,6 +2314,41 @@ export async function buildDailyOperationsSnapshotWithCtx(
   };
 }
 
+async function buildCompactDailyOperationsWeekSnapshotsWithCtx(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    endAt?: number;
+    includeManagerReviewEvidence: boolean;
+    operatingDate: string;
+    operatingTimezoneOffsetMinutes?: number;
+    startAt?: number;
+    storeId: Id<"store">;
+    storePulseWindow?: DailyOperationsStorePulseWindow;
+    weekEndOperatingDate?: string;
+  },
+  weekMetrics: Awaited<
+    ReturnType<typeof buildDailyOperationsSnapshotWithCtx>
+  >["weekMetrics"],
+) {
+  const { endAt: _endAt, startAt: _startAt, ...weekSnapshotArgs } = args;
+
+  return Promise.all(
+    weekMetrics.map((metric) =>
+      buildDailyOperationsSnapshotWithCtx(ctx, {
+        ...weekSnapshotArgs,
+        includeAnalyticsDetails: false,
+        includeFinancialDetails: args.includeManagerReviewEvidence,
+        includeManagerReviewEvidence: args.includeManagerReviewEvidence,
+        includeScheduledRunSummaries: false,
+        operatingDate: metric.operatingDate,
+        scheduledRunSummariesLimit: 0,
+        timelineLimit: 0,
+        timelinePreviewLimit: 0,
+      }),
+    ),
+  );
+}
+
 function maybeRedactCloseSummary(
   summary: DailyOperationsCloseSummary,
   includeFinancialDetails: boolean,
@@ -2405,8 +2417,8 @@ export const getDailyOperationsSnapshot = query({
       includeManagerReviewEvidence,
       includeScheduledRunSummaries: includeManagerReviewEvidence,
       scheduledRunSummariesLimit: COMPACT_SCHEDULED_RUN_SUMMARY_LIMIT,
-      timelineLimit: COMPACT_OPERATIONS_TIMELINE_LIMIT + 1,
-      timelinePreviewLimit: COMPACT_OPERATIONS_TIMELINE_LIMIT,
+      timelineLimit: 0,
+      timelinePreviewLimit: 0,
     });
   },
 });
@@ -2419,14 +2431,92 @@ export const getDailyOperationsDetailSnapshot = query({
     const { includeManagerReviewEvidence } =
       await authorizeDailyOperationsSnapshot(ctx, args);
 
-    return buildDailyOperationsSnapshotWithCtx(ctx, {
+    const snapshot = await buildDailyOperationsSnapshotWithCtx(ctx, {
       ...args,
       includeAnalyticsDetails: includeManagerReviewEvidence,
       includeFinancialDetails: includeManagerReviewEvidence,
       includeManagerReviewEvidence,
-      includeScheduledRunSummaries: includeManagerReviewEvidence,
-      scheduledRunSummariesLimit: FULL_SCHEDULED_RUN_SUMMARY_LIMIT,
-      timelineLimit: MAX_OPERATIONS_QUERY_LIMIT,
+      includeScheduledRunSummaries: false,
+      includeStorePulseDetails: false,
+      scheduledRunSummariesLimit: 0,
+      timelineLimit: 0,
+      timelinePreviewLimit: 0,
     });
+
+    const weekSnapshots = await buildCompactDailyOperationsWeekSnapshotsWithCtx(
+      ctx,
+      {
+        ...args,
+        includeManagerReviewEvidence,
+      },
+      snapshot.weekMetrics,
+    );
+    return {
+      ...snapshot,
+      weekSnapshots,
+    };
+  },
+});
+
+export const getDailyOperationsStorePulseSnapshot = query({
+  args: dailyOperationsSnapshotArgsValidator,
+  handler: async (ctx, args) => {
+    const { includeManagerReviewEvidence } =
+      await authorizeDailyOperationsSnapshot(ctx, args);
+    const range = resolveRange(args);
+    const storePulse = includeManagerReviewEvidence
+      ? await getStorePulseSummaryForWindow(ctx, {
+          currentDayEnd: range.endAt - 1,
+          currentDayStart: range.startAt,
+          currentOperatingDate: args.operatingDate,
+          pulseWindow: args.storePulseWindow ?? "today",
+          storeId: args.storeId,
+        })
+      : null;
+
+    return {
+      operatingDate: args.operatingDate,
+      storePulse,
+    };
+  },
+});
+
+export const getDailyOperationsTimelineSnapshot = query({
+  args: dailyOperationsSnapshotArgsValidator,
+  handler: async (ctx, args) => {
+    const { includeManagerReviewEvidence } =
+      await authorizeDailyOperationsSnapshot(ctx, args);
+    const range = resolveRange(args);
+
+    return {
+      operatingDate: args.operatingDate,
+      timeline: await listTimelineEvents(ctx, {
+        ...range,
+        includeManagerReviewEvidence,
+        limit: MAX_OPERATIONS_QUERY_LIMIT,
+        storeId: args.storeId,
+      }),
+    };
+  },
+});
+
+export const getDailyOperationsTimelinePreviewSnapshot = query({
+  args: dailyOperationsSnapshotArgsValidator,
+  handler: async (ctx, args) => {
+    const { includeManagerReviewEvidence } =
+      await authorizeDailyOperationsSnapshot(ctx, args);
+    const range = resolveRange(args);
+    const timeline = await listTimelineEvents(ctx, {
+      ...range,
+      includeManagerReviewEvidence,
+      limit: COMPACT_OPERATIONS_TIMELINE_LIMIT + 1,
+      storeId: args.storeId,
+    });
+
+    return {
+      operatingDate: args.operatingDate,
+      timeline: timeline.slice(0, COMPACT_OPERATIONS_TIMELINE_LIMIT),
+      timelineHasMore: timeline.length > COMPACT_OPERATIONS_TIMELINE_LIMIT,
+    };
   },
 });

--- a/packages/athena-webapp/convex/pos/application/queries/storePulse.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/storePulse.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from "vitest";
+import type { Id } from "../../../_generated/dataModel";
+import type { QueryCtx } from "../../../_generated/server";
+import { getStorePulseSummariesForOperatingDateRanges } from "./storePulse";
+
+type TableName = "posTransaction" | "posTransactionItem";
+type Row = Record<string, unknown> & { _id: string };
+
+function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
+  const tables = new Map<TableName, Map<string, Row>>();
+
+  const tableFor = (table: TableName) => {
+    if (!tables.has(table)) {
+      tables.set(table, new Map());
+    }
+
+    return tables.get(table)!;
+  };
+
+  Object.entries(seed).forEach(([tableName, rows]) => {
+    const table = tableFor(tableName as TableName);
+    rows?.forEach((row) => table.set(row._id, { ...row }));
+  });
+
+  const query = (table: TableName) => {
+    const filters: Array<
+      [string, unknown | { gte?: number; lte?: number }]
+    > = [];
+    const filteredRows = () =>
+      Array.from(tableFor(table).values()).filter((row) =>
+        filters.every(([field, value]) => {
+          if (value && typeof value === "object" && !Array.isArray(value)) {
+            if (
+              "gte" in value &&
+              typeof value.gte === "number" &&
+              Number(row[field]) < value.gte
+            ) {
+              return false;
+            }
+
+            if (
+              "lte" in value &&
+              typeof value.lte === "number" &&
+              Number(row[field]) > value.lte
+            ) {
+              return false;
+            }
+
+            return true;
+          }
+
+          return row[field] === value;
+        }),
+      );
+
+    const chain = {
+      async *[Symbol.asyncIterator]() {
+        for (const row of filteredRows()) {
+          yield row;
+        }
+      },
+      withIndex(
+        _index: string,
+        applyIndex: (builder: {
+          eq: (field: string, value: unknown) => typeof builder;
+          gte: (field: string, value: number) => typeof builder;
+          lte: (field: string, value: number) => typeof builder;
+        }) => unknown,
+      ) {
+        const builder = {
+          eq(field: string, value: unknown) {
+            filters.push([field, value]);
+            return builder;
+          },
+          gte(field: string, value: number) {
+            filters.push([field, { gte: value }]);
+            return builder;
+          },
+          lte(field: string, value: number) {
+            filters.push([field, { lte: value }]);
+            return builder;
+          },
+        };
+
+        applyIndex(builder);
+        return chain;
+      },
+    };
+
+    return chain;
+  };
+
+  return { db: { query } } as unknown as QueryCtx;
+}
+
+function transaction({
+  completedAt,
+  id,
+  payments,
+  storeId = "store-1",
+  total,
+}: {
+  completedAt: number;
+  id: string;
+  payments: Array<{ amount: number; method: string }>;
+  storeId?: string;
+  total: number;
+}) {
+  return {
+    _id: id,
+    completedAt,
+    paymentMethod: payments[0]?.method,
+    payments: payments.map((payment) => ({
+      ...payment,
+      timestamp: completedAt,
+    })),
+    status: "completed",
+    storeId,
+    total,
+    totalPaid: total,
+  };
+}
+
+function item({
+  id,
+  productName,
+  quantity,
+  totalPrice,
+  transactionId,
+}: {
+  id: string;
+  productName: string;
+  quantity: number;
+  totalPrice: number;
+  transactionId: string;
+}) {
+  return {
+    _id: id,
+    productId: `${id}-product`,
+    productName,
+    productSku: `${id}-sku`,
+    productSkuId: `${id}-sku-id`,
+    quantity,
+    totalPrice,
+    transactionId,
+  };
+}
+
+describe("getStorePulseSummariesForOperatingDateRanges", () => {
+  it("returns no summaries when no date ranges are provided", async () => {
+    await expect(
+      getStorePulseSummariesForOperatingDateRanges(createDb(), {
+        dateRanges: [],
+        storeId: "store-1" as Id<"store">,
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("aggregates completed transactions into sorted operating-date buckets", async () => {
+    const dayOneStart = Date.UTC(2026, 5, 21, 0);
+    const dayTwoStart = Date.UTC(2026, 5, 22, 0);
+    const dayThreeStart = Date.UTC(2026, 5, 23, 0);
+    const outsideRange = Date.UTC(2026, 5, 23, 2);
+    const ctx = createDb({
+      posTransaction: [
+        transaction({
+          completedAt: dayOneStart + 9 * 60 * 60 * 1000,
+          id: "txn-day-one",
+          payments: [{ amount: 1000, method: "cash" }],
+          total: 1000,
+        }),
+        transaction({
+          completedAt: dayTwoStart + 13 * 60 * 60 * 1000,
+          id: "txn-day-two-mobile",
+          payments: [{ amount: 2500, method: "mobile_money" }],
+          total: 2500,
+        }),
+        transaction({
+          completedAt: dayTwoStart + 13 * 60 * 60 * 1000 + 5,
+          id: "txn-day-two-cash",
+          payments: [{ amount: 1500, method: "cash" }],
+          total: 1500,
+        }),
+        transaction({
+          completedAt: outsideRange,
+          id: "txn-outside-bucket",
+          payments: [{ amount: 5000, method: "cash" }],
+          total: 5000,
+        }),
+      ],
+      posTransactionItem: [
+        item({
+          id: "item-day-one",
+          productName: "Day one item",
+          quantity: 1,
+          totalPrice: 1000,
+          transactionId: "txn-day-one",
+        }),
+        item({
+          id: "item-day-two-mobile",
+          productName: "Mobile item",
+          quantity: 2,
+          totalPrice: 2500,
+          transactionId: "txn-day-two-mobile",
+        }),
+        item({
+          id: "item-day-two-cash",
+          productName: "Cash item",
+          quantity: 3,
+          totalPrice: 1500,
+          transactionId: "txn-day-two-cash",
+        }),
+        item({
+          id: "item-outside",
+          productName: "Outside item",
+          quantity: 10,
+          totalPrice: 5000,
+          transactionId: "txn-outside-bucket",
+        }),
+      ],
+    });
+
+    const summaries = await getStorePulseSummariesForOperatingDateRanges(ctx, {
+      dateRanges: [
+        {
+          endAt: dayOneStart,
+          operatingDate: "2026-06-20",
+          startAt: dayOneStart - 24 * 60 * 60 * 1000,
+        },
+        {
+          endAt: dayThreeStart,
+          operatingDate: "2026-06-22",
+          startAt: dayTwoStart,
+        },
+        {
+          endAt: dayTwoStart,
+          operatingDate: "2026-06-21",
+          startAt: dayOneStart,
+        },
+      ],
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(summaries.map((summary) => summary.date)).toEqual([
+      "2026-06-20",
+      "2026-06-21",
+      "2026-06-22",
+    ]);
+    expect(summaries[0]).toMatchObject({
+      averageTransaction: 0,
+      totalItemsSold: 0,
+      totalSales: 0,
+      totalTransactions: 0,
+    });
+    expect(summaries[0]?.operatorSnapshot).toMatchObject({
+      busiestHour: null,
+      paymentMix: [],
+      topItems: [],
+      usableHistoryDays: 0,
+    });
+    expect(summaries[1]).toMatchObject({
+      averageTransaction: 1000,
+      totalItemsSold: 1,
+      totalSales: 1000,
+      totalTransactions: 1,
+    });
+    expect(summaries[1]?.operatorSnapshot.paymentMix).toEqual([
+      expect.objectContaining({ count: 1, method: "cash", share: 100, total: 1000 }),
+    ]);
+    expect(summaries[1]?.operatorSnapshot.topItems).toEqual([
+      expect.objectContaining({
+        name: "Day one item",
+        quantity: 1,
+        totalSales: 1000,
+      }),
+    ]);
+    expect(summaries[2]).toMatchObject({
+      averageTransaction: 2000,
+      totalItemsSold: 5,
+      totalSales: 4000,
+      totalTransactions: 2,
+    });
+    expect(summaries[2]?.operatorSnapshot.busiestHour).toMatchObject({
+      hour: 13,
+      totalSales: 4000,
+      transactionCount: 2,
+    });
+    expect(summaries[2]?.operatorSnapshot.paymentMix).toEqual([
+      expect.objectContaining({
+        count: 1,
+        method: "mobile_money",
+        share: 63,
+        total: 2500,
+      }),
+      expect.objectContaining({ count: 1, method: "cash", share: 38, total: 1500 }),
+    ]);
+    expect(summaries[2]?.operatorSnapshot.topItems).toEqual([
+      expect.objectContaining({
+        name: "Cash item",
+        quantity: 3,
+        totalSales: 1500,
+      }),
+      expect.objectContaining({
+        name: "Mobile item",
+        quantity: 2,
+        totalSales: 2500,
+      }),
+    ]);
+    expect(
+      summaries
+        .flatMap((summary) => summary.operatorSnapshot.topItems)
+        .map((topItem) => topItem.name),
+    ).not.toContain("Outside item");
+  });
+});

--- a/packages/athena-webapp/convex/pos/application/queries/storePulse.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/storePulse.ts
@@ -148,6 +148,189 @@ export async function getStorePulseSummaryForWindow(
   };
 }
 
+export async function getStorePulseSummariesForOperatingDateRanges(
+  ctx: QueryCtx,
+  args: {
+    dateRanges: Array<{
+      endAt: number;
+      operatingDate: string;
+      startAt: number;
+    }>;
+    storeId: Id<"store">;
+  },
+) {
+  if (!args.dateRanges.length) return [];
+
+  const orderedDateRanges = [...args.dateRanges].sort(
+    (first, second) => first.startAt - second.startAt,
+  );
+  const rangeStart = orderedDateRanges[0]!.startAt;
+  const rangeEnd = orderedDateRanges.at(-1)!.endAt - 1;
+  const transactions = await listCompletedTransactionsForRange(ctx, {
+    completedFrom: rangeStart,
+    completedTo: rangeEnd,
+    storeId: args.storeId,
+  });
+  const bucketByDate = new Map(
+    orderedDateRanges.map((range) => [
+      range.operatingDate,
+      {
+        hourBuckets: new Map<
+          number,
+          { hour: number; totalSales: number; transactionCount: number }
+        >(),
+        itemBuckets: new Map<string, PosOperatorItemBucket>(),
+        paymentBuckets: new Map<string, PosOperatorPaymentBucket>(),
+        totalItemsSold: 0,
+        totalSales: 0,
+        totalTransactions: 0,
+      },
+    ]),
+  );
+
+  for (const transaction of transactions) {
+    const operatingRange = orderedDateRanges.find(
+      (range) =>
+        transaction.completedAt >= range.startAt &&
+        transaction.completedAt < range.endAt,
+    );
+    if (!operatingRange) continue;
+
+    const bucket = bucketByDate.get(operatingRange.operatingDate);
+    if (!bucket) continue;
+
+    bucket.totalSales += transaction.total;
+    bucket.totalTransactions += 1;
+
+    const hour = new Date(transaction.completedAt).getUTCHours();
+    const hourBucket = bucket.hourBuckets.get(hour) ?? {
+      hour,
+      totalSales: 0,
+      transactionCount: 0,
+    };
+    hourBucket.totalSales += transaction.total;
+    hourBucket.transactionCount += 1;
+    bucket.hourBuckets.set(hour, hourBucket);
+
+    for (const payment of transactionPaymentTotals(transaction)) {
+      const method = payment.method || "unknown";
+      const existing = bucket.paymentBuckets.get(method) ?? {
+        count: 0,
+        label: formatPaymentMethodLabel(method),
+        method,
+        share: 0,
+        total: 0,
+      };
+      existing.count += 1;
+      existing.total += payment.amount;
+      bucket.paymentBuckets.set(method, existing);
+    }
+
+    const items = await listTransactionItems(ctx, transaction._id);
+    bucket.totalItemsSold += items.reduce(
+      (sum, item) => sum + item.quantity,
+      0,
+    );
+
+    for (const item of items) {
+      const key = `${item.productId}:${item.productSkuId}`;
+      const existing = bucket.itemBuckets.get(key) ?? {
+        name: item.productName,
+        productSku: item.productSku || null,
+        quantity: 0,
+        totalSales: 0,
+      };
+      existing.quantity += item.quantity;
+      existing.totalSales += item.totalPrice;
+      bucket.itemBuckets.set(key, existing);
+    }
+  }
+
+  return orderedDateRanges.map((range) => {
+    const bucket = bucketByDate.get(range.operatingDate)!;
+    const averageTransaction =
+      bucket.totalTransactions > 0
+        ? bucket.totalSales / bucket.totalTransactions
+        : 0;
+    const totalPaymentSales = Array.from(bucket.paymentBuckets.values()).reduce(
+      (sum, payment) => sum + payment.total,
+      0,
+    );
+    const paymentMix = Array.from(bucket.paymentBuckets.values())
+      .map((payment) => ({
+        ...payment,
+        share:
+          totalPaymentSales > 0
+            ? Math.round((payment.total / totalPaymentSales) * 100)
+            : 0,
+      }))
+      .sort((first, second) => second.total - first.total)
+      .slice(0, 4);
+    const topItems = Array.from(bucket.itemBuckets.values())
+      .sort((first, second) => {
+        if (second.quantity !== first.quantity) {
+          return second.quantity - first.quantity;
+        }
+        return second.totalSales - first.totalSales;
+      })
+      .slice(0, 10);
+    const busiestHour = Array.from(bucket.hourBuckets.values()).sort(
+      (first, second) => {
+        if (second.transactionCount !== first.transactionCount) {
+          return second.transactionCount - first.transactionCount;
+        }
+        return second.totalSales - first.totalSales;
+      },
+    )[0];
+    const trendDay = {
+      averageTransaction,
+      date: range.operatingDate,
+      label: formatShortDate(range.operatingDate),
+      totalItemsSold: bucket.totalItemsSold,
+      totalSales: bucket.totalSales,
+      transactionCount: bucket.totalTransactions,
+    };
+
+    return {
+      averageTransaction,
+      date: range.operatingDate,
+      operatorSnapshot: {
+        busiestHour: busiestHour
+          ? {
+              hour: busiestHour.hour,
+              label: formatHourLabel(busiestHour.hour),
+              totalSales: busiestHour.totalSales,
+              transactionCount: busiestHour.transactionCount,
+            }
+          : null,
+        comparison: {
+          averageTransactionDeltaPercent: 0,
+          currentAverageTransaction: averageTransaction,
+          currentItemsSold: bucket.totalItemsSold,
+          currentSales: bucket.totalSales,
+          currentTransactions: bucket.totalTransactions,
+          itemsSoldDeltaPercent: 0,
+          salesDeltaPercent: 0,
+          transactionDeltaPercent: 0,
+          yesterdayAverageTransaction: 0,
+          yesterdayItemsSold: 0,
+          yesterdaySales: 0,
+          yesterdayTransactions: 0,
+        },
+        historyDays: 1,
+        isLimited: false,
+        paymentMix,
+        topItems,
+        trend: [trendDay],
+        usableHistoryDays: bucket.totalTransactions > 0 ? 1 : 0,
+      },
+      totalItemsSold: bucket.totalItemsSold,
+      totalSales: bucket.totalSales,
+      totalTransactions: bucket.totalTransactions,
+    };
+  });
+}
+
 export async function summarizePosPulseTransactions(
   ctx: QueryCtx,
   transactions: Array<{ _id: Id<"posTransaction">; total: number }>,

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 16 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, cycleCountDrafts.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 8 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCaseTracing.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 19 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 611 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 613 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 9 file(s); key children: README.md, SUMMARY.md, pos, prod.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -123,6 +123,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/pos/application/posSessionTracing.test.ts`](../../convex/pos/application/posSessionTracing.test.ts)
 - [`convex/pos/application/queries/listRegisterCatalog.test.ts`](../../convex/pos/application/queries/listRegisterCatalog.test.ts)
 - [`convex/pos/application/queries/searchCatalog.test.ts`](../../convex/pos/application/queries/searchCatalog.test.ts)
+- [`convex/pos/application/queries/storePulse.test.ts`](../../convex/pos/application/queries/storePulse.test.ts)
 - [`convex/pos/application/queries/terminals.test.ts`](../../convex/pos/application/queries/terminals.test.ts)
 - [`convex/pos/application/sessionCommands.test.ts`](../../convex/pos/application/sessionCommands.test.ts)
 - [`convex/pos/application/sync/ingestLocalEvents.test.ts`](../../convex/pos/application/sync/ingestLocalEvents.test.ts)

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -1,13 +1,5 @@
-import {
-  fireEvent,
-  render,
-  screen,
-  within,
-} from "@testing-library/react";
-import React, {
-  type AnchorHTMLAttributes,
-  type ReactNode,
-} from "react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import React, { type AnchorHTMLAttributes, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -28,6 +20,10 @@ const mockedHooks = vi.hoisted(() => ({
 const mockedApi = vi.hoisted(() => ({
   getDailyOperationsDetailSnapshot: "getDailyOperationsDetailSnapshot",
   getDailyOperationsSnapshot: "getDailyOperationsSnapshot",
+  getDailyOperationsStorePulseSnapshot: "getDailyOperationsStorePulseSnapshot",
+  getDailyOperationsTimelinePreviewSnapshot:
+    "getDailyOperationsTimelinePreviewSnapshot",
+  getDailyOperationsTimelineSnapshot: "getDailyOperationsTimelineSnapshot",
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -76,17 +72,50 @@ vi.mock("@/hooks/use-mobile", () => ({
 }));
 
 vi.mock("recharts", () => ({
-  Area: () => <path data-testid="store-pulse-area" />,
+  Area: ({
+    animateNewValues,
+    animationBegin,
+    animationDuration,
+    animationEasing,
+    animationId,
+    "data-replay-key": replayKey,
+    isAnimationActive,
+    pathLength,
+  }: {
+    animateNewValues?: boolean;
+    animationBegin?: number;
+    animationDuration?: number;
+    animationEasing?: string;
+    animationId?: number;
+    "data-replay-key"?: string;
+    isAnimationActive?: boolean;
+    pathLength?: number;
+  }) => (
+    <path
+      data-animate-new-values={String(Boolean(animateNewValues))}
+      data-animation-begin={animationBegin ?? ""}
+      data-animation-duration={animationDuration ?? ""}
+      data-animation-easing={animationEasing ?? ""}
+      data-animation-id={animationId ?? ""}
+      data-animation-active={String(Boolean(isAnimationActive))}
+      data-path-length={pathLength ?? ""}
+      data-replay-key={replayKey ?? ""}
+      data-testid="store-pulse-area"
+    />
+  ),
   AreaChart: ({
     children,
+    className,
     data = [],
     margin,
   }: {
     children?: React.ReactNode;
+    className?: string;
     data?: Array<{ displayDate?: string; displayLabel?: string }>;
     margin?: { bottom?: number; left?: number; right?: number; top?: number };
   }) => (
     <svg
+      className={className}
       data-display-dates={data.map((day) => day.displayDate).join("|")}
       data-display-labels={data.map((day) => day.displayLabel).join("|")}
       data-margin-right={margin?.right ?? ""}
@@ -105,7 +134,9 @@ vi.mock("recharts", () => ({
   }) => (
     <g
       data-testid="store-pulse-x-axis"
-      data-tick-labels={ticks?.map((tick) => tickFormatter?.(tick)).join("|") ?? ""}
+      data-tick-labels={
+        ticks?.map((tick) => tickFormatter?.(tick)).join("|") ?? ""
+      }
       data-ticks={ticks?.join("|") ?? ""}
     />
   ),
@@ -208,10 +239,20 @@ const weekMetrics = [
   },
 ] satisfies DailyOperationsSnapshot["weekMetrics"];
 
-function buildStorePulseSummary(): NonNullable<DailyOperationsSnapshot["storePulse"]> {
+function buildStorePulseSummary({
+  date = "2026-06-20",
+  itemName = "Braiding hair",
+  paymentLabel = "Cash",
+  paymentMethod = "cash",
+}: {
+  date?: string;
+  itemName?: string;
+  paymentLabel?: string;
+  paymentMethod?: string;
+} = {}): NonNullable<DailyOperationsSnapshot["storePulse"]> {
   return {
     averageTransaction: 6_250,
-    date: "2026-06-20",
+    date,
     operatorSnapshot: {
       busiestHour: {
         hour: 14,
@@ -238,8 +279,8 @@ function buildStorePulseSummary(): NonNullable<DailyOperationsSnapshot["storePul
       paymentMix: [
         {
           count: 1,
-          label: "Cash",
-          method: "cash",
+          label: paymentLabel,
+          method: paymentMethod,
           share: 60,
           total: 7_500,
         },
@@ -253,7 +294,7 @@ function buildStorePulseSummary(): NonNullable<DailyOperationsSnapshot["storePul
       ],
       topItems: [
         {
-          name: "Braiding hair",
+          name: itemName,
           productSku: "BRAID-1",
           quantity: 2,
           totalSales: 8_000,
@@ -270,8 +311,8 @@ function buildStorePulseSummary(): NonNullable<DailyOperationsSnapshot["storePul
         },
         {
           averageTransaction: 6_250,
-          date: "2026-06-20",
-          label: "Jun 20",
+          date,
+          label: "Selected day",
           totalItemsSold: 3,
           totalSales: 12_500,
           transactionCount: 2,
@@ -347,13 +388,35 @@ const operatingSnapshot: DailyOperationsSnapshot = {
   weekMetrics,
 };
 
+function buildWeekSnapshots(): DailyOperationsSnapshot[] {
+  return weekMetrics.map((metric) => ({
+    ...operatingSnapshot,
+    closeSummary: {
+      ...operatingSnapshot.closeSummary,
+      currentDayCashTotal: metric.currentDayCashTotal,
+      currentDayCashTransactionCount: metric.currentDayCashTransactionCount,
+      expenseTotal: metric.expenseTotal,
+      expenseTransactionCount: metric.expenseTransactionCount,
+      salesTotal: metric.salesTotal,
+      transactionCount: metric.transactionCount,
+    },
+    operatingDate: metric.operatingDate,
+    storePulse: undefined,
+    weekMetrics: weekMetrics.map((weekMetric) => ({
+      ...weekMetric,
+      isSelected: weekMetric.operatingDate === metric.operatingDate,
+    })),
+  }));
+}
+
 const blockedSnapshot: DailyOperationsSnapshot = {
   ...operatingSnapshot,
   attentionItems: [
     {
       id: "register_session:register-1:open",
       label: "Register session is still open",
-      message: "Close the register session before completing the end of day review.",
+      message:
+        "Close the register session before completing the end of day review.",
       owner: "daily_close",
       severity: "critical",
       source: {
@@ -417,7 +480,7 @@ const closedSnapshot: DailyOperationsSnapshot = {
     status: "closed",
   },
   primaryAction: {
-      label: "Review EOD Review",
+    label: "Review EOD Review",
     to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
   },
   timeline: [
@@ -695,8 +758,7 @@ const automationReviewSnapshot: DailyOperationsSnapshot = {
         {
           id: "register-session-review",
           label: "Register session still needs closeout",
-          message:
-            "Close the carried-over register session in Cash Controls.",
+          message: "Close the carried-over register session in Cash Controls.",
           source: {
             id: "session-1",
             label: "Register 1",
@@ -872,6 +934,16 @@ function renderContent(
     React.ComponentProps<typeof DailyOperationsViewContent>
   > = {},
 ) {
+  const defaultTimelinePreviewSnapshot =
+    snapshot && !overrides.timelinePreviewSnapshot
+      ? {
+          operatingDate: snapshot.operatingDate,
+          timeline: snapshot.timeline.slice(0, 5),
+          timelineHasMore:
+            snapshot.timelineHasMore ?? snapshot.timeline.length > 5,
+        }
+      : undefined;
+
   return render(
     <DailyOperationsViewContent
       currency="GHS"
@@ -885,6 +957,7 @@ function renderContent(
       snapshot={snapshot}
       storePulseWindow="today"
       storeUrlSlug="osu"
+      timelinePreviewSnapshot={defaultTimelinePreviewSnapshot}
       {...overrides}
     />,
   );
@@ -946,7 +1019,9 @@ describe("DailyOperationsViewContent", () => {
     expect(screen.getByText("2 payments")).toBeInTheDocument();
     expect(screen.getByText("Carried-over cash")).toBeInTheDocument();
     expect(screen.getAllByText("GH₵0")).not.toHaveLength(0);
-    expect(screen.getByText("No registers from prior days")).toBeInTheDocument();
+    expect(
+      screen.getByText("No registers from prior days"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Expenses")).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: "Open expense reports" }),
@@ -1050,10 +1125,12 @@ describe("DailyOperationsViewContent", () => {
     renderContent({
       ...operatingSnapshot,
       operatingDate: getCurrentLocalOperatingDate(),
+      storePulse: buildStorePulseSummary(),
     });
 
     expect(screen.getByText("Today's net sales")).toBeInTheDocument();
     expect(screen.getByText("Today's cash")).toBeInTheDocument();
+    expect(screen.getByText("Today's top items")).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: "Open transactions" }),
     ).toHaveAttribute(
@@ -1161,7 +1238,9 @@ describe("DailyOperationsViewContent", () => {
         screen.getByRole("heading", { name: "Week at a glance" }),
       ) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
-    expect(screen.getByText("Athena started Opening Handoff.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Athena started Opening Handoff."),
+    ).toBeInTheDocument();
     expect(
       screen.getByText("Athena prepared EOD Review for manager review."),
     ).toBeInTheDocument();
@@ -1172,8 +1251,13 @@ describe("DailyOperationsViewContent", () => {
     expect(closeAutomationMessage).not.toHaveClass("truncate");
     expect(closeAutomationMessage).toHaveClass("break-words", "leading-5");
     expect(
-      screen.getByRole("link", { name: "Open Opening Handoff automation source" }),
-    ).toHaveAttribute("href", "/wigclub/store/osu/operations/opening?o=%252Fwigclub%252Fstore%252Fosu%252Foperations");
+      screen.getByRole("link", {
+        name: "Open Opening Handoff automation source",
+      }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/operations/opening?o=%252Fwigclub%252Fstore%252Fosu%252Foperations",
+    );
     expect(
       screen.getByRole("link", { name: "Open EOD Review automation source" }),
     ).toHaveAttribute(
@@ -1208,7 +1292,9 @@ describe("DailyOperationsViewContent", () => {
       screen.getByText("Athena completed EOD Review under store policy."),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("Policy checked low-risk review evidence before completion."),
+      screen.getByText(
+        "Policy checked low-risk review evidence before completion.",
+      ),
     ).toBeInTheDocument();
     expect(
       screen.queryByText(
@@ -1254,7 +1340,9 @@ describe("DailyOperationsViewContent", () => {
       screen.getByText("Restricted close evidence is hidden for this account."),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText("Policy checked low-risk review evidence and preserved carry-forward work for Opening."),
+      screen.queryByText(
+        "Policy checked low-risk review evidence and preserved carry-forward work for Opening.",
+      ),
     ).not.toBeInTheDocument();
   });
 
@@ -1270,7 +1358,9 @@ describe("DailyOperationsViewContent", () => {
     expect(
       screen.queryByText(/Checkout completion ran/i),
     ).not.toBeInTheDocument();
-    expect(screen.queryByText(/provider|exception|stack/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/provider|exception|stack/i),
+    ).not.toBeInTheDocument();
   });
 
   it("renders store pulse visualizations in the main workspace when provided", () => {
@@ -1303,25 +1393,28 @@ describe("DailyOperationsViewContent", () => {
       "data-display-labels",
       "Sun, May 3|Mon, May 4|Tue, May 5|Wed, May 6|Thu, May 7|Fri, May 8",
     );
-    expect(within(storePulse).getByTestId("store-pulse-x-axis")).toHaveAttribute(
-      "data-ticks",
-      "0|1|2|3|4|5",
-    );
+    expect(
+      within(storePulse).getByTestId("store-pulse-x-axis"),
+    ).toHaveAttribute("data-ticks", "0|1|2|3|4|5");
     expect(chart).toHaveAttribute("data-margin-right", "72");
     expect(within(storePulse).getByText("Braiding Hair")).toBeInTheDocument();
-    expect(
-      within(storePulse).getByText("Today's top items"),
-    ).toBeInTheDocument();
+    expect(within(storePulse).getByText("Top items")).toBeInTheDocument();
     expect(
       within(storePulse).getByLabelText("Total items sold: 3"),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Store-day timeline")).toBeInTheDocument();
     expect(within(storePulse).queryByRole("tablist")).not.toBeInTheDocument();
-    expect(within(storePulse).queryByText("Average sale")).not.toBeInTheDocument();
-    expect(within(storePulse).queryByText("Items sold")).not.toBeInTheDocument();
+    expect(
+      within(storePulse).queryByText("Average sale"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(storePulse).queryByText("Items sold"),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("Store pulse")).not.toBeInTheDocument();
     expect(
-      screen.queryByText("POS sales activity for the selected reporting window."),
+      screen.queryByText(
+        "POS sales activity for the selected reporting window.",
+      ),
     ).not.toBeInTheDocument();
     expect(
       within(storePulse).getByText("This week's completed POS sales."),
@@ -1352,16 +1445,15 @@ describe("DailyOperationsViewContent", () => {
     );
   });
 
-  it("shows a bounded empty state when store pulse is omitted", () => {
+  it("omits store pulse detail when no pulse data or request handler is available", () => {
     renderContent(operatingSnapshot);
 
-    expect(screen.getByText("Store pulse unavailable")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "Store pulse is not available for this view. Financially restricted or historical snapshots can omit POS pulse details.",
-      ),
-    ).toBeInTheDocument();
-    expect(screen.queryByLabelText("Store pulse loading")).not.toBeInTheDocument();
+      screen.queryByRole("region", { name: "Store pulse" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Store pulse loading"),
+    ).not.toBeInTheDocument();
   });
 
   it("surfaces Opening auto-start review evidence for managers", () => {
@@ -1375,7 +1467,9 @@ describe("DailyOperationsViewContent", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Pending checkout")).toBeInTheDocument();
     expect(screen.getByText("4")).toBeInTheDocument();
-    expect(screen.getByText("2 other manager review items")).toBeInTheDocument();
+    expect(
+      screen.getByText("2 other manager review items"),
+    ).toBeInTheDocument();
     expect(
       screen.queryByText("Register session still needs closeout"),
     ).not.toBeInTheDocument();
@@ -1429,9 +1523,9 @@ describe("DailyOperationsViewContent", () => {
       .getByText("Today's net sales")
       .closest("a,article,div");
 
-    expect(screen.getAllByRole("heading", { name: "Opening review" })).toHaveLength(
-      1,
-    );
+    expect(
+      screen.getAllByRole("heading", { name: "Opening review" }),
+    ).toHaveLength(1);
     expect(automationPanel?.compareDocumentPosition(openingReview!)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
@@ -1843,8 +1937,12 @@ describe("DailyOperationsViewContent", () => {
     expect(
       screen.getByRole("heading", { name: "Historical store-day view" }),
     ).toBeInTheDocument();
-    expect(screen.queryByLabelText("Operator attention")).not.toBeInTheDocument();
-    expect(screen.queryByText("Register session is still open")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Operator attention"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Register session is still open"),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps historical EOD Review links on the selected operating date", () => {
@@ -1903,7 +2001,12 @@ describe("DailyOperationsViewContent", () => {
   });
 
   it("previews the five most recent timeline events and opens the full list in a sheet", () => {
-    renderContent(timelineOverflowSnapshot);
+    renderContent(timelineOverflowSnapshot, {
+      timelineSnapshot: {
+        operatingDate: timelineOverflowSnapshot.operatingDate,
+        timeline: timelineOverflowSnapshot.timeline,
+      },
+    });
 
     const timeline = screen.getByRole("region", {
       name: "Store-day timeline",
@@ -1915,7 +2018,9 @@ describe("DailyOperationsViewContent", () => {
       within(timeline).queryByText("Timeline event 6"),
     ).not.toBeInTheDocument();
 
-    fireEvent.click(within(timeline).getByRole("button", { name: "Show more" }));
+    fireEvent.click(
+      within(timeline).getByRole("button", { name: "Show more" }),
+    );
 
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getAllByText("Store-day timeline")).not.toHaveLength(0);
@@ -1927,10 +2032,10 @@ describe("DailyOperationsViewContent", () => {
   });
 
   it("offers timeline detail when the compact snapshot has hidden events", () => {
-    const onRequestDetailSnapshot = vi.fn();
+    const onRequestTimelineSnapshot = vi.fn();
 
     renderContent(compactTimelineOverflowSnapshot, {
-      onRequestDetailSnapshot,
+      onRequestTimelineSnapshot,
     });
 
     const timeline = screen.getByRole("region", {
@@ -1941,10 +2046,13 @@ describe("DailyOperationsViewContent", () => {
       within(timeline).getByText("Compact timeline event 5"),
     ).toBeInTheDocument();
 
-    fireEvent.click(within(timeline).getByRole("button", { name: "Show more" }));
+    fireEvent.click(
+      within(timeline).getByRole("button", { name: "Show more" }),
+    );
 
-    expect(onRequestDetailSnapshot).toHaveBeenCalledTimes(1);
+    expect(onRequestTimelineSnapshot).toHaveBeenCalledTimes(1);
     expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Timeline loading")).toBeInTheDocument();
   });
 
   it("links quick-add product names to the product detail page with origin search", () => {
@@ -1954,9 +2062,7 @@ describe("DailyOperationsViewContent", () => {
 
     expect(productLink).toHaveAttribute(
       "href",
-      expect.stringContaining(
-        "/wigclub/store/osu/products/product-1?o=",
-      ),
+      expect.stringContaining("/wigclub/store/osu/products/product-1?o="),
     );
     expect(productLink).toHaveAttribute(
       "href",
@@ -2093,9 +2199,7 @@ describe("DailyOperationsViewContent", () => {
 
     expect(skuLink).toHaveAttribute(
       "href",
-      expect.stringContaining(
-        "/wigclub/store/osu/products/product-1?o=",
-      ),
+      expect.stringContaining("/wigclub/store/osu/products/product-1?o="),
     );
     expect(skuLink).toHaveAttribute(
       "href",
@@ -2146,10 +2250,22 @@ describe("DailyOperationsView", () => {
     (
       mockedApi as { getDailyOperationsSnapshot?: unknown }
     ).getDailyOperationsSnapshot = "getDailyOperationsSnapshot";
+    (
+      mockedApi as { getDailyOperationsStorePulseSnapshot?: unknown }
+    ).getDailyOperationsStorePulseSnapshot =
+      "getDailyOperationsStorePulseSnapshot";
+    (
+      mockedApi as { getDailyOperationsTimelinePreviewSnapshot?: unknown }
+    ).getDailyOperationsTimelinePreviewSnapshot =
+      "getDailyOperationsTimelinePreviewSnapshot";
+    (
+      mockedApi as { getDailyOperationsTimelineSnapshot?: unknown }
+    ).getDailyOperationsTimelineSnapshot = "getDailyOperationsTimelineSnapshot";
     window.scrollTo = vi.fn();
     mockedHooks.useProtectedAdminPageState.mockReturnValue({
       activeStore: { _id: "store-1", currency: "GHS" },
       canQueryProtectedData: true,
+      hasFinancialDetailsAccess: true,
       hasFullAdminAccess: true,
       isAuthenticated: true,
       isLoadingAccess: false,
@@ -2178,19 +2294,8 @@ describe("DailyOperationsView", () => {
     ).toBeInTheDocument();
   });
 
-  it("skips analytics detail until explicitly requested", () => {
+  it("hydrates analytics detail on initial load for an uncached week", () => {
     render(<DailyOperationsView />);
-
-    expect(mockedHooks.useQuery).toHaveBeenCalledWith(
-      mockedApi.getDailyOperationsDetailSnapshot,
-      "skip",
-    );
-  });
-
-  it("queries analytics detail through the explicit companion query after request", () => {
-    render(<DailyOperationsView />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Load analytics" }));
 
     expect(mockedHooks.useQuery).toHaveBeenCalledWith(
       mockedApi.getDailyOperationsDetailSnapshot,
@@ -2203,10 +2308,403 @@ describe("DailyOperationsView", () => {
     );
   });
 
-  it("does not carry a detail request across operating-date changes", () => {
+  it("mirrors the analytics layout before detail is loaded", () => {
+    mockedHooks.useQuery.mockImplementation((query, args) => {
+      if (args === "skip") return undefined;
+      if (query === mockedApi.getDailyOperationsDetailSnapshot) {
+        return undefined;
+      }
+      return operatingSnapshot;
+    });
+    render(<DailyOperationsView />);
+
+    expect(
+      screen.getByRole("heading", { name: "Week at a glance" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Week sales")).toBeInTheDocument();
+    expect(screen.getAllByText("Loading analytics").length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("button", {
+        name: "Load analytics for week at a glance",
+      }),
+    ).toBeInTheDocument();
+
+    const storePulse = screen.getByRole("region", { name: "Store pulse" });
+
+    expect(
+      within(storePulse).getByRole("button", {
+        name: "Load analytics for sales trend",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(storePulse).getByRole("heading", { name: "Sales trend" }),
+    ).toBeInTheDocument();
+    expect(
+      within(storePulse).getByTestId("sales-trend-preview-grid"),
+    ).toBeInTheDocument();
+    expect(
+      within(storePulse).queryByTestId("sales-trend-preview-line"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(storePulse).getByText("Store pulse detail loads with analytics."),
+    ).toBeInTheDocument();
+    expect(
+      within(storePulse).getByRole("heading", { name: "Top items" }),
+    ).toBeInTheDocument();
+    expect(
+      within(storePulse).getByRole("heading", { name: "How customers paid" }),
+    ).toBeInTheDocument();
+  });
+
+  it("uses the explicit companion query for analytics hydration", () => {
+    render(<DailyOperationsView />);
+
+    expect(mockedHooks.useQuery).toHaveBeenCalledWith(
+      mockedApi.getDailyOperationsDetailSnapshot,
+      expect.objectContaining({
+        operatingTimezoneOffsetMinutes: expect.any(Number),
+        storeId: "store-1",
+        storePulseWindow: "today",
+        weekEndOperatingDate: getCurrentSaturdayWeekEndOperatingDate(),
+      }),
+    );
+  });
+
+  it("queries analytics detail when the empty analytics shell is clicked", () => {
+    mockedHooks.useQuery.mockImplementation((query, args) => {
+      if (args === "skip") return undefined;
+      if (query === mockedApi.getDailyOperationsDetailSnapshot) {
+        return undefined;
+      }
+      return operatingSnapshot;
+    });
+    render(<DailyOperationsView />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Load analytics for week at a glance",
+      }),
+    );
+
+    expect(mockedHooks.useQuery).toHaveBeenCalledWith(
+      mockedApi.getDailyOperationsDetailSnapshot,
+      expect.objectContaining({
+        operatingTimezoneOffsetMinutes: expect.any(Number),
+        storeId: "store-1",
+        storePulseWindow: "today",
+        weekEndOperatingDate: getCurrentSaturdayWeekEndOperatingDate(),
+      }),
+    );
+  });
+
+  it("queries selected-day store pulse detail on mount when auto hydration is enabled", () => {
+    mockedHooks.useQuery.mockImplementation((query, args) => {
+      if (args === "skip") return undefined;
+      if (query === mockedApi.getDailyOperationsStorePulseSnapshot) {
+        return undefined;
+      }
+      return operatingSnapshot;
+    });
+    render(<DailyOperationsView />);
+
+    expect(mockedHooks.useQuery).toHaveBeenCalledWith(
+      mockedApi.getDailyOperationsStorePulseSnapshot,
+      expect.objectContaining({
+        operatingTimezoneOffsetMinutes: expect.any(Number),
+        storeId: "store-1",
+        storePulseWindow: "today",
+        weekEndOperatingDate: getCurrentSaturdayWeekEndOperatingDate(),
+      }),
+    );
+  });
+
+  it("keeps the week chart stable when selected-day pulse detail hydrates", async () => {
+    let shouldReturnPulseDetail = false;
+
+    mockedHooks.useQuery.mockImplementation((query, args) => {
+      if (args === "skip") return undefined;
+      if (query === mockedApi.getDailyOperationsDetailSnapshot) {
+        return {
+          ...operatingSnapshot,
+          weekSnapshots: buildWeekSnapshots(),
+        };
+      }
+      if (query === mockedApi.getDailyOperationsStorePulseSnapshot) {
+        if (!shouldReturnPulseDetail) return undefined;
+
+        return {
+          operatingDate: "2026-05-08",
+          storePulse: buildStorePulseSummary({
+            date: "2026-05-08",
+            itemName: "Hydrated selected item",
+            paymentLabel: "Mobile Money",
+            paymentMethod: "mobile_money",
+          }),
+        };
+      }
+      return operatingSnapshot;
+    });
+    mockedHooks.useSearch.mockReturnValue({
+      operatingDate: "2026-05-08",
+      weekEndOperatingDate: "2026-05-09",
+    });
     const view = render(<DailyOperationsView />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Load analytics" }));
+    expect(await screen.findByText(/Data refreshed at /)).toBeInTheDocument();
+    const chart = screen.getByTestId("store-pulse-chart");
+    const replayKey = screen
+      .getByTestId("store-pulse-area")
+      .getAttribute("data-replay-key");
+
+    expect(chart).toHaveAttribute(
+      "data-display-labels",
+      "Sun, May 3|Mon, May 4|Tue, May 5|Wed, May 6|Thu, May 7|Fri, May 8",
+    );
+
+    shouldReturnPulseDetail = true;
+    view.rerender(<DailyOperationsView />);
+
+    expect(
+      await screen.findByText("Hydrated Selected Item"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Mobile Money")).toBeInTheDocument();
+    expect(screen.getByTestId("store-pulse-chart")).toHaveAttribute(
+      "data-display-labels",
+      "Sun, May 3|Mon, May 4|Tue, May 5|Wed, May 6|Thu, May 7|Fri, May 8",
+    );
+    expect(screen.getByTestId("store-pulse-area")).toHaveAttribute(
+      "data-replay-key",
+      replayKey,
+    );
+  });
+
+  it("queries timeline detail separately when the timeline asks for more", () => {
+    mockedHooks.useQuery.mockImplementation((query, args) => {
+      if (args === "skip") return undefined;
+      if (query === mockedApi.getDailyOperationsTimelinePreviewSnapshot) {
+        return compactTimelineOverflowSnapshot;
+      }
+      if (query === mockedApi.getDailyOperationsTimelineSnapshot) {
+        return {
+          operatingDate: compactTimelineOverflowSnapshot.operatingDate,
+          timeline: timelineOverflowSnapshot.timeline,
+        };
+      }
+      return compactTimelineOverflowSnapshot;
+    });
+    render(<DailyOperationsView />);
+
+    const timeline = screen.getByRole("region", {
+      name: "Store-day timeline",
+    });
+
+    fireEvent.click(
+      within(timeline).getByRole("button", { name: "Show more" }),
+    );
+
+    expect(mockedHooks.useQuery).toHaveBeenCalledWith(
+      mockedApi.getDailyOperationsTimelineSnapshot,
+      expect.objectContaining({
+        operatingTimezoneOffsetMinutes: expect.any(Number),
+        storeId: "store-1",
+      }),
+    );
+    expect(mockedHooks.useQuery).toHaveBeenCalledWith(
+      mockedApi.getDailyOperationsDetailSnapshot,
+      expect.objectContaining({
+        operatingTimezoneOffsetMinutes: expect.any(Number),
+        storeId: "store-1",
+      }),
+    );
+  });
+
+  it("renders the store-day timeline from the separate preview query", () => {
+    mockedHooks.useQuery.mockImplementation((query, args) => {
+      if (args === "skip") return undefined;
+      if (query === mockedApi.getDailyOperationsTimelinePreviewSnapshot) {
+        return {
+          operatingDate: operatingSnapshot.operatingDate,
+          timeline: [
+            {
+              createdAt: Date.UTC(2026, 4, 8, 23),
+              id: "fresh-preview-event",
+              message: "Latest preview event from timeline query.",
+              subject: {
+                id: "timeline-preview",
+                type: "operations",
+              },
+              type: "operations.event",
+            },
+          ],
+          timelineHasMore: false,
+        };
+      }
+
+      return {
+        ...operatingSnapshot,
+        timeline: [
+          {
+            createdAt: Date.UTC(2026, 4, 8, 8),
+            id: "stale-main-snapshot-event",
+            message: "Stale event from main snapshot.",
+            subject: {
+              id: "main-snapshot",
+              type: "operations",
+            },
+            type: "operations.event",
+          },
+        ],
+      };
+    });
+
+    render(<DailyOperationsView />);
+
+    const timeline = screen.getByRole("region", {
+      name: "Store-day timeline",
+    });
+
+    expect(
+      within(timeline).getByText("Latest preview event from timeline query."),
+    ).toBeInTheDocument();
+    expect(
+      within(timeline).queryByText("Stale event from main snapshot."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps loaded week analytics visible when navigating within the same week", async () => {
+    mockedHooks.useQuery.mockImplementation((query, args) => {
+      if (args === "skip") return undefined;
+      if (query === mockedApi.getDailyOperationsDetailSnapshot) {
+        return {
+          ...operatingSnapshot,
+          closeSummary: {
+            ...operatingSnapshot.closeSummary,
+            salesTotal: 999,
+            transactionCount: 99,
+          },
+          weekSnapshots: buildWeekSnapshots(),
+        };
+      }
+      return operatingSnapshot;
+    });
+    mockedHooks.useSearch.mockReturnValue({
+      operatingDate: "2026-05-08",
+      weekEndOperatingDate: "2026-05-09",
+    });
+    const view = render(<DailyOperationsView />);
+
+    expect(await screen.findByText(/Data refreshed at /)).toBeInTheDocument();
+    expect(
+      screen.getAllByText((_, node) => node?.textContent === "GH₵15,331")
+        .length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText("99 transactions")).not.toBeInTheDocument();
+    mockedHooks.useQuery.mockClear();
+
+    mockedHooks.useSearch.mockReturnValue({
+      operatingDate: "2026-05-07",
+      weekEndOperatingDate: "2026-05-09",
+    });
+    view.rerender(<DailyOperationsView />);
+
+    expect(screen.getByText(/Data refreshed at /)).toBeInTheDocument();
+    expect(mockedHooks.useQuery).toHaveBeenCalledWith(
+      mockedApi.getDailyOperationsSnapshot,
+      "skip",
+    );
+    expect(mockedHooks.useQuery).not.toHaveBeenCalledWith(
+      mockedApi.getDailyOperationsSnapshot,
+      expect.objectContaining({
+        operatingDate: "2026-05-07",
+      }),
+    );
+    expect(
+      screen.getByText((_, node) => node?.textContent === "GH₵17,461"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText((_, node) => node?.textContent === "GH₵450").length,
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText("1 transaction").length).toBeGreaterThan(0);
+    expect(
+      screen.queryByRole("button", {
+        name: "Load analytics for week at a glance",
+      }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("store-pulse-chart")).toBeInTheDocument();
+    expect(screen.getByTestId("store-pulse-chart")).toHaveAttribute(
+      "data-display-labels",
+      "Sun, May 3|Mon, May 4|Tue, May 5|Wed, May 6|Thu, May 7",
+    );
+    expect(screen.getByTestId("store-pulse-chart")).toHaveClass(
+      "store-pulse-sales-trend-plot",
+    );
+    expect(screen.getByTestId("store-pulse-area")).toHaveAttribute(
+      "data-animate-new-values",
+      "false",
+    );
+    expect(screen.getByTestId("store-pulse-area")).toHaveAttribute(
+      "data-animation-active",
+      "false",
+    );
+    expect(screen.getByTestId("store-pulse-area")).toHaveAttribute(
+      "data-animation-duration",
+      "",
+    );
+    expect(screen.getByTestId("store-pulse-area")).toHaveAttribute(
+      "data-path-length",
+      "1",
+    );
+    expect(screen.getByTestId("store-pulse-area")).toHaveAttribute(
+      "data-replay-key",
+      "2026-05-07",
+    );
+    expect(
+      screen.queryByTestId("sales-trend-preview-grid"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Load analytics for Top items",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Load analytics for How customers paid",
+      }),
+    ).toBeInTheDocument();
+
+    mockedHooks.useQuery.mockClear();
+    mockedHooks.useSearch.mockReturnValue({
+      operatingDate: "2026-05-08",
+      weekEndOperatingDate: "2026-05-09",
+    });
+    view.rerender(<DailyOperationsView />);
+
+    expect(mockedHooks.useQuery).toHaveBeenCalledWith(
+      mockedApi.getDailyOperationsSnapshot,
+      "skip",
+    );
+    expect(mockedHooks.useQuery).toHaveBeenCalledWith(
+      mockedApi.getDailyOperationsDetailSnapshot,
+      "skip",
+    );
+    expect(mockedHooks.useQuery).not.toHaveBeenCalledWith(
+      mockedApi.getDailyOperationsDetailSnapshot,
+      expect.objectContaining({
+        operatingDate: "2026-05-08",
+      }),
+    );
+    expect(screen.getByTestId("store-pulse-area")).toHaveAttribute(
+      "data-animate-new-values",
+      "false",
+    );
+    expect(screen.getByTestId("store-pulse-area")).toHaveAttribute(
+      "data-replay-key",
+      "2026-05-08",
+    );
+  });
+
+  it("hydrates analytics detail again after navigating to an uncached week", () => {
+    const view = render(<DailyOperationsView />);
 
     expect(mockedHooks.useQuery).toHaveBeenCalledWith(
       mockedApi.getDailyOperationsDetailSnapshot,
@@ -2233,7 +2731,10 @@ describe("DailyOperationsView", () => {
     );
     expect(mockedHooks.useQuery).toHaveBeenCalledWith(
       mockedApi.getDailyOperationsDetailSnapshot,
-      "skip",
+      expect.objectContaining({
+        operatingDate: "2026-05-07",
+        storeId: "store-1",
+      }),
     );
   });
 
@@ -2249,7 +2750,11 @@ describe("DailyOperationsView", () => {
       mockedApi.getDailyOperationsSnapshot,
       expect.objectContaining({
         operatingDate: "2026-05-07",
-        operatingTimezoneOffsetMinutes: new Date(2026, 4, 7).getTimezoneOffset(),
+        operatingTimezoneOffsetMinutes: new Date(
+          2026,
+          4,
+          7,
+        ).getTimezoneOffset(),
         storeId: "store-1",
         storePulseWindow: "today",
         weekEndOperatingDate: "2026-05-09",
@@ -2287,7 +2792,7 @@ describe("DailyOperationsView", () => {
 
     expect(within(storePulse).queryByRole("tablist")).not.toBeInTheDocument();
     expect(
-      within(storePulse).getByText("This week's completed POS sales."),
+      within(storePulse).getByText("Cached sales trend through the selected day."),
     ).toBeInTheDocument();
   });
 

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useMemo, useState } from "react";
+import {
+  useEffect,
+  type KeyboardEvent,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
 import {
   Link,
   useNavigate,
@@ -57,7 +63,10 @@ import {
 import { OperationsSummaryMetric } from "./OperationsSummaryMetric";
 import { formatOperationsMetricHelper } from "./operationsMetricFormatting";
 import {
+  PaymentMethodsPanel,
   StorePulseSummaryView,
+  StorePulseTimeline,
+  TopItemsPanel,
   type StorePulseSummary,
   type StorePulseTrendDay,
   type StorePulseWindow,
@@ -66,6 +75,9 @@ import {
 type DailyOperationsApi = {
   getDailyOperationsDetailSnapshot?: unknown;
   getDailyOperationsSnapshot?: unknown;
+  getDailyOperationsStorePulseSnapshot?: unknown;
+  getDailyOperationsTimelinePreviewSnapshot?: unknown;
+  getDailyOperationsTimelineSnapshot?: unknown;
 };
 
 const useExpectedDailyOperationsQuery = useQuery as unknown as (
@@ -293,26 +305,74 @@ export type DailyOperationsSnapshot = {
     salesTotal: number;
     transactionCount: number;
   }>;
+  weekStorePulses?: Array<{
+    operatingDate: string;
+    storePulse?: StorePulseSummary | null;
+  }>;
+  weekSnapshots?: DailyOperationsSnapshot[];
 };
 
 type DailyOperationsViewContentProps = {
+  cachedWeekAnalyticsFetchedAt?: number;
+  cachedWeekMetrics?: DailyOperationsSnapshot["weekMetrics"];
+  cachedWeekStorePulse?: StorePulseSummary | null;
   currency: string;
   hasDetailSnapshot: boolean;
   hasFullAdminAccess: boolean;
   hasFinancialDetailsAccess: boolean;
   isLoadingDetailSnapshot?: boolean;
+  isLoadingStorePulseSnapshot?: boolean;
+  isLoadingTimelinePreviewSnapshot?: boolean;
+  isLoadingTimelineSnapshot?: boolean;
   isAuthenticated: boolean;
   isLoadingAccess: boolean;
   isLoadingSnapshot: boolean;
   onRequestDetailSnapshot?: () => void;
+  onRequestStorePulseSnapshot?: () => void;
+  onRequestTimelineSnapshot?: () => void;
   onOperatingDateChange?: (date: Date) => void;
   orgUrlSlug: string;
   snapshot?: DailyOperationsSnapshot;
   storePulseWindow: StorePulseWindow;
   storeUrlSlug: string;
+  storePulseSnapshot?: DailyOperationsStorePulseSnapshot;
+  timelinePreviewSnapshot?: DailyOperationsTimelinePreviewSnapshot;
+  timelineSnapshot?: DailyOperationsTimelineSnapshot;
 };
 
+type CachedWeekAnalytics = {
+  daySnapshots: Record<
+    string,
+    {
+      hasDetail: boolean;
+      snapshot: DailyOperationsSnapshot;
+    }
+  >;
+  fetchedAt: number;
+  metrics: DailyOperationsSnapshot["weekMetrics"];
+  storePulse?: StorePulseSummary | null;
+};
+
+type DailyOperationsStorePulseSnapshot = {
+  operatingDate: string;
+  storePulse?: StorePulseSummary | null;
+};
+
+type DailyOperationsTimelineSnapshot = {
+  operatingDate: string;
+  timeline: DailyOperationsSnapshot["timeline"];
+};
+
+type DailyOperationsTimelinePreviewSnapshot =
+  DailyOperationsTimelineSnapshot & {
+    timelineHasMore: boolean;
+  };
+
+type StorePulseDetailHydrationMode = "manual" | "auto";
+
 const TIMELINE_PREVIEW_LIMIT = 5;
+// Switch to "auto" to hydrate top items/payment mix on mount.
+const STORE_PULSE_DETAIL_HYDRATION_MODE: StorePulseDetailHydrationMode = "auto";
 
 function getDailyOperationsApi(): DailyOperationsApi {
   return (
@@ -522,6 +582,16 @@ function getWeekEndOperatingDateFromSearch(weekEndOperatingDate?: unknown) {
   return getSaturdayWeekEndOperatingDate(getLocalOperatingDate());
 }
 
+function selectWeekMetricsForOperatingDate(
+  metrics: DailyOperationsSnapshot["weekMetrics"],
+  operatingDate: string,
+) {
+  return metrics.map((metric) => ({
+    ...metric,
+    isSelected: metric.operatingDate === operatingDate,
+  }));
+}
+
 function shouldShowPrimaryAction(snapshot: DailyOperationsSnapshot) {
   return !isHistoricalOperatingDate(snapshot.operatingDate);
 }
@@ -679,6 +749,13 @@ function formatWeekdayDate(operatingDate: string) {
   if (!parsed) return operatingDate;
 
   return parsed.toLocaleDateString([], { day: "numeric", month: "short" });
+}
+
+function formatAnalyticsCacheTimestamp(timestamp: number) {
+  return new Date(timestamp).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }
 
 function formatEntityCount(
@@ -1309,7 +1386,10 @@ export function ScheduledRunEvidencePanel({
     <section className="rounded-md border border-border bg-surface-raised px-layout-md py-layout-sm shadow-surface">
       <div className="flex flex-col gap-layout-sm">
         <h3 className="flex shrink-0 items-center gap-layout-xs text-sm font-medium text-foreground">
-          <Clock3 aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
+          <Clock3
+            aria-hidden="true"
+            className="h-4 w-4 text-muted-foreground"
+          />
           Scheduled runs
         </h3>
         <div className="flex min-w-0 flex-col gap-layout-xs">
@@ -1488,6 +1568,12 @@ function HistoricalWorkflowPanel({
   );
 }
 
+function getTopItemsTitle(operatingDate: string) {
+  return operatingDate === getLocalOperatingDate()
+    ? "Today's top items"
+    : "Top items";
+}
+
 function DailyOperationsStorePulsePanel({
   currency,
   hasFullAdminAccess,
@@ -1504,13 +1590,14 @@ function DailyOperationsStorePulsePanel({
       {storePulseSummary ? (
         <StorePulseSummaryView
           canViewFinancialDetails={hasFullAdminAccess}
+          chartAnimationKey={snapshot.operatingDate}
           currencyFormatter={currencyFormatter(currency)}
           onPulseWindowChange={() => undefined}
           pulseWindow="this_week"
           showPulseWindowFilter={false}
           showSummaryMetrics={false}
           summary={storePulseSummary}
-          topItemsTitle="Today's top items"
+          topItemsTitle={getTopItemsTitle(snapshot.operatingDate)}
         />
       ) : (
         <div className="rounded-lg border border-border bg-surface p-layout-md shadow-surface">
@@ -1572,6 +1659,646 @@ function buildWeekToDateStorePulseSummary(
       ),
     },
   };
+}
+
+function buildCachedWeekStorePulseSummary(
+  snapshot: DailyOperationsSnapshot,
+): StorePulseSummary | null | undefined {
+  const summary = snapshot.storePulse;
+  const operatorSnapshot = summary?.operatorSnapshot;
+
+  if (!summary || !operatorSnapshot) {
+    return buildWeekMetricStorePulseSummary(snapshot);
+  }
+
+  const knownTrendByDate = new Map(
+    operatorSnapshot.trend.map((day) => [day.date, day]),
+  );
+  const weekTrend = snapshot.weekMetrics.map((metric): StorePulseTrendDay => {
+    const knownTrendDay = knownTrendByDate.get(metric.operatingDate);
+
+    return {
+      averageTransaction:
+        metric.transactionCount > 0
+          ? metric.salesTotal / metric.transactionCount
+          : 0,
+      date: metric.operatingDate,
+      hasKnownItemCount: knownTrendDay ? true : false,
+      label: knownTrendDay?.label ?? formatOperatingDate(metric.operatingDate),
+      totalItemsSold: knownTrendDay?.totalItemsSold ?? 0,
+      totalSales: metric.salesTotal,
+      transactionCount: metric.transactionCount,
+    };
+  });
+
+  if (weekTrend.length === 0) return summary;
+
+  return {
+    ...summary,
+    operatorSnapshot: {
+      ...operatorSnapshot,
+      historyDays: Math.max(operatorSnapshot.historyDays, weekTrend.length),
+      trend: weekTrend,
+      usableHistoryDays: Math.max(
+        operatorSnapshot.usableHistoryDays,
+        weekTrend.filter((day) => day.transactionCount > 0).length,
+      ),
+    },
+  };
+}
+
+function buildWeekMetricStorePulseSummary(
+  snapshot: DailyOperationsSnapshot,
+): StorePulseSummary | null {
+  const trend = snapshot.weekMetrics.map((metric): StorePulseTrendDay => {
+    const averageTransaction =
+      metric.transactionCount > 0
+        ? metric.salesTotal / metric.transactionCount
+        : 0;
+
+    return {
+      averageTransaction,
+      date: metric.operatingDate,
+      label: formatOperatingDate(metric.operatingDate),
+      totalItemsSold: 0,
+      totalSales: metric.salesTotal,
+      transactionCount: metric.transactionCount,
+    };
+  });
+  const selectedMetric =
+    snapshot.weekMetrics.find(
+      (metric) => metric.operatingDate === snapshot.operatingDate,
+    ) ?? snapshot.weekMetrics.at(-1);
+
+  if (!trend.length || !selectedMetric) return null;
+
+  const selectedAverageTransaction =
+    selectedMetric.transactionCount > 0
+      ? selectedMetric.salesTotal / selectedMetric.transactionCount
+      : 0;
+
+  return {
+    averageTransaction: selectedAverageTransaction,
+    date: snapshot.operatingDate,
+    operatorSnapshot: {
+      busiestHour: null,
+      comparison: {
+        averageTransactionDeltaPercent: 0,
+        currentAverageTransaction: selectedAverageTransaction,
+        currentItemsSold: 0,
+        currentSales: selectedMetric.salesTotal,
+        currentTransactions: selectedMetric.transactionCount,
+        itemsSoldDeltaPercent: 0,
+        salesDeltaPercent: 0,
+        transactionDeltaPercent: 0,
+        yesterdayAverageTransaction: 0,
+        yesterdayItemsSold: 0,
+        yesterdaySales: 0,
+        yesterdayTransactions: 0,
+      },
+      historyDays: trend.length,
+      isLimited: false,
+      paymentMix: [],
+      topItems: [],
+      trend,
+      usableHistoryDays: trend.filter((day) => day.transactionCount > 0).length,
+    },
+    totalItemsSold: 0,
+    totalSales: selectedMetric.salesTotal,
+    totalTransactions: selectedMetric.transactionCount,
+  };
+}
+
+function buildCachedStorePulseForOperatingDate({
+  operatingDate,
+  selectedDayStorePulse,
+  weekStorePulse,
+}: {
+  operatingDate: string;
+  selectedDayStorePulse?: StorePulseSummary | null;
+  weekStorePulse?: StorePulseSummary | null;
+}): StorePulseSummary | null | undefined {
+  const baseSummary = selectedDayStorePulse ?? weekStorePulse;
+  const weekOperatorSnapshot = weekStorePulse?.operatorSnapshot;
+  const selectedDayOperatorSnapshot = selectedDayStorePulse?.operatorSnapshot;
+
+  if (!baseSummary) return baseSummary;
+
+  const combinedSummary =
+    weekOperatorSnapshot && selectedDayOperatorSnapshot
+      ? {
+          ...baseSummary,
+          operatorSnapshot: {
+            ...selectedDayOperatorSnapshot,
+            historyDays: weekOperatorSnapshot.historyDays,
+            trend: weekOperatorSnapshot.trend,
+            usableHistoryDays: weekOperatorSnapshot.usableHistoryDays,
+          },
+        }
+      : baseSummary;
+
+  return selectStorePulseTrendThroughOperatingDate(
+    combinedSummary,
+    operatingDate,
+  );
+}
+
+function selectStorePulseTrendThroughOperatingDate(
+  summary: StorePulseSummary | null | undefined,
+  operatingDate: string,
+): StorePulseSummary | null | undefined {
+  const operatorSnapshot = summary?.operatorSnapshot;
+
+  if (!summary || !operatorSnapshot) return summary;
+
+  const trend = operatorSnapshot.trend.filter(
+    (day) => day.date <= operatingDate,
+  );
+
+  if (trend.length === operatorSnapshot.trend.length) return summary;
+
+  return {
+    ...summary,
+    operatorSnapshot: {
+      ...operatorSnapshot,
+      historyDays: trend.length,
+      trend,
+      usableHistoryDays: trend.filter((day) => day.transactionCount > 0).length,
+    },
+  };
+}
+
+function buildCachedWeekDaySnapshots(
+  snapshot: DailyOperationsSnapshot,
+): CachedWeekAnalytics["daySnapshots"] {
+  const daySnapshots: CachedWeekAnalytics["daySnapshots"] = {};
+  const weekMetricByDate = new Map(
+    snapshot.weekMetrics.map((metric) => [metric.operatingDate, metric]),
+  );
+
+  for (const weekSnapshot of snapshot.weekSnapshots ?? []) {
+    const weekMetric = weekMetricByDate.get(weekSnapshot.operatingDate);
+
+    daySnapshots[weekSnapshot.operatingDate] = {
+      hasDetail: false,
+      snapshot: weekMetric
+        ? normalizeDailyOperationsSnapshotWithWeekMetric(
+            weekSnapshot,
+            weekMetric,
+            snapshot.weekMetrics,
+          )
+        : weekSnapshot,
+    };
+  }
+
+  const selectedWeekMetric = weekMetricByDate.get(snapshot.operatingDate);
+
+  daySnapshots[snapshot.operatingDate] = {
+    hasDetail: true,
+    snapshot: selectedWeekMetric
+      ? normalizeDailyOperationsSnapshotWithWeekMetric(
+          snapshot,
+          selectedWeekMetric,
+          snapshot.weekMetrics,
+        )
+      : snapshot,
+  };
+
+  return daySnapshots;
+}
+
+function mergeDailyOperationsSnapshots(
+  baseSnapshot: DailyOperationsSnapshot,
+  detailSnapshot: DailyOperationsSnapshot,
+): DailyOperationsSnapshot {
+  return {
+    ...baseSnapshot,
+    ...detailSnapshot,
+    scheduledRunSummaries:
+      detailSnapshot.scheduledRunSummaries?.length === 0
+        ? baseSnapshot.scheduledRunSummaries
+        : detailSnapshot.scheduledRunSummaries,
+    timeline:
+      detailSnapshot.timeline.length === 0
+        ? baseSnapshot.timeline
+        : detailSnapshot.timeline,
+    timelineHasMore:
+      detailSnapshot.timeline.length === 0
+        ? baseSnapshot.timelineHasMore
+        : detailSnapshot.timelineHasMore,
+  };
+}
+
+function areTimelinePreviewSnapshotsEqual(
+  left: DailyOperationsTimelinePreviewSnapshot | undefined,
+  right: DailyOperationsTimelinePreviewSnapshot,
+) {
+  if (!left) return false;
+  if (left.operatingDate !== right.operatingDate) return false;
+  if (left.timelineHasMore !== right.timelineHasMore) return false;
+  if (left.timeline.length !== right.timeline.length) return false;
+
+  return left.timeline.every(
+    (event, index) =>
+      event.id === right.timeline[index]?.id &&
+      event.createdAt === right.timeline[index]?.createdAt,
+  );
+}
+
+function normalizeDailyOperationsSnapshotWithWeekMetric(
+  snapshot: DailyOperationsSnapshot,
+  metric: DailyOperationsSnapshot["weekMetrics"][number],
+  weekMetrics: DailyOperationsSnapshot["weekMetrics"],
+): DailyOperationsSnapshot {
+  const selectedWeekMetrics = selectWeekMetricsForOperatingDate(
+    weekMetrics,
+    snapshot.operatingDate,
+  );
+
+  return {
+    ...snapshot,
+    closeSummary: {
+      ...snapshot.closeSummary,
+      currentDayCashTotal: metric.currentDayCashTotal,
+      currentDayCashTransactionCount: metric.currentDayCashTransactionCount,
+      expenseTotal: metric.expenseTotal,
+      expenseTransactionCount: metric.expenseTransactionCount,
+      paymentTotals:
+        metric.paymentTotals?.map((paymentTotal) => ({
+          ...paymentTotal,
+          transactionCount: paymentTotal.transactionCount ?? undefined,
+        })) ?? [],
+      salesTotal: metric.salesTotal,
+      transactionCount: metric.transactionCount,
+    },
+    priorDayMetric: selectedWeekMetrics.find(
+      (weekMetric) =>
+        weekMetric.operatingDate ===
+        getPreviousOperatingDate(snapshot.operatingDate),
+    ),
+    weekMetrics: selectedWeekMetrics,
+  };
+}
+
+const WEEK_METRICS_PREVIEW_HEIGHT = 28;
+const WEEKDAY_PREVIEW_LABELS = [
+  "Sun",
+  "Mon",
+  "Tue",
+  "Wed",
+  "Thu",
+  "Fri",
+  "Sat",
+];
+
+function handleDeferredAnalyticsKeyDown(
+  event: KeyboardEvent<HTMLElement>,
+  onRequest: () => void,
+) {
+  if (event.key !== "Enter" && event.key !== " ") return;
+
+  event.preventDefault();
+  onRequest();
+}
+
+function DailyOperationsWeekMetricsPreview({
+  isLoading,
+  metrics,
+  onRequest,
+  operatingDate,
+}: {
+  isLoading?: boolean;
+  metrics: DailyOperationsSnapshot["weekMetrics"];
+  onRequest: () => void;
+  operatingDate: string;
+}) {
+  const previewWeekStart = getSundayWeekStartOperatingDate(operatingDate);
+  const previewMetrics =
+    metrics.length > 0
+      ? metrics
+      : WEEKDAY_PREVIEW_LABELS.map((_, index) => ({
+          isClosed: index < 3,
+          isReopened: false,
+          isSelected: false,
+          operatingDate: shiftLocalOperatingDate(previewWeekStart, index),
+          transactionCount: 0,
+        }));
+  const weekEndOperatingDate = metrics.at(-1)?.operatingDate;
+
+  return (
+    <section className="space-y-layout-sm">
+      <div className="flex flex-col gap-layout-xs sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h3 className="text-base font-medium text-foreground">
+            Week at a glance
+          </h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {weekEndOperatingDate
+              ? `Seven days ending ${formatOperatingDate(weekEndOperatingDate)}.`
+              : "Seven-day sales and close status."}
+          </p>
+        </div>
+        <div className="flex flex-col gap-layout-sm sm:flex-row sm:items-center">
+          <p className="flex items-baseline justify-between gap-2 text-sm text-muted-foreground sm:justify-start">
+            <span>Week sales</span>
+            <span className="font-numeric text-base font-semibold tabular-nums text-muted-foreground">
+              -
+            </span>
+          </p>
+          <Button
+            className="w-full shrink-0 transition-[background-color,border-color,color,transform] duration-150 ease-out active:scale-[0.98] sm:w-auto"
+            disabled={isLoading}
+            onClick={onRequest}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            {isLoading ? "Loading analytics" : "Load analytics"}
+          </Button>
+        </div>
+      </div>
+      <div
+        aria-label="Load analytics for week at a glance"
+        className="group relative cursor-pointer overflow-x-auto rounded-lg border border-border bg-surface-raised p-layout-sm shadow-surface transition-[box-shadow] duration-200 ease-out hover:shadow-sm focus:outline-none focus-visible:border-action-workflow-border focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-within:border-action-workflow-border focus-within:shadow-sm"
+        onClick={() => {
+          if (!isLoading) onRequest();
+        }}
+        onKeyDown={(event) => {
+          if (!isLoading) handleDeferredAnalyticsKeyDown(event, onRequest);
+        }}
+        role="button"
+        tabIndex={isLoading ? -1 : 0}
+      >
+        <DailyOperationsDeferredAnalyticsAction
+          className="absolute right-layout-sm top-layout-sm z-10"
+          isLoading={isLoading}
+        />
+        <div className="flex min-w-max snap-x gap-layout-xs md:grid md:min-w-[42rem] md:grid-cols-7">
+          {previewMetrics.map((metric, index) => (
+            <article
+              className={cn(
+                "w-[10.5rem] shrink-0 snap-start rounded-md border px-layout-sm py-layout-sm text-left text-muted-foreground md:w-auto",
+                metric.isSelected
+                  ? "border-action-workflow-border bg-action-workflow-soft ring-1 ring-inset ring-action-workflow-border"
+                  : "border-transparent",
+              )}
+              key={metric.operatingDate || index}
+            >
+              <div className="flex items-center justify-between gap-layout-xs">
+                <span className="text-xs font-medium uppercase tracking-wide">
+                  {metric.operatingDate
+                    ? formatWeekdayLabel(metric.operatingDate)
+                    : WEEKDAY_PREVIEW_LABELS[index]}
+                </span>
+              </div>
+              {metric.operatingDate ? (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {formatWeekdayDate(metric.operatingDate)}
+                </p>
+              ) : null}
+              <div className="mt-layout-sm h-12">
+                <span
+                  aria-hidden="true"
+                  className="block w-full rounded-sm bg-muted"
+                  style={{ height: WEEK_METRICS_PREVIEW_HEIGHT }}
+                />
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function DailyOperationsStorePulsePreview({
+  cachedSelectedStorePulse,
+  cachedStorePulse,
+  currency,
+  hasFullAdminAccess,
+  isLoading,
+  onRequest,
+  operatingDate,
+}: {
+  cachedSelectedStorePulse?: StorePulseSummary | null;
+  cachedStorePulse?: StorePulseSummary | null;
+  currency: string;
+  hasFullAdminAccess: boolean;
+  isLoading?: boolean;
+  onRequest: () => void;
+  operatingDate: string;
+}) {
+  const topItemsTitle = getTopItemsTitle(operatingDate);
+  const selectedCachedStorePulse = buildCachedStorePulseForOperatingDate({
+    operatingDate,
+    selectedDayStorePulse: cachedSelectedStorePulse,
+    weekStorePulse: cachedStorePulse,
+  });
+  const selectedCachedStorePulseTrend =
+    selectStorePulseTrendThroughOperatingDate(cachedStorePulse, operatingDate);
+  const hasCachedPulseTrendChart = Boolean(
+    selectedCachedStorePulseTrend?.operatorSnapshot?.trend.length,
+  );
+  const detailSnapshot = cachedSelectedStorePulse?.operatorSnapshot
+    ? selectedCachedStorePulse?.operatorSnapshot
+    : undefined;
+
+  return (
+    <section
+      aria-label="Store pulse"
+      className="space-y-layout-xl md:space-y-layout-2xl"
+    >
+      <section className="space-y-layout-2xl">
+        {hasCachedPulseTrendChart ? (
+          <StorePulseTimeline
+            animationKey={operatingDate}
+            canViewFinancialDetails={hasFullAdminAccess}
+            description="Cached sales trend through the selected day."
+            currencyFormatter={currencyFormatter(currency)}
+            pulseWindow="this_week"
+            snapshot={selectedCachedStorePulseTrend!.operatorSnapshot!}
+          />
+        ) : (
+          <section
+            aria-label="Sales trend preview"
+            className="space-y-layout-sm"
+          >
+            <div className="flex flex-col gap-layout-xs sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h3 className="text-base font-medium text-foreground">
+                  Sales trend
+                </h3>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Store pulse detail loads with analytics.
+                </p>
+              </div>
+              <span className="rounded-md border border-border bg-background px-2 py-1 text-xs font-medium text-muted-foreground">
+                Paused
+              </span>
+            </div>
+            <div
+              aria-label="Load analytics for sales trend"
+              className="group relative cursor-pointer overflow-hidden rounded-lg border border-border bg-surface-raised p-8 shadow-surface transition-[box-shadow] duration-200 ease-out hover:shadow-sm focus:outline-none focus-visible:border-action-workflow-border focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-within:border-action-workflow-border focus-within:shadow-sm"
+              onClick={() => {
+                if (!isLoading) onRequest();
+              }}
+              onKeyDown={(event) => {
+                if (!isLoading)
+                  handleDeferredAnalyticsKeyDown(event, onRequest);
+              }}
+              role="button"
+              tabIndex={isLoading ? -1 : 0}
+            >
+              <DailyOperationsDeferredAnalyticsAction
+                className="absolute right-layout-md top-layout-md z-10"
+                isLoading={isLoading}
+              />
+              <div className="relative h-[22rem] w-full">
+                <div className="absolute inset-y-0 left-0 flex w-16 flex-col justify-between py-1">
+                  {Array.from({ length: 5 }).map((_, index) => (
+                    <span
+                      aria-hidden="true"
+                      className="h-3 w-12 rounded-sm bg-muted"
+                      key={index}
+                    />
+                  ))}
+                </div>
+                <div
+                  className="absolute inset-y-0 left-20 right-0 flex flex-col justify-between"
+                  data-testid="sales-trend-preview-grid"
+                >
+                  {Array.from({ length: 5 }).map((_, index) => (
+                    <span
+                      aria-hidden="true"
+                      className="h-px w-full rounded-sm bg-muted"
+                      key={index}
+                    />
+                  ))}
+                </div>
+              </div>
+            </div>
+          </section>
+        )}
+      </section>
+
+      <PageWorkspaceGrid className="xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <PageWorkspaceMain>
+          {detailSnapshot ? (
+            <TopItemsPanel
+              canViewFinancialDetails={hasFullAdminAccess}
+              currencyFormatter={currencyFormatter(currency)}
+              snapshot={detailSnapshot}
+              title={topItemsTitle}
+            />
+          ) : (
+            <DailyOperationsStorePulsePreviewList
+              description="Highest-volume items for the selected day."
+              isLoading={isLoading}
+              onRequest={onRequest}
+              rowCount={5}
+              title={topItemsTitle}
+            />
+          )}
+        </PageWorkspaceMain>
+        <PageWorkspaceRail>
+          {detailSnapshot ? (
+            <PaymentMethodsPanel snapshot={detailSnapshot} />
+          ) : (
+            <DailyOperationsStorePulsePreviewList
+              description="Share of synced POS sales by payment method."
+              isLoading={isLoading}
+              onRequest={onRequest}
+              rowCount={3}
+              title="How customers paid"
+            />
+          )}
+        </PageWorkspaceRail>
+      </PageWorkspaceGrid>
+    </section>
+  );
+}
+
+function DailyOperationsStorePulsePreviewList({
+  description,
+  isLoading,
+  onRequest,
+  rowCount,
+  title,
+}: {
+  description: string;
+  isLoading?: boolean;
+  onRequest: () => void;
+  rowCount: number;
+  title: string;
+}) {
+  return (
+    <section aria-label={`${title} preview`} className="space-y-layout-md">
+      <div>
+        <h3 className="text-base font-medium text-foreground">{title}</h3>
+        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+      </div>
+      <div
+        aria-label={`Load analytics for ${title}`}
+        className="group relative cursor-pointer rounded-lg border border-border bg-surface-raised shadow-surface transition-[box-shadow] duration-200 ease-out hover:shadow-sm focus:outline-none focus-visible:border-action-workflow-border focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-within:border-action-workflow-border focus-within:shadow-sm"
+        onClick={() => {
+          if (!isLoading) onRequest();
+        }}
+        onKeyDown={(event) => {
+          if (!isLoading) handleDeferredAnalyticsKeyDown(event, onRequest);
+        }}
+        role="button"
+        tabIndex={isLoading ? -1 : 0}
+      >
+        <DailyOperationsDeferredAnalyticsAction
+          className="absolute right-layout-sm top-layout-sm z-10"
+          isLoading={isLoading}
+        />
+        <div className="divide-y divide-border/70">
+          {Array.from({ length: rowCount }).map((_, index) => (
+            <div
+              className="grid gap-2 px-layout-md py-layout-sm sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center"
+              key={index}
+            >
+              <span
+                aria-hidden="true"
+                className="h-6 w-6 rounded-sm bg-muted"
+              />
+              <div className="min-w-0">
+                <span
+                  aria-hidden="true"
+                  className="block h-4 w-32 rounded-sm bg-muted"
+                />
+                <span
+                  aria-hidden="true"
+                  className="mt-2 block h-3 w-44 max-w-full rounded-sm bg-muted"
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function DailyOperationsDeferredAnalyticsAction({
+  className,
+  isLoading,
+}: {
+  className?: string;
+  isLoading?: boolean;
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "inline-flex h-9 translate-y-1 items-center justify-center gap-2 whitespace-nowrap rounded-md border border-border bg-background px-3 text-sm font-medium text-foreground opacity-0 shadow-surface transition-[opacity,transform] duration-200 ease-out group-hover:translate-y-0 group-hover:opacity-100 group-focus-within:translate-y-0 group-focus-within:opacity-100",
+        className,
+      )}
+    >
+      {isLoading ? "Loading analytics" : "Load analytics"}
+    </span>
+  );
 }
 
 function SupportingWorkspaceLinks({
@@ -1681,6 +2408,7 @@ function OperatingDatePicker({
 }
 
 function WeekMetricsStrip({
+  analyticsFetchedAt,
   currency,
   hasFinancialDetailsAccess,
   metrics,
@@ -1688,6 +2416,7 @@ function WeekMetricsStrip({
   storePulseWindow,
   storeUrlSlug,
 }: {
+  analyticsFetchedAt?: number;
   currency: string;
   hasFinancialDetailsAccess: boolean;
   metrics: DailyOperationsSnapshot["weekMetrics"];
@@ -1738,7 +2467,13 @@ function WeekMetricsStrip({
             Week at a glance
           </h3>
           <p className="mt-1 text-sm text-muted-foreground">
-            Seven days ending {formatOperatingDate(weekEndOperatingDate)}.
+            Seven days ending {formatOperatingDate(weekEndOperatingDate)}
+            {analyticsFetchedAt ? (
+              <span className="ml-2 whitespace-nowrap">
+                · Data refreshed at{" "}
+                {formatAnalyticsCacheTimestamp(analyticsFetchedAt)}
+              </span>
+            ) : null}
           </p>
         </div>
         <div className="flex flex-col gap-layout-sm sm:flex-row sm:items-center">
@@ -1914,20 +2649,31 @@ function WeekMetricsStrip({
 }
 
 export function DailyOperationsViewContent({
+  cachedWeekAnalyticsFetchedAt,
+  cachedWeekMetrics,
+  cachedWeekStorePulse,
   currency,
   hasDetailSnapshot,
   hasFullAdminAccess,
   hasFinancialDetailsAccess,
   isLoadingDetailSnapshot,
+  isLoadingStorePulseSnapshot,
+  isLoadingTimelinePreviewSnapshot,
+  isLoadingTimelineSnapshot,
   isAuthenticated,
   isLoadingAccess,
   isLoadingSnapshot,
   onRequestDetailSnapshot,
+  onRequestStorePulseSnapshot,
+  onRequestTimelineSnapshot,
   onOperatingDateChange,
   orgUrlSlug,
   snapshot,
   storePulseWindow,
   storeUrlSlug,
+  storePulseSnapshot,
+  timelinePreviewSnapshot,
+  timelineSnapshot,
 }: DailyOperationsViewContentProps) {
   const [isTimelineSheetOpen, setIsTimelineSheetOpen] = useState(false);
   const isMobile = useIsMobile();
@@ -1946,10 +2692,17 @@ export function DailyOperationsViewContent({
     return <NoPermissionView />;
   }
 
-  const previewTimeline = snapshot?.timeline.slice(0, TIMELINE_PREVIEW_LIMIT);
-  const hasMoreTimelineEvents =
-    snapshot?.timelineHasMore ??
-    (snapshot?.timeline.length ?? 0) > TIMELINE_PREVIEW_LIMIT;
+  const timelinePreview =
+    snapshot &&
+    timelinePreviewSnapshot?.operatingDate === snapshot.operatingDate
+      ? timelinePreviewSnapshot
+      : undefined;
+  const previewTimeline = timelinePreview?.timeline;
+  const hasMoreTimelineEvents = timelinePreview?.timelineHasMore ?? false;
+  const fullTimelineEvents =
+    snapshot && timelineSnapshot?.operatingDate === snapshot.operatingDate
+      ? timelineSnapshot.timeline
+      : undefined;
   const metricLabels = snapshot
     ? getDailyOperationsMetricLabels(snapshot.operatingDate)
     : undefined;
@@ -1977,6 +2730,33 @@ export function DailyOperationsViewContent({
   const actionableLanes = snapshot
     ? snapshot.lanes.filter(isActionableLane)
     : [];
+  const weekMetricsForDisplay =
+    snapshot && (hasDetailSnapshot || !cachedWeekMetrics)
+      ? snapshot.weekMetrics
+      : cachedWeekMetrics;
+  const hasHydratedWeekAnalytics =
+    hasDetailSnapshot || cachedWeekMetrics !== undefined;
+  const weekAnalyticsFetchedAt = hasHydratedWeekAnalytics
+    ? cachedWeekAnalyticsFetchedAt
+    : undefined;
+  const selectedWeekOperatingDate =
+    cachedWeekMetrics?.find((metric) => metric.isSelected)?.operatingDate ??
+    snapshot?.operatingDate;
+  const loadedStorePulse =
+    snapshot && storePulseSnapshot?.operatingDate === snapshot.operatingDate
+      ? storePulseSnapshot.storePulse
+      : snapshot?.storePulse;
+  const storePulseDetailSnapshot =
+    snapshot && loadedStorePulse !== undefined
+      ? {
+          ...snapshot,
+          storePulse: loadedStorePulse,
+        }
+      : undefined;
+  const requestStorePulseSnapshot =
+    onRequestStorePulseSnapshot ?? onRequestDetailSnapshot;
+  const storePulsePreviewSummary =
+    cachedWeekStorePulse ?? storePulseDetailSnapshot?.storePulse;
 
   return (
     <View hideBorder hideHeaderBottomBorder scrollMode="page">
@@ -2108,7 +2888,7 @@ export function DailyOperationsViewContent({
                   </>
                 ) : null}
 
-                <div className="grid gap-layout-sm sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-5">
+                <div className="grid gap-layout-sm [grid-template-columns:repeat(auto-fit,minmax(min(14rem,100%),1fr))]">
                   <OperationsSummaryMetric
                     helper={formatOperationsMetricHelper({
                       currentValue: snapshot.closeSummary.salesTotal,
@@ -2293,42 +3073,55 @@ export function DailyOperationsViewContent({
                   ) : null}
                 </div>
 
-                    {hasDetailSnapshot ? (
-                      <WeekMetricsStrip
-                        currency={snapshot.currency ?? currency}
-                        hasFinancialDetailsAccess={hasFinancialDetailsAccess}
-                        metrics={snapshot.weekMetrics}
-                        orgUrlSlug={orgUrlSlug}
-                        storePulseWindow={storePulseWindow}
-                        storeUrlSlug={storeUrlSlug}
-                      />
-                    ) : onRequestDetailSnapshot ? (
-                      <div className="flex justify-start">
-                        <Button
-                          disabled={isLoadingDetailSnapshot}
-                          onClick={onRequestDetailSnapshot}
-                          type="button"
-                          variant="outline"
-                        >
-                          {isLoadingDetailSnapshot
-                            ? "Loading analytics"
-                            : "Load analytics"}
-                        </Button>
-                      </div>
-                    ) : null}
-                  </section>
+                {hasHydratedWeekAnalytics && weekMetricsForDisplay ? (
+                  <WeekMetricsStrip
+                    analyticsFetchedAt={weekAnalyticsFetchedAt}
+                    currency={snapshot.currency ?? currency}
+                    hasFinancialDetailsAccess={hasFinancialDetailsAccess}
+                    metrics={weekMetricsForDisplay}
+                    orgUrlSlug={orgUrlSlug}
+                    storePulseWindow={storePulseWindow}
+                    storeUrlSlug={storeUrlSlug}
+                  />
+                ) : onRequestDetailSnapshot ? (
+                  <DailyOperationsWeekMetricsPreview
+                    isLoading={isLoadingDetailSnapshot}
+                    metrics={snapshot.weekMetrics}
+                    onRequest={onRequestDetailSnapshot}
+                    operatingDate={
+                      selectedWeekOperatingDate ?? snapshot.operatingDate
+                    }
+                  />
+                ) : null}
+              </section>
 
               <PageWorkspaceGrid>
                 <PageWorkspaceMain className="xl:col-start-1 xl:row-start-1">
-                  {hasDetailSnapshot ? (
+                  {requestStorePulseSnapshot ? (
+                    <DailyOperationsStorePulsePreview
+                      cachedSelectedStorePulse={loadedStorePulse}
+                      cachedStorePulse={storePulsePreviewSummary}
+                      currency={snapshot.currency ?? currency}
+                      hasFullAdminAccess={hasFullAdminAccess}
+                      isLoading={
+                        isLoadingStorePulseSnapshot || isLoadingDetailSnapshot
+                      }
+                      onRequest={requestStorePulseSnapshot}
+                      operatingDate={
+                        selectedWeekOperatingDate ?? snapshot.operatingDate
+                      }
+                    />
+                  ) : storePulseDetailSnapshot ? (
                     <DailyOperationsStorePulsePanel
                       currency={snapshot.currency ?? currency}
                       hasFullAdminAccess={hasFullAdminAccess}
-                      snapshot={snapshot}
+                      snapshot={storePulseDetailSnapshot}
                     />
                   ) : null}
                   <DailyOperationsCompletionAttributionNotice
-                    carryForwardCount={snapshot.completedClose?.carryForwardCount}
+                    carryForwardCount={
+                      snapshot.completedClose?.carryForwardCount
+                    }
                     completedClose={snapshot.completedClose}
                   />
                 </PageWorkspaceMain>
@@ -2343,13 +3136,23 @@ export function DailyOperationsViewContent({
                       Store-day timeline
                     </h3>
                     <div className="mt-layout-md space-y-layout-md">
-                      {snapshot.timeline.length === 0 ? (
+                      {isLoadingTimelinePreviewSnapshot && !previewTimeline ? (
+                        Array.from({ length: TIMELINE_PREVIEW_LIMIT }).map(
+                          (_, index) => (
+                            <div className="space-y-2" key={index}>
+                              <span className="block h-3 w-16 rounded-sm bg-muted" />
+                              <span className="block h-4 w-full rounded-sm bg-muted" />
+                              <span className="block h-4 w-2/3 rounded-sm bg-muted" />
+                            </div>
+                          ),
+                        )
+                      ) : !previewTimeline || previewTimeline.length === 0 ? (
                         <EmptyState
                           description="No operational events have been recorded for this store day."
                           title="No timeline yet"
                         />
                       ) : (
-                        previewTimeline?.map((event) => (
+                        previewTimeline.map((event) => (
                           <TimelineEventItem
                             event={event}
                             key={event.id}
@@ -2362,15 +3165,18 @@ export function DailyOperationsViewContent({
                     {hasMoreTimelineEvents ? (
                       <Button
                         className="mt-layout-md w-full"
+                        disabled={isLoadingTimelineSnapshot}
                         onClick={() => {
-                          onRequestDetailSnapshot?.();
+                          onRequestTimelineSnapshot?.();
                           setIsTimelineSheetOpen(true);
                         }}
                         size="sm"
                         type="button"
                         variant="outline"
                       >
-                        Show more
+                        {isLoadingTimelineSnapshot
+                          ? "Loading timeline"
+                          : "Show more"}
                       </Button>
                     ) : null}
                   </section>
@@ -2440,16 +3246,33 @@ export function DailyOperationsViewContent({
                     </SheetDescription>
                   </SheetHeader>
                   <div className="min-h-0 flex-1 overflow-y-auto px-layout-lg py-layout-md">
-                    <div className="space-y-layout-md">
-                      {snapshot.timeline.map((event) => (
-                        <TimelineEventItem
-                          event={event}
-                          key={event.id}
-                          orgUrlSlug={orgUrlSlug}
-                          storeUrlSlug={storeUrlSlug}
-                        />
-                      ))}
-                    </div>
+                    {isLoadingTimelineSnapshot ? (
+                      <div className="space-y-layout-md">
+                        {Array.from({ length: 5 }).map((_, index) => (
+                          <div className="space-y-2" key={index}>
+                            <span className="block h-3 w-16 rounded-sm bg-muted" />
+                            <span className="block h-4 w-full rounded-sm bg-muted" />
+                            <span className="block h-4 w-2/3 rounded-sm bg-muted" />
+                          </div>
+                        ))}
+                      </div>
+                    ) : fullTimelineEvents && fullTimelineEvents.length > 0 ? (
+                      <div className="space-y-layout-md">
+                        {fullTimelineEvents.map((event) => (
+                          <TimelineEventItem
+                            event={event}
+                            key={event.id}
+                            orgUrlSlug={orgUrlSlug}
+                            storeUrlSlug={storeUrlSlug}
+                          />
+                        ))}
+                      </div>
+                    ) : (
+                      <EmptyState
+                        description="Timeline detail is not loaded yet."
+                        title="Timeline loading"
+                      />
+                    )}
                   </div>
                 </SheetContent>
               </Sheet>
@@ -2484,9 +3307,15 @@ function DailyOperationsApiPendingView() {
 function DailyOperationsConnectedView({
   getDailyOperationsDetailSnapshot,
   getDailyOperationsSnapshot,
+  getDailyOperationsStorePulseSnapshot,
+  getDailyOperationsTimelinePreviewSnapshot,
+  getDailyOperationsTimelineSnapshot,
 }: {
   getDailyOperationsDetailSnapshot?: unknown;
   getDailyOperationsSnapshot: unknown;
+  getDailyOperationsStorePulseSnapshot?: unknown;
+  getDailyOperationsTimelinePreviewSnapshot?: unknown;
+  getDailyOperationsTimelineSnapshot?: unknown;
 }) {
   const {
     activeStore,
@@ -2533,28 +3362,201 @@ function DailyOperationsConnectedView({
     snapshotArgs === "skip"
       ? "skip"
       : `${String(snapshotArgs.storeId)}:${snapshotArgs.operatingDate}:${snapshotArgs.startAt ?? ""}:${snapshotArgs.endAt ?? ""}:${snapshotArgs.weekEndOperatingDate ?? ""}:${snapshotArgs.storePulseWindow}`;
+  const weekAnalyticsCacheKey =
+    snapshotArgs === "skip"
+      ? "skip"
+      : `${String(snapshotArgs.storeId)}:${snapshotArgs.weekEndOperatingDate}:${snapshotArgs.storePulseWindow}`;
   const [requestedDetailSnapshotKey, setRequestedDetailSnapshotKey] = useState<
     string | null
   >(null);
+  const [requestedTimelineSnapshotKey, setRequestedTimelineSnapshotKey] =
+    useState<string | null>(null);
+  const [requestedStorePulseSnapshotKey, setRequestedStorePulseSnapshotKey] =
+    useState<string | null>(null);
+  const [weekAnalyticsCache, setWeekAnalyticsCache] = useState<
+    Record<string, CachedWeekAnalytics>
+  >({});
+  const [storePulseCache, setStorePulseCache] = useState<
+    Record<string, DailyOperationsStorePulseSnapshot>
+  >({});
+  const [timelinePreviewCache, setTimelinePreviewCache] = useState<
+    Record<string, DailyOperationsTimelinePreviewSnapshot>
+  >({});
   const isDetailSnapshotRequested =
     snapshotRequestKey !== "skip" &&
     requestedDetailSnapshotKey === snapshotRequestKey;
+  const isTimelineSnapshotRequested =
+    snapshotRequestKey !== "skip" &&
+    requestedTimelineSnapshotKey === snapshotRequestKey;
+  const cachedWeekAnalytics =
+    weekAnalyticsCacheKey === "skip"
+      ? undefined
+      : weekAnalyticsCache[weekAnalyticsCacheKey];
+  const shouldAutoHydrateWeekAnalytics =
+    weekAnalyticsCacheKey !== "skip" && cachedWeekAnalytics === undefined;
+  const cachedDaySnapshotEntry =
+    cachedWeekAnalytics && snapshotArgs !== "skip"
+      ? cachedWeekAnalytics.daySnapshots[snapshotArgs.operatingDate]
+      : undefined;
+  const hasCachedDetailSnapshot = cachedDaySnapshotEntry?.hasDetail === true;
+  const shouldQueryDetailSnapshot =
+    Boolean(getDailyOperationsDetailSnapshot) &&
+    canQueryProtectedData &&
+    (isDetailSnapshotRequested || shouldAutoHydrateWeekAnalytics) &&
+    !hasCachedDetailSnapshot;
+  const cachedStorePulseSnapshot =
+    snapshotRequestKey === "skip"
+      ? undefined
+      : storePulseCache[snapshotRequestKey];
+  const isStorePulseSnapshotRequested =
+    snapshotRequestKey !== "skip" &&
+    requestedStorePulseSnapshotKey === snapshotRequestKey;
+  const shouldAutoHydrateStorePulseSnapshot =
+    STORE_PULSE_DETAIL_HYDRATION_MODE === "auto" &&
+    snapshotRequestKey !== "skip";
+  const shouldQueryStorePulseSnapshot =
+    Boolean(getDailyOperationsStorePulseSnapshot) &&
+    canQueryProtectedData &&
+    (isStorePulseSnapshotRequested || shouldAutoHydrateStorePulseSnapshot) &&
+    cachedStorePulseSnapshot === undefined;
 
   const compactSnapshot = useExpectedDailyOperationsQuery(
     getDailyOperationsSnapshot,
-    snapshotArgs,
+    cachedDaySnapshotEntry ? "skip" : snapshotArgs,
   ) as DailyOperationsSnapshot | undefined;
   const detailSnapshot = useExpectedDailyOperationsQuery(
     getDailyOperationsDetailSnapshot ?? getDailyOperationsSnapshot,
-    getDailyOperationsDetailSnapshot &&
-      canQueryProtectedData &&
-      isDetailSnapshotRequested
+    shouldQueryDetailSnapshot ? snapshotArgs : "skip",
+  ) as DailyOperationsSnapshot | undefined;
+  const queriedStorePulseSnapshot = useExpectedDailyOperationsQuery(
+    getDailyOperationsStorePulseSnapshot ?? getDailyOperationsSnapshot,
+    shouldQueryStorePulseSnapshot ? snapshotArgs : "skip",
+  ) as DailyOperationsStorePulseSnapshot | undefined;
+  const queriedTimelinePreviewSnapshot = useExpectedDailyOperationsQuery(
+    getDailyOperationsTimelinePreviewSnapshot ?? getDailyOperationsSnapshot,
+    getDailyOperationsTimelinePreviewSnapshot && canQueryProtectedData
       ? snapshotArgs
       : "skip",
-  ) as DailyOperationsSnapshot | undefined;
-  const snapshot = compactSnapshot
-    ? { ...compactSnapshot, ...(detailSnapshot ?? {}) }
-    : detailSnapshot;
+  ) as DailyOperationsTimelinePreviewSnapshot | undefined;
+  const timelineSnapshot = useExpectedDailyOperationsQuery(
+    getDailyOperationsTimelineSnapshot ?? getDailyOperationsSnapshot,
+    getDailyOperationsTimelineSnapshot &&
+      canQueryProtectedData &&
+      isTimelineSnapshotRequested
+      ? snapshotArgs
+      : "skip",
+  ) as DailyOperationsTimelineSnapshot | undefined;
+  const detailSnapshotMetric = detailSnapshot?.weekMetrics.find(
+    (metric) => metric.operatingDate === detailSnapshot.operatingDate,
+  );
+  const normalizedDetailSnapshot =
+    detailSnapshot && detailSnapshotMetric
+      ? normalizeDailyOperationsSnapshotWithWeekMetric(
+          detailSnapshot,
+          detailSnapshotMetric,
+          detailSnapshot.weekMetrics,
+        )
+      : detailSnapshot;
+  const baseSnapshot = compactSnapshot ?? cachedDaySnapshotEntry?.snapshot;
+  const snapshot = baseSnapshot
+    ? normalizedDetailSnapshot
+      ? mergeDailyOperationsSnapshots(baseSnapshot, normalizedDetailSnapshot)
+      : baseSnapshot
+    : normalizedDetailSnapshot;
+  const cachedTimelinePreviewSnapshot =
+    snapshotRequestKey === "skip"
+      ? undefined
+      : timelinePreviewCache[snapshotRequestKey];
+  const timelinePreviewSnapshot =
+    queriedTimelinePreviewSnapshot ?? cachedTimelinePreviewSnapshot;
+  const storePulseSnapshot =
+    queriedStorePulseSnapshot ?? cachedStorePulseSnapshot;
+  const cachedWeekMetrics =
+    cachedWeekAnalytics && snapshotArgs !== "skip"
+      ? selectWeekMetricsForOperatingDate(
+          cachedWeekAnalytics.metrics,
+          snapshotArgs.operatingDate,
+        )
+      : undefined;
+
+  useEffect(() => {
+    if (
+      weekAnalyticsCacheKey === "skip" ||
+      !detailSnapshot?.weekMetrics?.length
+    ) {
+      return;
+    }
+
+    setWeekAnalyticsCache((current) => {
+      const existingWeekAnalytics = current[weekAnalyticsCacheKey];
+
+      if (
+        existingWeekAnalytics?.metrics === detailSnapshot.weekMetrics &&
+        existingWeekAnalytics.daySnapshots[detailSnapshot.operatingDate]
+          ?.hasDetail
+      ) {
+        return current;
+      }
+
+      return {
+        ...current,
+        [weekAnalyticsCacheKey]: {
+          daySnapshots: {
+            ...existingWeekAnalytics?.daySnapshots,
+            ...buildCachedWeekDaySnapshots(detailSnapshot),
+          },
+          fetchedAt: Date.now(),
+          metrics: detailSnapshot.weekMetrics,
+          storePulse: buildCachedWeekStorePulseSummary(detailSnapshot),
+        },
+      };
+    });
+  }, [detailSnapshot, weekAnalyticsCacheKey]);
+
+  useEffect(() => {
+    if (
+      snapshotRequestKey === "skip" ||
+      queriedStorePulseSnapshot === undefined
+    ) {
+      return;
+    }
+
+    setStorePulseCache((current) => {
+      if (current[snapshotRequestKey] === queriedStorePulseSnapshot) {
+        return current;
+      }
+
+      return {
+        ...current,
+        [snapshotRequestKey]: queriedStorePulseSnapshot,
+      };
+    });
+  }, [queriedStorePulseSnapshot, snapshotRequestKey]);
+
+  useEffect(() => {
+    if (
+      snapshotRequestKey === "skip" ||
+      queriedTimelinePreviewSnapshot === undefined
+    ) {
+      return;
+    }
+
+    setTimelinePreviewCache((current) => {
+      if (
+        areTimelinePreviewSnapshotsEqual(
+          current[snapshotRequestKey],
+          queriedTimelinePreviewSnapshot,
+        )
+      ) {
+        return current;
+      }
+
+      return {
+        ...current,
+        [snapshotRequestKey]: queriedTimelinePreviewSnapshot,
+      };
+    });
+  }, [queriedTimelinePreviewSnapshot, snapshotRequestKey]);
 
   const handleOperatingDateChange = (date: Date) => {
     const nextRange = getLocalOperatingDateRange(date);
@@ -2574,17 +3576,45 @@ function DailyOperationsConnectedView({
   return (
     <DailyOperationsViewContent
       currency={activeStore?.currency ?? "GHS"}
-      hasDetailSnapshot={detailSnapshot !== undefined}
+      cachedWeekAnalyticsFetchedAt={cachedWeekAnalytics?.fetchedAt}
+      cachedWeekMetrics={cachedWeekMetrics}
+      cachedWeekStorePulse={cachedWeekAnalytics?.storePulse}
+      hasDetailSnapshot={
+        detailSnapshot !== undefined ||
+        cachedDaySnapshotEntry?.hasDetail === true
+      }
       hasFullAdminAccess={canAccessSurface}
       hasFinancialDetailsAccess={hasFinancialDetailsAccess}
       isAuthenticated={isAuthenticated}
       isLoadingAccess={isLoadingAccess}
       isLoadingDetailSnapshot={
-        isDetailSnapshotRequested && detailSnapshot === undefined
+        shouldQueryDetailSnapshot && detailSnapshot === undefined
       }
-      isLoadingSnapshot={compactSnapshot === undefined}
+      isLoadingStorePulseSnapshot={
+        shouldQueryStorePulseSnapshot && queriedStorePulseSnapshot === undefined
+      }
+      isLoadingTimelinePreviewSnapshot={
+        Boolean(getDailyOperationsTimelinePreviewSnapshot) &&
+        canQueryProtectedData &&
+        queriedTimelinePreviewSnapshot === undefined &&
+        cachedTimelinePreviewSnapshot === undefined
+      }
+      isLoadingTimelineSnapshot={
+        isTimelineSnapshotRequested && timelineSnapshot === undefined
+      }
+      isLoadingSnapshot={snapshot === undefined}
       onRequestDetailSnapshot={() =>
         setRequestedDetailSnapshotKey(
+          snapshotRequestKey === "skip" ? null : snapshotRequestKey,
+        )
+      }
+      onRequestStorePulseSnapshot={() =>
+        setRequestedStorePulseSnapshotKey(
+          snapshotRequestKey === "skip" ? null : snapshotRequestKey,
+        )
+      }
+      onRequestTimelineSnapshot={() =>
+        setRequestedTimelineSnapshotKey(
           snapshotRequestKey === "skip" ? null : snapshotRequestKey,
         )
       }
@@ -2593,6 +3623,9 @@ function DailyOperationsConnectedView({
       snapshot={snapshot}
       storePulseWindow={storePulseWindow}
       storeUrlSlug={params?.storeUrlSlug ?? ""}
+      storePulseSnapshot={storePulseSnapshot}
+      timelinePreviewSnapshot={timelinePreviewSnapshot}
+      timelineSnapshot={timelineSnapshot}
     />
   );
 }
@@ -2610,6 +3643,15 @@ export function DailyOperationsView() {
         dailyOperationsApi.getDailyOperationsDetailSnapshot
       }
       getDailyOperationsSnapshot={dailyOperationsApi.getDailyOperationsSnapshot}
+      getDailyOperationsStorePulseSnapshot={
+        dailyOperationsApi.getDailyOperationsStorePulseSnapshot
+      }
+      getDailyOperationsTimelinePreviewSnapshot={
+        dailyOperationsApi.getDailyOperationsTimelinePreviewSnapshot
+      }
+      getDailyOperationsTimelineSnapshot={
+        dailyOperationsApi.getDailyOperationsTimelineSnapshot
+      }
     />
   );
 }

--- a/packages/athena-webapp/src/components/operations/OperationsSummaryMetric.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsSummaryMetric.tsx
@@ -100,7 +100,7 @@ export function OperationsSummaryMetric({
       {helper ? (
         <p
           className={cn(
-            "mt-1 whitespace-nowrap text-xs leading-5 text-muted-foreground [&>span]:flex-nowrap",
+            "mt-1 text-xs leading-5 text-muted-foreground",
             helperClassName,
           )}
         >
@@ -110,11 +110,11 @@ export function OperationsSummaryMetric({
     </>
   );
   const rootClassName = cn(
-    "min-w-max rounded-lg border border-border bg-surface shadow-surface",
+    "min-w-0 rounded-lg border border-border bg-surface shadow-surface",
     tone === "quiet" ? "px-layout-md py-layout-md" : "px-layout-md py-layout-sm",
     onClick
       ? "block w-full text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-default disabled:hover:bg-surface"
-      : null,
+      : "w-full",
     className,
   );
 

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -1761,6 +1761,72 @@ describe("POSRegisterView", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("keeps the completed transaction workspace visible while closeout sync is pending", async () => {
+    const onRetrySync = vi.fn();
+    mockUseRegisterViewModel.mockReturnValue({
+      hasActiveStore: true,
+      header: {
+        title: "POS",
+        isSessionActive: false,
+      },
+      registerInfo: {
+        customerName: undefined,
+        registerLabel: "Front Counter",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {
+        disabled: true,
+        productSearchQuery: "",
+        setProductSearchQuery: vi.fn(),
+        onBarcodeSubmit: vi.fn(),
+      },
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: true,
+        total: 2700,
+      },
+      sessionPanel: {},
+      cashierCard: {},
+      closeoutControl: {
+        canCloseout: false,
+        canShowOpeningFloatCorrection: false,
+        canCorrectOpeningFloat: false,
+        onRequestCloseout: vi.fn(),
+        onRequestOpeningFloatCorrection: vi.fn(),
+      },
+      authDialog: {
+        open: false,
+      },
+      drawerGate: null,
+      syncStatus: {
+        description:
+          "This register was closed locally. Athena will reconcile the closeout after sync.",
+        label: "Locally closed",
+        reconciliationItems: [],
+        status: "locally_closed_pending_sync",
+        tone: "warning",
+        onRetrySync,
+      },
+      onNavigateBack: vi.fn(),
+    });
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    render(<POSRegisterView />);
+
+    expect(
+      screen.queryByText("Register closed locally"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("register-checkout-panel")).toBeInTheDocument();
+    expect(screen.getByText("checkout-total-2700")).toBeInTheDocument();
+    expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Ready for product lookup"),
+    ).not.toBeInTheDocument();
+  });
+
   it("focuses the product lookup entry when the empty lookup workspace is clicked", async () => {
     const setShowProductLookup = vi.fn();
 

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -1732,6 +1732,7 @@ function POSRegisterViewContent({
     } satisfies RegisterViewModel["onboarding"]);
   const isLocallyClosedPendingSync =
     isPosWorkflow &&
+    !viewModel.checkout.isTransactionCompleted &&
     viewModel.syncStatus?.status === "locally_closed_pending_sync";
   const isPosRegisterLocked = isPosWorkflow && isAwaitingCashierAuth;
   const shouldShowOnboarding =

--- a/packages/athena-webapp/src/components/store-pulse/StorePulseSummaryView.tsx
+++ b/packages/athena-webapp/src/components/store-pulse/StorePulseSummaryView.tsx
@@ -315,13 +315,15 @@ function getTrendValue({
     : day.transactionCount;
 }
 
-function StorePulseTimeline({
+export function StorePulseTimeline({
+  animationKey,
   canViewFinancialDetails,
   description,
   currencyFormatter,
   pulseWindow,
   snapshot,
 }: {
+  animationKey?: string;
   canViewFinancialDetails: boolean;
   description: string;
   currencyFormatter: Intl.NumberFormat;
@@ -344,6 +346,10 @@ function StorePulseTimeline({
         value: getTrendValue({ canViewFinancialDetails, day }),
       })),
     [canViewFinancialDetails, pulseWindow, snapshot.trend],
+  );
+  const chartAnimationKey = useMemo(
+    () => animationKey ?? chartData.map((day) => day.date).join("|"),
+    [animationKey, chartData],
   );
   const xAxisTicks = useMemo(() => {
     if (isMobile) {
@@ -390,9 +396,10 @@ function StorePulseTimeline({
       <div className="overflow-hidden rounded-lg border border-border bg-surface-raised px-layout-sm py-8 shadow-surface sm:p-8">
         <ChartContainer
           config={salesPulseChartConfig}
-          className="h-[22rem] w-full"
+          className="store-pulse-sales-trend-chart h-[22rem] w-full"
         >
           <AreaChart
+            className="store-pulse-sales-trend-plot"
             data={chartData}
             margin={{ left: 0, right: salesTrendAxisInset, top: 0, bottom: 0 }}
           >
@@ -485,10 +492,14 @@ function StorePulseTimeline({
               }
             />
             <Area
+              key={chartAnimationKey}
+              data-replay-key={chartAnimationKey}
               dataKey="value"
               fill="url(#store-pulse-sales-fill)"
               fillOpacity={1}
+              isAnimationActive={false}
               name={chartLabel}
+              pathLength={1}
               type="monotone"
               stroke="var(--color-value)"
               strokeWidth={3}
@@ -502,7 +513,7 @@ function StorePulseTimeline({
   );
 }
 
-function TopItemsPanel({
+export function TopItemsPanel({
   canViewFinancialDetails,
   currencyFormatter,
   snapshot,
@@ -616,7 +627,7 @@ function TopItemsPanel({
   );
 }
 
-function PaymentMethodsPanel({
+export function PaymentMethodsPanel({
   snapshot,
 }: {
   snapshot: StorePulseOperatorSnapshot;
@@ -833,18 +844,24 @@ function StorePulseSkeleton({
 
 export function StorePulseSummaryView({
   canViewFinancialDetails,
+  chartAnimationKey,
+  chartDescription,
   currencyFormatter,
   onPulseWindowChange,
   pulseWindow,
+  showDetailPanels = true,
   showPulseWindowFilter = true,
   showSummaryMetrics = true,
   summary,
   topItemsTitle = "Top items",
 }: {
   canViewFinancialDetails: boolean;
+  chartAnimationKey?: string;
+  chartDescription?: string;
   currencyFormatter: Intl.NumberFormat;
   onPulseWindowChange: (pulseWindow: StorePulseWindow) => void;
   pulseWindow: StorePulseWindow;
+  showDetailPanels?: boolean;
   showPulseWindowFilter?: boolean;
   showSummaryMetrics?: boolean;
   summary: StorePulseSummary | undefined;
@@ -992,8 +1009,9 @@ export function StorePulseSummaryView({
 
             {canViewFinancialDetails ? (
               <StorePulseTimeline
+                animationKey={chartAnimationKey}
                 canViewFinancialDetails={canViewFinancialDetails}
-                description={copy.chartDescription}
+                description={chartDescription ?? copy.chartDescription}
                 currencyFormatter={currencyFormatter}
                 pulseWindow={pulseWindow}
                 snapshot={snapshot}
@@ -1001,7 +1019,7 @@ export function StorePulseSummaryView({
             ) : null}
           </section>
 
-          {canViewFinancialDetails ? (
+          {canViewFinancialDetails && showDetailPanels ? (
             <PageWorkspaceGrid className="xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
               <PageWorkspaceMain>
                 <TopItemsPanel

--- a/packages/athena-webapp/src/index.css
+++ b/packages/athena-webapp/src/index.css
@@ -289,6 +289,51 @@
   }
 }
 
+@keyframes store-pulse-sales-trend-draw {
+  0% {
+    opacity: 0.38;
+    stroke-dashoffset: 1;
+  }
+
+  35% {
+    opacity: 0.82;
+  }
+
+  100% {
+    opacity: 1;
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes store-pulse-sales-trend-fill {
+  0% {
+    opacity: 0;
+  }
+
+  40% {
+    opacity: 0.12;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .store-pulse-sales-trend-chart .recharts-area-curve {
+    animation: store-pulse-sales-trend-draw 520ms
+      var(--ease-emphasized) both;
+    stroke-dasharray: 1;
+    stroke-dashoffset: 0;
+  }
+
+  .store-pulse-sales-trend-chart .recharts-area-area {
+    animation: store-pulse-sales-trend-fill 380ms
+      var(--ease-standard) both;
+    animation-delay: 120ms;
+  }
+}
+
 @layer utilities {
   .dark .bg-white,
   .dark .hover\:bg-white:hover {

--- a/scripts/harness-inferential-review.test.ts
+++ b/scripts/harness-inferential-review.test.ts
@@ -21,6 +21,7 @@ async function runFixtureCommand(rootDir: string, command: string[]) {
     cwd: rootDir,
     stdout: "pipe",
     stderr: "pipe",
+    env: gitFixtureEnv(),
   });
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(process.stdout).text(),
@@ -33,6 +34,12 @@ async function runFixtureCommand(rootDir: string, command: string[]) {
       `Fixture command failed: ${command.join(" ")}\n${stdout}\n${stderr}`,
     );
   }
+}
+
+function gitFixtureEnv() {
+  return Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")),
+  );
 }
 
 async function createFixtureRepo() {

--- a/scripts/harness-inferential-review.ts
+++ b/scripts/harness-inferential-review.ts
@@ -147,13 +147,19 @@ async function runCommand(
   command: string[],
   spawn: (
     command: string[],
-    options: { cwd: string; stdout: "pipe"; stderr: "pipe" },
+    options: {
+      cwd: string;
+      stdout: "pipe";
+      stderr: "pipe";
+      env: Record<string, string | undefined>;
+    },
   ) => SpawnedProcess = Bun.spawn,
 ) {
   const process = spawn(command, {
     cwd: rootDir,
     stdout: "pipe",
     stderr: "pipe",
+    env: buildGitProcessEnv(),
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([
@@ -167,6 +173,12 @@ async function runCommand(
     stderr,
     exitCode,
   };
+}
+
+function buildGitProcessEnv(env: NodeJS.ProcessEnv = process.env) {
+  return Object.fromEntries(
+    Object.entries(env).filter(([key]) => !key.startsWith("GIT_")),
+  );
 }
 
 export async function getChangedFilesForInferentialReview(

--- a/scripts/pr-athena-delivery-run.test.ts
+++ b/scripts/pr-athena-delivery-run.test.ts
@@ -15,6 +15,7 @@ function runGit(rootDir: string, args: string[]) {
   const result = spawnSync("git", args, {
     cwd: rootDir,
     encoding: "utf8",
+    env: gitFixtureEnv(),
   });
 
   if (result.status !== 0) {
@@ -22,6 +23,12 @@ function runGit(rootDir: string, args: string[]) {
   }
 
   return result.stdout.trim();
+}
+
+function gitFixtureEnv() {
+  return Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")),
+  );
 }
 
 describe("pr-athena delivery run wrapper", () => {

--- a/scripts/pr-athena-delivery-run.ts
+++ b/scripts/pr-athena-delivery-run.ts
@@ -79,6 +79,7 @@ async function runGitStdout(rootDir: string, args: string[]) {
     cwd: rootDir,
     stdout: "pipe",
     stderr: "pipe",
+    env: buildGitProcessEnv(),
   });
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(process.stdout).text(),
@@ -91,6 +92,12 @@ async function runGitStdout(rootDir: string, args: string[]) {
   }
 
   return stdout.trim();
+}
+
+function buildGitProcessEnv(env: NodeJS.ProcessEnv = process.env) {
+  return Object.fromEntries(
+    Object.entries(env).filter(([key]) => !key.startsWith("GIT_")),
+  );
 }
 
 export async function writePrAthenaProviderEvidence(


### PR DESCRIPTION
## Summary
- Stabilizes Daily Operations analytics hydration with separate cache boundaries for week data, store pulse detail, and timeline preview/detail.
- Keeps the user-selected store pulse detail hydration mode set to auto while preserving click-to-load affordances where configured.
- Reuses cached week strip data for selected-day trend rendering and avoids chart redraws when store pulse detail hydrates.
- Reduces Daily Operations snapshot read pressure by trimming timeline/detail payloads from the initial week query and moving heavy detail reads behind separate cacheable calls.
- Keeps the package-local Convex AI guide mirror and updates AGENTS guidance so agents can find both the repo-root guide and package mirror.
- Hardens harness Git subprocesses by sanitizing inherited hook GIT_* variables.

## Validation
- Reviewer loop: correctness, performance, frontend race, testing, project standards, harness patch, guide mirror, and env sanitization reviewers all approved.
- Focused Vitest: Daily Operations, POS register, store pulse query, operations close/open suites.
- Full pre-push gate passed locally before push: graphify, harness review, full webapp test sweep, Convex audit, changed-file lint, typecheck, production build, POS E2E, Storybook, and harness behavior scenarios.
- `bun run compound:check` passed after adding the delivery solution note.

## Notes
- Browser validation was intentionally left to the operator per prior direction.
- The package-local Convex guide is intentional: it mirrors `convex/_generated/ai/guidelines.md` so package-scoped agents do not miss the Convex guidance.