### PR TITLE
Refresh current-day operations facts

### DIFF
--- a/docs/solutions/logic-errors/athena-daily-operations-current-day-refresh-2026-06-30.md
+++ b/docs/solutions/logic-errors/athena-daily-operations-current-day-refresh-2026-06-30.md
@@ -1,0 +1,77 @@
+---
+title: Athena Daily Operations Uses Store-Day Currentness for Refreshable Facts
+date: 2026-06-30
+category: logic-errors
+module: athena-webapp
+problem_type: logic_error
+component: operations
+symptoms:
+  - "The POS pulse could show sales for today when there were no current store-day sales"
+  - "Daily Operations cached week analytics could age while the timeline continued updating"
+  - "Operators needed refreshed current-day sales trend, top item, and payment mix facts without a full live query"
+root_cause: stale_current_day_boundary
+resolution_type: code_fix
+severity: medium
+tags:
+  - daily-operations
+  - store-day
+  - pos
+  - cache
+  - convex
+---
+
+# Athena Daily Operations Uses Store-Day Currentness for Refreshable Facts
+
+## Problem
+
+Athena operations surfaces mix two kinds of data:
+
+- Live operational events, such as the store-day timeline.
+- Cached or compact analytics, such as sales totals, sales trend, top items,
+  and payment mix.
+
+If "today" is inferred from wall-clock date or stale history alone, the UI can
+show the wrong facts for the active store day. If cached analytics are only
+hydrated on initial page load, operators may see an updated timeline beside
+stale current-day sales facts.
+
+## Solution
+
+Use the store-day window as the current-day boundary, and refresh only the
+current-day facts that age:
+
+- Resolve POS "today" from the active Opening Handoff store-day object when it
+  contains the current time.
+- Ignore stale unclosed openings whose expected store-day window is no longer
+  active.
+- Add a narrow current-day refresh query for Daily Operations instead of
+  refetching the full weekly detail snapshot.
+- Merge the refresh payload into the local display cache for the selected day:
+  summary cards, selected week metric, sales trend, top items, and payment mix.
+- Leave timeline refresh on its existing path; do not route it through the
+  analytics refresh button.
+- Treat cached current-day analytics as stale after a bounded interval and
+  trigger the same scoped refresh path automatically.
+
+## Prevention
+
+- Do not key POS or operations "today" from a bare date comparison when a
+  store-day object exists. Validate that the store-day window contains `now`
+  before using it as the current operating day.
+- Do not add a broad live query for the full Daily Operations page just to
+  refresh current-day analytics. Return the selected day metric, prior-day
+  comparison metric, summary cards, and store pulse payload only.
+- Keep the manual refresh control and stale-time auto refresh on the same query
+  path so tests cover both operator and timer-triggered updates.
+- The timestamp may update after either initial week hydration or current-day
+  refresh, but operator copy should remain generic: "Data refreshed at ...".
+- Add regression coverage for stale store-day windows, clear no-sales copy, the
+  scoped refresh query, and the stale timer boundary.
+
+## Related Validation
+
+- `bun run test -- convex/operations/dailyOperations.test.ts`
+- `bun run test -- src/components/operations/DailyOperationsView.test.tsx`
+- `bun run test -- convex/pos/application/getTransactions.test.ts`
+- `bun run test -- src/components/pos/sales-pulse/POSSalesPulseView.test.tsx`
+- `bun run pr:athena`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8318 nodes · 9932 edges · 2074 communities detected
+- 8322 nodes · 9938 edges · 2074 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2213,35 +2213,35 @@ Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), colle
 
 ### Community 25 - "Community 25"
 Cohesion: 0.11
-Nodes (21): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), buildLocalAvailabilityEventIndex(), cartItemLineEventKey(), cartItemLineKey(), cartItemsFromLocalRegisterModel(), cartLineSourceKey(), formatLocalPendingCheckoutSku() (+13 more)
+Nodes (23): applyTodayRefreshSnapshot(), buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), formatPendingApprovalsLabel(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate() (+15 more)
 
 ### Community 26 - "Community 26"
+Cohesion: 0.11
+Nodes (21): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), buildLocalAvailabilityEventIndex(), cartItemLineEventKey(), cartItemLineKey(), cartItemsFromLocalRegisterModel(), cartLineSourceKey(), formatLocalPendingCheckoutSku() (+13 more)
+
+### Community 27 - "Community 27"
 Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.15
 Nodes (27): addDays(), addField(), contextWindowsForDate(), dayOfWeek(), exceptionWindowsOverlap(), findNextWindow(), getFormatter(), getMissingStoreScheduleContext() (+19 more)
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.12
 Nodes (25): buildDiagnosticEvidence(), buildTerminalOperationalExplanation(), buildTerminalOperationalState(), buildTerminalRecoveryActions(), buildTerminalRecoveryManualReview(), classifySalesReadiness(), classifySupportRecovery(), classifyTerminalHealth() (+17 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.12
 Nodes (26): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildInventorySnapshotRowsForProductSkusWithCtx(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle() (+18 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.11
 Nodes (24): buildGitProcessEnv(), buildProviderSkip(), collectCommandsForChangedFiles(), commandDisplayName(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs() (+16 more)
-
-### Community 32 - "Community 32"
-Cohesion: 0.12
-Nodes (21): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), formatPendingApprovalsLabel(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate() (+13 more)
 
 ### Community 33 - "Community 33"
 Cohesion: 0.13
@@ -2336,24 +2336,24 @@ Cohesion: 0.12
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
 
 ### Community 56 - "Community 56"
-Cohesion: 0.17
-Nodes (21): buildHomepageSnapshotV1(), hydrateCategory(), hydrateFeaturedItem(), hydrateProduct(), hydrateSubcategory(), hydrateTargetProducts(), isCustomerVisibleProduct(), isCustomerVisibleSku() (+13 more)
+Cohesion: 0.15
+Nodes (17): findCurrentStoreDayOpening(), getTodaySummary(), getTransactionById(), isActivePosSummaryOpeningAt(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents() (+9 more)
 
 ### Community 57 - "Community 57"
 Cohesion: 0.17
-Nodes (19): assertValidEodLocalCompletionWindowMinutes(), assertValidEodThreshold(), assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getEodAutoCompletePolicyConfigWithCtx() (+11 more)
+Nodes (21): buildHomepageSnapshotV1(), hydrateCategory(), hydrateFeaturedItem(), hydrateProduct(), hydrateSubcategory(), hydrateTargetProducts(), isCustomerVisibleProduct(), isCustomerVisibleSku() (+13 more)
 
 ### Community 58 - "Community 58"
+Cohesion: 0.17
+Nodes (19): assertValidEodLocalCompletionWindowMinutes(), assertValidEodThreshold(), assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getEodAutoCompletePolicyConfigWithCtx() (+11 more)
+
+### Community 59 - "Community 59"
 Cohesion: 0.16
 Nodes (17): asRecord(), buildSnapshotHash(), buildStoreInsightsPromptFromContextBundle(), buildStoreInsightsPromptFromContextEvents(), buildUserInsightsPromptFromContextBundle(), buildUserInsightsPromptFromContextEvents(), compactContextEventsForPrompt(), compactEnvironmentForPrompt() (+9 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
-
-### Community 60 - "Community 60"
-Cohesion: 0.15
-Nodes (16): findLatestOpenOperatingDay(), getTodaySummary(), getTransactionById(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile() (+8 more)
 
 ### Community 61 - "Community 61"
 Cohesion: 0.1
@@ -2884,28 +2884,28 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 193 - "Community 193"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 194 - "Community 194"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 195 - "Community 195"
+### Community 194 - "Community 194"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 196 - "Community 196"
+### Community 195 - "Community 195"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 197 - "Community 197"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
-
-### Community 198 - "Community 198"
+### Community 196 - "Community 196"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 197 - "Community 197"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 198 - "Community 198"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.22
@@ -3356,8 +3356,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 311 - "Community 311"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 312 - "Community 312"
 Cohesion: 0.33
@@ -3372,80 +3372,80 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 315 - "Community 315"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 316 - "Community 316"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 316 - "Community 316"
+### Community 317 - "Community 317"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
-### Community 317 - "Community 317"
+### Community 318 - "Community 318"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.53
 Nodes (5): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 321 - "Community 321"
+### Community 322 - "Community 322"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 322 - "Community 322"
+### Community 323 - "Community 323"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 323 - "Community 323"
+### Community 324 - "Community 324"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 324 - "Community 324"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 325 - "Community 325"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 326 - "Community 326"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 327 - "Community 327"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 328 - "Community 328"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 329 - "Community 329"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 330 - "Community 330"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 331 - "Community 331"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 332 - "Community 332"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 332 - "Community 332"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 333 - "Community 333"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 334 - "Community 334"
 Cohesion: 0.53
@@ -6213,11 +6213,11 @@ Nodes (0):
 
 ### Community 1025 - "Community 1025"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1026 - "Community 1026"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1027 - "Community 1027"
 Cohesion: 1.0
@@ -10708,67 +10708,69 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 893`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 894`** (2 nodes): `getTodayRefreshCalls()`, `DailyOperationsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 895`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 896`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 897`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 898`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 899`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 900`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 901`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 902`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 903`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 904`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 905`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 906`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 907`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 908`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
+- **Thin community `Community 909`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 910`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 911`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 912`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 913`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 914`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 915`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 916`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 917`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 918`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 919`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 920`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 921`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 922`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 923`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 924`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 925`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -10804,1333 +10806,1331 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 926`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 927`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 928`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 929`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 930`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 931`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 932`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 933`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 934`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 935`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
+- **Thin community `Community 936`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 937`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 938`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 939`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 940`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 941`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 942`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 943`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 944`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 945`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 946`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 947`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 948`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 949`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 950`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 951`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 952`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 953`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 954`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 955`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 956`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 957`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 958`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 959`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 960`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 961`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 962`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 963`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 964`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 965`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 966`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 967`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 968`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 969`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 970`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 971`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 972`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 973`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 974`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 975`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 976`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 977`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 978`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 979`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 980`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 981`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 982`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 983`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 984`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 985`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 986`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 987`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 988`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 989`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 990`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 991`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 992`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 993`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 994`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 995`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 996`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 997`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 998`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 999`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1000`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1001`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1002`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1003`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1004`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1005`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1006`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1007`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1008`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1009`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1010`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1011`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1012`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1013`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1014`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1015`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1016`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1017`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1018`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1019`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1020`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1021`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1022`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1023`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1024`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1025`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1026`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1027`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1028`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1029`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1030`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1031`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1032`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1033`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 1034`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1035`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1036`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1037`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1038`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1039`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1040`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1041`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1042`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1043`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1044`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1045`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
+- **Thin community `Community 1046`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1047`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1048`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1049`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1050`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
+- **Thin community `Community 1051`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1052`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1053`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1054`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1055`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1056`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1057`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1058`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1059`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1060`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1061`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1062`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1063`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `Index()`, `-index-route-view.tsx`
+- **Thin community `Community 1064`** (2 nodes): `Index()`, `-index-route-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1065`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1066`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1067`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1068`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1069`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1070`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1071`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1072`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1073`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
+- **Thin community `Community 1074`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1075`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1076`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1077`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1078`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1079`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1080`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1081`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1082`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1083`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1084`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1085`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1086`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1087`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1088`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1089`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1090`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1091`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1092`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1093`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1094`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1095`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1096`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1097`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1098`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1099`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1100`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1101`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1102`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1103`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1104`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1105`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1106`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1107`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1108`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1109`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1110`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1111`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1112`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1113`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1114`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1115`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1116`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1117`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1118`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1119`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1120`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1121`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1122`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1123`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1124`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1125`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1126`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1127`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1128`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1129`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1130`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1131`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1132`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1133`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1134`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1135`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1136`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1137`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1138`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1139`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1140`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1141`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1142`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1143`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1144`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1145`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1146`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1147`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1148`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1149`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1150`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1151`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1152`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1153`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1154`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1155`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1156`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1157`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1158`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1159`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1160`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1161`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1162`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1163`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1164`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1165`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1166`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1167`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1168`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1169`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1170`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1171`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1172`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1173`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1174`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1175`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1176`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1177`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1178`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1179`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1180`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1181`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1182`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1183`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1184`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1185`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1186`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1187`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1188`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1189`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1190`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1191`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1192`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1193`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1194`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1195`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1196`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1197`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1198`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1199`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1200`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1201`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1202`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1203`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1204`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1205`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1206`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1207`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1208`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1209`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1210`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1211`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1212`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1213`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1214`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1215`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1216`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1217`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1218`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1219`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `api.js`
+- **Thin community `Community 1220`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1221`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1222`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `server.js`
+- **Thin community `Community 1223`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `app.ts`
+- **Thin community `Community 1224`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1225`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1226`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1227`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1228`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `auth.ts`
+- **Thin community `Community 1229`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1230`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1231`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1232`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `countries.ts`
+- **Thin community `Community 1233`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `email.ts`
+- **Thin community `Community 1234`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1235`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `payment.ts`
+- **Thin community `Community 1236`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `contextEvents.test.ts`
+- **Thin community `Community 1237`** (1 nodes): `contextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1238`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `types.ts`
+- **Thin community `Community 1239`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1240`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `crons.ts`
+- **Thin community `Community 1241`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1242`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `internal.ts`
+- **Thin community `Community 1243`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1244`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1245`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1246`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1247`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1248`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1249`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1250`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1251`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1252`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1253`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1254`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `env.ts`
+- **Thin community `Community 1255`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1256`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `auth.ts`
+- **Thin community `Community 1257`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1258`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `colors.ts`
+- **Thin community `Community 1259`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `index.ts`
+- **Thin community `Community 1260`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1261`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `products.ts`
+- **Thin community `Community 1262`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1263`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `stores.ts`
+- **Thin community `Community 1264`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1265`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `bag.ts`
+- **Thin community `Community 1266`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `guest.ts`
+- **Thin community `Community 1267`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1268`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `index.ts`
+- **Thin community `Community 1269`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `me.ts`
+- **Thin community `Community 1270`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `offers.ts`
+- **Thin community `Community 1271`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1272`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1273`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1274`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1275`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1276`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1277`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1278`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1279`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1280`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `user.ts`
+- **Thin community `Community 1281`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1282`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `index.ts`
+- **Thin community `Community 1283`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1284`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `http.ts`
+- **Thin community `Community 1285`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `access.ts`
+- **Thin community `Community 1286`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1287`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1288`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1289`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `index.ts`
+- **Thin community `Community 1290`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1291`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `types.ts`
+- **Thin community `Community 1292`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1293`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `categories.ts`
+- **Thin community `Community 1294`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `colors.ts`
+- **Thin community `Community 1295`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1296`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1297`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1298`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1299`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `pos.ts`
+- **Thin community `Community 1300`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1301`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1302`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1303`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1304`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1305`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1306`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1307`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1308`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1309`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1310`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1311`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1312`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1313`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1314`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1315`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1316`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1317`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `types.ts`
+- **Thin community `Community 1318`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1319`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1320`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1321`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1322`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1323`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1324`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `dto.ts`
+- **Thin community `Community 1325`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1326`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1327`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1328`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `types.ts`
+- **Thin community `Community 1329`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `facts.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `types.ts`
+- **Thin community `Community 1330`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1331`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1332`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `types.ts`
+- **Thin community `Community 1333`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1334`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `customers.ts`
+- **Thin community `Community 1335`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `register.test.ts`
+- **Thin community `Community 1336`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `register.ts`
+- **Thin community `Community 1337`** (1 nodes): `register.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `sync.ts`
+- **Thin community `Community 1338`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1339`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1340`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1341`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `schema.ts`
+- **Thin community `Community 1342`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `automation.ts`
+- **Thin community `Community 1343`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1344`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1345`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `index.ts`
+- **Thin community `Community 1346`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1347`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1348`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1349`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1350`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1351`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1352`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1353`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `category.ts`
+- **Thin community `Community 1354`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `color.ts`
+- **Thin community `Community 1355`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1356`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1357`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `index.ts`
+- **Thin community `Community 1358`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1359`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1360`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1361`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1362`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `organization.ts`
+- **Thin community `Community 1363`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1364`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `product.ts`
+- **Thin community `Community 1365`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1366`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1367`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1368`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `store.ts`
+- **Thin community `Community 1369`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1370`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1371`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `index.ts`
+- **Thin community `Community 1372`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1373`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1374`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1375`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1376`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1377`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1378`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1379`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `index.ts`
+- **Thin community `Community 1380`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1381`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1382`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1383`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1384`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1385`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1386`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1387`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1388`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1389`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1390`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1391`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `customer.ts`
+- **Thin community `Community 1392`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1393`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1394`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1395`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1396`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `index.ts`
+- **Thin community `Community 1397`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1398`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1399`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1400`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1401`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1402`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1403`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1404`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1405`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1406`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1407`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1408`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1409`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1410`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1411`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1412`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1413`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1414`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1415`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1416`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `index.ts`
+- **Thin community `Community 1417`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1418`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1419`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `index.ts`
+- **Thin community `Community 1420`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1421`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1422`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1423`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1424`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1425`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1426`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `index.ts`
+- **Thin community `Community 1427`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1428`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1429`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1430`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1431`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1432`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1433`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `bag.ts`
+- **Thin community `Community 1434`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1435`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1436`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1437`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `guest.ts`
+- **Thin community `Community 1438`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `index.ts`
+- **Thin community `Community 1439`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `offer.ts`
+- **Thin community `Community 1440`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1441`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1442`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `review.ts`
+- **Thin community `Community 1443`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1444`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1445`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1446`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1447`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1448`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1449`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1450`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1451`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1452`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `bag.ts`
+- **Thin community `Community 1453`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1454`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `customer.ts`
+- **Thin community `Community 1455`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `guest.ts`
+- **Thin community `Community 1456`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1457`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1458`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1459`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1460`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1461`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1462`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1463`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `users.ts`
+- **Thin community `Community 1464`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `payment.ts`
+- **Thin community `Community 1465`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1466`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1467`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1468`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1469`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1470`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1471`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1472`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `index.ts`
+- **Thin community `Community 1473`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1474`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1475`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1476`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1477`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `auth.ts`
+- **Thin community `Community 1478`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1479`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1480`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1481`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1482`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1483`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1484`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1485`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `index.ts`
+- **Thin community `Community 1486`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1487`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1488`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1489`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1490`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1491`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1492`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1493`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1494`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1495`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1496`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1497`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1498`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1499`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1500`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1501`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1502`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1503`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1504`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1505`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1506`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1507`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `constants.ts`
+- **Thin community `Community 1508`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1509`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1510`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1511`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `types.ts`
+- **Thin community `Community 1512`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1513`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1514`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1515`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1516`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1517`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1518`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1519`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1520`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1521`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1522`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1523`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1524`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1525`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1526`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1527`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1528`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1529`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1530`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1531`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1532`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `constants.ts`
+- **Thin community `Community 1533`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1534`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1535`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1536`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `data.ts`
+- **Thin community `Community 1537`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1538`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1539`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1540`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1541`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1542`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1543`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1544`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1545`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1546`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `constants.ts`
+- **Thin community `Community 1547`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1548`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1549`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1550`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `data.ts`
+- **Thin community `Community 1551`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1552`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1553`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1554`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1555`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1556`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1557`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1558`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1559`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1560`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1561`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1562`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1563`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `constants.ts`
+- **Thin community `Community 1564`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1565`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1566`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1567`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1568`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1569`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1570`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1571`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1572`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1573`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1574`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1575`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1576`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1577`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1578`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1579`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1580`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1581`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1582`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1583`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1584`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1585`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1586`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1587`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `DailyOperationsView.test.tsx`
+- **Thin community `Community 1588`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1589`** (1 nodes): `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2147
-- Graph nodes: 8318
-- Graph edges: 9932
+- Graph nodes: 8322
+- Graph edges: 9938
 - Communities: 2074
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -7,6 +7,7 @@ import {
   getDailyOperationsDetailSnapshot,
   getDailyOperationsSnapshot,
   getDailyOperationsStorePulseSnapshot,
+  getDailyOperationsTodayRefreshSnapshot,
   getDailyOperationsTimelinePreviewSnapshot,
   getDailyOperationsTimelineSnapshot,
 } from "./dailyOperations";
@@ -530,13 +531,14 @@ describe("daily operations overview read model", () => {
       },
     );
 
-    expect(snapshot.automationStatuses.find((status) => status.lane === "close"))
-      .toMatchObject({
-        bucket: "needs_review",
-        id: "automation-close-prepare",
-        outcome: "prepared",
-        policyMode: "enabled",
-      });
+    expect(
+      snapshot.automationStatuses.find((status) => status.lane === "close"),
+    ).toMatchObject({
+      bucket: "needs_review",
+      id: "automation-close-prepare",
+      outcome: "prepared",
+      policyMode: "enabled",
+    });
   });
 
   it("prefers applied EOD auto-complete status for closed days over stale skipped dry-run runs", async () => {
@@ -566,7 +568,8 @@ describe("daily operations overview read model", () => {
                 maxVoidedSaleTotal: 0,
               },
             },
-            decisionReason: "EOD Review is clean and eligible for auto-complete.",
+            decisionReason:
+              "EOD Review is clean and eligible for auto-complete.",
             domain: "daily_operations",
             idempotencyKey:
               "daily_operations:eod.auto_complete:store-1:2026-05-08",
@@ -585,7 +588,8 @@ describe("daily operations overview read model", () => {
             _id: "automation-close-stale-skipped",
             action: "eod.auto_complete",
             createdAt: Date.UTC(2026, 4, 8, 23),
-            decisionReason: "EOD Review is already completed for this store day.",
+            decisionReason:
+              "EOD Review is already completed for this store day.",
             domain: "daily_operations",
             idempotencyKey:
               "daily_operations:eod.auto_complete:store-1:2026-05-08:retry",
@@ -677,20 +681,22 @@ describe("daily operations overview read model", () => {
     expect(snapshot.lifecycle.status).toBe("closed");
     expect(snapshot.completedClose).toMatchObject({
       actorType: "automation",
-      automationDecisionReason: "EOD Review is clean and eligible for auto-complete.",
+      automationDecisionReason:
+        "EOD Review is clean and eligible for auto-complete.",
       automationRunId: "automation-close-applied",
     });
-    expect(snapshot.automationStatuses.find((status) => status.lane === "close"))
-      .toMatchObject({
-        decisionEvidence: {
-          kind: "eod_auto_complete",
-        },
-        decisionReason: "EOD Review is clean and eligible for auto-complete.",
-        id: "automation-close-applied",
-        outcome: "applied",
-        policyMode: "enabled",
-        policyVersion: "daily-operations.v1",
-      });
+    expect(
+      snapshot.automationStatuses.find((status) => status.lane === "close"),
+    ).toMatchObject({
+      decisionEvidence: {
+        kind: "eod_auto_complete",
+      },
+      decisionReason: "EOD Review is clean and eligible for auto-complete.",
+      id: "automation-close-applied",
+      outcome: "applied",
+      policyMode: "enabled",
+      policyVersion: "daily-operations.v1",
+    });
   });
 
   it("redacts EOD auto-complete decision evidence for broad Daily Operations readers", async () => {
@@ -818,7 +824,9 @@ describe("daily operations overview read model", () => {
       actorType: "automation",
       automationRunId: "automation-close-applied",
     });
-    expect(snapshot.completedClose).not.toHaveProperty("policyReviewedItemKeys");
+    expect(snapshot.completedClose).not.toHaveProperty(
+      "policyReviewedItemKeys",
+    );
   });
 
   it("exposes only operator-visible scheduled run evidence for the store day", async () => {
@@ -1075,7 +1083,8 @@ describe("daily operations overview read model", () => {
     });
     expect(snapshot.lanes.find((lane) => lane.key === "opening")).toMatchObject(
       {
-        description: "1 opening item will be reviewed when Opening Handoff starts.",
+        description:
+          "1 opening item will be reviewed when Opening Handoff starts.",
         status: "needs_attention",
       },
     );
@@ -1195,7 +1204,9 @@ describe("daily operations overview read model", () => {
       transactionCount: 1,
     });
     expect(
-      snapshot.weekMetrics.find((metric) => metric.operatingDate === "2026-05-08"),
+      snapshot.weekMetrics.find(
+        (metric) => metric.operatingDate === "2026-05-08",
+      ),
     ).toMatchObject({
       adjustedSalesTotal: 43000,
       adjustmentCashSettlementTotal: -7000,
@@ -1240,8 +1251,7 @@ describe("daily operations overview read model", () => {
     expect(
       snapshot.attentionItems.some(
         (item) =>
-          item.owner === "daily_close" &&
-          item.label === "EOD Review reopened",
+          item.owner === "daily_close" && item.label === "EOD Review reopened",
       ),
     ).toBe(false);
   });
@@ -1386,7 +1396,9 @@ describe("daily operations overview read model", () => {
       "2026-05-09",
     ]);
     expect(
-      snapshot.weekMetrics.find((metric) => metric.operatingDate === "2026-05-07"),
+      snapshot.weekMetrics.find(
+        (metric) => metric.operatingDate === "2026-05-07",
+      ),
     ).toMatchObject({
       isClosed: true,
       isSelected: false,
@@ -1394,7 +1406,9 @@ describe("daily operations overview read model", () => {
       transactionCount: 1,
     });
     expect(
-      snapshot.weekMetrics.find((metric) => metric.operatingDate === "2026-05-08"),
+      snapshot.weekMetrics.find(
+        (metric) => metric.operatingDate === "2026-05-08",
+      ),
     ).toMatchObject({
       currentDayCashTotal: 80000,
       expenseTotal: 12000,
@@ -1412,7 +1426,9 @@ describe("daily operations overview read model", () => {
       transactionCount: 1,
     });
     expect(
-      snapshot.weekMetrics.find((metric) => metric.operatingDate === "2026-05-05"),
+      snapshot.weekMetrics.find(
+        (metric) => metric.operatingDate === "2026-05-05",
+      ),
     ).toMatchObject({
       isSelected: true,
       salesTotal: 0,
@@ -1763,7 +1779,9 @@ describe("daily operations overview read model", () => {
       transactionCount: 1,
     });
     expect(
-      snapshot.weekMetrics.find((metric) => metric.operatingDate === "2026-06-21"),
+      snapshot.weekMetrics.find(
+        (metric) => metric.operatingDate === "2026-06-21",
+      ),
     ).toMatchObject({
       salesTotal: 20000,
       transactionCount: 1,
@@ -1869,7 +1887,9 @@ describe("daily operations overview read model", () => {
     });
     vi.mocked(
       athenaUserAuth.requireOrganizationMemberRoleWithCtx,
-    ).mockRejectedValue(new Error("You cannot view daily operations for this store."));
+    ).mockRejectedValue(
+      new Error("You cannot view daily operations for this store."),
+    );
 
     await expect(
       getHandler(getDailyOperationsSnapshot)(
@@ -2217,6 +2237,121 @@ describe("daily operations overview read model", () => {
     });
   });
 
+  it("returns a current-day refresh payload with selected day metric and store pulse detail", async () => {
+    vi.setSystemTime(new Date("2026-05-08T18:30:00.000Z"));
+    vi.mocked(
+      athenaUserAuth.requireAuthenticatedAthenaUserWithCtx,
+    ).mockResolvedValue({
+      _creationTime: 0,
+      _id: "user-1" as Id<"athenaUser">,
+      email: "admin@wigclub.store",
+    });
+    vi.mocked(
+      athenaUserAuth.requireOrganizationMemberRoleWithCtx,
+    ).mockResolvedValue({
+      _creationTime: 0,
+      _id: "member-admin" as Id<"organizationMember">,
+      organizationId: "org-1" as Id<"organization">,
+      role: "full_admin",
+      userId: "user-1" as Id<"athenaUser">,
+    });
+
+    const snapshot = await getHandler(getDailyOperationsTodayRefreshSnapshot)(
+      buildCtx({
+        dailyClose: [priorClose],
+        dailyOpening: [startedOpening],
+        posTransaction: [
+          {
+            _id: "txn-prior",
+            changeGiven: 0,
+            completedAt: Date.UTC(2026, 4, 7, 16),
+            paymentMethod: "cash",
+            paymentAllocations: [],
+            payments: [{ amount: 20000, method: "cash" }],
+            status: "completed",
+            storeId: "store-1",
+            terminalId: "terminal-1",
+            total: 20000,
+            totalPaid: 20000,
+            transactionNumber: "TXN-PRIOR",
+          },
+          {
+            _id: "txn-current",
+            changeGiven: 0,
+            completedAt: Date.UTC(2026, 4, 8, 16),
+            paymentMethod: "cash",
+            paymentAllocations: [],
+            payments: [{ amount: 821500, method: "cash" }],
+            status: "completed",
+            storeId: "store-1",
+            terminalId: "terminal-1",
+            total: 821500,
+            totalPaid: 821500,
+            transactionNumber: "TXN-CURRENT",
+          },
+        ],
+        posTransactionItem: [
+          {
+            _id: "txn-item-current",
+            productId: "product-1",
+            productName: "Braiding Hair",
+            productSku: "BRAID-1",
+            productSkuId: "sku-1",
+            quantity: 2,
+            totalPrice: 821500,
+            transactionId: "txn-current",
+            unitPrice: 410750,
+          },
+        ],
+        store: [store],
+      }) as never,
+      {
+        operatingDate: "2026-05-08",
+        refreshRequestedAt: 12345,
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(snapshot).toMatchObject({
+      closeSummary: {
+        salesTotal: 821500,
+        transactionCount: 1,
+      },
+      operatingDate: "2026-05-08",
+      refreshedAt: Date.parse("2026-05-08T18:30:00.000Z"),
+      refreshRequestedAt: 12345,
+      storePulse: {
+        operatorSnapshot: {
+          paymentMix: [
+            expect.objectContaining({
+              method: "cash",
+              total: 821500,
+            }),
+          ],
+          topItems: [
+            expect.objectContaining({
+              name: "Braiding Hair",
+              quantity: 2,
+            }),
+          ],
+        },
+      },
+      weekMetric: expect.objectContaining({
+        isSelected: true,
+        operatingDate: "2026-05-08",
+        salesTotal: 821500,
+        transactionCount: 1,
+      }),
+    });
+    expect(snapshot.priorDayMetric).toMatchObject({
+      operatingDate: "2026-05-07",
+      salesTotal: 20000,
+      transactionCount: 1,
+    });
+    expect(snapshot).not.toHaveProperty("weekSnapshots");
+    expect(snapshot).not.toHaveProperty("timeline");
+  });
+
   it("returns full bounded timeline history from the explicit timeline query", async () => {
     vi.mocked(
       athenaUserAuth.requireAuthenticatedAthenaUserWithCtx,
@@ -2349,13 +2484,17 @@ describe("daily operations overview read model", () => {
     );
 
     expect(
-      snapshot.weekMetrics.find((metric) => metric.operatingDate === "2026-05-10"),
+      snapshot.weekMetrics.find(
+        (metric) => metric.operatingDate === "2026-05-10",
+      ),
     ).toMatchObject({
       salesTotal: 187899,
       transactionCount: 1,
     });
     expect(
-      snapshot.weekMetrics.find((metric) => metric.operatingDate === "2026-05-11"),
+      snapshot.weekMetrics.find(
+        (metric) => metric.operatingDate === "2026-05-11",
+      ),
     ).toMatchObject({
       salesTotal: 0,
       transactionCount: 0,
@@ -3240,7 +3379,8 @@ describe("daily operations overview read model", () => {
             _id: "event-variance-review-requested",
             createdAt: Date.UTC(2026, 4, 8, 20, 45),
             eventType: "register_session_variance_review_requested",
-            message: "Variance of -19500 exceeded the closeout approval threshold.",
+            message:
+              "Variance of -19500 exceeded the closeout approval threshold.",
             metadata: {
               countedCash: 124_500,
               expectedCash: 144_000,
@@ -3584,10 +3724,10 @@ describe("daily operations overview read model", () => {
 
   it("surfaces pending synced register count submissions for the operating day", async () => {
     const ctx = buildCtx(buildPendingRegisterCountSeed());
-    const snapshot = await buildDailyOperationsSnapshotWithCtx(
-      ctx,
-      { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
-    );
+    const snapshot = await buildDailyOperationsSnapshotWithCtx(ctx, {
+      operatingDate: "2026-05-08",
+      storeId: "store-1" as Id<"store">,
+    });
 
     expect(snapshot.timeline[0]).toMatchObject({
       id: "pos_local_sync_register_count:sync-register-count",

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -358,40 +358,39 @@ async function buildWeekMetricForDate(
     appliedTransactionAdjustments,
     expenseTransactions,
     dailyClose,
-  ] =
-    await Promise.all([
-      ctx.db
-        .query("posTransaction")
-        .withIndex("by_storeId_status_completedAt", (q) =>
-          q
-            .eq("storeId", args.storeId)
-            .eq("status", "completed")
-            .gte("completedAt", range.startAt)
-            .lt("completedAt", range.endAt),
-        )
-        .take(MAX_OPERATIONS_QUERY_LIMIT),
-      listAppliedTransactionAdjustmentsForDay(ctx, {
-        endAt: range.endAt,
-        startAt: range.startAt,
-        storeId: args.storeId,
-      }),
-      ctx.db
-        .query("expenseTransaction")
-        .withIndex("by_storeId_status_completedAt", (q) =>
-          q
-            .eq("storeId", args.storeId)
-            .eq("status", "completed")
-            .gte("completedAt", range.startAt)
-            .lt("completedAt", range.endAt),
-        )
-        .take(MAX_OPERATIONS_QUERY_LIMIT),
-      ctx.db
-        .query("dailyClose")
-        .withIndex("by_storeId_operatingDate", (q) =>
-          q.eq("storeId", args.storeId).eq("operatingDate", args.operatingDate),
-        )
-        .take(MAX_OPERATIONS_QUERY_LIMIT),
-    ]);
+  ] = await Promise.all([
+    ctx.db
+      .query("posTransaction")
+      .withIndex("by_storeId_status_completedAt", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("status", "completed")
+          .gte("completedAt", range.startAt)
+          .lt("completedAt", range.endAt),
+      )
+      .take(MAX_OPERATIONS_QUERY_LIMIT),
+    listAppliedTransactionAdjustmentsForDay(ctx, {
+      endAt: range.endAt,
+      startAt: range.startAt,
+      storeId: args.storeId,
+    }),
+    ctx.db
+      .query("expenseTransaction")
+      .withIndex("by_storeId_status_completedAt", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("status", "completed")
+          .gte("completedAt", range.startAt)
+          .lt("completedAt", range.endAt),
+      )
+      .take(MAX_OPERATIONS_QUERY_LIMIT),
+    ctx.db
+      .query("dailyClose")
+      .withIndex("by_storeId_operatingDate", (q) =>
+        q.eq("storeId", args.storeId).eq("operatingDate", args.operatingDate),
+      )
+      .take(MAX_OPERATIONS_QUERY_LIMIT),
+  ]);
   const currentDailyClose =
     dailyClose.find((close) => close.isCurrent) ?? dailyClose[0];
   const currentDayCashTotal = completedTransactions.reduce(
@@ -534,13 +533,12 @@ async function listOpenQueueSnapshot(
     .flatMap((batch) => batch)
     .slice(0, MAX_OPERATIONS_QUERY_LIMIT);
   const currentTime = Date.now();
-  const dayApprovalRequests = pendingApprovalRequests.filter(
-    (request) =>
-      approvalRequestBelongsToOperationsDay({
-        ...args,
-        currentTime,
-        request,
-      }),
+  const dayApprovalRequests = pendingApprovalRequests.filter((request) =>
+    approvalRequestBelongsToOperationsDay({
+      ...args,
+      currentTime,
+      request,
+    }),
   );
   const approvalRequests = dayApprovalRequests.slice(
     0,
@@ -605,7 +603,10 @@ async function listTimelineEvents(
     .order("desc")
     .take(operationalEventLimit);
   const storePromise = ctx.db.get("store", args.storeId);
-  const registerSessionsPromise = listTimelineRegisterSessions(ctx, args.storeId);
+  const registerSessionsPromise = listTimelineRegisterSessions(
+    ctx,
+    args.storeId,
+  );
   const pendingRegisterCountsPromise = args.includeManagerReviewEvidence
     ? listPendingRegisterCountTimelineEvents(ctx, args)
     : Promise.resolve([]);
@@ -616,14 +617,13 @@ async function listTimelineEvents(
     pendingRegisterCountEvents,
     store,
     terminalNamesById,
-  ] =
-    await Promise.all([
-      eventsPromise,
-      registerSessionsPromise,
-      pendingRegisterCountsPromise,
-      storePromise,
-      terminalNamesPromise,
-    ]);
+  ] = await Promise.all([
+    eventsPromise,
+    registerSessionsPromise,
+    pendingRegisterCountsPromise,
+    storePromise,
+    terminalNamesPromise,
+  ]);
   const operationalCloseoutKeys = new Set(
     events
       .map((event) => getOperationalRegisterCloseoutKey(event))
@@ -687,7 +687,10 @@ async function listPendingRegisterCountTimelineEvents(
       ),
     ),
   ]);
-  const eventsById = new Map<Id<"posLocalSyncEvent">, Doc<"posLocalSyncEvent">>();
+  const eventsById = new Map<
+    Id<"posLocalSyncEvent">,
+    Doc<"posLocalSyncEvent">
+  >();
 
   for (const event of eventBatches.flat()) {
     if (
@@ -840,7 +843,9 @@ async function mapOperationalTimelineEvent(
   const productSku = productSkuId
     ? await ctx.db.get("productSku", productSkuId)
     : null;
-  const isRegisterSessionEvent = isRegisterSessionSubjectType(event.subjectType);
+  const isRegisterSessionEvent = isRegisterSessionSubjectType(
+    event.subjectType,
+  );
   const registerSessionId =
     event.registerSessionId ??
     (isRegisterSessionEvent
@@ -869,7 +874,7 @@ async function mapOperationalTimelineEvent(
   const sku =
     typeof metadata.sku === "string"
       ? metadata.sku
-      : productSku?.sku ?? undefined;
+      : (productSku?.sku ?? undefined);
   const isPendingCheckoutItemEvent =
     event.subjectType === "pos_pending_checkout_item" &&
     productSkuId !== undefined;
@@ -878,12 +883,11 @@ async function mapOperationalTimelineEvent(
     productSku?.productName && sku
       ? `${productSku.productName} (${sku})`
       : productSku?.productName || productName;
-  const productLinkLabel =
-    isPendingCheckoutItemEvent
+  const productLinkLabel = isPendingCheckoutItemEvent
+    ? productName
+    : event.subjectType === "product_sku"
       ? productName
-      : event.subjectType === "product_sku"
-        ? productName
-        : productSkuLabel || productSkuDisplayLabel;
+      : productSkuLabel || productSkuDisplayLabel;
   const canLinkProduct =
     event.subjectType === "product_sku" ||
     isPendingCheckoutItemEvent ||
@@ -924,13 +928,12 @@ async function mapOperationalTimelineEvent(
   const terminalName = registerSession?.terminalId
     ? args.terminalNamesById.get(registerSession.terminalId)
     : undefined;
-  const registerLabel =
-    isRegisterSessionEvent
-      ? formatTerminalRegisterLinkLabel({
-          registerNumber: event.subjectLabel ?? registerNumber,
-          terminalName,
-        })
-      : undefined;
+  const registerLabel = isRegisterSessionEvent
+    ? formatTerminalRegisterLinkLabel({
+        registerNumber: event.subjectLabel ?? registerNumber,
+        terminalName,
+      })
+    : undefined;
   const approvalSubjectLabel = getApprovalTimelineSubjectLabel({
     event,
     metadata,
@@ -978,7 +981,9 @@ async function mapOperationalTimelineEvent(
 }
 
 function isRegisterSessionSubjectType(subjectType: string) {
-  return subjectType === "register_session" || subjectType === "registerSession";
+  return (
+    subjectType === "register_session" || subjectType === "registerSession"
+  );
 }
 
 function isPosTransactionSubjectType(subjectType: string) {
@@ -1039,7 +1044,10 @@ function normalizeTimelineEventMessage(
   if (context?.eventType === "pos_transaction_void_approval_requested") {
     const actorName = context.actorName?.trim();
     return actorName
-      ? message.replace(/^Void requested for\b/i, `Void requested by ${actorName} for`)
+      ? message.replace(
+          /^Void requested for\b/i,
+          `Void requested by ${actorName} for`,
+        )
       : message;
   }
 
@@ -1053,7 +1061,9 @@ function normalizeTimelineEventMessage(
       ? punctuateTimelineSentence(
           `${registerLabel} opened by ${actorName}${openingFloatPhrase}`,
         )
-      : punctuateTimelineSentence(`${registerLabel} opened${openingFloatPhrase}`);
+      : punctuateTimelineSentence(
+          `${registerLabel} opened${openingFloatPhrase}`,
+        );
   }
 
   if (/^Register session closed with an exact cash match\.$/i.test(message)) {
@@ -1067,7 +1077,11 @@ function normalizeTimelineEventMessage(
     return `${context?.registerLabel ?? "Register"} closeout recorded with a cash variance of ${recordedVarianceMatch[1]}.`;
   }
 
-  if (/^Register\s+\S+\s+closeout recorded with an exact cash match\.$/i.test(message)) {
+  if (
+    /^Register\s+\S+\s+closeout recorded with an exact cash match\.$/i.test(
+      message,
+    )
+  ) {
     return `${context?.registerLabel ?? "Register"} closeout recorded with an exact cash match.`;
   }
 
@@ -1079,7 +1093,9 @@ function normalizeTimelineEventMessage(
     return `${context.registerLabel ?? "Register session"} closeout recorded with a cash variance of ${formatTimelineAmount(context.currency ?? "GHS", context.variance)}.`;
   }
 
-  if (context?.eventType === "register_session_sync_closeout_review_requested") {
+  if (
+    context?.eventType === "register_session_sync_closeout_review_requested"
+  ) {
     const amount =
       typeof context.variance === "number" && context.variance !== 0
         ? formatTimelineAmount(context.currency ?? "GHS", context.variance)
@@ -1123,7 +1139,9 @@ function normalizeApprovalTimelineEventMessage(context?: {
   }
 
   if (context.eventType === "approval.proof_consumed") {
-    return punctuateTimelineSentence(`Manager approval applied${subjectPhrase}`);
+    return punctuateTimelineSentence(
+      `Manager approval applied${subjectPhrase}`,
+    );
   }
 
   return null;
@@ -1378,7 +1396,9 @@ function numberFromRecord(record: unknown, key: string) {
   if (!record || typeof record !== "object") return undefined;
 
   const value = (record as Record<string, unknown>)[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
 }
 
 function formatRegisterSessionLabel(registerNumber?: string) {
@@ -1458,7 +1478,8 @@ function compareTimelineEvents(
     createdAt: number;
   },
 ) {
-  if (left.createdAt !== right.createdAt) return right.createdAt - left.createdAt;
+  if (left.createdAt !== right.createdAt)
+    return right.createdAt - left.createdAt;
   return String(right._id).localeCompare(String(left._id));
 }
 
@@ -1564,9 +1585,11 @@ async function getLatestAppliedAutomationRunForAction(
     storeId: args.storeId,
   });
 
-  return runs
-    .filter((run) => run.outcome === "applied")
-    .sort(compareAutomationRuns)[0] ?? null;
+  return (
+    runs
+      .filter((run) => run.outcome === "applied")
+      .sort(compareAutomationRuns)[0] ?? null
+  );
 }
 
 function automationRunClassification(run: Doc<"automationRun">) {
@@ -1880,7 +1903,8 @@ function lifecycleCopy(status: LifecycleStatus) {
 
   if (status === "ready_to_close") {
     return {
-      description: "Opening Handoff is complete and the end of day review has no blockers.",
+      description:
+        "Opening Handoff is complete and the end of day review has no blockers.",
       label: "Ready to close",
     };
   }
@@ -2110,57 +2134,55 @@ export async function buildDailyOperationsSnapshotWithCtx(
     store,
     storePulse,
     weekMetrics,
-  ] =
-    await Promise.all([
-      buildDailyOpeningSnapshotWithCtx(ctx, args),
-      buildDailyCloseSnapshotWithCtx(ctx, args),
-      getDailyCloseRecordForDate(ctx, args),
-      listOpenQueueSnapshot(ctx, {
-        ...range,
-        storeId: args.storeId,
-      }),
-      args.includeScheduledRunSummaries &&
-      (args.includeManagerReviewEvidence ?? true)
-        ? listDailyOperationsScheduledRunSummaries(ctx, {
-            ...range,
-            limit: args.scheduledRunSummariesLimit,
-            storeId: args.storeId,
-          })
-        : Promise.resolve([]),
-      listTimelineEvents(ctx, {
-        ...range,
-        includeManagerReviewEvidence:
-          args.includeManagerReviewEvidence ?? true,
-        limit: args.timelineLimit,
-        storeId: args.storeId,
-      }),
-      ctx.db.get("store", args.storeId),
-      includeStorePulseDetails
-        ? getStorePulseSummaryForWindow(ctx as QueryCtx, {
-            currentDayEnd: range.endAt - 1,
-            currentDayStart: range.startAt,
-            currentOperatingDate: args.operatingDate,
-            pulseWindow: args.storePulseWindow ?? "today",
-            storeId: args.storeId,
-          })
-        : Promise.resolve(undefined),
-      includeAnalyticsDetails
-        ? buildWeekMetrics(ctx, args)
-        : Promise.resolve([]),
-    ]);
+  ] = await Promise.all([
+    buildDailyOpeningSnapshotWithCtx(ctx, args),
+    buildDailyCloseSnapshotWithCtx(ctx, args),
+    getDailyCloseRecordForDate(ctx, args),
+    listOpenQueueSnapshot(ctx, {
+      ...range,
+      storeId: args.storeId,
+    }),
+    args.includeScheduledRunSummaries &&
+    (args.includeManagerReviewEvidence ?? true)
+      ? listDailyOperationsScheduledRunSummaries(ctx, {
+          ...range,
+          limit: args.scheduledRunSummariesLimit,
+          storeId: args.storeId,
+        })
+      : Promise.resolve([]),
+    listTimelineEvents(ctx, {
+      ...range,
+      includeManagerReviewEvidence: args.includeManagerReviewEvidence ?? true,
+      limit: args.timelineLimit,
+      storeId: args.storeId,
+    }),
+    ctx.db.get("store", args.storeId),
+    includeStorePulseDetails
+      ? getStorePulseSummaryForWindow(ctx as QueryCtx, {
+          currentDayEnd: range.endAt - 1,
+          currentDayStart: range.startAt,
+          currentOperatingDate: args.operatingDate,
+          pulseWindow: args.storePulseWindow ?? "today",
+          storeId: args.storeId,
+        })
+      : Promise.resolve(undefined),
+    includeAnalyticsDetails ? buildWeekMetrics(ctx, args) : Promise.resolve([]),
+  ]);
   const automationStatuses = await listDailyOperationsAutomationStatuses(ctx, {
     ...args,
     closeCompletion: closeSnapshot.completedClose,
   });
   const priorOperatingDate = shiftOperatingDate(args.operatingDate, -1);
   const priorDayMetric = includeAnalyticsDetails
-    ? weekMetrics.find((metric) => metric.operatingDate === priorOperatingDate) ??
+    ? (weekMetrics.find(
+        (metric) => metric.operatingDate === priorOperatingDate,
+      ) ??
       (await buildWeekMetricForDate(ctx, {
         isSelected: false,
         operatingDate: priorOperatingDate,
         operatingTimezoneOffsetMinutes: args.operatingTimezoneOffsetMinutes,
         storeId: args.storeId,
-      }))
+      })))
     : undefined;
   const visibleTimeline =
     typeof args.timelinePreviewLimit === "number"
@@ -2240,7 +2262,7 @@ export async function buildDailyOperationsSnapshotWithCtx(
           ? "ready_to_close"
           : isCloseReopened
             ? "reopened"
-          : "operating";
+            : "operating";
   const lifecycle = {
     status: lifecycleStatus,
     ...lifecycleCopy(lifecycleStatus),
@@ -2382,6 +2404,11 @@ const dailyOperationsSnapshotArgsValidator = {
   weekEndOperatingDate: v.optional(v.string()),
 };
 
+const dailyOperationsRefreshArgsValidator = {
+  ...dailyOperationsSnapshotArgsValidator,
+  refreshRequestedAt: v.optional(v.number()),
+};
+
 async function authorizeDailyOperationsSnapshot(
   ctx: QueryCtx,
   args: { storeId: Id<"store"> },
@@ -2477,6 +2504,60 @@ export const getDailyOperationsStorePulseSnapshot = query({
     return {
       operatingDate: args.operatingDate,
       storePulse,
+    };
+  },
+});
+
+export const getDailyOperationsTodayRefreshSnapshot = query({
+  args: dailyOperationsRefreshArgsValidator,
+  handler: async (ctx, args) => {
+    const { includeManagerReviewEvidence } =
+      await authorizeDailyOperationsSnapshot(ctx, args);
+    const snapshot = await buildDailyOperationsSnapshotWithCtx(ctx, {
+      ...args,
+      includeAnalyticsDetails: false,
+      includeFinancialDetails: includeManagerReviewEvidence,
+      includeManagerReviewEvidence,
+      includeScheduledRunSummaries: false,
+      includeStorePulseDetails: includeManagerReviewEvidence,
+      scheduledRunSummariesLimit: 0,
+      timelineLimit: 0,
+      timelinePreviewLimit: 0,
+    });
+    const weekMetric = includeManagerReviewEvidence
+      ? await buildWeekMetricForDate(ctx, {
+          isSelected: true,
+          operatingDate: args.operatingDate,
+          operatingTimezoneOffsetMinutes: args.operatingTimezoneOffsetMinutes,
+          storeId: args.storeId,
+        })
+      : null;
+    const priorDayMetric = includeManagerReviewEvidence
+      ? await buildWeekMetricForDate(ctx, {
+          isSelected: false,
+          operatingDate: shiftOperatingDate(args.operatingDate, -1),
+          operatingTimezoneOffsetMinutes: args.operatingTimezoneOffsetMinutes,
+          storeId: args.storeId,
+        })
+      : null;
+
+    return {
+      attentionItems: snapshot.attentionItems,
+      closeSummary: snapshot.closeSummary,
+      completedClose: snapshot.completedClose ?? null,
+      currency: snapshot.currency,
+      endAt: snapshot.endAt,
+      lanes: snapshot.lanes,
+      lifecycle: snapshot.lifecycle,
+      operatingDate: snapshot.operatingDate,
+      primaryAction: snapshot.primaryAction,
+      priorDayMetric,
+      refreshedAt: Date.now(),
+      refreshRequestedAt: args.refreshRequestedAt ?? null,
+      startAt: snapshot.startAt,
+      storeId: snapshot.storeId,
+      storePulse: snapshot.storePulse ?? null,
+      weekMetric,
     };
   },
 });

--- a/packages/athena-webapp/convex/pos/application/getTransactions.test.ts
+++ b/packages/athena-webapp/convex/pos/application/getTransactions.test.ts
@@ -64,7 +64,7 @@ function mockCorrectionHistoryDb(overrides?: {
                 ? (overrides?.serviceLines ?? [])
                 : tableName === "paymentAllocation"
                   ? (overrides?.paymentAllocations ?? [])
-              : (overrides?.correctionHistory ?? []),
+                  : (overrides?.correctionHistory ?? []),
           ),
         take: vi
           .fn()
@@ -95,9 +95,12 @@ describe("getCompletedTransactions", () => {
     vi.mocked(getPosSessionById).mockResolvedValue(null as never);
     vi.mocked(listTransactionItems).mockResolvedValue([] as never);
 
-    const result = await getCompletedTransactions({ db: mockCorrectionHistoryDb() } as never, {
-      storeId: "store-1" as Id<"store">,
-    });
+    const result = await getCompletedTransactions(
+      { db: mockCorrectionHistoryDb() } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+      },
+    );
 
     expect(result).toEqual([
       expect.objectContaining({
@@ -128,9 +131,12 @@ describe("getCompletedTransactions", () => {
     } as never);
     vi.mocked(listTransactionItems).mockResolvedValue([] as never);
 
-    const result = await getCompletedTransactions({ db: mockCorrectionHistoryDb() } as never, {
-      storeId: "store-1" as Id<"store">,
-    });
+    const result = await getCompletedTransactions(
+      { db: mockCorrectionHistoryDb() } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+      },
+    );
 
     expect(result).toEqual([
       expect.objectContaining({
@@ -197,9 +203,12 @@ describe("getCompletedTransactions", () => {
     vi.mocked(getPosSessionById).mockResolvedValue(null as never);
     vi.mocked(listTransactionItems).mockResolvedValue([] as never);
 
-    const result = await getCompletedTransactions({ db: mockCorrectionHistoryDb() } as never, {
-      storeId: "store-1" as Id<"store">,
-    });
+    const result = await getCompletedTransactions(
+      { db: mockCorrectionHistoryDb() } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+      },
+    );
 
     expect(result).toEqual([
       expect.objectContaining({
@@ -231,9 +240,12 @@ describe("getCompletedTransactions", () => {
     vi.mocked(getPosSessionById).mockResolvedValue(null as never);
     vi.mocked(listTransactionItems).mockResolvedValue([] as never);
 
-    const result = await getCompletedTransactions({ db: mockCorrectionHistoryDb() } as never, {
-      storeId: "store-1" as Id<"store">,
-    });
+    const result = await getCompletedTransactions(
+      { db: mockCorrectionHistoryDb() } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+      },
+    );
 
     expect(result).toEqual([
       expect.objectContaining({
@@ -289,7 +301,9 @@ describe("getTodaySummary", () => {
               ? [
                   {
                     _id: "opening-2026-06-19",
+                    endAt: Date.parse("2026-06-20T04:00:00.000Z"),
                     operatingDate: "2026-06-19",
+                    startAt: Date.parse("2026-06-19T04:00:00.000Z"),
                     status: "started",
                     storeId: "store-1",
                   },
@@ -312,8 +326,8 @@ describe("getTodaySummary", () => {
     expect(listCompletedTransactionsForDay).toHaveBeenCalledWith(
       expect.anything(),
       {
-        endOfDay: Date.parse("2026-06-19T23:59:59.999Z"),
-        startOfDay: Date.parse("2026-06-19T00:00:00.000Z"),
+        endOfDay: Date.parse("2026-06-20T03:59:59.999Z"),
+        startOfDay: Date.parse("2026-06-19T04:00:00.000Z"),
         storeId: "store-1",
       },
     );
@@ -468,6 +482,83 @@ describe("getTodaySummary", () => {
         transactionCount: 2,
       }),
     ]);
+  });
+
+  it("ignores stale unclosed openings when keying the POS pulse today window", async () => {
+    vi.setSystemTime(new Date("2026-06-30T12:00:00.000Z"));
+    vi.mocked(listCompletedTransactionsForRange)
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([
+        {
+          _id: "txn-yesterday" as Id<"posTransaction">,
+          completedAt: Date.parse("2026-06-29T16:00:00.000Z"),
+          payments: [{ amount: 6_290, method: "cash", timestamp: 1 }],
+          storeId: "store-1" as Id<"store">,
+          total: 6_290,
+        },
+      ] as never);
+    vi.mocked(listCompletedTransactionsSince).mockResolvedValue([] as never);
+    vi.mocked(listTransactionItems).mockResolvedValueOnce([
+      { quantity: 82 },
+    ] as never);
+    const query = vi.fn((tableName: string) => ({
+      withIndex: vi.fn(() => ({
+        collect: vi.fn().mockResolvedValue([]),
+        take: vi.fn().mockResolvedValue([]),
+        order: vi.fn(() => ({
+          take: vi.fn().mockResolvedValue(
+            tableName === "dailyOpening"
+              ? [
+                  {
+                    _id: "opening-2026-06-29",
+                    endAt: Date.parse("2026-06-30T04:00:00.000Z"),
+                    operatingDate: "2026-06-29",
+                    startAt: Date.parse("2026-06-29T04:00:00.000Z"),
+                    status: "started",
+                    storeId: "store-1",
+                  },
+                ]
+              : [],
+          ),
+        })),
+      })),
+    }));
+
+    const result = await getTodaySummary(
+      {
+        db: { query },
+      } as never,
+      {
+        pulseWindow: "today",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(listCompletedTransactionsForRange).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      {
+        completedFrom: Date.parse("2026-06-30T00:00:00.000Z"),
+        completedTo: Date.parse("2026-06-30T23:59:59.999Z"),
+        storeId: "store-1",
+      },
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        date: "2026-06-30",
+        totalItemsSold: 0,
+        totalSales: 0,
+        totalTransactions: 0,
+      }),
+    );
+    expect(result.operatorSnapshot.comparison).toMatchObject({
+      currentItemsSold: 0,
+      currentSales: 0,
+      currentTransactions: 0,
+      yesterdayItemsSold: 82,
+      yesterdaySales: 6_290,
+      yesterdayTransactions: 1,
+    });
   });
 
   it("falls back to the server calendar day when the latest opening is already closed", async () => {

--- a/packages/athena-webapp/convex/pos/application/queries/getTransactions.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/getTransactions.ts
@@ -63,7 +63,6 @@ type MixedServiceLine = {
   unitPrice: number;
 };
 
-
 function summarizeCashierName(args: {
   fullName?: string;
   firstName?: string;
@@ -227,7 +226,9 @@ function normalizeAdjustmentLineItem(lineItem: Record<string, unknown>) {
       stringFromMetadata(lineItem.productName) ??
       stringFromMetadata(lineItem.name) ??
       "Unnamed item",
-    productSku: stringFromMetadata(lineItem.productSku) ?? stringFromMetadata(lineItem.sku),
+    productSku:
+      stringFromMetadata(lineItem.productSku) ??
+      stringFromMetadata(lineItem.sku),
     originalQuantity: numberFromMetadata(lineItem.originalQuantity),
     adjustedQuantity: numberFromMetadata(lineItem.adjustedQuantity),
     quantityDelta:
@@ -241,11 +242,13 @@ function normalizeAdjustmentLineItem(lineItem: Record<string, unknown>) {
 }
 
 function normalizeAdjustmentMetadata(metadata?: Record<string, unknown>) {
-  const adjustment = (metadata?.adjustment &&
-  typeof metadata.adjustment === "object" &&
-  !Array.isArray(metadata.adjustment)
-    ? metadata.adjustment
-    : metadata) as AdjustmentMetadata | undefined;
+  const adjustment = (
+    metadata?.adjustment &&
+    typeof metadata.adjustment === "object" &&
+    !Array.isArray(metadata.adjustment)
+      ? metadata.adjustment
+      : metadata
+  ) as AdjustmentMetadata | undefined;
 
   const rawLineItems = Array.isArray(adjustment?.lineItems)
     ? adjustment.lineItems
@@ -262,7 +265,9 @@ function normalizeAdjustmentMetadata(metadata?: Record<string, unknown>) {
     lineItems: rawLineItems
       .filter(
         (lineItem): lineItem is Record<string, unknown> =>
-          typeof lineItem === "object" && lineItem !== null && !Array.isArray(lineItem),
+          typeof lineItem === "object" &&
+          lineItem !== null &&
+          !Array.isArray(lineItem),
       )
       .map(normalizeAdjustmentLineItem),
     originalTotal: numberFromMetadata(adjustment?.originalTotal),
@@ -293,7 +298,10 @@ async function listMixedServiceLinesForTransaction(
     serviceLines.map(async (line) => {
       const serviceCase = await ctx.db.get("serviceCase", line.serviceCaseId);
       const workItem = serviceCase?.operationalWorkItemId
-        ? await ctx.db.get("operationalWorkItem", serviceCase.operationalWorkItemId)
+        ? await ctx.db.get(
+            "operationalWorkItem",
+            serviceCase.operationalWorkItemId,
+          )
         : null;
       const refundedAmount =
         line.isRefunded && line.refundedQuantity
@@ -367,7 +375,10 @@ export async function getCompletedTransactions(
         ? await getPosSessionById(ctx, transaction.sessionId)
         : null;
       const items = await listTransactionItems(ctx, transaction._id);
-      const serviceLines = await listMixedServiceLinesForTransaction(ctx, transaction);
+      const serviceLines = await listMixedServiceLinesForTransaction(
+        ctx,
+        transaction,
+      );
       const sessionTraceId = session?.workflowTraceId ?? null;
       const customerProfileId =
         transaction.customerProfileId ?? session?.customerProfileId;
@@ -388,9 +399,7 @@ export async function getCompletedTransactions(
         voidApprovalProofId: transaction.voidApprovalProofId,
         hasTrace: Boolean(sessionTraceId),
         sessionTraceId,
-        cashierName: cashier
-          ? formatStaffDisplayName(cashier)
-          : null,
+        cashierName: cashier ? formatStaffDisplayName(cashier) : null,
         customerProfileId,
         customerName:
           customerProfile?.fullName ?? transaction.customerInfo?.name ?? null,
@@ -432,7 +441,9 @@ export async function getTransactionById(
     session?.registerNumber ??
     registerSession?.registerNumber;
   const terminalId =
-    transaction.terminalId ?? session?.terminalId ?? registerSession?.terminalId;
+    transaction.terminalId ??
+    session?.terminalId ??
+    registerSession?.terminalId;
   const terminal = terminalId ? await getTerminalById(ctx, terminalId) : null;
   const items = await listTransactionItems(ctx, transaction._id);
   const serviceLines = await listMixedServiceLinesForTransaction(ctx, {
@@ -461,21 +472,19 @@ export async function getTransactionById(
   });
   const actorStaffNamesById = await listStaffNames(
     ctx,
-    new Set(
-      [
-        ...correctionHistory.flatMap((event) =>
-          event.actorStaffProfileId ? [event.actorStaffProfileId] : [],
-        ),
-        ...receiptDeliveries.flatMap((delivery) =>
-          delivery.actorStaffProfileId ? [delivery.actorStaffProfileId] : [],
-        ),
-        ...pendingItemAdjustmentApprovals.flatMap((approval) =>
-          approval.requestedByStaffProfileId
-            ? [approval.requestedByStaffProfileId]
-            : [],
-        ),
-      ],
-    ),
+    new Set([
+      ...correctionHistory.flatMap((event) =>
+        event.actorStaffProfileId ? [event.actorStaffProfileId] : [],
+      ),
+      ...receiptDeliveries.flatMap((delivery) =>
+        delivery.actorStaffProfileId ? [delivery.actorStaffProfileId] : [],
+      ),
+      ...pendingItemAdjustmentApprovals.flatMap((approval) =>
+        approval.requestedByStaffProfileId
+          ? [approval.requestedByStaffProfileId]
+          : [],
+      ),
+    ]),
   );
   const appliedAdjustmentSummaries = correctionHistory
     .filter((event) => ITEM_ADJUSTMENT_EVENT_TYPES.has(event.eventType))
@@ -488,7 +497,7 @@ export async function getTransactionById(
         appliedAt: event.createdAt,
         reason: event.reason ?? undefined,
         actorStaffName: event.actorStaffProfileId
-          ? actorStaffNamesById.get(event.actorStaffProfileId) ?? null
+          ? (actorStaffNamesById.get(event.actorStaffProfileId) ?? null)
           : null,
         ...adjustment,
         originalTotal: adjustment.originalTotal ?? transaction.total,
@@ -507,7 +516,8 @@ export async function getTransactionById(
         createdAt: approval.createdAt,
         reason: approval.reason ?? approval.notes ?? undefined,
         actorStaffName: approval.requestedByStaffProfileId
-          ? actorStaffNamesById.get(approval.requestedByStaffProfileId) ?? null
+          ? (actorStaffNamesById.get(approval.requestedByStaffProfileId) ??
+            null)
           : null,
         ...adjustment,
         originalTotal: adjustment.originalTotal ?? transaction.total,
@@ -596,7 +606,7 @@ export async function getTransactionById(
               _id: undefined,
               customerProfileId,
             }
-        : null,
+          : null,
     customerInfo: transaction.customerInfo,
     correctionHistory: correctionHistory.map((event) => ({
       _id: event._id,
@@ -608,7 +618,7 @@ export async function getTransactionById(
       actorUserId: event.actorUserId,
       actorStaffProfileId: event.actorStaffProfileId,
       actorStaffName: event.actorStaffProfileId
-        ? actorStaffNamesById.get(event.actorStaffProfileId) ?? null
+        ? (actorStaffNamesById.get(event.actorStaffProfileId) ?? null)
         : null,
     })),
     receiptDeliveryHistory: receiptDeliveries.map((delivery) => ({
@@ -619,7 +629,7 @@ export async function getTransactionById(
       recipientDisplay: delivery.recipientDisplay,
       actorStaffProfileId: delivery.actorStaffProfileId,
       actorStaffName: delivery.actorStaffProfileId
-        ? actorStaffNamesById.get(delivery.actorStaffProfileId) ?? null
+        ? (actorStaffNamesById.get(delivery.actorStaffProfileId) ?? null)
         : null,
       createdAt: delivery.createdAt,
       updatedAt: delivery.updatedAt,
@@ -748,7 +758,6 @@ export async function getTodaySummary(
   };
 }
 
-
 async function resolveCurrentPosSummaryWindow(
   ctx: Pick<QueryCtx, "db">,
   args: {
@@ -756,24 +765,20 @@ async function resolveCurrentPosSummaryWindow(
     storeId: Id<"store">;
   },
 ) {
-  const activeOpening = await findLatestOpenOperatingDay(ctx, {
+  const currentStoreDay = await findCurrentStoreDayOpening(ctx, {
+    now: args.now,
     storeId: args.storeId,
   });
   const operatingDate =
-    activeOpening?.operatingDate ??
+    currentStoreDay?.operatingDate ??
     new Date(args.now).toISOString().slice(0, 10);
   const fallbackStartOfDay = Date.parse(`${operatingDate}T00:00:00.000Z`);
-  const activeOpeningStartAt = activeOpening?.startAt;
-  const activeOpeningEndAt = activeOpening?.endAt;
-  const activeOpeningRange =
-    typeof activeOpeningStartAt === "number" &&
-    typeof activeOpeningEndAt === "number" &&
-    isValidPosSummaryWindowRange(activeOpeningStartAt, activeOpeningEndAt)
-      ? {
-          endOfDay: activeOpeningEndAt - 1,
-          startOfDay: activeOpeningStartAt,
-        }
-      : null;
+  const storeDayRange = currentStoreDay
+    ? {
+        endOfDay: currentStoreDay.endAt - 1,
+        startOfDay: currentStoreDay.startAt,
+      }
+    : null;
 
   if (!Number.isFinite(fallbackStartOfDay)) {
     const fallbackStart = Date.parse(
@@ -788,9 +793,9 @@ async function resolveCurrentPosSummaryWindow(
   }
 
   return {
-    endOfDay: activeOpeningRange?.endOfDay ?? fallbackStartOfDay + DAY_MS - 1,
+    endOfDay: storeDayRange?.endOfDay ?? fallbackStartOfDay + DAY_MS - 1,
     operatingDate,
-    startOfDay: activeOpeningRange?.startOfDay ?? fallbackStartOfDay,
+    startOfDay: storeDayRange?.startOfDay ?? fallbackStartOfDay,
   };
 }
 
@@ -805,12 +810,19 @@ function isValidPosSummaryWindowRange(startAt: unknown, endAt: unknown) {
   );
 }
 
-async function findLatestOpenOperatingDay(
+type CurrentStoreDayOpening = {
+  endAt: number;
+  operatingDate: string;
+  startAt: number;
+};
+
+async function findCurrentStoreDayOpening(
   ctx: Pick<QueryCtx, "db">,
   args: {
+    now: number;
     storeId: Id<"store">;
   },
-) {
+): Promise<CurrentStoreDayOpening | null> {
   const startedOpenings = await ctx.db
     .query("dailyOpening")
     .withIndex("by_storeId_status_operatingDate", (q) =>
@@ -820,6 +832,10 @@ async function findLatestOpenOperatingDay(
     .take(10);
 
   for (const opening of startedOpenings) {
+    if (!isActivePosSummaryOpeningAt(opening, args.now)) {
+      continue;
+    }
+
     const closes = await ctx.db
       .query("dailyClose")
       .withIndex("by_storeId_operatingDate", (q) =>
@@ -839,4 +855,20 @@ async function findLatestOpenOperatingDay(
   }
 
   return null;
+}
+
+function isActivePosSummaryOpeningAt(
+  opening: { endAt?: number; startAt?: number },
+  now: number,
+): opening is { endAt: number; startAt: number } {
+  const { endAt, startAt } = opening;
+
+  return (
+    typeof startAt === "number" &&
+    typeof endAt === "number" &&
+    isValidPosSummaryWindowRange(startAt, endAt) &&
+    Number.isFinite(now) &&
+    now >= startAt &&
+    now < endAt
+  );
 }

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import React, { type AnchorHTMLAttributes, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -21,6 +21,8 @@ const mockedApi = vi.hoisted(() => ({
   getDailyOperationsDetailSnapshot: "getDailyOperationsDetailSnapshot",
   getDailyOperationsSnapshot: "getDailyOperationsSnapshot",
   getDailyOperationsStorePulseSnapshot: "getDailyOperationsStorePulseSnapshot",
+  getDailyOperationsTodayRefreshSnapshot:
+    "getDailyOperationsTodayRefreshSnapshot",
   getDailyOperationsTimelinePreviewSnapshot:
     "getDailyOperationsTimelinePreviewSnapshot",
   getDailyOperationsTimelineSnapshot: "getDailyOperationsTimelineSnapshot",
@@ -2255,6 +2257,10 @@ describe("DailyOperationsView", () => {
     ).getDailyOperationsStorePulseSnapshot =
       "getDailyOperationsStorePulseSnapshot";
     (
+      mockedApi as { getDailyOperationsTodayRefreshSnapshot?: unknown }
+    ).getDailyOperationsTodayRefreshSnapshot =
+      "getDailyOperationsTodayRefreshSnapshot";
+    (
       mockedApi as { getDailyOperationsTimelinePreviewSnapshot?: unknown }
     ).getDailyOperationsTimelinePreviewSnapshot =
       "getDailyOperationsTimelinePreviewSnapshot";
@@ -2476,6 +2482,232 @@ describe("DailyOperationsView", () => {
       "data-replay-key",
       replayKey,
     );
+  });
+
+  it("refreshes current-day operations facts without loading timeline detail", () => {
+    vi.useFakeTimers();
+    const refreshNow = new Date(2026, 4, 8, 12).getTime();
+    vi.setSystemTime(refreshNow);
+
+    try {
+      const refreshedSnapshot = {
+        attentionItems: operatingSnapshot.attentionItems,
+        closeSummary: {
+          ...operatingSnapshot.closeSummary,
+          currentDayCashTotal: 420000,
+          currentDayCashTransactionCount: 3,
+          paymentTotals: [
+            { amount: 420000, method: "cash", transactionCount: 3 },
+            {
+              amount: 2080000,
+              method: "mobile_money",
+              transactionCount: 6,
+            },
+          ],
+          salesTotal: 2500000,
+          transactionCount: 9,
+        },
+        completedClose: undefined,
+        currency: operatingSnapshot.currency,
+        endAt: Date.UTC(2026, 4, 9),
+        lanes: operatingSnapshot.lanes,
+        lifecycle: operatingSnapshot.lifecycle,
+        operatingDate: "2026-05-08",
+        primaryAction: operatingSnapshot.primaryAction,
+        priorDayMetric: weekMetrics[4],
+        refreshedAt: refreshNow,
+        refreshRequestedAt: refreshNow,
+        startAt: Date.UTC(2026, 4, 8),
+        storeId: operatingSnapshot.storeId,
+        storePulse: buildStorePulseSummary({
+          date: "2026-05-08",
+          itemName: "refreshed today item",
+          paymentLabel: "Mobile Money",
+          paymentMethod: "mobile_money",
+        }),
+        weekMetric: {
+          ...weekMetrics[5],
+          currentDayCashTotal: 420000,
+          currentDayCashTransactionCount: 3,
+          isSelected: true,
+          paymentTotals: [
+            { amount: 420000, method: "cash", transactionCount: 3 },
+            {
+              amount: 2080000,
+              method: "mobile_money",
+              transactionCount: 6,
+            },
+          ],
+          salesTotal: 2500000,
+          transactionCount: 9,
+        },
+      };
+
+      mockedHooks.useQuery.mockImplementation((query, args) => {
+        if (args === "skip") return undefined;
+        if (query === mockedApi.getDailyOperationsDetailSnapshot) {
+          return {
+            ...operatingSnapshot,
+            weekSnapshots: buildWeekSnapshots(),
+          };
+        }
+        if (query === mockedApi.getDailyOperationsStorePulseSnapshot) {
+          return {
+            operatingDate: "2026-05-08",
+            storePulse: buildStorePulseSummary({
+              date: "2026-05-08",
+              itemName: "hydrated selected item",
+              paymentLabel: "Cash",
+              paymentMethod: "cash",
+            }),
+          };
+        }
+        if (query === mockedApi.getDailyOperationsTodayRefreshSnapshot) {
+          const refreshArgs = args as { refreshRequestedAt?: unknown };
+
+          return {
+            ...refreshedSnapshot,
+            refreshRequestedAt: refreshArgs.refreshRequestedAt
+              ? Number(refreshArgs.refreshRequestedAt)
+              : refreshedSnapshot.refreshRequestedAt,
+          };
+        }
+        if (query === mockedApi.getDailyOperationsTimelinePreviewSnapshot) {
+          return {
+            operatingDate: "2026-05-08",
+            timeline: [],
+            timelineHasMore: false,
+          };
+        }
+
+        return operatingSnapshot;
+      });
+
+      render(<DailyOperationsView />);
+
+      const refreshButton = screen.getByRole("button", { name: "Refresh" });
+
+      mockedHooks.useQuery.mockClear();
+      fireEvent.click(refreshButton);
+
+      expect(mockedHooks.useQuery).toHaveBeenCalledWith(
+        mockedApi.getDailyOperationsTodayRefreshSnapshot,
+        expect.objectContaining({
+          operatingDate: "2026-05-08",
+          refreshRequestedAt: refreshNow,
+          storeId: "store-1",
+          storePulseWindow: "today",
+        }),
+      );
+      expect(mockedHooks.useQuery).not.toHaveBeenCalledWith(
+        mockedApi.getDailyOperationsTimelineSnapshot,
+        expect.objectContaining({
+          operatingDate: "2026-05-08",
+        }),
+      );
+      expect(screen.getAllByText("GH₵25,000").length).toBeGreaterThan(1);
+      expect(screen.getAllByText("9 transactions").length).toBeGreaterThan(1);
+      expect(screen.getByText("Refreshed Today Item")).toBeInTheDocument();
+      expect(screen.getAllByText("Mobile Money").length).toBeGreaterThan(1);
+      expect(screen.getByText(/Data refreshed at /)).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("auto-refreshes current-day operations after the displayed data is stale", async () => {
+    vi.useFakeTimers();
+    const initialFetchAt = new Date(2026, 4, 8, 12).getTime();
+    vi.setSystemTime(initialFetchAt);
+
+    try {
+      mockedHooks.useQuery.mockImplementation((query, args) => {
+        if (args === "skip") return undefined;
+        if (query === mockedApi.getDailyOperationsDetailSnapshot) {
+          return {
+            ...operatingSnapshot,
+            weekSnapshots: buildWeekSnapshots(),
+          };
+        }
+        if (query === mockedApi.getDailyOperationsTodayRefreshSnapshot) {
+          const refreshArgs = args as { refreshRequestedAt?: unknown };
+
+          return {
+            attentionItems: operatingSnapshot.attentionItems,
+            closeSummary: operatingSnapshot.closeSummary,
+            completedClose: undefined,
+            currency: operatingSnapshot.currency,
+            endAt: Date.UTC(2026, 4, 9),
+            lanes: operatingSnapshot.lanes,
+            lifecycle: operatingSnapshot.lifecycle,
+            operatingDate: "2026-05-08",
+            primaryAction: operatingSnapshot.primaryAction,
+            priorDayMetric: weekMetrics[4],
+            refreshedAt: Number(refreshArgs.refreshRequestedAt),
+            refreshRequestedAt: Number(refreshArgs.refreshRequestedAt),
+            startAt: Date.UTC(2026, 4, 8),
+            storeId: operatingSnapshot.storeId,
+            storePulse: buildStorePulseSummary({ date: "2026-05-08" }),
+            weekMetric: weekMetrics[5],
+          };
+        }
+        if (query === mockedApi.getDailyOperationsTimelinePreviewSnapshot) {
+          return {
+            operatingDate: "2026-05-08",
+            timeline: [],
+            timelineHasMore: false,
+          };
+        }
+
+        return operatingSnapshot;
+      });
+
+      render(<DailyOperationsView />);
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(screen.getByText(/Data refreshed at /)).toBeInTheDocument();
+
+      const getTodayRefreshCalls = () =>
+        mockedHooks.useQuery.mock.calls.filter(
+          ([query, args]) =>
+            query === mockedApi.getDailyOperationsTodayRefreshSnapshot &&
+            args !== "skip",
+        );
+
+      mockedHooks.useQuery.mockClear();
+
+      act(() => {
+        vi.advanceTimersByTime(10 * 60 * 1000 - 1);
+      });
+
+      expect(getTodayRefreshCalls()).toHaveLength(0);
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+
+      expect(getTodayRefreshCalls()).toHaveLength(1);
+      expect(mockedHooks.useQuery).toHaveBeenCalledWith(
+        mockedApi.getDailyOperationsTodayRefreshSnapshot,
+        expect.objectContaining({
+          operatingDate: "2026-05-08",
+          refreshRequestedAt: initialFetchAt + 10 * 60 * 1000,
+          storeId: "store-1",
+          storePulseWindow: "today",
+        }),
+      );
+      expect(mockedHooks.useQuery).not.toHaveBeenCalledWith(
+        mockedApi.getDailyOperationsTimelineSnapshot,
+        expect.objectContaining({
+          operatingDate: "2026-05-08",
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("queries timeline detail separately when the timeline asks for more", () => {
@@ -2792,7 +3024,9 @@ describe("DailyOperationsView", () => {
 
     expect(within(storePulse).queryByRole("tablist")).not.toBeInTheDocument();
     expect(
-      within(storePulse).getByText("Cached sales trend through the selected day."),
+      within(storePulse).getByText(
+        "Cached sales trend through the selected day.",
+      ),
     ).toBeInTheDocument();
   });
 

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -25,6 +25,7 @@ import {
   CircleAlert,
   Clock3,
   PackageSearch,
+  RefreshCw,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
@@ -76,6 +77,7 @@ type DailyOperationsApi = {
   getDailyOperationsDetailSnapshot?: unknown;
   getDailyOperationsSnapshot?: unknown;
   getDailyOperationsStorePulseSnapshot?: unknown;
+  getDailyOperationsTodayRefreshSnapshot?: unknown;
   getDailyOperationsTimelinePreviewSnapshot?: unknown;
   getDailyOperationsTimelineSnapshot?: unknown;
 };
@@ -324,10 +326,12 @@ type DailyOperationsViewContentProps = {
   isLoadingStorePulseSnapshot?: boolean;
   isLoadingTimelinePreviewSnapshot?: boolean;
   isLoadingTimelineSnapshot?: boolean;
+  isRefreshingToday?: boolean;
   isAuthenticated: boolean;
   isLoadingAccess: boolean;
   isLoadingSnapshot: boolean;
   onRequestDetailSnapshot?: () => void;
+  onRefreshToday?: () => void;
   onRequestStorePulseSnapshot?: () => void;
   onRequestTimelineSnapshot?: () => void;
   onOperatingDateChange?: (date: Date) => void;
@@ -336,6 +340,7 @@ type DailyOperationsViewContentProps = {
   storePulseWindow: StorePulseWindow;
   storeUrlSlug: string;
   storePulseSnapshot?: DailyOperationsStorePulseSnapshot;
+  todayRefreshedAt?: number;
   timelinePreviewSnapshot?: DailyOperationsTimelinePreviewSnapshot;
   timelineSnapshot?: DailyOperationsTimelineSnapshot;
 };
@@ -368,9 +373,31 @@ type DailyOperationsTimelinePreviewSnapshot =
     timelineHasMore: boolean;
   };
 
+type DailyOperationsTodayRefreshSnapshot = Pick<
+  DailyOperationsSnapshot,
+  | "attentionItems"
+  | "closeSummary"
+  | "completedClose"
+  | "currency"
+  | "endAt"
+  | "lanes"
+  | "lifecycle"
+  | "operatingDate"
+  | "primaryAction"
+  | "startAt"
+  | "storeId"
+> & {
+  priorDayMetric?: DailyOperationsSnapshot["weekMetrics"][number] | null;
+  refreshedAt: number;
+  refreshRequestedAt?: number | null;
+  storePulse?: StorePulseSummary | null;
+  weekMetric?: DailyOperationsSnapshot["weekMetrics"][number] | null;
+};
+
 type StorePulseDetailHydrationMode = "manual" | "auto";
 
 const TIMELINE_PREVIEW_LIMIT = 5;
+const TODAY_REFRESH_STALE_MS = 10 * 60 * 1000;
 // Switch to "auto" to hydrate top items/payment mix on mount.
 const STORE_PULSE_DETAIL_HYDRATION_MODE: StorePulseDetailHydrationMode = "auto";
 
@@ -590,6 +617,67 @@ function selectWeekMetricsForOperatingDate(
     ...metric,
     isSelected: metric.operatingDate === operatingDate,
   }));
+}
+
+function replaceWeekMetricForOperatingDate(
+  metrics: DailyOperationsSnapshot["weekMetrics"] | undefined,
+  refreshedMetric:
+    | DailyOperationsSnapshot["weekMetrics"][number]
+    | null
+    | undefined,
+  operatingDate: string,
+) {
+  if (!metrics || !refreshedMetric) return metrics;
+
+  let didReplace = false;
+  const nextMetrics = metrics.map((metric) => {
+    if (metric.operatingDate !== operatingDate) {
+      return {
+        ...metric,
+        isSelected: metric.isSelected && metric.operatingDate === operatingDate,
+      };
+    }
+
+    didReplace = true;
+    return {
+      ...refreshedMetric,
+      isSelected: metric.isSelected,
+    };
+  });
+
+  return didReplace ? nextMetrics : metrics;
+}
+
+function applyTodayRefreshSnapshot(
+  snapshot: DailyOperationsSnapshot | undefined,
+  refreshSnapshot: DailyOperationsTodayRefreshSnapshot | undefined,
+) {
+  if (!snapshot || !refreshSnapshot) return snapshot;
+  if (snapshot.operatingDate !== refreshSnapshot.operatingDate) return snapshot;
+
+  const weekMetrics =
+    replaceWeekMetricForOperatingDate(
+      snapshot.weekMetrics,
+      refreshSnapshot.weekMetric,
+      snapshot.operatingDate,
+    ) ?? snapshot.weekMetrics;
+
+  return {
+    ...snapshot,
+    attentionItems: refreshSnapshot.attentionItems,
+    closeSummary: refreshSnapshot.closeSummary,
+    completedClose: refreshSnapshot.completedClose ?? undefined,
+    currency: refreshSnapshot.currency,
+    endAt: refreshSnapshot.endAt,
+    lanes: refreshSnapshot.lanes,
+    lifecycle: refreshSnapshot.lifecycle,
+    primaryAction: refreshSnapshot.primaryAction,
+    priorDayMetric: refreshSnapshot.priorDayMetric ?? undefined,
+    startAt: refreshSnapshot.startAt,
+    storeId: refreshSnapshot.storeId,
+    storePulse: refreshSnapshot.storePulse ?? snapshot.storePulse,
+    weekMetrics,
+  };
 }
 
 function shouldShowPrimaryAction(snapshot: DailyOperationsSnapshot) {
@@ -2411,18 +2499,24 @@ function WeekMetricsStrip({
   analyticsFetchedAt,
   currency,
   hasFinancialDetailsAccess,
+  isRefreshingToday,
   metrics,
+  onRefreshToday,
   orgUrlSlug,
   storePulseWindow,
   storeUrlSlug,
+  todayRefreshedAt,
 }: {
   analyticsFetchedAt?: number;
   currency: string;
   hasFinancialDetailsAccess: boolean;
+  isRefreshingToday?: boolean;
   metrics: DailyOperationsSnapshot["weekMetrics"];
+  onRefreshToday?: () => void;
   orgUrlSlug: string;
   storePulseWindow: StorePulseWindow;
   storeUrlSlug: string;
+  todayRefreshedAt?: number;
 }) {
   const scrollSelectedDayIntoView = useCallback(
     (element: HTMLElement | null) => {
@@ -2458,6 +2552,13 @@ function WeekMetricsStrip({
     (total, metric) => total + metric.salesTotal,
     0,
   );
+  const selectedMetric = metrics.find((metric) => metric.isSelected);
+  const canRefreshToday = Boolean(
+    onRefreshToday &&
+    selectedMetric?.operatingDate === currentOperatingDate &&
+    selectedMetric.operatingDate <= currentOperatingDate,
+  );
+  const refreshedAt = todayRefreshedAt ?? analyticsFetchedAt;
 
   return (
     <section className="space-y-layout-sm">
@@ -2466,15 +2567,35 @@ function WeekMetricsStrip({
           <h3 className="text-base font-medium text-foreground">
             Week at a glance
           </h3>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Seven days ending {formatOperatingDate(weekEndOperatingDate)}
-            {analyticsFetchedAt ? (
-              <span className="ml-2 whitespace-nowrap">
-                · Data refreshed at{" "}
-                {formatAnalyticsCacheTimestamp(analyticsFetchedAt)}
+          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+            <span>
+              Seven days ending {formatOperatingDate(weekEndOperatingDate)}
+            </span>
+            {refreshedAt ? (
+              <span className="whitespace-nowrap">
+                · Data refreshed at {formatAnalyticsCacheTimestamp(refreshedAt)}
               </span>
             ) : null}
-          </p>
+            {canRefreshToday ? (
+              <Button
+                aria-label="Refresh"
+                className="h-7 w-7"
+                disabled={isRefreshingToday}
+                onClick={onRefreshToday}
+                size="icon"
+                type="button"
+                variant="outline"
+              >
+                <RefreshCw
+                  aria-hidden="true"
+                  className={cn(
+                    "h-3.5 w-3.5",
+                    isRefreshingToday ? "animate-spin" : undefined,
+                  )}
+                />
+              </Button>
+            ) : null}
+          </div>
         </div>
         <div className="flex flex-col gap-layout-sm sm:flex-row sm:items-center">
           <p className="flex items-baseline justify-between gap-2 text-sm text-muted-foreground sm:justify-start">
@@ -2660,10 +2781,12 @@ export function DailyOperationsViewContent({
   isLoadingStorePulseSnapshot,
   isLoadingTimelinePreviewSnapshot,
   isLoadingTimelineSnapshot,
+  isRefreshingToday,
   isAuthenticated,
   isLoadingAccess,
   isLoadingSnapshot,
   onRequestDetailSnapshot,
+  onRefreshToday,
   onRequestStorePulseSnapshot,
   onRequestTimelineSnapshot,
   onOperatingDateChange,
@@ -2672,6 +2795,7 @@ export function DailyOperationsViewContent({
   storePulseWindow,
   storeUrlSlug,
   storePulseSnapshot,
+  todayRefreshedAt,
   timelinePreviewSnapshot,
   timelineSnapshot,
 }: DailyOperationsViewContentProps) {
@@ -3078,10 +3202,13 @@ export function DailyOperationsViewContent({
                     analyticsFetchedAt={weekAnalyticsFetchedAt}
                     currency={snapshot.currency ?? currency}
                     hasFinancialDetailsAccess={hasFinancialDetailsAccess}
+                    isRefreshingToday={isRefreshingToday}
                     metrics={weekMetricsForDisplay}
+                    onRefreshToday={onRefreshToday}
                     orgUrlSlug={orgUrlSlug}
                     storePulseWindow={storePulseWindow}
                     storeUrlSlug={storeUrlSlug}
+                    todayRefreshedAt={todayRefreshedAt}
                   />
                 ) : onRequestDetailSnapshot ? (
                   <DailyOperationsWeekMetricsPreview
@@ -3308,12 +3435,14 @@ function DailyOperationsConnectedView({
   getDailyOperationsDetailSnapshot,
   getDailyOperationsSnapshot,
   getDailyOperationsStorePulseSnapshot,
+  getDailyOperationsTodayRefreshSnapshot,
   getDailyOperationsTimelinePreviewSnapshot,
   getDailyOperationsTimelineSnapshot,
 }: {
   getDailyOperationsDetailSnapshot?: unknown;
   getDailyOperationsSnapshot: unknown;
   getDailyOperationsStorePulseSnapshot?: unknown;
+  getDailyOperationsTodayRefreshSnapshot?: unknown;
   getDailyOperationsTimelinePreviewSnapshot?: unknown;
   getDailyOperationsTimelineSnapshot?: unknown;
 }) {
@@ -3373,11 +3502,18 @@ function DailyOperationsConnectedView({
     useState<string | null>(null);
   const [requestedStorePulseSnapshotKey, setRequestedStorePulseSnapshotKey] =
     useState<string | null>(null);
+  const [todayRefreshRequest, setTodayRefreshRequest] = useState<{
+    requestedAt: number;
+    snapshotRequestKey: string;
+  } | null>(null);
   const [weekAnalyticsCache, setWeekAnalyticsCache] = useState<
     Record<string, CachedWeekAnalytics>
   >({});
   const [storePulseCache, setStorePulseCache] = useState<
     Record<string, DailyOperationsStorePulseSnapshot>
+  >({});
+  const [todayRefreshCache, setTodayRefreshCache] = useState<
+    Record<string, DailyOperationsTodayRefreshSnapshot>
   >({});
   const [timelinePreviewCache, setTimelinePreviewCache] = useState<
     Record<string, DailyOperationsTimelinePreviewSnapshot>
@@ -3419,6 +3555,22 @@ function DailyOperationsConnectedView({
     canQueryProtectedData &&
     (isStorePulseSnapshotRequested || shouldAutoHydrateStorePulseSnapshot) &&
     cachedStorePulseSnapshot === undefined;
+  const isTodayRefreshRequested =
+    snapshotRequestKey !== "skip" &&
+    todayRefreshRequest?.snapshotRequestKey === snapshotRequestKey;
+  const shouldQueryTodayRefreshSnapshot =
+    Boolean(getDailyOperationsTodayRefreshSnapshot) &&
+    canQueryProtectedData &&
+    isTodayRefreshRequested;
+  const todayRefreshArgs =
+    shouldQueryTodayRefreshSnapshot &&
+    snapshotArgs !== "skip" &&
+    todayRefreshRequest
+      ? {
+          ...snapshotArgs,
+          refreshRequestedAt: todayRefreshRequest.requestedAt,
+        }
+      : "skip";
 
   const compactSnapshot = useExpectedDailyOperationsQuery(
     getDailyOperationsSnapshot,
@@ -3432,6 +3584,10 @@ function DailyOperationsConnectedView({
     getDailyOperationsStorePulseSnapshot ?? getDailyOperationsSnapshot,
     shouldQueryStorePulseSnapshot ? snapshotArgs : "skip",
   ) as DailyOperationsStorePulseSnapshot | undefined;
+  const queriedTodayRefreshSnapshot = useExpectedDailyOperationsQuery(
+    getDailyOperationsTodayRefreshSnapshot ?? getDailyOperationsSnapshot,
+    todayRefreshArgs,
+  ) as DailyOperationsTodayRefreshSnapshot | undefined;
   const queriedTimelinePreviewSnapshot = useExpectedDailyOperationsQuery(
     getDailyOperationsTimelinePreviewSnapshot ?? getDailyOperationsSnapshot,
     getDailyOperationsTimelinePreviewSnapshot && canQueryProtectedData
@@ -3458,26 +3614,59 @@ function DailyOperationsConnectedView({
         )
       : detailSnapshot;
   const baseSnapshot = compactSnapshot ?? cachedDaySnapshotEntry?.snapshot;
-  const snapshot = baseSnapshot
+  const mergedSnapshot = baseSnapshot
     ? normalizedDetailSnapshot
       ? mergeDailyOperationsSnapshots(baseSnapshot, normalizedDetailSnapshot)
       : baseSnapshot
     : normalizedDetailSnapshot;
+  const cachedTodayRefreshSnapshot =
+    snapshotRequestKey === "skip"
+      ? undefined
+      : todayRefreshCache[snapshotRequestKey];
+  const snapshot = applyTodayRefreshSnapshot(
+    mergedSnapshot,
+    cachedTodayRefreshSnapshot,
+  );
   const cachedTimelinePreviewSnapshot =
     snapshotRequestKey === "skip"
       ? undefined
       : timelinePreviewCache[snapshotRequestKey];
   const timelinePreviewSnapshot =
     queriedTimelinePreviewSnapshot ?? cachedTimelinePreviewSnapshot;
+  const refreshedStorePulseSnapshot =
+    snapshotArgs !== "skip" && cachedTodayRefreshSnapshot
+      ? {
+          operatingDate: cachedTodayRefreshSnapshot.operatingDate,
+          storePulse: cachedTodayRefreshSnapshot.storePulse ?? null,
+        }
+      : undefined;
   const storePulseSnapshot =
-    queriedStorePulseSnapshot ?? cachedStorePulseSnapshot;
-  const cachedWeekMetrics =
+    refreshedStorePulseSnapshot ??
+    queriedStorePulseSnapshot ??
+    cachedStorePulseSnapshot;
+  const rawCachedWeekMetrics =
     cachedWeekAnalytics && snapshotArgs !== "skip"
       ? selectWeekMetricsForOperatingDate(
           cachedWeekAnalytics.metrics,
           snapshotArgs.operatingDate,
         )
       : undefined;
+  const cachedWeekMetrics =
+    snapshotArgs !== "skip"
+      ? replaceWeekMetricForOperatingDate(
+          rawCachedWeekMetrics,
+          cachedTodayRefreshSnapshot?.weekMetric,
+          snapshotArgs.operatingDate,
+        )
+      : rawCachedWeekMetrics;
+  const cachedWeekStorePulse =
+    cachedTodayRefreshSnapshot?.storePulse && snapshot
+      ? buildCachedWeekStorePulseSummary({
+          ...snapshot,
+          storePulse: cachedTodayRefreshSnapshot.storePulse,
+          weekMetrics: cachedWeekMetrics ?? snapshot.weekMetrics,
+        })
+      : cachedWeekAnalytics?.storePulse;
 
   useEffect(() => {
     if (
@@ -3536,6 +3725,31 @@ function DailyOperationsConnectedView({
   useEffect(() => {
     if (
       snapshotRequestKey === "skip" ||
+      queriedTodayRefreshSnapshot === undefined ||
+      !todayRefreshRequest ||
+      todayRefreshRequest.snapshotRequestKey !== snapshotRequestKey ||
+      queriedTodayRefreshSnapshot.refreshRequestedAt !==
+        todayRefreshRequest.requestedAt
+    ) {
+      return;
+    }
+
+    setTodayRefreshCache((current) => {
+      if (current[snapshotRequestKey] === queriedTodayRefreshSnapshot) {
+        return current;
+      }
+
+      return {
+        ...current,
+        [snapshotRequestKey]: queriedTodayRefreshSnapshot,
+      };
+    });
+    setTodayRefreshRequest(null);
+  }, [queriedTodayRefreshSnapshot, snapshotRequestKey, todayRefreshRequest]);
+
+  useEffect(() => {
+    if (
+      snapshotRequestKey === "skip" ||
       queriedTimelinePreviewSnapshot === undefined
     ) {
       return;
@@ -3572,13 +3786,57 @@ function DailyOperationsConnectedView({
       })) as never,
     });
   };
+  const canRefreshToday =
+    Boolean(getDailyOperationsTodayRefreshSnapshot) &&
+    canQueryProtectedData &&
+    snapshotArgs !== "skip" &&
+    snapshotArgs.operatingDate === getLocalOperatingDate();
+  const requestTodayRefresh = useCallback(() => {
+    if (!canRefreshToday || snapshotRequestKey === "skip") return;
+
+    setTodayRefreshRequest((current) => {
+      if (current?.snapshotRequestKey === snapshotRequestKey) {
+        return current;
+      }
+
+      return {
+        requestedAt: Date.now(),
+        snapshotRequestKey,
+      };
+    });
+  }, [canRefreshToday, snapshotRequestKey]);
+  const todayRefreshLastFetchedAt =
+    cachedTodayRefreshSnapshot?.refreshedAt ?? cachedWeekAnalytics?.fetchedAt;
+
+  useEffect(() => {
+    if (
+      !canRefreshToday ||
+      isTodayRefreshRequested ||
+      todayRefreshLastFetchedAt === undefined
+    ) {
+      return;
+    }
+
+    const staleDelayMs = Math.max(
+      todayRefreshLastFetchedAt + TODAY_REFRESH_STALE_MS - Date.now(),
+      0,
+    );
+    const timeoutId = window.setTimeout(requestTodayRefresh, staleDelayMs);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [
+    canRefreshToday,
+    isTodayRefreshRequested,
+    requestTodayRefresh,
+    todayRefreshLastFetchedAt,
+  ]);
 
   return (
     <DailyOperationsViewContent
       currency={activeStore?.currency ?? "GHS"}
       cachedWeekAnalyticsFetchedAt={cachedWeekAnalytics?.fetchedAt}
       cachedWeekMetrics={cachedWeekMetrics}
-      cachedWeekStorePulse={cachedWeekAnalytics?.storePulse}
+      cachedWeekStorePulse={cachedWeekStorePulse}
       hasDetailSnapshot={
         detailSnapshot !== undefined ||
         cachedDaySnapshotEntry?.hasDetail === true
@@ -3603,6 +3861,7 @@ function DailyOperationsConnectedView({
         isTimelineSnapshotRequested && timelineSnapshot === undefined
       }
       isLoadingSnapshot={snapshot === undefined}
+      isRefreshingToday={isTodayRefreshRequested}
       onRequestDetailSnapshot={() =>
         setRequestedDetailSnapshotKey(
           snapshotRequestKey === "skip" ? null : snapshotRequestKey,
@@ -3619,11 +3878,13 @@ function DailyOperationsConnectedView({
         )
       }
       onOperatingDateChange={handleOperatingDateChange}
+      onRefreshToday={canRefreshToday ? requestTodayRefresh : undefined}
       orgUrlSlug={params?.orgUrlSlug ?? ""}
       snapshot={snapshot}
       storePulseWindow={storePulseWindow}
       storeUrlSlug={params?.storeUrlSlug ?? ""}
       storePulseSnapshot={storePulseSnapshot}
+      todayRefreshedAt={cachedTodayRefreshSnapshot?.refreshedAt}
       timelinePreviewSnapshot={timelinePreviewSnapshot}
       timelineSnapshot={timelineSnapshot}
     />
@@ -3645,6 +3906,9 @@ export function DailyOperationsView() {
       getDailyOperationsSnapshot={dailyOperationsApi.getDailyOperationsSnapshot}
       getDailyOperationsStorePulseSnapshot={
         dailyOperationsApi.getDailyOperationsStorePulseSnapshot
+      }
+      getDailyOperationsTodayRefreshSnapshot={
+        dailyOperationsApi.getDailyOperationsTodayRefreshSnapshot
       }
       getDailyOperationsTimelinePreviewSnapshot={
         dailyOperationsApi.getDailyOperationsTimelinePreviewSnapshot

--- a/packages/athena-webapp/src/components/pos/sales-pulse/POSSalesPulseView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/sales-pulse/POSSalesPulseView.test.tsx
@@ -165,9 +165,7 @@ describe("POSStorePulseSection", () => {
     expect(screen.getByText("Sales")).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Today" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "All time" })).toBeInTheDocument();
-    expect(
-      screen.queryByText(/Compared with/),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Compared with/)).not.toBeInTheDocument();
     expect(screen.getByText("Sales trend")).toBeInTheDocument();
     expect(screen.queryByText("Busiest hour")).not.toBeInTheDocument();
     expect(screen.getByText("How customers paid")).toBeInTheDocument();
@@ -265,6 +263,19 @@ describe("POSStorePulseSection", () => {
 
     expect(screen.getByRole("tab", { name: "This week" })).toBeInTheDocument();
     expect(screen.getAllByText(/vs last week/).length).toBeGreaterThan(0);
+  });
+
+  it("uses clear no-sales copy when the prior window has no sales", () => {
+    const todaySummary = buildTodaySummary();
+    todaySummary.operatorSnapshot.comparison.yesterdayAverageTransaction = 0;
+    todaySummary.operatorSnapshot.comparison.yesterdayItemsSold = 0;
+    todaySummary.operatorSnapshot.comparison.yesterdaySales = 0;
+    todaySummary.operatorSnapshot.comparison.yesterdayTransactions = 0;
+
+    renderStorePulse({ todaySummary });
+
+    expect(screen.getAllByText("No sales yesterday")).toHaveLength(4);
+    expect(screen.queryByText("No yesterday")).not.toBeInTheDocument();
   });
 
   it("uses operator-friendly labels for the sales trend chart", () => {

--- a/packages/athena-webapp/src/components/store-pulse/StorePulseSummaryView.tsx
+++ b/packages/athena-webapp/src/components/store-pulse/StorePulseSummaryView.tsx
@@ -167,7 +167,7 @@ function formatComparisonHelper({
 }) {
   return formatOperationsMetricComparison({
     deltaPercent,
-    missingComparisonLabel: `No ${priorWindowLabel}`,
+    missingComparisonLabel: `No sales ${priorWindowLabel}`,
     priorValue,
     priorWindowLabel,
   });
@@ -698,7 +698,11 @@ export function PaymentMethodsPanel({
   );
 }
 
-function StorePulseRail({ snapshot }: { snapshot: StorePulseOperatorSnapshot }) {
+function StorePulseRail({
+  snapshot,
+}: {
+  snapshot: StorePulseOperatorSnapshot;
+}) {
   return (
     <PageWorkspaceRail>
       <PaymentMethodsPanel snapshot={snapshot} />
@@ -944,7 +948,9 @@ export function StorePulseSummaryView({
                           canView={canViewFinancialDetails}
                           label="Sales"
                         >
-                          {currencyFormatter.format(toDisplayAmount(totalSales))}
+                          {currencyFormatter.format(
+                            toDisplayAmount(totalSales),
+                          )}
                         </FinancialValue>
                       }
                     />


### PR DESCRIPTION
## Summary
- key POS pulse today off the active store-day window instead of stale unclosed openings
- add a scoped current-day Daily Operations refresh query and UI cache merge for summary cards, trend, top items, and payment mix
- add manual icon refresh plus 10-minute stale auto-refresh for current-day operations facts
- document the reusable store-day currentness pattern

## Validation
- bun run test -- convex/operations/dailyOperations.test.ts
- bun run test -- src/components/operations/DailyOperationsView.test.tsx
- bun run test -- convex/pos/application/getTransactions.test.ts
- bun run test -- src/components/pos/sales-pulse/POSSalesPulseView.test.tsx
- bun run pr:athena