### PR TITLE
fix(pos): reduce register catalog reads

### DIFF
--- a/docs/solutions/performance/athena-pos-register-catalog-snapshot-and-closeout-gate-2026-06-30.md
+++ b/docs/solutions/performance/athena-pos-register-catalog-snapshot-and-closeout-gate-2026-06-30.md
@@ -1,0 +1,104 @@
+---
+title: Athena POS Register Catalog Uses Projection Snapshots
+date: 2026-06-30
+category: performance
+module: athena-webapp
+problem_type: performance_issue
+component: database
+symptoms:
+  - "Convex warned that pos/public/catalog:listRegisterCatalogSnapshot was nearing the single-function read limit"
+  - "The register closeout sync gate could take over the full POS body instead of preserving the register shell"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - convex
+  - performance
+  - pos
+  - catalog
+  - closeout
+---
+
+# Athena POS Register Catalog Uses Projection Snapshots
+
+## Problem
+
+The POS register catalog snapshot is a register boot hot path. It must not scan
+every SKU and then read each related product, category, color, and provisional
+import row one document at a time.
+
+The same register boot surface can also show blocking local runtime states. A
+local closeout sync gate should block sale actions without replacing the POS
+shell context that cashiers use to orient themselves.
+
+## Symptoms
+
+- Convex emitted `Many reads in a single function execution` for
+  `pos/public/catalog:listRegisterCatalogSnapshot`.
+- The warning reported roughly 3,472 reads against a 4,096 limit on a local
+  register catalog load.
+- The locally closed pending sync gate rendered as a full-width screen, hiding
+  the customer/totals strip and cart/payment rail used by other drawer gates.
+
+## What Didn't Work
+
+- Bounded frontend search and local IndexedDB caching did not remove the backend
+  warning because the snapshot query itself still hydrated catalog rows from
+  `productSku` plus per-row related documents.
+- Treating the closeout sync state as a special full-body workspace solved the
+  block but diverged from the drawer gate interaction pattern.
+
+## Solution
+
+Build the register catalog snapshot from the already-denormalized
+`productSkuSearch` projection:
+
+- Query `productSkuSearch.by_storeId` once for the store.
+- Filter trusted register rows from projection fields such as
+  `productAvailability`, `productIsVisible`, `categorySlug`, and `isVisible`.
+- Map register catalog row fields directly from projection fields such as
+  `productName`, `categoryName`, `colorName`, `images`, `price`, and `netPrice`.
+- Read active provisional imports separately and hydrate them from matching
+  projection rows when available.
+- Keep explicit category reads only for pending checkout item labels, and cache
+  those category documents by id.
+
+For the local closeout sync UI, keep the gate inside
+`register-main-workspace`. Do not special-case it as a two-column full-body
+state. The POS header, customer attribution, totals strip, empty cart, and
+payment rail should remain visible while sale entry/search actions stay blocked.
+
+## Why This Works
+
+The search projection already carries the denormalized fields needed by the POS
+catalog row. Reusing it converts the snapshot from many per-row document reads
+into one store-scoped projection read plus the small amount of pending-checkout
+and provisional-import evidence that is genuinely separate.
+
+Keeping the local closeout sync state in the main workspace also matches the
+drawer gate contract: the gate owns the action area, not the whole POS shell.
+That preserves operator context while still preventing new sale work until the
+closeout sync state clears.
+
+## Prevention
+
+- Do not rebuild POS catalog snapshots from `productSku` plus per-row product,
+  category, and color reads when a denormalized projection already exists.
+- Add high-cardinality tests that fail if register catalog snapshot generation
+  reads once per SKU through related documents.
+- Keep POS blocker states inside the established shell unless the blocker is
+  truly outside register context, such as store-day setup.
+- Run focused tests for both backend read shape and frontend shell layout before
+  rerunning `pr:athena`.
+
+## Related Validation
+
+- `bun run test -- convex/pos/application/queries/listRegisterCatalog.test.ts -t "uses the catalog snapshot to avoid reading every active SKU"`
+- `bun run test -- src/components/pos/register/POSRegisterView.test.tsx -t "locally closed sync gate"`
+- `bun run --filter '@athena/webapp' typecheck`
+- `bun run pr:athena`
+
+## Related
+
+- `docs/solutions/performance/athena-convex-read-amplification-2026-06-29.md`
+- `docs/solutions/logic-errors/athena-pos-synced-closeout-readiness-2026-06-17.md`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8316 nodes · 9930 edges · 2074 communities detected
+- 8318 nodes · 9932 edges · 2074 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2192,16 +2192,16 @@ Cohesion: 0.11
 Nodes (33): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+25 more)
 
 ### Community 20 - "Community 20"
+Cohesion: 0.12
+Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
+
+### Community 21 - "Community 21"
 Cohesion: 0.08
 Nodes (21): buildDisplaySafeConflictSummary(), buildTerminalSyncReviewSummary(), classifyTerminalSyncReviewConflict(), dedupeConflictsById(), emptyTerminalSyncReviewSummary(), getConflictBusinessKey(), getCurrentConflictKey(), getLatestRuntimeStatusForTerminal() (+13 more)
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.07
 Nodes (15): buildMissingDraftResult(), formatQueueWorkItemValue(), formatWorkItemTitle(), getQueueWorkItemArrayMetadataCount(), getQueueWorkItemInventoryReviewLineCount(), getQueueWorkItemStockAdjustmentSkuId(), getQueueWorkItemStringMetadata(), getQueueWorkItemTransactionId() (+7 more)
-
-### Community 22 - "Community 22"
-Cohesion: 0.12
-Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
 ### Community 23 - "Community 23"
 Cohesion: 0.07
@@ -2392,40 +2392,40 @@ Cohesion: 0.13
 Nodes (9): asCloudOperableSession(), countPendingSyncableLocalEventsForStaff(), hasSyncedSaleLocalEventsForStaff(), hasUploadedLocalEventsForStaff(), isCloudOperableSession(), isEmptyLocalSaleShell(), selectPassiveCloseoutBlockedRegisterSession(), trimOptional() (+1 more)
 
 ### Community 70 - "Community 70"
+Cohesion: 0.21
+Nodes (19): getRegisterCatalogPrice(), getRegisterCatalogProjectionPrice(), isActiveProvisionalImportSkuForStore(), isDraftAllowedInTrustedRegisterCatalog(), isTrustedRegisterCatalogProjection(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailability() (+11 more)
+
+### Community 71 - "Community 71"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.27
 Nodes (18): assertConformsToExportedReturns(), collectReturnValidatorIssues(), decodeSerializedFloat64(), decodeSerializedInt64(), decodeSerializedLiteralValue(), describeValue(), formatReturnValidatorIssues(), isConvexValue() (+10 more)
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.22
 Nodes (15): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), classifyRegisterSessionSyncReview(), findProjectedRegisterSessionIdForRepairableMissingMapping(), findTransactionIdForSyncEvent(), hasInventoryReviewWorkItemForProjectedSale(), isNonSaleMissingRegisterSessionMappingConflict() (+7 more)
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.22
 Nodes (18): assertPrAthenaProofReady(), classifySnapshotError(), collectFilesUnder(), collectProofSnapshot(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof() (+10 more)
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.17
 Nodes (13): buildProviderRegistry(), createIntelligenceRun(), defaultFakeOutput(), failedGenerationResult(), getStoreInsightsSnapshotFallback(), isActivityTrend(), isDeviceDistribution(), isInsightGenerationInProgressError() (+5 more)
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.16
 Nodes (10): buildProductSkuSearchProjection(), buildSearchText(), hydrateCanonicalProjection(), normalizeAttributes(), normalizeLookup(), projectionsEqual(), requireProductSkuSearchAccess(), requireProductSkuSearchAdmin() (+2 more)
-
-### Community 78 - "Community 78"
-Cohesion: 0.25
-Nodes (17): getRegisterCatalogPrice(), isActiveProvisionalImportSkuForStore(), isDraftAllowedInTrustedRegisterCatalog(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailability(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogAvailabilitySkus() (+9 more)
 
 ### Community 79 - "Community 79"
 Cohesion: 0.11
@@ -2884,28 +2884,28 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 193 - "Community 193"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
-### Community 194 - "Community 194"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
-### Community 195 - "Community 195"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 196 - "Community 196"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 197 - "Community 197"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 198 - "Community 198"
+### Community 194 - "Community 194"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
+
+### Community 195 - "Community 195"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
+### Community 196 - "Community 196"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 197 - "Community 197"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+
+### Community 198 - "Community 198"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.22

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2147
-- Graph nodes: 8316
-- Graph edges: 9930
+- Graph nodes: 8318
+- Graph edges: 9932
 - Communities: 2074
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
@@ -15,7 +15,8 @@ type TableName =
   | "inventoryImportProvisionalSku"
   | "posPendingCheckoutItem"
   | "product"
-  | "productSku";
+  | "productSku"
+  | "productSkuSearch";
 type Row = Record<string, unknown> & { _id: string };
 type IndexedFilter = {
   field: string;
@@ -36,6 +37,7 @@ function createRegisterCatalogCtx(
         "posPendingCheckoutItem",
         "product",
         "productSku",
+        "productSkuSearch",
       ] as TableName[]
     ).map((table) => [table, 0]),
   ) as Record<TableName, number>;
@@ -47,6 +49,7 @@ function createRegisterCatalogCtx(
     posPendingCheckoutItem: new Map(),
     product: new Map(),
     productSku: new Map(),
+    productSkuSearch: new Map(),
   };
 
   for (const [table, rows] of Object.entries(seed) as Array<
@@ -60,6 +63,64 @@ function createRegisterCatalogCtx(
         ...row,
       }),
     );
+  }
+
+  if (!seed.productSkuSearch) {
+    Array.from(tables.productSku.values()).forEach((sku, index) => {
+      const productId = sku.productId as string | undefined;
+      const product = productId ? tables.product.get(productId) : null;
+      if (!product) return;
+
+      const categoryId = product.categoryId as string | undefined;
+      const category = categoryId ? tables.category.get(categoryId) : null;
+      const colorId = sku.color as string | undefined;
+      const color = colorId ? tables.color.get(colorId) : null;
+      const skuCreationTime =
+        typeof sku._creationTime === "number" ? sku._creationTime : index;
+
+      tables.productSkuSearch.set(`search-${sku._id}`, {
+        _creationTime: skuCreationTime,
+        _id: `search-${sku._id}`,
+        barcode: sku.barcode,
+        categoryId,
+        categoryName: category?.name,
+        categorySlug: category?.slug,
+        colorId,
+        colorName: color?.name,
+        images: Array.isArray(sku.images) ? sku.images : [],
+        inventoryCount:
+          typeof sku.inventoryCount === "number" ? sku.inventoryCount : 0,
+        isVisible: sku.isVisible,
+        length: sku.length,
+        netPrice: sku.netPrice,
+        price: typeof sku.price === "number" ? sku.price : 0,
+        productAvailability: product.availability ?? "live",
+        productCategoryId: categoryId,
+        productDescription: product.description,
+        productId: product._id,
+        productInventoryCount:
+          typeof product.inventoryCount === "number"
+            ? product.inventoryCount
+            : 0,
+        productIsVisible: product.isVisible,
+        productName: product.name,
+        productProcessingFeesAbsorbed: product.areProcessingFeesAbsorbed,
+        productQuantityAvailable: product.quantityAvailable,
+        productSkuCreationTime: skuCreationTime,
+        productSkuId: sku._id,
+        productSubcategoryId: product.subcategoryId ?? "subcategory-missing",
+        quantityAvailable:
+          typeof sku.quantityAvailable === "number"
+            ? sku.quantityAvailable
+            : 0,
+        searchText: "",
+        size: sku.size,
+        sku: sku.sku,
+        storeId: sku.storeId,
+        updatedAt: 1,
+        sourceUpdatedAt: 1,
+      });
+    });
   }
 
   function countRead(table: TableName, count = 1) {
@@ -885,7 +946,7 @@ describe("listRegisterCatalog", () => {
       price: 1100 + index,
       quantityAvailable: 5,
     }));
-    const { ctx } = createRegisterCatalogCtx(
+    const { ctx, readCounts } = createRegisterCatalogCtx(
       {
         category: [
           {
@@ -911,6 +972,10 @@ describe("listRegisterCatalog", () => {
       name: "Club",
       price: 1504,
     });
+    expect(readCounts.category).toBe(0);
+    expect(readCounts.product).toBe(0);
+    expect(readCounts.productSku).toBe(0);
+    expect(readCounts.productSkuSearch).toBe(505);
   });
 
   it("returns bounded store-scoped availability for requested SKU ids after active holds", async () => {

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
@@ -52,8 +52,12 @@ type InventoryImportProvisionalSku = {
   importedProductName: string;
   importedSku?: string;
   importedBarcode?: string;
+  importedCategory?: string;
+  importedColor?: string;
+  importedLength?: number;
   importedPrice: number;
   importedQuantity: number;
+  importedSize?: string;
   provisionalQuantitySold?: number;
   provisionalTransactionCount?: number;
 };
@@ -77,9 +81,9 @@ function isDraftAllowedInTrustedRegisterCatalog(categorySlug?: string) {
   );
 }
 
-async function readCategoryName(
+async function readCategoryDoc(
   ctx: QueryCtx,
-  cache: Map<Id<"category">, string>,
+  cache: Map<Id<"category">, Doc<"category"> | null>,
   categoryId: Id<"category">,
 ) {
   const cached = cache.get(categoryId);
@@ -88,76 +92,80 @@ async function readCategoryName(
   }
 
   const category = await ctx.db.get("category", categoryId);
-  const name = category?.name ?? "";
-  cache.set(categoryId, name);
+  cache.set(categoryId, category);
 
-  return name;
+  return category;
 }
 
-async function readColorName(
-  ctx: QueryCtx,
-  cache: Map<Id<"color">, string>,
-  colorId: Id<"color"> | undefined,
-) {
-  if (!colorId) {
-    return "";
-  }
-
-  const cached = cache.get(colorId);
-  if (cached !== undefined) {
-    return cached;
-  }
-
-  const color = await ctx.db.get("color", colorId);
-  const name = color?.name ?? "";
-  cache.set(colorId, name);
-
-  return name;
-}
-
-function mapSkuToRegisterCatalogRow(args: {
-  product: Doc<"product">;
-  sku: Doc<"productSku">;
-  category: string;
-  color: string;
+function mapProjectionToRegisterCatalogRow(args: {
   pendingCheckoutItem?: PosPendingCheckoutItem;
-  provisionalSku?: InventoryImportProvisionalSku;
+  projection: Doc<"productSkuSearch">;
 }): RegisterCatalogRow {
   return {
-    id: args.provisionalSku?._id ?? args.sku._id,
-    productSkuId: args.sku._id,
-    skuId: args.sku._id,
-    productId: args.product._id,
-    ...(args.provisionalSku
-      ? { inventoryImportProvisionalSkuId: args.provisionalSku._id }
-      : {}),
+    id: args.projection.productSkuId,
+    productSkuId: args.projection.productSkuId,
+    skuId: args.projection.productSkuId,
+    productId: args.projection.productId,
     ...(args.pendingCheckoutItem
       ? { pendingCheckoutItemId: args.pendingCheckoutItem._id }
       : {}),
-    name: args.provisionalSku?.importedProductName ?? args.product.name,
-    sku: args.sku.sku || args.provisionalSku?.importedSku || "",
-    barcode: args.sku.barcode || args.provisionalSku?.importedBarcode || "",
+    name: args.projection.productName,
+    sku: args.projection.sku ?? "",
+    barcode: args.projection.barcode ?? "",
     price:
       args.pendingCheckoutItem?.provisionalPrice ??
-      args.provisionalSku?.importedPrice ??
-      getRegisterCatalogPrice(args.sku),
-    category: args.category,
-    description: args.product.description ?? "",
-    image: args.sku.images[0] ?? null,
-    size: args.sku.size ?? "",
-    length: args.sku.length ?? null,
-    color: args.color,
-    areProcessingFeesAbsorbed: args.product.areProcessingFeesAbsorbed ?? false,
+      getRegisterCatalogProjectionPrice(args.projection),
+    category: args.projection.categoryName ?? "",
+    description: args.projection.productDescription ?? "",
+    image: args.projection.images[0] ?? null,
+    size: args.projection.size ?? "",
+    length: args.projection.length ?? null,
+    color: args.projection.colorName ?? "",
+    areProcessingFeesAbsorbed:
+      args.projection.productProcessingFeesAbsorbed ?? false,
     availabilityPolicy: args.pendingCheckoutItem
       ? "pending_checkout"
-      : args.provisionalSku
-        ? "active_provisional_import"
-        : "trusted_inventory",
+      : "trusted_inventory",
+  };
+}
+
+function mapProvisionalSkuToRegisterCatalogRow(
+  provisionalSku: InventoryImportProvisionalSku,
+  projection?: Doc<"productSkuSearch">,
+): RegisterCatalogRow | null {
+  if (!provisionalSku.productId || !provisionalSku.productSkuId) {
+    return null;
+  }
+
+  return {
+    id: provisionalSku._id,
+    productSkuId: provisionalSku.productSkuId,
+    skuId: provisionalSku.productSkuId,
+    productId: provisionalSku.productId,
+    inventoryImportProvisionalSkuId: provisionalSku._id,
+    name: provisionalSku.importedProductName,
+    sku: projection?.sku || provisionalSku.importedSku || "",
+    barcode: projection?.barcode || provisionalSku.importedBarcode || "",
+    price: provisionalSku.importedPrice,
+    category:
+      projection?.categoryName ?? provisionalSku.importedCategory ?? "",
+    description: projection?.productDescription ?? "",
+    image: projection?.images[0] ?? null,
+    size: projection?.size ?? provisionalSku.importedSize ?? "",
+    length: projection?.length ?? provisionalSku.importedLength ?? null,
+    color: projection?.colorName ?? provisionalSku.importedColor ?? "",
+    areProcessingFeesAbsorbed:
+      projection?.productProcessingFeesAbsorbed ?? false,
+    availabilityPolicy: "active_provisional_import",
   };
 }
 
 function getRegisterCatalogPrice(sku: Doc<"productSku">) {
   return sku.netPrice ?? sku.price;
+}
+
+function getRegisterCatalogProjectionPrice(projection: Doc<"productSkuSearch">) {
+  return projection.netPrice ?? projection.price;
 }
 
 export function isTrustedRegisterCatalogSku(args: {
@@ -180,61 +188,75 @@ export function isTrustedRegisterCatalogSku(args: {
   );
 }
 
-async function listScopedRegisterCatalogSkus(
+function isTrustedRegisterCatalogProjection(
+  projection: Doc<"productSkuSearch">,
+) {
+  const isReservedPosOperationalProduct = projection.categorySlug
+    ? POS_OPERATIONAL_CATEGORY_SLUGS.has(projection.categorySlug)
+    : false;
+  const isDraftAllowed = isDraftAllowedInTrustedRegisterCatalog(
+    projection.categorySlug,
+  );
+
+  return (
+    projection.productAvailability !== "archived" &&
+    (projection.productAvailability !== "draft" || isDraftAllowed) &&
+    (projection.productIsVisible !== false || isReservedPosOperationalProduct) &&
+    (projection.isVisible !== false || isDraftAllowed)
+  );
+}
+
+async function listScopedRegisterCatalogProjections(
   ctx: QueryCtx,
   args: {
+    activeProvisionalProductSkuIds: Set<Id<"productSku">>;
     storeId: Id<"store">;
   },
 ) {
-  const rows: Array<{ product: Doc<"product">; sku: Doc<"productSku"> }> = [];
-  const productCache = new Map<Id<"product">, Doc<"product"> | null>();
+  const rows: Array<Doc<"productSkuSearch">> = [];
+  const projectionsBySkuId = new Map<
+    Id<"productSku">,
+    Doc<"productSkuSearch">
+  >();
+  const seenSkuIds = new Set<Id<"productSku">>();
   // Convex allows only one paginated query per function; this POS snapshot must read the store catalog in one query.
   // eslint-disable-next-line @convex-dev/no-collect-in-query
-  const skus = await ctx.db
-    .query("productSku")
+  const projections = await ctx.db
+    .query("productSkuSearch")
     .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
     .collect();
 
-  for (const sku of skus) {
-    let product = productCache.get(sku.productId);
-
-    if (product === undefined) {
-      product = (await ctx.db.get("product", sku.productId)) ?? null;
-      productCache.set(sku.productId, product);
-    }
-
-    if (!product || product.storeId !== args.storeId) {
+  for (const projection of projections.sort(
+    (left, right) => left.productSkuCreationTime - right.productSkuCreationTime,
+  )) {
+    if (seenSkuIds.has(projection.productSkuId)) {
       continue;
     }
+    seenSkuIds.add(projection.productSkuId);
+    projectionsBySkuId.set(projection.productSkuId, projection);
 
-    const category = await ctx.db.get("category", product.categoryId);
-
-    if (!isTrustedRegisterCatalogSku({ product, sku, category })) {
+    if (!isTrustedRegisterCatalogProjection(projection)) {
       continue;
     }
 
     if (
-      category?.slug === "legacy-import" &&
-      (product.availability === "draft" ||
-        product.isVisible === false ||
-        sku.isVisible === false) &&
-      (await readActiveProvisionalImportSkuForStoreSku(ctx, {
-        storeId: args.storeId,
-        productId: product._id,
-        productSkuId: sku._id,
-      }))
+      projection.categorySlug === "legacy-import" &&
+      (projection.productAvailability === "draft" ||
+        projection.productIsVisible === false ||
+        projection.isVisible === false) &&
+      args.activeProvisionalProductSkuIds.has(projection.productSkuId)
     ) {
       continue;
     }
 
-    if (getRegisterCatalogPrice(sku) <= 0) {
+    if (getRegisterCatalogProjectionPrice(projection) <= 0) {
       continue;
     }
 
-    rows.push({ product, sku });
+    rows.push(projection);
   }
 
-  return rows;
+  return { projectionsBySkuId, rows };
 }
 
 async function listScopedRegisterCatalogAvailabilitySkus(
@@ -245,6 +267,7 @@ async function listScopedRegisterCatalogAvailabilitySkus(
   },
 ) {
   const rows: Array<Doc<"productSku">> = [];
+  const categoryCache = new Map<Id<"category">, Doc<"category"> | null>();
   const productCache = new Map<Id<"product">, Doc<"product"> | null>();
   // Convex allows only one paginated query per function; this POS snapshot must read the store catalog in one query.
   // eslint-disable-next-line @convex-dev/no-collect-in-query
@@ -274,7 +297,7 @@ async function listScopedRegisterCatalogAvailabilitySkus(
       product.isVisible === false ||
       sku.isVisible === false;
     const category = needsOperationalCategoryCheck
-      ? await ctx.db.get("category", product.categoryId)
+      ? await readCategoryDoc(ctx, categoryCache, product.categoryId)
       : null;
 
     if (!isTrustedRegisterCatalogSku({ product, sku, category })) {
@@ -474,8 +497,15 @@ export async function listRegisterCatalog(
   },
 ) {
   const rows: RegisterCatalogRow[] = [];
-  const categoryCache = new Map<Id<"category">, string>();
-  const colorCache = new Map<Id<"color">, string>();
+  const activeProvisionalSkus = await queryActiveProvisionalImportSkusForStore(
+    ctx,
+    args,
+  );
+  const activeProvisionalProductSkuIds = new Set(
+    activeProvisionalSkus.flatMap((row) =>
+      row.productSkuId ? [row.productSkuId] : [],
+    ),
+  );
   const pendingCheckoutItemsBySkuId = new Map(
     (await queryActivePendingCheckoutItemsForStore(ctx, args)).flatMap(
       (item) =>
@@ -486,63 +516,51 @@ export async function listRegisterCatalog(
   );
   const trustedAvailableSkuIds = new Set<Id<"productSku">>();
 
-  for (const { product, sku } of await listScopedRegisterCatalogSkus(
+  const catalogProjectionSnapshot = await listScopedRegisterCatalogProjections(
     ctx,
-    args,
-  )) {
-    if (sku.quantityAvailable > 0) {
-      trustedAvailableSkuIds.add(sku._id);
+    {
+      activeProvisionalProductSkuIds,
+      storeId: args.storeId,
+    },
+  );
+
+  for (const projection of catalogProjectionSnapshot.rows) {
+    if (projection.quantityAvailable > 0) {
+      trustedAvailableSkuIds.add(projection.productSkuId);
     }
     rows.push(
-      mapSkuToRegisterCatalogRow({
-        product,
-        sku,
-        category: await readCategoryName(
-          ctx,
-          categoryCache,
-          product.categoryId,
+      mapProjectionToRegisterCatalogRow({
+        projection,
+        pendingCheckoutItem: pendingCheckoutItemsBySkuId.get(
+          projection.productSkuId,
         ),
-        color: await readColorName(ctx, colorCache, sku.color),
-        pendingCheckoutItem: pendingCheckoutItemsBySkuId.get(sku._id),
       }),
     );
   }
 
-  for (const provisionalSku of await queryActiveProvisionalImportSkusForStore(
-    ctx,
-    args,
-  )) {
-    const [product, sku] = await Promise.all([
-      ctx.db.get("product", provisionalSku.productId),
-      ctx.db.get("productSku", provisionalSku.productSkuId),
-    ]);
-
+  for (const provisionalSku of activeProvisionalSkus) {
     if (
-      !product ||
-      !sku ||
-      product.storeId !== args.storeId ||
-      product.availability === "archived" ||
-      sku.storeId !== args.storeId ||
-      sku.productId !== product._id ||
+      !provisionalSku.productSkuId ||
       trustedAvailableSkuIds.has(provisionalSku.productSkuId) ||
       provisionalSku.importedPrice <= 0
     ) {
       continue;
     }
 
-    rows.push(
-      mapSkuToRegisterCatalogRow({
-        product,
-        sku,
-        category: await readCategoryName(
-          ctx,
-          categoryCache,
-          product.categoryId,
-        ),
-        color: await readColorName(ctx, colorCache, sku.color),
-        provisionalSku,
-      }),
+    const projection = catalogProjectionSnapshot.projectionsBySkuId.get(
+      provisionalSku.productSkuId,
     );
+    if (projection?.productAvailability === "archived") {
+      continue;
+    }
+
+    const row = mapProvisionalSkuToRegisterCatalogRow(
+      provisionalSku,
+      projection,
+    );
+    if (row) {
+      rows.push(row);
+    }
   }
 
   return rows;

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -1686,7 +1686,7 @@ describe("POSRegisterView", () => {
     expect(onRetrySync).not.toHaveBeenCalled();
   });
 
-  it("hides sale controls while a locally closed register is waiting to sync", async () => {
+  it("shows the locally closed sync gate inside the register shell", async () => {
     const onRetrySync = vi.fn();
     mockUseRegisterViewModel.mockReturnValue({
       hasActiveStore: true,
@@ -1750,12 +1750,14 @@ describe("POSRegisterView", () => {
       screen.getByRole("button", { name: /retry sync/i }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText("register-customer-panel"),
-    ).not.toBeInTheDocument();
+      within(screen.getByTestId("register-main-workspace")).getByText(
+        "Register closed locally",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("register-customer-panel")).toBeInTheDocument();
+    expect(screen.getByText("register-checkout-panel")).toBeInTheDocument();
+    expect(screen.getByText("cart-items")).toBeInTheDocument();
     expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
-    expect(
-      screen.queryByText("register-checkout-panel"),
-    ).not.toBeInTheDocument();
     expect(
       screen.queryByText("Ready for product lookup"),
     ).not.toBeInTheDocument();

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -1462,32 +1462,36 @@ function LocalRegisterClosedWorkspace({
   syncStatus: NonNullable<RegisterViewModel["syncStatus"]>;
 }) {
   return (
-    <section className="flex h-full min-h-0 items-center justify-center rounded-lg border border-warning/30 bg-warning/10 px-layout-lg py-layout-xl text-center">
-      <div className="max-w-xl space-y-layout-md">
-        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-warning/30 bg-background text-warning">
-          <Cloud aria-hidden className="h-5 w-5" />
+    <section className="flex h-full min-h-0 items-start justify-center overflow-y-auto rounded-lg border border-border bg-surface-raised px-6 py-10 text-center sm:px-8 sm:pt-20">
+      <div className="w-[min(100%,40rem)]">
+        <div className="mx-auto flex max-w-2xl flex-col rounded-lg border border-border bg-surface-raised p-8 shadow-surface">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-warning/30 bg-warning/10 text-warning">
+            <Cloud aria-hidden className="h-5 w-5" />
+          </div>
+          <div className="mt-6 space-y-layout-xs">
+            <p className="text-xs font-medium uppercase tracking-[0.18em] text-warning">
+              Pending sync
+            </p>
+            <h2 className="font-display text-2xl font-semibold text-foreground">
+              Register closed locally
+            </h2>
+            <p className="text-sm leading-6 text-muted-foreground">
+              {syncStatus.description}
+            </p>
+          </div>
+          {syncStatus.onRetrySync ? (
+            <div className="mt-6 flex justify-center">
+              <button
+                className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-border bg-background px-4 text-sm font-medium text-foreground transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                onClick={syncStatus.onRetrySync}
+                type="button"
+              >
+                <RefreshCw className="h-4 w-4" />
+                Retry sync
+              </button>
+            </div>
+          ) : null}
         </div>
-        <div className="space-y-layout-xs">
-          <p className="text-xs font-medium uppercase tracking-[0.18em] text-warning">
-            Pending sync
-          </p>
-          <h2 className="font-display text-2xl font-semibold text-foreground">
-            Register closed locally
-          </h2>
-          <p className="text-sm leading-6 text-muted-foreground">
-            {syncStatus.description}
-          </p>
-        </div>
-        {syncStatus.onRetrySync ? (
-          <button
-            className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-border bg-background px-4 text-sm font-medium text-foreground transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-            onClick={syncStatus.onRetrySync}
-            type="button"
-          >
-            <RefreshCw className="h-4 w-4" />
-            Retry sync
-          </button>
-        ) : null}
       </div>
     </section>
   );
@@ -1730,11 +1734,13 @@ function POSRegisterViewContent({
       cashierCount: viewModel.cashierCard ? 1 : 0,
       nextStep: "ready",
     } satisfies RegisterViewModel["onboarding"]);
+  const localCloseoutSyncStatus = viewModel.syncStatus;
   const isLocallyClosedPendingSync =
     isPosWorkflow &&
     !viewModel.checkout.isTransactionCompleted &&
-    viewModel.syncStatus?.status === "locally_closed_pending_sync";
-  const isPosRegisterLocked = isPosWorkflow && isAwaitingCashierAuth;
+    localCloseoutSyncStatus?.status === "locally_closed_pending_sync";
+  const isPosRegisterLocked =
+    isPosWorkflow && isAwaitingCashierAuth && !isLocallyClosedPendingSync;
   const shouldShowOnboarding =
     isPosWorkflow &&
     onboardingState.shouldShow &&
@@ -1779,7 +1785,7 @@ function POSRegisterViewContent({
   const isRegisterOperable =
     isPosWorkflow && isHeaderProductSearchSupported && !viewModel.drawerGate;
   const shouldRenderSaleSurface = isPosWorkflow
-    ? !viewModel.checkout.isTransactionCompleted && !isLocallyClosedPendingSync
+    ? !viewModel.checkout.isTransactionCompleted
     : true;
   const shouldRenderExpenseCompletionWorkspace =
     !isPosWorkflow &&
@@ -1820,8 +1826,7 @@ function POSRegisterViewContent({
     !isResolvingRegisterSetup &&
     (shouldRenderCartSidebar ||
       shouldRenderCheckoutPanel ||
-      isAwaitingCashierAuth) &&
-    !isLocallyClosedPendingSync;
+      isAwaitingCashierAuth);
   const shouldPreviewCompletedExpenseItems =
     !isPosWorkflow && viewModel.checkout.isTransactionCompleted;
   const completedExpenseCartItems = shouldPreviewCompletedExpenseItems
@@ -2162,7 +2167,7 @@ function POSRegisterViewContent({
                 {isPosWorkflow ? (
                   <RegisterSyncStatusChip
                     isRegisterOperable={isRegisterOperable}
-                    syncStatus={viewModel.syncStatus}
+                    syncStatus={localCloseoutSyncStatus}
                   />
                 ) : null}
               </div>
@@ -2248,13 +2253,7 @@ function POSRegisterViewContent({
           ) : null}
 
           <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 overflow-hidden lg:grid-cols-[minmax(0,2fr)_minmax(340px,1fr)]">
-            {isLocallyClosedPendingSync && viewModel.syncStatus ? (
-              <div className="lg:col-span-2">
-                <LocalRegisterClosedWorkspace
-                  syncStatus={viewModel.syncStatus}
-                />
-              </div>
-            ) : shouldRenderSaleSurface ? (
+            {shouldRenderSaleSurface ? (
               <div
                 data-testid="register-main-workspace"
                 className={cn(
@@ -2262,7 +2261,11 @@ function POSRegisterViewContent({
                   !shouldRenderWorkspaceSidebar && "lg:col-span-2",
                 )}
               >
-                {shouldShowOnboarding ? (
+                {isLocallyClosedPendingSync && localCloseoutSyncStatus ? (
+                  <LocalRegisterClosedWorkspace
+                    syncStatus={localCloseoutSyncStatus}
+                  />
+                ) : shouldShowOnboarding ? (
                   <POSOnboardingWorkspace onboarding={onboardingState} />
                 ) : isResolvingCashierPresence ? (
                   <RegisterSetupResolvingWorkspace />


### PR DESCRIPTION
## Summary
- Reworks the POS register catalog snapshot to build trusted rows from the denormalized product SKU search projection instead of per-SKU product/category/color reads.
- Keeps active provisional import and pending checkout rows in the register snapshot without reintroducing broad related-document hydration.
- Aligns the locally closed pending-sync POS gate with the drawer-gate shell pattern so the customer/totals strip and cart/payment rail remain visible.
- Adds a solution note for the reusable Convex read-amplification and POS shell-gate patterns.

## Why
The local POS register was still warning on `pos/public/catalog:listRegisterCatalogSnapshot` with roughly 3,472 reads, close to Convex's single-function read limit. The closeout sync gate also diverged from the rest of the register shell by replacing the full POS workspace.

## Validation
- `bun run test -- convex/pos/application/queries/listRegisterCatalog.test.ts -t "uses the catalog snapshot to avoid reading every active SKU"`
- `bun run test -- src/components/pos/register/POSRegisterView.test.tsx -t "locally closed sync gate"`
- `bun run --filter '@athena/webapp' typecheck`
- `bun run pr:athena` (passed on rebased branch; proof recorded)