### PR TITLE
Polish EOD reporting and operations context

### DIFF
--- a/docs/solutions/logic-errors/athena-eod-report-transaction-metadata-2026-06-30.md
+++ b/docs/solutions/logic-errors/athena-eod-report-transaction-metadata-2026-06-30.md
@@ -1,0 +1,53 @@
+---
+title: Athena EOD Report Transaction Metadata
+date: 2026-06-30
+category: logic-errors
+module: athena-webapp
+problem_type: ui_state_and_report_snapshot
+component: daily-close
+resolution_type: pattern
+severity: medium
+tags:
+  - daily-close
+  - eod-review
+  - report-snapshot
+  - url-state
+---
+
+# Athena EOD Report Transaction Metadata
+
+## Problem
+
+The EOD Review transaction report is a drill-in sheet that operators use while
+moving between transaction detail pages and the close workspace. If the sheet
+open state lives only in component state, returning from a transaction detail
+page collapses the report and loses the operator's context.
+
+Transaction report rows also depend on metadata captured into the daily-close
+report snapshot. New fields such as item counts need to be written when the
+close snapshot is built; old completed snapshots should not silently trigger
+extra read-time backfills for every historical row.
+
+## Solution
+
+Keep report sheet state in route search:
+
+- Use a narrow enum-style search value such as `report=transactions`.
+- Let the open button add that value while preserving existing search params.
+- Let sheet close remove only that report key so `o`, `tab`, `page`, and
+  `operatingDate` survive.
+
+Persist transaction row metadata at snapshot-build time:
+
+- Add item counts to current sale, voided-sale, and expense report items before
+  completion stores the report snapshot.
+- Render counts only when present and positive.
+- Treat historic snapshots without item counts as legacy data instead of adding
+  per-row item-table queries to completed-close reads.
+
+## Prevention
+
+When extending EOD report rows, cover both the backend snapshot metadata and the
+sheet rendering path. Include a route-search test for any report sheet state that
+must survive navigation. Avoid historical read-time enrichment unless the UX gain
+justifies the extra indexed reads on every completed close view.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8324 nodes · 9942 edges · 2074 communities detected
+- 8329 nodes · 9951 edges · 2074 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2087,7 +2087,7 @@
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
-2. `buildDailyCloseSnapshotWithCtx()` - 33 edges
+2. `buildDailyCloseSnapshotWithCtx()` - 35 edges
 3. `collectConvexQueryWriteBoundaryFindings()` - 28 edges
 4. `projectLocalRegisterReadModel()` - 27 edges
 5. `buildDailyOpeningSnapshotWithCtx()` - 18 edges
@@ -2113,7 +2113,7 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.05
-Nodes (75): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildApprovalRequestsById(), buildDailyCloseApprovalSubject() (+67 more)
+Nodes (77): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildApprovalRequestsById(), buildDailyCloseApprovalSubject() (+69 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.06
@@ -2125,7 +2125,7 @@ Nodes (68): buildLegacyOperationalExplanation(), buildRecoveryBlockers(), buildR
 
 ### Community 3 - "Community 3"
 Cohesion: 0.06
-Nodes (62): attentionSeverity(), automationRunClassification(), automationStatusBucketForRun(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildRegisterCloseoutTimelineMessage() (+54 more)
+Nodes (64): attentionSeverity(), automationRunClassification(), automationStatusBucketForRun(), buildApprovalsLane(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents() (+56 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.09
@@ -2208,12 +2208,12 @@ Cohesion: 0.07
 Nodes (11): formatCompactTextList(), formatPaymentMethods(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary(), formatReviewTypeSummary(), formatTimestamp() (+3 more)
 
 ### Community 24 - "Community 24"
-Cohesion: 0.15
-Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
-
-### Community 25 - "Community 25"
 Cohesion: 0.11
 Nodes (23): applyTodayRefreshSnapshot(), buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), formatPendingApprovalsLabel(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate() (+15 more)
+
+### Community 25 - "Community 25"
+Cohesion: 0.15
+Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
 ### Community 26 - "Community 26"
 Cohesion: 0.11
@@ -2676,64 +2676,64 @@ Cohesion: 0.29
 Nodes (8): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), resolveStoreOperatingRangeForDateWithCtx(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
 
 ### Community 141 - "Community 141"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 142 - "Community 142"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.2
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.2
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.25
 Nodes (5): getRuntimeStatusPublishMaterialSignature(), getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusPublishMaterial(), normalizeRuntimeStatusSignature()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.25
 Nodes (7): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
-
-### Community 155 - "Community 155"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 156 - "Community 156"
 Cohesion: 0.18
@@ -2884,28 +2884,28 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 193 - "Community 193"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
-### Community 194 - "Community 194"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
-### Community 195 - "Community 195"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 196 - "Community 196"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 197 - "Community 197"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+### Community 194 - "Community 194"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 198 - "Community 198"
+### Community 195 - "Community 195"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
+### Community 196 - "Community 196"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 197 - "Community 197"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 198 - "Community 198"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.22
@@ -3360,8 +3360,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 312 - "Community 312"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 313 - "Community 313"
 Cohesion: 0.33
@@ -3376,76 +3376,76 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 316 - "Community 316"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 317 - "Community 317"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 318 - "Community 318"
+### Community 317 - "Community 317"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
+
+### Community 318 - "Community 318"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 319 - "Community 319"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 320 - "Community 320"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 321 - "Community 321"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 322 - "Community 322"
+### Community 321 - "Community 321"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 323 - "Community 323"
+### Community 322 - "Community 322"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 324 - "Community 324"
+### Community 323 - "Community 323"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 324 - "Community 324"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 325 - "Community 325"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 326 - "Community 326"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 327 - "Community 327"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 328 - "Community 328"
+### Community 327 - "Community 327"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 329 - "Community 329"
+### Community 328 - "Community 328"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 329 - "Community 329"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 330 - "Community 330"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 331 - "Community 331"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 332 - "Community 332"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 333 - "Community 333"
+### Community 332 - "Community 332"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 333 - "Community 333"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 334 - "Community 334"
 Cohesion: 0.53

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,15 +8,15 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2147
-- Graph nodes: 8324
-- Graph edges: 9942
+- Graph nodes: 8329
+- Graph edges: 9951
 - Communities: 2074
 
 ## Graph Hotspots
-- `dailyClose.ts` (88 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (90 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-inferential-review.ts` (86 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `terminalHealthPresentation.ts` (75 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
-- `dailyOperations.ts` (67 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `dailyOperations.ts` (69 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `DailyCloseView.tsx` (65 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `projectLocalEvents.ts` (65 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 6) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,9 +17,9 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `dailyClose.ts` (88 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (90 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `terminalHealthPresentation.ts` (75 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
-- `dailyOperations.ts` (67 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `dailyOperations.ts` (69 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `DailyCloseView.tsx` (65 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `projectLocalEvents.ts` (65 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -29,6 +29,7 @@ type TableName =
   | "dailyClose"
   | "expenseSession"
   | "expenseTransaction"
+  | "expenseTransactionItem"
   | "operationalEvent"
   | "operationalWorkItem"
   | "paymentAllocation"
@@ -36,6 +37,7 @@ type TableName =
   | "posTerminal"
   | "posTransactionAdjustment"
   | "posTransaction"
+  | "posTransactionItem"
   | "registerSession"
   | "staffProfile"
   | "store";
@@ -856,6 +858,28 @@ describe("end-of-day review backend foundation", () => {
           transactionNumber: "EXP-PRIOR",
         },
       ],
+      expenseTransactionItem: [
+        {
+          _id: "expense-1-item-1",
+          costPrice: 1000,
+          productId: "expense-product-1",
+          productName: "Packing Paper",
+          productSku: "PP-1",
+          productSkuId: "expense-sku-1",
+          quantity: 4,
+          transactionId: "expense-1",
+        },
+        {
+          _id: "expense-2-item-1",
+          costPrice: 2500,
+          productId: "expense-product-2",
+          productName: "Carrier Bags",
+          productSku: "CB-1",
+          productSkuId: "expense-sku-2",
+          quantity: 1,
+          transactionId: "expense-2",
+        },
+      ],
       expenseSession: [
         {
           _id: "expense-session-1",
@@ -1003,6 +1027,41 @@ describe("end-of-day review backend foundation", () => {
           total: 7000,
           totalPaid: 7000,
           transactionNumber: "TXN-NEXT",
+        },
+      ],
+      posTransactionItem: [
+        {
+          _id: "txn-1-item-1",
+          productId: "product-1",
+          productName: "Lace Wig",
+          productSku: "LW-1",
+          productSkuId: "sku-1",
+          quantity: 1,
+          totalPrice: 7000,
+          transactionId: "txn-1",
+          unitPrice: 7000,
+        },
+        {
+          _id: "txn-1-item-2",
+          productId: "product-2",
+          productName: "Wig Cap",
+          productSku: "WC-1",
+          productSkuId: "sku-2",
+          quantity: 2,
+          totalPrice: 5000,
+          transactionId: "txn-1",
+          unitPrice: 2500,
+        },
+        {
+          _id: "txn-void-item-1",
+          productId: "product-3",
+          productName: "Closure Wig",
+          productSku: "CW-1",
+          productSkuId: "sku-3",
+          quantity: 2,
+          totalPrice: 5000,
+          transactionId: "txn-void",
+          unitPrice: 2500,
         },
       ],
       registerSession: [
@@ -1173,6 +1232,7 @@ describe("end-of-day review backend foundation", () => {
       )?.metadata,
     ).toMatchObject({
       completedAt: Date.UTC(2026, 4, 7, 15),
+      itemCount: 2,
       paymentMethods: "Card",
       total: 5000,
       totalPaid: 5000,
@@ -1197,6 +1257,7 @@ describe("end-of-day review backend foundation", () => {
       completedAt: Date.UTC(2026, 4, 7, 14),
       customer: "0240000000",
       owner: "Kofi Mensah",
+      itemCount: 3,
       paymentMethods: "Cash, Mobile Money",
       terminal: "Front counter terminal / Register A1",
       total: 12000,
@@ -1242,6 +1303,7 @@ describe("end-of-day review backend foundation", () => {
       },
       metadata: {
         completedAt: Date.UTC(2026, 4, 7, 17),
+        itemCount: 4,
         notes: "Restocked petty cash supplies.",
         owner: "Kofi Mensah",
         report: "EXP-1",

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -1416,6 +1416,62 @@ async function listExpensesForDay(
   });
 }
 
+async function buildTransactionItemCountsByTransactionId(
+  ctx: Pick<QueryCtx, "db">,
+  transactions: Array<Doc<"posTransaction">>,
+) {
+  const entries = await Promise.all(
+    transactions.map(async (transaction) => {
+      const items = await ctx.db
+        .query("posTransactionItem")
+        .withIndex("by_transactionId", (q) =>
+          q.eq("transactionId", transaction._id),
+        )
+        .take(DAILY_CLOSE_QUERY_LIMIT);
+      const itemCount = items.reduce(
+        (sum, item) =>
+          sum +
+          (typeof item.quantity === "number" && Number.isFinite(item.quantity)
+            ? item.quantity
+            : 0),
+        0,
+      );
+
+      return [String(transaction._id), itemCount] as const;
+    }),
+  );
+
+  return new Map(entries);
+}
+
+async function buildExpenseTransactionItemCountsByTransactionId(
+  ctx: Pick<QueryCtx, "db">,
+  transactions: Array<Doc<"expenseTransaction">>,
+) {
+  const entries = await Promise.all(
+    transactions.map(async (transaction) => {
+      const items = await ctx.db
+        .query("expenseTransactionItem")
+        .withIndex("by_transactionId", (q) =>
+          q.eq("transactionId", transaction._id),
+        )
+        .take(DAILY_CLOSE_QUERY_LIMIT);
+      const itemCount = items.reduce(
+        (sum, item) =>
+          sum +
+          (typeof item.quantity === "number" && Number.isFinite(item.quantity)
+            ? item.quantity
+            : 0),
+        0,
+      );
+
+      return [String(transaction._id), itemCount] as const;
+    }),
+  );
+
+  return new Map(entries);
+}
+
 async function listDepositsForDay(
   ctx: Pick<QueryCtx, "db">,
   args: {
@@ -2423,6 +2479,16 @@ export async function buildDailyCloseSnapshotWithCtx(
   const appliedTransactionAdjustments = appliedTransactionAdjustmentRead.rows;
   const voidedTransactions = voidedTransactionRead.rows;
   const expenseTransactions = expenseTransactionRead.rows;
+  const completedTransactionItemCountsById =
+    await buildTransactionItemCountsByTransactionId(ctx, [
+      ...completedTransactions,
+      ...voidedTransactions,
+    ]);
+  const expenseTransactionItemCountsById =
+    await buildExpenseTransactionItemCountsByTransactionId(
+      ctx,
+      expenseTransactions,
+    );
   const cashDeposits = cashDepositRead.rows;
   const pendingApprovals = pendingApprovalRead.rows;
   const openPosSessions = openPosSessionRead.rows;
@@ -2960,6 +3026,13 @@ export async function buildDailyCloseSnapshotWithCtx(
         completedAt: transaction.completedAt,
         total: transaction.total,
         totalPaid: transaction.totalPaid,
+        ...(completedTransactionItemCountsById.get(String(transaction._id))
+          ? {
+              itemCount: completedTransactionItemCountsById.get(
+                String(transaction._id),
+              ),
+            }
+          : {}),
         ...(typeof transaction.changeGiven === "number"
           ? { changeGiven: transaction.changeGiven }
           : {}),
@@ -3060,6 +3133,13 @@ export async function buildDailyCloseSnapshotWithCtx(
         ...(transaction.notes ? { notes: transaction.notes } : {}),
         total: transaction.totalValue,
         completedAt: transaction.completedAt,
+        ...(expenseTransactionItemCountsById.get(String(transaction._id))
+          ? {
+              itemCount: expenseTransactionItemCountsById.get(
+                String(transaction._id),
+              ),
+            }
+          : {}),
       },
     });
   });
@@ -3111,6 +3191,13 @@ export async function buildDailyCloseSnapshotWithCtx(
         total: transaction.total,
         totalPaid: transaction.totalPaid,
         completedAt: transaction.completedAt,
+        ...(completedTransactionItemCountsById.get(String(transaction._id))
+          ? {
+              itemCount: completedTransactionItemCountsById.get(
+                String(transaction._id),
+              ),
+            }
+          : {}),
         ...(typeof transaction.voidedAt === "number"
           ? { voidedAt: transaction.voidedAt }
           : {}),

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -7,6 +7,7 @@ import {
   getDailyOperationsDetailSnapshot,
   getDailyOperationsSnapshot,
   getDailyOperationsStorePulseSnapshot,
+  getDailyOperationsStoreRequestsSnapshot,
   getDailyOperationsTodayRefreshSnapshot,
   getDailyOperationsTimelinePreviewSnapshot,
   getDailyOperationsTimelineSnapshot,
@@ -2580,6 +2581,7 @@ describe("daily operations overview read model", () => {
     ).toMatchObject({
       count: 1,
       status: "blocked",
+      to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls",
     });
   });
 
@@ -2849,6 +2851,94 @@ describe("daily operations overview read model", () => {
     expect(snapshot.attentionItems.map((item) => item.id)).not.toContain(
       "approval_request:approval-future-day:pending",
     );
+  });
+
+  it("returns pending approval requests through a separate store requests snapshot", async () => {
+    vi.setSystemTime(new Date("2026-05-08T12:00:00.000Z"));
+    vi.mocked(
+      athenaUserAuth.requireAuthenticatedAthenaUserWithCtx,
+    ).mockResolvedValue({
+      _creationTime: 0,
+      _id: "user-1" as Id<"athenaUser">,
+      email: "admin@wigclub.store",
+    });
+    vi.mocked(
+      athenaUserAuth.requireOrganizationMemberRoleWithCtx,
+    ).mockResolvedValue({
+      _creationTime: 0,
+      _id: "member-admin" as Id<"organizationMember">,
+      organizationId: "org-1" as Id<"organization">,
+      role: "full_admin",
+      userId: "user-1" as Id<"athenaUser">,
+    });
+
+    const snapshot = await getHandler(getDailyOperationsStoreRequestsSnapshot)(
+      buildCtx({
+        approvalRequest: [
+          {
+            _id: "approval-prior-day",
+            createdAt: Date.UTC(2026, 4, 7, 20),
+            reason: "Prior day variance review",
+            requestType: "variance_review",
+            status: "pending",
+            storeId: "store-1",
+            subjectId: "register-prior",
+            subjectType: "register_session",
+          },
+          {
+            _id: "approval-current-day",
+            createdAt: Date.UTC(2026, 4, 8, 10),
+            reason: "Current day variance review",
+            requestType: "variance_review",
+            status: "pending",
+            storeId: "store-1",
+            subjectId: "register-current",
+            subjectType: "register_session",
+          },
+          {
+            _id: "approval-approved",
+            createdAt: Date.UTC(2026, 4, 8, 11),
+            reason: "Resolved",
+            requestType: "variance_review",
+            status: "approved",
+            storeId: "store-1",
+            subjectId: "register-resolved",
+            subjectType: "register_session",
+          },
+        ],
+        operationalWorkItem: [
+          {
+            _id: "work-open",
+            approvalState: "not_required",
+            createdAt: 1,
+            organizationId: "org-1",
+            priority: "normal",
+            status: "open",
+            storeId: "store-1",
+            title: "Call customer",
+            type: "customer_follow_up",
+          },
+        ],
+        store: [store],
+      }) as never,
+      {
+        operatingDate: "2026-05-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(snapshot).toEqual({
+      approvalsLane: {
+        count: 2,
+        countLabel: "2",
+        description: "2 approvals pending.",
+        key: "approvals",
+        label: "Approvals",
+        status: "blocked",
+        to: "/$orgUrlSlug/store/$storeUrlSlug/operations/approvals",
+      },
+      operatingDate: "2026-05-08",
+    });
   });
 
   it("keeps a completed store day reviewable and scopes timeline events to the day", async () => {

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -521,17 +521,48 @@ async function listOpenQueueSnapshot(
           .take(MAX_OPERATIONS_LOOKAHEAD_LIMIT),
       ),
     ),
-    ctx.db
-      .query("approvalRequest")
-      .withIndex("by_storeId_status", (q) =>
-        q.eq("storeId", args.storeId).eq("status", "pending"),
-      )
-      .take(MAX_OPERATIONS_LOOKAHEAD_LIMIT),
+    listPendingApprovalRequestsSnapshot(ctx, args),
   ]);
 
   const openWorkItems = workItemBatches
     .flatMap((batch) => batch)
     .slice(0, MAX_OPERATIONS_QUERY_LIMIT);
+  const hasMoreOpenWorkItems =
+    workItemBatches.some(
+      (batch) => batch.length > MAX_OPERATIONS_QUERY_LIMIT,
+    ) ||
+    workItemBatches.reduce((total, batch) => total + batch.length, 0) >
+      MAX_OPERATIONS_QUERY_LIMIT;
+  const hasMoreApprovalRequests =
+    pendingApprovalRequests.hasMoreApprovalRequests;
+
+  return {
+    approvalRequests: pendingApprovalRequests.approvalRequests,
+    approvalRequestsCountLabel:
+      pendingApprovalRequests.approvalRequestsCountLabel,
+    hasMoreApprovalRequests,
+    hasMoreOpenWorkItems,
+    openWorkItems,
+    openWorkItemsCountLabel: hasMoreOpenWorkItems
+      ? `${MAX_OPERATIONS_QUERY_LIMIT}+`
+      : String(openWorkItems.length),
+  };
+}
+
+async function listPendingApprovalRequestsSnapshot(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    endAt: number;
+    startAt: number;
+    storeId: Id<"store">;
+  },
+) {
+  const pendingApprovalRequests = await ctx.db
+    .query("approvalRequest")
+    .withIndex("by_storeId_status", (q) =>
+      q.eq("storeId", args.storeId).eq("status", "pending"),
+    )
+    .take(MAX_OPERATIONS_LOOKAHEAD_LIMIT);
   const currentTime = Date.now();
   const dayApprovalRequests = pendingApprovalRequests.filter((request) =>
     approvalRequestBelongsToOperationsDay({
@@ -544,12 +575,6 @@ async function listOpenQueueSnapshot(
     0,
     MAX_OPERATIONS_QUERY_LIMIT,
   );
-  const hasMoreOpenWorkItems =
-    workItemBatches.some(
-      (batch) => batch.length > MAX_OPERATIONS_QUERY_LIMIT,
-    ) ||
-    workItemBatches.reduce((total, batch) => total + batch.length, 0) >
-      MAX_OPERATIONS_QUERY_LIMIT;
   const hasMoreApprovalRequests =
     dayApprovalRequests.length > MAX_OPERATIONS_QUERY_LIMIT;
 
@@ -559,11 +584,6 @@ async function listOpenQueueSnapshot(
       ? `${MAX_OPERATIONS_QUERY_LIMIT}+`
       : String(approvalRequests.length),
     hasMoreApprovalRequests,
-    hasMoreOpenWorkItems,
-    openWorkItems,
-    openWorkItemsCountLabel: hasMoreOpenWorkItems
-      ? `${MAX_OPERATIONS_QUERY_LIMIT}+`
-      : String(openWorkItems.length),
   };
 }
 
@@ -2048,20 +2068,10 @@ function buildLanes(args: {
       status: args.queueCounts.workItemCount > 0 ? "needs_attention" : "ready",
       to: "/$orgUrlSlug/store/$storeUrlSlug/operations/open-work",
     },
-    {
-      count: args.queueCounts.approvalCount,
-      countLabel: args.queueCounts.approvalCountLabel,
-      description:
-        args.queueCounts.approvalCount > 0
-          ? `${args.queueCounts.approvalCountLabel} approval${
-              args.queueCounts.approvalCount === 1 ? "" : "s"
-            } pending.`
-          : "No pending approvals.",
-      key: "approvals",
-      label: "Approvals",
-      status: args.queueCounts.approvalCount > 0 ? "blocked" : "ready",
-      to: "/$orgUrlSlug/store/$storeUrlSlug/operations/approvals",
-    },
+    buildApprovalsLane({
+      approvalCount: args.queueCounts.approvalCount,
+      approvalCountLabel: args.queueCounts.approvalCountLabel,
+    }),
     {
       count: args.closeBlockerCounts.registerCount,
       description:
@@ -2071,7 +2081,7 @@ function buildLanes(args: {
       key: "registers",
       label: "Registers",
       status: args.closeBlockerCounts.registerCount > 0 ? "blocked" : "ready",
-      to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
+      to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls",
     },
     {
       count: args.closeBlockerCounts.posSessionCount,
@@ -2096,6 +2106,26 @@ function buildLanes(args: {
       to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
     },
   ];
+}
+
+function buildApprovalsLane(args: {
+  approvalCount: number;
+  approvalCountLabel: string;
+}): DailyOperationsLane {
+  return {
+    count: args.approvalCount,
+    countLabel: args.approvalCountLabel,
+    description:
+      args.approvalCount > 0
+        ? `${args.approvalCountLabel} approval${
+            args.approvalCount === 1 ? "" : "s"
+          } pending.`
+        : "No pending approvals.",
+    key: "approvals",
+    label: "Approvals",
+    status: args.approvalCount > 0 ? "blocked" : "ready",
+    to: "/$orgUrlSlug/store/$storeUrlSlug/operations/approvals",
+  };
 }
 
 export async function buildDailyOperationsSnapshotWithCtx(
@@ -2504,6 +2534,26 @@ export const getDailyOperationsStorePulseSnapshot = query({
     return {
       operatingDate: args.operatingDate,
       storePulse,
+    };
+  },
+});
+
+export const getDailyOperationsStoreRequestsSnapshot = query({
+  args: dailyOperationsSnapshotArgsValidator,
+  handler: async (ctx, args) => {
+    await authorizeDailyOperationsSnapshot(ctx, args);
+    const range = resolveRange(args);
+    const approvals = await listPendingApprovalRequestsSnapshot(ctx, {
+      ...range,
+      storeId: args.storeId,
+    });
+
+    return {
+      approvalsLane: buildApprovalsLane({
+        approvalCount: approvals.approvalRequests.length,
+        approvalCountLabel: approvals.approvalRequestsCountLabel,
+      }),
+      operatingDate: args.operatingDate,
     };
   },
 });

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.auth.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.auth.test.tsx
@@ -55,6 +55,9 @@ vi.mock("../common/PageHeader", () => ({
       <div>{trailingContent}</div>
     </div>
   ),
+  NavigateBackButton: ({ label = "Back" }: { label?: string }) => (
+    <button type="button">{label}</button>
+  ),
 }));
 
 const readyProtectedState = {

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx
@@ -42,6 +42,9 @@ vi.mock("../common/PageHeader", () => ({
       <div>{trailingContent}</div>
     </div>
   ),
+  NavigateBackButton: ({ label = "Back" }: { label?: string }) => (
+    <button type="button">{label}</button>
+  ),
 }));
 
 const baseSnapshot = {

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
@@ -361,8 +361,8 @@ function needsVarianceReview(session: CashControlsDashboardSession) {
   const syncStatus = getSessionSyncStatus(session);
   return Boolean(
     session.pendingApprovalRequest ||
-      session.variance ||
-      syncStatus.status === "needs_review",
+    session.variance ||
+    syncStatus.status === "needs_review",
   );
 }
 
@@ -855,7 +855,9 @@ function ClosedSessionsSummary({
                     <Link
                       aria-label={`Open ${formatRegisterName(session.registerNumber)} variance ${formatCurrency(
                         currency,
-                        hasFinancialDetailsAccess ? (session.variance ?? 0) : null,
+                        hasFinancialDetailsAccess
+                          ? (session.variance ?? 0)
+                          : null,
                       )}`}
                       className="block h-full w-full px-4 py-4 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
                       params={{
@@ -1329,6 +1331,7 @@ export function CashControlsDashboardContent({
       <FadeIn className="container mx-auto py-layout-xl">
         <PageWorkspace>
           <PageLevelHeader
+            showBackButton
             eyebrow="Cash Ops"
             title="Cash controls"
             description="Track live drawers, review deposited totals, and move into session detail before shifting work into closeouts."

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -113,6 +113,7 @@ const baseSummary = {
   totalSales: 125500,
   transactionCount: 14,
   varianceTotal: 0,
+  voidedTransactionCount: 1,
 };
 
 const readySnapshot: DailyCloseSnapshot = {
@@ -152,6 +153,7 @@ const readySnapshot: DailyCloseSnapshot = {
       id: "ready-2",
       metadata: {
         completedAt: Date.UTC(2026, 4, 7, 14),
+        itemCount: 2,
         owner: "Kofi Mensah",
         paymentMethods: "Cash, Mobile Money",
         terminal: "Front counter terminal / Register A1",
@@ -177,6 +179,7 @@ const readySnapshot: DailyCloseSnapshot = {
       },
       metadata: {
         completedAt: Date.UTC(2026, 4, 7, 16),
+        itemCount: 4,
         notes: "Bought packing supplies.",
         owner: "Akosua Mensah",
         report: "EXP-1",
@@ -192,6 +195,30 @@ const readySnapshot: DailyCloseSnapshot = {
     },
   ],
   reviewItems: [
+    {
+      category: "voided_sale",
+      description: "Review voided sales before completing the end of day review.",
+      id: "review-void-1",
+      link: {
+        label: "View transaction",
+        params: { transactionId: "txn-void-1" },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId",
+      },
+      metadata: {
+        completedAt: Date.UTC(2026, 4, 7, 15),
+        itemCount: 3,
+        owner: "Kofi Mensah",
+        paymentMethods: "Card",
+        total: 71000,
+        transaction: "VOID-1",
+      },
+      subject: {
+        id: "txn-void-1",
+        label: "VOID-1",
+        type: "pos_transaction",
+      },
+      title: "Voided sale needs review",
+    },
     {
       description: "Reviewed by manager before close.",
       id: "review-1",
@@ -1025,7 +1052,7 @@ describe("DailyCloseViewContent", () => {
   it("opens a POS and expense transaction report as line items", async () => {
     const user = userEvent.setup();
 
-    renderContent(readySnapshot);
+    const { unmount } = renderContent(readySnapshot);
 
     expect(
       screen.queryByRole("region", {
@@ -1049,17 +1076,40 @@ describe("DailyCloseViewContent", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByText(
-        "14 POS sales, 1 expense transaction, no voided sales available for review.",
+        "14 POS sales, 1 expense transaction, 1 voided sale available for review.",
       ),
     ).not.toBeInTheDocument();
 
     await user.click(reportButton);
 
+    expect(mockedRouter.navigate).toHaveBeenCalledWith({
+      search: expect.any(Function),
+    });
+    const reportSearchUpdater = mockedRouter.navigate.mock.calls[0]?.[0]
+      ?.search as (current: Record<string, unknown>) => Record<string, unknown>;
+    expect(
+      reportSearchUpdater({
+        o: "%2Fwigclub%2Fstore%2Fwigclub%2Foperations",
+        page: 2,
+        tab: "ready",
+      }),
+    ).toEqual({
+      o: "%2Fwigclub%2Fstore%2Fwigclub%2Foperations",
+      page: 2,
+      report: "transactions",
+      tab: "ready",
+    });
+
+    unmount();
+    vi.clearAllMocks();
+    mockedRouter.search = { report: "transactions" };
+    renderContent(readySnapshot);
+
     const report = await screen.findByRole("dialog");
 
     expect(
       within(report).getByText(
-        "14 POS sales, 1 expense transaction, no voided sales available from the end of day review workspace.",
+        "14 POS sales, 1 expense transaction, 1 voided sale available from the end of day review workspace.",
       ),
     ).toBeInTheDocument();
     expect(within(report).getByText("Item")).toBeInTheDocument();
@@ -1069,8 +1119,26 @@ describe("DailyCloseViewContent", () => {
     expect(within(report).getByText("Amount")).toBeInTheDocument();
     expect(within(report).queryByText("POS sale")).not.toBeInTheDocument();
     expect(within(report).getByText("#TXN-1")).toBeInTheDocument();
+    expect(within(report).getByText("2 items")).toHaveClass(
+      "text-muted-foreground",
+    );
     expect(within(report).getByText("#EXP-1")).toBeInTheDocument();
-    expect(within(report).getByText("Kofi Mensah")).toBeInTheDocument();
+    expect(within(report).getByText("4 items")).toHaveClass(
+      "text-muted-foreground",
+    );
+    expect(within(report).getByText("#VOID-1")).toBeInTheDocument();
+    expect(within(report).getByText("3 items")).toHaveClass(
+      "text-muted-foreground",
+    );
+    expect(within(report).getByText("Voided")).toHaveClass(
+      "text-destructive",
+    );
+    expect(
+      within(report)
+        .getByText("#VOID-1")
+        .closest("[data-transaction-report-row]"),
+    ).toHaveClass("bg-destructive/5");
+    expect(within(report).getAllByText("Kofi Mensah")).toHaveLength(2);
     expect(within(report).getByText("Akosua Mensah")).toBeInTheDocument();
     expect(within(report).getByText("Cash, Mobile Money")).toBeInTheDocument();
     expect(within(report).getByText("Expense")).toBeInTheDocument();
@@ -1090,6 +1158,41 @@ describe("DailyCloseViewContent", () => {
       "href",
       "/wigclub/store/osu/pos/expense-reports/expense-1?o=%252F",
     );
+  });
+
+  it("removes only the transaction report search param when closing the report sheet", async () => {
+    const user = userEvent.setup();
+    mockedRouter.search = {
+      o: "%2Fwigclub%2Fstore%2Fwigclub%2Foperations",
+      page: 2,
+      report: "transactions",
+      tab: "ready",
+    };
+
+    renderContent(readySnapshot);
+
+    const report = await screen.findByRole("dialog");
+    await user.click(within(report).getByRole("button", { name: /close/i }));
+
+    expect(mockedRouter.navigate).toHaveBeenCalledWith({
+      search: expect.any(Function),
+    });
+    const searchUpdater = mockedRouter.navigate.mock.calls[0]?.[0]?.search as (
+      current: Record<string, unknown>,
+    ) => Record<string, unknown>;
+
+    expect(
+      searchUpdater({
+        o: "%2Fwigclub%2Fstore%2Fwigclub%2Foperations",
+        page: 2,
+        report: "transactions",
+        tab: "ready",
+      }),
+    ).toEqual({
+      o: "%2Fwigclub%2Fstore%2Fwigclub%2Foperations",
+      page: 2,
+      tab: "ready",
+    });
   });
 
   it("uses the preserved item link when redacted sale rows expose only a transaction number", () => {
@@ -1131,7 +1234,7 @@ describe("DailyCloseViewContent", () => {
   });
 
   it("uses sentence-case fragments in the empty transaction report summary", async () => {
-    const user = userEvent.setup();
+    mockedRouter.search = { report: "transactions" };
 
     renderContent({
       ...readySnapshot,
@@ -1143,8 +1246,6 @@ describe("DailyCloseViewContent", () => {
         voidedTransactionCount: 0,
       },
     });
-
-    await user.click(screen.getByRole("button", { name: /view report/i }));
 
     expect(
       await screen.findByText(

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -265,6 +265,7 @@ const bucketTabValues: BucketStatus[] = [
   "review",
 ];
 const DAILY_CLOSE_ITEMS_PER_PAGE = 5;
+const TRANSACTION_REPORT_SEARCH_VALUE = "transactions";
 
 type BucketConfig = {
   ariaLabel: string;
@@ -1950,6 +1951,24 @@ function getTransactionReportIdentifier(item: DailyCloseItem) {
     : (item.subject?.label ?? item.title);
 }
 
+function getTransactionReportItemCountLabel(item: DailyCloseItem) {
+  if (
+    item.category !== "sale" &&
+    item.category !== "expense" &&
+    item.category !== "voided_sale"
+  ) {
+    return null;
+  }
+
+  const itemCount = getNumericMetadataValue(
+    getMetadataStringOrNumber(item.metadata, "itemCount"),
+  );
+
+  if (itemCount === null || itemCount <= 0) return null;
+
+  return itemCount === 1 ? "1 item" : `${itemCount} items`;
+}
+
 function getTransactionReportAmount(item: DailyCloseItem, currency: string) {
   const amount = getNumericMetadataValue(
     getMetadataStringOrNumber(item.metadata, "total"),
@@ -2054,32 +2073,54 @@ function TransactionReportIdentifierLink({
   const identifier = getTransactionReportIdentifier(item);
   const link = getTransactionReportLink(item);
   const label = identifier.startsWith("#") ? identifier : `#${identifier}`;
+  const itemCountLabel = getTransactionReportItemCountLabel(item);
+  const voidedCue =
+    item.category === "voided_sale" ? (
+      <Badge size="sm" variant="destructive">
+        Voided
+      </Badge>
+    ) : null;
+  const count = itemCountLabel ? (
+    <span className="text-xs font-normal text-muted-foreground">
+      {itemCountLabel}
+    </span>
+  ) : null;
 
   if (!link?.to) {
-    return <span className="font-medium text-foreground">{label}</span>;
+    return (
+      <span className="inline-flex items-baseline gap-2">
+        <span className="font-medium text-foreground">{label}</span>
+        {count}
+        {voidedCue}
+      </span>
+    );
   }
 
   return (
-    <Link
-      className="inline-flex items-center gap-1 font-medium text-foreground underline-offset-4 transition-colors hover:text-primary hover:underline"
-      params={
-        {
-          orgUrlSlug,
-          storeUrlSlug,
-          ...(link.params ?? {}),
-        } as never
-      }
-      search={
-        {
-          o: getOrigin(),
-          ...(link.search ?? {}),
-        } as never
-      }
-      to={link.to as never}
-    >
-      {label}
-      <ArrowUpRight aria-hidden="true" className="h-3 w-3" />
-    </Link>
+    <span className="inline-flex items-baseline gap-2">
+      <Link
+        className="inline-flex items-center gap-1 font-medium text-foreground underline-offset-4 transition-colors hover:text-primary hover:underline"
+        params={
+          {
+            orgUrlSlug,
+            storeUrlSlug,
+            ...(link.params ?? {}),
+          } as never
+        }
+        search={
+          {
+            o: getOrigin(),
+            ...(link.search ?? {}),
+          } as never
+        }
+        to={link.to as never}
+      >
+        {label}
+        <ArrowUpRight aria-hidden="true" className="h-3 w-3" />
+      </Link>
+      {count}
+      {voidedCue}
+    </span>
   );
 }
 
@@ -2439,17 +2480,20 @@ function BucketTabs({
 function TransactionReportAction({
   canViewFinancialDetails,
   currency,
+  isOpen,
+  onOpenChange,
   orgUrlSlug,
   snapshot,
   storeUrlSlug,
 }: {
   canViewFinancialDetails: boolean;
   currency: string;
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
   orgUrlSlug: string;
   snapshot: DailyCloseSnapshot;
   storeUrlSlug: string;
 }) {
-  const [isOpen, setIsOpen] = useState(false);
   const items = getTransactionReportItems(snapshot);
   const reportSummary = [
     formatPosSaleCount(
@@ -2467,7 +2511,7 @@ function TransactionReportAction({
     <>
       <Button
         className="shrink-0"
-        onClick={() => setIsOpen(true)}
+        onClick={() => onOpenChange(true)}
         type="button"
         variant="outline"
       >
@@ -2475,7 +2519,7 @@ function TransactionReportAction({
         View report
       </Button>
 
-      <Sheet open={isOpen} onOpenChange={setIsOpen}>
+      <Sheet open={isOpen} onOpenChange={onOpenChange}>
         <SheetContent
           className="flex w-[min(100vw,72rem)] max-w-[calc(100vw-1rem)] flex-col overflow-hidden border-border bg-surface-raised p-0 shadow-overlay sm:max-w-6xl"
           side="right"
@@ -2508,7 +2552,13 @@ function TransactionReportAction({
 
                     return (
                       <div
-                        className="grid grid-cols-1 gap-layout-sm px-layout-xl py-layout-md text-sm md:grid-cols-[minmax(10rem,1.25fr)_minmax(8rem,0.9fr)_minmax(10rem,1fr)_minmax(10rem,0.9fr)_minmax(7rem,0.7fr)] md:items-center md:gap-layout-lg"
+                        className={cn(
+                          "grid grid-cols-1 gap-layout-sm px-layout-xl py-layout-md text-sm md:grid-cols-[minmax(10rem,1.25fr)_minmax(8rem,0.9fr)_minmax(10rem,1fr)_minmax(10rem,0.9fr)_minmax(7rem,0.7fr)] md:items-center md:gap-layout-lg",
+                          item.category === "voided_sale"
+                            ? "bg-destructive/5"
+                            : null,
+                        )}
+                        data-transaction-report-row=""
                         key={getItemId(item)}
                       >
                         <div className="min-w-0">
@@ -2570,6 +2620,8 @@ export function DailyCloseReadOnlyReport({
   const [selectedBucketValue, setSelectedBucketValue] =
     useState<BucketStatus>(defaultBucketValue);
   const [selectedBucketPage, setSelectedBucketPage] = useState(1);
+  const [isTransactionReportOpen, setIsTransactionReportOpen] =
+    useState(false);
   const selectedBucket =
     buckets.find((bucket) => bucket.value === selectedBucketValue) ??
     buckets.find((bucket) => bucket.value === defaultBucketValue) ??
@@ -2595,6 +2647,8 @@ export function DailyCloseReadOnlyReport({
             <TransactionReportAction
               canViewFinancialDetails={canViewFinancialDetails}
               currency={currency}
+              isOpen={isTransactionReportOpen}
+              onOpenChange={setIsTransactionReportOpen}
               orgUrlSlug={orgUrlSlug}
               snapshot={displaySnapshot}
               storeUrlSlug={storeUrlSlug}
@@ -3202,6 +3256,7 @@ export function DailyCloseViewContent({
   const search = useSearch({ strict: false }) as {
     o?: unknown;
     page?: unknown;
+    report?: unknown;
     tab?: unknown;
   };
   const carryForwardWorkItemIds = useMemo(
@@ -3290,6 +3345,8 @@ export function DailyCloseViewContent({
   const selectedBucketValue =
     normalizeBucketTab(search.tab) ?? defaultBucketValue;
   const selectedBucketPage = normalizePage(search.page);
+  const isTransactionReportOpen =
+    search.report === TRANSACTION_REPORT_SEARCH_VALUE;
 
   const handleComplete = async () => {
     if (!snapshot || isBlocked || isCompleted) return;
@@ -3418,6 +3475,23 @@ export function DailyCloseViewContent({
     });
   };
 
+  const handleTransactionReportOpenChange = (isOpen: boolean) => {
+    void navigate({
+      search: ((current: Record<string, unknown>) => {
+        if (isOpen) {
+          return {
+            ...current,
+            report: TRANSACTION_REPORT_SEARCH_VALUE,
+          };
+        }
+
+        const nextSearch = { ...current };
+        delete nextSearch.report;
+        return nextSearch;
+      }) as never,
+    });
+  };
+
   return (
     <OperationReviewWorkspace
       actions={
@@ -3426,6 +3500,8 @@ export function DailyCloseViewContent({
             <TransactionReportAction
               canViewFinancialDetails={hasFinancialDetailsAccess}
               currency={currency}
+              isOpen={isTransactionReportOpen}
+              onOpenChange={handleTransactionReportOpenChange}
               orgUrlSlug={orgUrlSlug}
               snapshot={displaySnapshot}
               storeUrlSlug={storeUrlSlug}

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -21,6 +21,8 @@ const mockedApi = vi.hoisted(() => ({
   getDailyOperationsDetailSnapshot: "getDailyOperationsDetailSnapshot",
   getDailyOperationsSnapshot: "getDailyOperationsSnapshot",
   getDailyOperationsStorePulseSnapshot: "getDailyOperationsStorePulseSnapshot",
+  getDailyOperationsStoreRequestsSnapshot:
+    "getDailyOperationsStoreRequestsSnapshot",
   getDailyOperationsTodayRefreshSnapshot:
     "getDailyOperationsTodayRefreshSnapshot",
   getDailyOperationsTimelinePreviewSnapshot:
@@ -438,7 +440,7 @@ const blockedSnapshot: DailyOperationsSnapshot = {
       key: "registers",
       label: "Registers",
       status: "blocked",
-      to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
+      to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls",
     },
   ],
   lifecycle: {
@@ -1910,6 +1912,45 @@ describe("DailyOperationsViewContent", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders pending approval requests from the separate store request snapshot", () => {
+    const operatingDate = getCurrentLocalOperatingDate();
+
+    renderContent(
+      {
+        ...blockedSnapshot,
+        lanes: blockedSnapshot.lanes.filter(
+          (lane) => lane.key !== "approvals",
+        ),
+        operatingDate,
+      },
+      {
+        storeRequestsSnapshot: {
+          approvalsLane: {
+            count: 3,
+            countLabel: "3",
+            description: "3 approvals pending.",
+            key: "approvals",
+            label: "Approvals",
+            status: "blocked",
+            to: "/$orgUrlSlug/store/$storeUrlSlug/operations/approvals",
+          },
+          operatingDate,
+        },
+      },
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Open 3 pending approvals" }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/operations/approvals?o=%252Fwigclub%252Fstore%252Fosu%252Foperations",
+    );
+    expect(screen.getByText("3")).toHaveClass(
+      "font-semibold",
+      "tabular-nums",
+    );
+  });
+
   it("passes origin context to current-day blocker review actions", () => {
     renderContent({
       ...blockedSnapshot,
@@ -1926,7 +1967,7 @@ describe("DailyOperationsViewContent", () => {
       screen.getByRole("link", { name: "Open Registers" }),
     ).toHaveAttribute(
       "href",
-      "/wigclub/store/osu/operations/daily-close?o=%252Fwigclub%252Fstore%252Fosu%252Foperations",
+      "/wigclub/store/osu/cash-controls?o=%252Fwigclub%252Fstore%252Fosu%252Foperations",
     );
   });
 
@@ -2257,6 +2298,10 @@ describe("DailyOperationsView", () => {
     ).getDailyOperationsStorePulseSnapshot =
       "getDailyOperationsStorePulseSnapshot";
     (
+      mockedApi as { getDailyOperationsStoreRequestsSnapshot?: unknown }
+    ).getDailyOperationsStoreRequestsSnapshot =
+      "getDailyOperationsStoreRequestsSnapshot";
+    (
       mockedApi as { getDailyOperationsTodayRefreshSnapshot?: unknown }
     ).getDailyOperationsTodayRefreshSnapshot =
       "getDailyOperationsTodayRefreshSnapshot";
@@ -2376,6 +2421,48 @@ describe("DailyOperationsView", () => {
     );
   });
 
+  it("subscribes to store requests separately from the daily operations snapshot", () => {
+    mockedHooks.useQuery.mockImplementation((query, args) => {
+      if (args === "skip") return undefined;
+      if (query === mockedApi.getDailyOperationsStoreRequestsSnapshot) {
+        return {
+          approvalsLane: {
+            count: 2,
+            countLabel: "2",
+            description: "2 approvals pending.",
+            key: "approvals",
+            label: "Approvals",
+            status: "blocked",
+            to: "/$orgUrlSlug/store/$storeUrlSlug/operations/approvals",
+          },
+          operatingDate: operatingSnapshot.operatingDate,
+        };
+      }
+
+      return {
+        ...operatingSnapshot,
+        lanes: operatingSnapshot.lanes.filter(
+          (lane) => lane.key !== "approvals",
+        ),
+      };
+    });
+
+    render(<DailyOperationsView />);
+
+    expect(mockedHooks.useQuery).toHaveBeenCalledWith(
+      mockedApi.getDailyOperationsStoreRequestsSnapshot,
+      expect.objectContaining({
+        operatingTimezoneOffsetMinutes: expect.any(Number),
+        storeId: "store-1",
+        storePulseWindow: "today",
+        weekEndOperatingDate: getCurrentSaturdayWeekEndOperatingDate(),
+      }),
+    );
+    expect(
+      screen.getByRole("link", { name: "Open 2 pending approvals" }),
+    ).toBeInTheDocument();
+  });
+
   it("queries analytics detail when the empty analytics shell is clicked", () => {
     mockedHooks.useQuery.mockImplementation((query, args) => {
       if (args === "skip") return undefined;
@@ -2456,7 +2543,8 @@ describe("DailyOperationsView", () => {
     });
     const view = render(<DailyOperationsView />);
 
-    expect(await screen.findByText(/Data refreshed at /)).toBeInTheDocument();
+    expect(await screen.findByText(/^Data refreshed at /)).toBeInTheDocument();
+    expect(screen.queryByText(/^· Data refreshed at /)).not.toBeInTheDocument();
     const chart = screen.getByTestId("store-pulse-chart");
     const replayKey = screen
       .getByTestId("store-pulse-area")
@@ -3025,7 +3113,7 @@ describe("DailyOperationsView", () => {
     expect(within(storePulse).queryByRole("tablist")).not.toBeInTheDocument();
     expect(
       within(storePulse).getByText(
-        "Cached sales trend through the selected day.",
+        "Synced sales trend through the selected day.",
       ),
     ).toBeInTheDocument();
   });

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -77,6 +77,7 @@ type DailyOperationsApi = {
   getDailyOperationsDetailSnapshot?: unknown;
   getDailyOperationsSnapshot?: unknown;
   getDailyOperationsStorePulseSnapshot?: unknown;
+  getDailyOperationsStoreRequestsSnapshot?: unknown;
   getDailyOperationsTodayRefreshSnapshot?: unknown;
   getDailyOperationsTimelinePreviewSnapshot?: unknown;
   getDailyOperationsTimelineSnapshot?: unknown;
@@ -340,6 +341,7 @@ type DailyOperationsViewContentProps = {
   storePulseWindow: StorePulseWindow;
   storeUrlSlug: string;
   storePulseSnapshot?: DailyOperationsStorePulseSnapshot;
+  storeRequestsSnapshot?: DailyOperationsStoreRequestsSnapshot;
   todayRefreshedAt?: number;
   timelinePreviewSnapshot?: DailyOperationsTimelinePreviewSnapshot;
   timelineSnapshot?: DailyOperationsTimelineSnapshot;
@@ -361,6 +363,11 @@ type CachedWeekAnalytics = {
 type DailyOperationsStorePulseSnapshot = {
   operatingDate: string;
   storePulse?: StorePulseSummary | null;
+};
+
+type DailyOperationsStoreRequestsSnapshot = {
+  approvalsLane: DailyOperationsSnapshot["lanes"][number];
+  operatingDate: string;
 };
 
 type DailyOperationsTimelineSnapshot = {
@@ -693,10 +700,27 @@ function shouldShowHistoricalEodReviewAction(
   );
 }
 
-function getPendingApprovalsLane(snapshot: DailyOperationsSnapshot) {
-  const approvalsLane = snapshot.lanes.find((lane) => lane.key === "approvals");
+function getPendingApprovalsLaneFromLanes(
+  lanes: DailyOperationsSnapshot["lanes"],
+) {
+  const approvalsLane = lanes.find((lane) => lane.key === "approvals");
 
   return approvalsLane && approvalsLane.count > 0 ? approvalsLane : null;
+}
+
+function replaceApprovalsLane(
+  lanes: DailyOperationsSnapshot["lanes"],
+  approvalsLane?: DailyOperationsSnapshot["lanes"][number],
+) {
+  if (!approvalsLane) return lanes;
+
+  const nextLanes = lanes.map((lane) =>
+    lane.key === "approvals" ? approvalsLane : lane,
+  );
+
+  return nextLanes.some((lane) => lane.key === "approvals")
+    ? nextLanes
+    : [...nextLanes, approvalsLane];
 }
 
 function getPendingApprovalsCountLabel(
@@ -2201,7 +2225,7 @@ function DailyOperationsStorePulsePreview({
           <StorePulseTimeline
             animationKey={operatingDate}
             canViewFinancialDetails={hasFullAdminAccess}
-            description="Cached sales trend through the selected day."
+            description="Synced sales trend through the selected day."
             currencyFormatter={currencyFormatter(currency)}
             pulseWindow="this_week"
             snapshot={selectedCachedStorePulseTrend!.operatorSnapshot!}
@@ -2568,12 +2592,20 @@ function WeekMetricsStrip({
             Week at a glance
           </h3>
           <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
-            <span>
+            <span className="basis-full sm:basis-auto">
               Seven days ending {formatOperatingDate(weekEndOperatingDate)}
             </span>
             {refreshedAt ? (
+              <span
+                aria-hidden="true"
+                className="hidden sm:inline"
+              >
+                ·
+              </span>
+            ) : null}
+            {refreshedAt ? (
               <span className="whitespace-nowrap">
-                · Data refreshed at {formatAnalyticsCacheTimestamp(refreshedAt)}
+                Data refreshed at {formatAnalyticsCacheTimestamp(refreshedAt)}
               </span>
             ) : null}
             {canRefreshToday ? (
@@ -2795,6 +2827,7 @@ export function DailyOperationsViewContent({
   storePulseWindow,
   storeUrlSlug,
   storePulseSnapshot,
+  storeRequestsSnapshot,
   todayRefreshedAt,
   timelinePreviewSnapshot,
   timelineSnapshot,
@@ -2848,12 +2881,16 @@ export function DailyOperationsViewContent({
   const isHistoricalDate = snapshot
     ? isHistoricalOperatingDate(snapshot.operatingDate)
     : false;
-  const pendingApprovalsLane = snapshot
-    ? getPendingApprovalsLane(snapshot)
-    : null;
-  const actionableLanes = snapshot
-    ? snapshot.lanes.filter(isActionableLane)
+  const storeRequestsApprovalsLane =
+    snapshot && storeRequestsSnapshot?.operatingDate === snapshot.operatingDate
+      ? storeRequestsSnapshot.approvalsLane
+      : undefined;
+  const operationLanes = snapshot
+    ? replaceApprovalsLane(snapshot.lanes, storeRequestsApprovalsLane)
     : [];
+  const pendingApprovalsLane =
+    getPendingApprovalsLaneFromLanes(operationLanes);
+  const actionableLanes = operationLanes.filter(isActionableLane);
   const weekMetricsForDisplay =
     snapshot && (hasDetailSnapshot || !cachedWeekMetrics)
       ? snapshot.weekMetrics
@@ -3435,6 +3472,7 @@ function DailyOperationsConnectedView({
   getDailyOperationsDetailSnapshot,
   getDailyOperationsSnapshot,
   getDailyOperationsStorePulseSnapshot,
+  getDailyOperationsStoreRequestsSnapshot,
   getDailyOperationsTodayRefreshSnapshot,
   getDailyOperationsTimelinePreviewSnapshot,
   getDailyOperationsTimelineSnapshot,
@@ -3442,6 +3480,7 @@ function DailyOperationsConnectedView({
   getDailyOperationsDetailSnapshot?: unknown;
   getDailyOperationsSnapshot: unknown;
   getDailyOperationsStorePulseSnapshot?: unknown;
+  getDailyOperationsStoreRequestsSnapshot?: unknown;
   getDailyOperationsTodayRefreshSnapshot?: unknown;
   getDailyOperationsTimelinePreviewSnapshot?: unknown;
   getDailyOperationsTimelineSnapshot?: unknown;
@@ -3584,6 +3623,12 @@ function DailyOperationsConnectedView({
     getDailyOperationsStorePulseSnapshot ?? getDailyOperationsSnapshot,
     shouldQueryStorePulseSnapshot ? snapshotArgs : "skip",
   ) as DailyOperationsStorePulseSnapshot | undefined;
+  const storeRequestsSnapshot = useExpectedDailyOperationsQuery(
+    getDailyOperationsStoreRequestsSnapshot ?? getDailyOperationsSnapshot,
+    getDailyOperationsStoreRequestsSnapshot && canQueryProtectedData
+      ? snapshotArgs
+      : "skip",
+  ) as DailyOperationsStoreRequestsSnapshot | undefined;
   const queriedTodayRefreshSnapshot = useExpectedDailyOperationsQuery(
     getDailyOperationsTodayRefreshSnapshot ?? getDailyOperationsSnapshot,
     todayRefreshArgs,
@@ -3884,6 +3929,7 @@ function DailyOperationsConnectedView({
       storePulseWindow={storePulseWindow}
       storeUrlSlug={params?.storeUrlSlug ?? ""}
       storePulseSnapshot={storePulseSnapshot}
+      storeRequestsSnapshot={storeRequestsSnapshot}
       todayRefreshedAt={cachedTodayRefreshSnapshot?.refreshedAt}
       timelinePreviewSnapshot={timelinePreviewSnapshot}
       timelineSnapshot={timelineSnapshot}
@@ -3906,6 +3952,9 @@ export function DailyOperationsView() {
       getDailyOperationsSnapshot={dailyOperationsApi.getDailyOperationsSnapshot}
       getDailyOperationsStorePulseSnapshot={
         dailyOperationsApi.getDailyOperationsStorePulseSnapshot
+      }
+      getDailyOperationsStoreRequestsSnapshot={
+        dailyOperationsApi.getDailyOperationsStoreRequestsSnapshot
       }
       getDailyOperationsTodayRefreshSnapshot={
         dailyOperationsApi.getDailyOperationsTodayRefreshSnapshot

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close.tsx
@@ -6,6 +6,7 @@ import { DailyCloseView } from "~/src/components/operations/DailyCloseView";
 const dailyCloseSearchSchema = z.object({
   operatingDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
   page: z.coerce.number().int().positive().optional(),
+  report: z.enum(["transactions"]).optional(),
   tab: z.enum(["blocked", "carry-forward", "ready", "review"]).optional(),
 });
 


### PR DESCRIPTION
## Summary
- Persist the EOD transaction report sheet state in the URL and preserve it when returning to daily close.
- Add item counts and voided-row cues to the EOD transaction report for new/current snapshots, including sales, voids, and expenses.
- Keep historical completed snapshots lightweight by not backfilling legacy item counts at read time, and document that boundary.
- Carry through the related daily operations and cash controls polish from the dirty set.

## Validation
- bun run test -- src/components/operations/DailyCloseView.test.tsx -t "transaction report"
- bun run test -- convex/operations/dailyClose.test.ts -t "classifies blockers, review items, carry-forward items, ready items, and summary totals"
- bun run test -- src/components/operations/DailyOperationsView.test.tsx convex/operations/dailyOperations.test.ts
- bun run test -- src/components/cash-controls/CashControlsDashboard.test.tsx src/components/cash-controls/CashControlsDashboard.auth.test.tsx
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- bun run pr:athena

Browser validation intentionally left to the operator.