### PR TITLE
[V26-912/V26-913/V26-914/V26-915] Collapse register closeout gate

### DIFF
--- a/docs/plans/2026-07-01-001-fix-register-closeout-gate-policy-plan.html
+++ b/docs/plans/2026-07-01-001-fix-register-closeout-gate-policy-plan.html
@@ -1,0 +1,295 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>fix: Collapse POS and Cash Controls closeout gating</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f6f7f9;
+      --panel: #ffffff;
+      --ink: #17202b;
+      --muted: #5f6f80;
+      --line: #d9e0e8;
+      --accent: #1f6f8b;
+      --accent-soft: #e7f5f8;
+      --risk: #8a4b12;
+      --risk-soft: #fff3e5;
+      --ok: #23623a;
+      --ok-soft: #e8f5ed;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 32px 24px 56px;
+    }
+    header, section {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 22px 24px;
+      margin-bottom: 18px;
+    }
+    h1, h2, h3 {
+      line-height: 1.2;
+      margin: 0 0 12px;
+    }
+    h1 { font-size: 29px; }
+    h2 { font-size: 20px; }
+    h3 { font-size: 16px; color: var(--muted); }
+    p { margin: 0 0 12px; }
+    a { color: var(--accent); }
+    .meta {
+      color: var(--muted);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px 18px;
+      margin-top: 12px;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      gap: 12px;
+    }
+    .callout {
+      border-left: 4px solid var(--accent);
+      background: var(--accent-soft);
+      padding: 12px 14px;
+      border-radius: 6px;
+    }
+    .risk {
+      border-left-color: var(--risk);
+      background: var(--risk-soft);
+    }
+    .ok {
+      border-left-color: var(--ok);
+      background: var(--ok-soft);
+    }
+    ul, ol { margin: 8px 0 0 20px; padding: 0; }
+    li { margin: 5px 0; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 10px;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 8px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: #f1f4f7; }
+    code {
+      background: #eef2f5;
+      border-radius: 4px;
+      padding: 1px 4px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.92em;
+    }
+    .unit {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px 16px;
+      margin-top: 12px;
+    }
+    .unit strong { color: var(--accent); }
+    .small { color: var(--muted); font-size: 13px; }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>fix: Collapse POS and Cash Controls closeout gating</h1>
+      <p>Register-session closeout variance should pass through one server-owned gate. Cash Controls and POS local-sync projection will use the same cash-controls threshold, manager-signoff flags, and closeout-hold precedence before deciding whether to close, wait, or request approval.</p>
+      <div class="meta">
+        <span>Type: fix</span>
+        <span>Status: active</span>
+        <span>Date: 2026-07-01</span>
+        <span>Worktree: <code>.worktrees/codex/closeout-gate-plan</code></span>
+        <span>Source: <a href="2026-07-01-001-fix-register-closeout-gate-policy-plan.md">Markdown plan</a></span>
+      </div>
+    </header>
+
+    <section>
+      <h2>Problem</h2>
+      <div class="grid">
+        <div class="callout risk">
+          <h3>Current POS Path</h3>
+          <p>POS closeout sync treats every non-zero variance as <code>register_closeout_variance</code> review unless an approved replay flag is present.</p>
+        </div>
+        <div class="callout risk">
+          <h3>Current Cash Controls Path</h3>
+          <p>Cash Controls applies store configuration: threshold, any-variance signoff, over signoff, and short signoff.</p>
+        </div>
+        <div class="callout ok">
+          <h3>Target</h3>
+          <p>The source path no longer determines manager-review policy. The shared gate decides once; each caller adapts the same result to its workflow.</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Requirements Digest</h2>
+      <ul>
+        <li>Cash Controls and POS projection evaluate variance with the same server-side policy and defaults.</li>
+        <li>Under-threshold POS variance closes during sync when no closeout holds remain.</li>
+        <li>Approval-required POS variance returns <code>projected</code>, creates a closeout mapping, and routes through one Cash Controls-owned review semantic.</li>
+        <li>Cash-affecting holds stay higher priority than variance approval.</li>
+        <li>Legacy <code>register_closeout_variance</code> conflicts remain resolvable.</li>
+        <li>Duplicate or ambiguous closeout uploads keep their existing conflict/reject behavior.</li>
+        <li>POS local-first continuity remains intact for unresolved local closeouts and replacement drawers.</li>
+        <li>Manager review evidence stays session-targeted and operator-readable.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Shared Gate Outcome</h2>
+      <table>
+        <thead>
+          <tr><th>Decision</th><th>Meaning</th><th>POS sync behavior</th><th>Cash Controls behavior</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>blocked_by_holds</code></td>
+            <td>Submitted facts exist, but cash-impacting work can still change expected cash.</td>
+            <td>Keep session <code>closing</code>; preserve submitted evidence; do not append final closeout records.</td>
+            <td>Return submitted/unresolved state or block finalization with hold copy.</td>
+          </tr>
+          <tr>
+            <td><code>approval_required</code></td>
+            <td>Variance requires manager approval by threshold or signoff flags.</td>
+            <td>Persist or reuse one Cash Controls review owner, patch the session to <code>closing</code> with <code>managerApprovalRequestId</code>, return <code>projected</code>, create a closeout mapping, and create no POS sync conflict.</td>
+            <td>Create/reuse approval request or require valid manager proof.</td>
+          </tr>
+          <tr>
+            <td><code>close_allowed</code></td>
+            <td>No holds and no policy-required approval.</td>
+            <td>Project as closed, map local event, and record closeout evidence.</td>
+            <td>Close or finalize immediately.</td>
+          </tr>
+          <tr>
+            <td><code>projection_conflict</code></td>
+            <td>Duplicate, ambiguous, stale, or identity-mismatched sync event.</td>
+            <td>Use existing sync conflict/reject behavior.</td>
+            <td>Not applicable to direct Cash Controls closeout.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Implementation Units</h2>
+      <div class="unit">
+        <p><strong>U1. Create the shared closeout gate</strong></p>
+        <p>Create <code>packages/athena-webapp/convex/operations/registerSessionCloseoutGate.ts</code> and tests. Move store config normalization and variance-review policy into a pure helper with no mutation side effects.</p>
+      </div>
+      <div class="unit">
+        <p><strong>U2. Wire Cash Controls to the gate</strong></p>
+        <p>Update <code>convex/cashControls/closeouts.ts</code> to use the helper while preserving current submit/finalize behavior, manager proof checks, and hold precedence. Extract a Cash Controls-owned idempotent review helper for POS sync approval-required variance.</p>
+      </div>
+      <div class="unit">
+        <p><strong>U3. Route POS local-sync projection through the gate</strong></p>
+        <p>Update <code>projectRegisterClosed</code> so under-threshold variance closes, approval-required variance persists review ownership then returns <code>projected</code>, and holds stay first.</p>
+      </div>
+      <div class="unit">
+        <p><strong>U4. Preserve legacy review resolution and deposit safety</strong></p>
+        <p>Keep historical <code>register_closeout_variance</code> conflicts approvable through the existing replay path while deposits remain blocked by unresolved closeout work.</p>
+      </div>
+      <div class="unit">
+        <p><strong>U5. Presentation, readiness, and continuity regression pass</strong></p>
+        <p>Verify under-threshold closeouts no longer show manager-review copy, approval-required variance still routes cleanly, and replacement drawer continuity remains intact.</p>
+      </div>
+      <div class="unit">
+        <p><strong>U6. Validation, graph, and documentation</strong></p>
+        <p>Run focused Vitest coverage, rebuild graph after code changes, and add a solution note for the shared gate invariant.</p>
+      </div>
+    </section>
+
+    <section>
+      <h2>Approval Persistence Contract</h2>
+      <ul>
+        <li>Reuse an existing pending <code>variance_review</code> for the same <code>registerSessionId</code> and identical closeout facts.</li>
+        <li>Never insert a second approval request when the same <code>localEventId</code> retries.</li>
+        <li>Conflict or reject changed closeout facts for the same register session before policy approval.</li>
+        <li>Patch the register session to <code>status: "closing"</code> with counted cash, variance, notes, <code>managerApprovalRequestId</code>, <code>closeoutOwnedAt</code>, <code>closeoutOwnershipSource: "approval_request"</code>, and closeout operating-date fields.</li>
+        <li>Store review metadata for counted cash, expected cash, variance, notes, local event id, local register-session id, terminal id, closeout time, <code>syncOrigin: "local_sync"</code>, and the gate decision/reason.</li>
+        <li><code>allowRegisterCloseoutVarianceProjection</code> bypasses only the variance-approval decision for approved legacy conflicts; identity, duplicate, stale-session, and hold checks still apply.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Validation Ladder</h2>
+      <ul>
+        <li><code>cd packages/athena-webapp &amp;&amp; bun run test -- convex/operations/registerSessionCloseoutGate.test.ts</code></li>
+        <li><code>cd packages/athena-webapp &amp;&amp; bun run test -- convex/cashControls/closeouts.test.ts</code></li>
+        <li><code>cd packages/athena-webapp &amp;&amp; bun run test -- convex/pos/application/sync/projectLocalEvents.test.ts -t "closeout"</code></li>
+        <li><code>cd packages/athena-webapp &amp;&amp; bun run test -- convex/cashControls/deposits.test.ts -t "closeout"</code></li>
+        <li><code>cd packages/athena-webapp &amp;&amp; bun run test -- convex/operations/dailyClose.test.ts -t "closeout"</code></li>
+        <li><code>cd packages/athena-webapp &amp;&amp; bun run test -- convex/operations/dailyOperations.test.ts -t "closeout"</code></li>
+        <li><code>cd packages/athena-webapp &amp;&amp; bun run test -- shared/registerSessionLifecyclePolicy.test.ts</code></li>
+        <li><code>cd packages/athena-webapp &amp;&amp; bun run test -- src/lib/pos/presentation/syncStatusPresentation.test.ts</code></li>
+        <li><code>cd packages/athena-webapp &amp;&amp; bun run test -- src/components/pos/register/POSRegisterView.test.tsx -t "closeout"</code></li>
+        <li><code>cd packages/athena-webapp &amp;&amp; bun run test -- src/components/pos/register/RegisterDrawerGate.test.tsx -t "closeout"</code></li>
+        <li><code>cd packages/athena-webapp &amp;&amp; bun run test -- src/components/cash-controls/RegisterSessionView.test.tsx -t "closeout"</code></li>
+        <li><code>cd packages/athena-webapp &amp;&amp; bun run test -- src/components/cash-controls/CashControlsDashboard.test.tsx -t "closeout"</code></li>
+        <li>After code changes: <code>bun run graphify:rebuild</code></li>
+        <li>Before PR: <code>bun run pr:athena</code></li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Risk Register</h2>
+      <table>
+        <thead>
+          <tr><th>Risk</th><th>Impact</th><th>Mitigation</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>POS projection creates duplicate review rows.</td>
+            <td>Managers see two queues for one closeout.</td>
+            <td>Use one Cash Controls-owned review semantic and test that policy-managed variance does not create a new POS-only conflict.</td>
+          </tr>
+          <tr>
+            <td>Variance closes before holds resolve.</td>
+            <td>Expected cash can change after closure.</td>
+            <td>Evaluate cash-affecting holds before variance approval or closure in both paths.</td>
+          </tr>
+          <tr>
+            <td>Cash Controls defaults drift during extraction.</td>
+            <td>Stores see changed approval behavior.</td>
+            <td>Keep existing threshold/signoff tests and add helper-level tests.</td>
+          </tr>
+          <tr>
+            <td>Legacy review rows become stranded.</td>
+            <td>Existing closeouts cannot be resolved.</td>
+            <td>Preserve <code>allowRegisterCloseoutVarianceProjection</code> and deposit review replay.</td>
+          </tr>
+          <tr>
+            <td>Approval-required POS sync retries side effects.</td>
+            <td>Duplicate approvals or repeated timeline evidence.</td>
+            <td>Require idempotent review creation, projected sync status, closeout mapping, and retry tests.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Reviewer Status</h2>
+      <ul>
+        <li>Research agents: repo mapping, institutional learnings, and flow analysis complete.</li>
+        <li>Scope reviewer approved the initial plan.</li>
+        <li>Feasibility, data-integrity, and testing feedback has been incorporated; second review is pending.</li>
+      </ul>
+      <p class="small">This HTML is paired with the markdown plan and should be regenerated or edited together if reviewer feedback changes the plan.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-07-01-001-fix-register-closeout-gate-policy-plan.md
+++ b/docs/plans/2026-07-01-001-fix-register-closeout-gate-policy-plan.md
@@ -1,0 +1,459 @@
+---
+title: "fix: Collapse POS and Cash Controls closeout gating"
+type: fix
+status: active
+date: 2026-07-01
+---
+
+# fix: Collapse POS and Cash Controls closeout gating
+
+## Summary
+
+Closeout variance policy should have one server-owned gate. Today Cash Controls applies the store cash-controls threshold and manager-signoff flags, while POS local-sync projection routes every non-zero closeout variance into a separate sync-review path. The work should extract the Cash Controls closeout policy into a pure Convex helper and make both Cash Controls and POS local-sync projection consume that helper before deciding whether a register session can close, must wait on cash-impacting holds, or needs manager approval.
+
+---
+
+## Problem Frame
+
+Athena currently has two register-session closeout paths:
+
+- Cash Controls closeouts compute variance policy from store configuration, including `varianceApprovalThreshold`, `requireManagerSignoffForAnyVariance`, `requireManagerSignoffForOvers`, and `requireManagerSignoffForShorts`.
+- POS local-first closeouts save a local `register_closed` event. During sync, `projectRegisterClosed` treats any non-zero variance as `register_closeout_variance` review, regardless of the Cash Controls threshold policy.
+
+That means a variance below the configured threshold can close through Cash Controls but becomes a manager-review conflict when it originated from POS. This is a money lifecycle divergence: the source of the closeout should not determine whether manager approval is required.
+
+---
+
+## Requirements
+
+- R1. Cash Controls and POS local-sync projection must evaluate closeout variance with the same server-side policy and config defaults.
+- R2. Absent store configuration must preserve the current Cash Controls defaults, including `varianceApprovalThreshold: 5000` and manager signoff flags defaulting to false.
+- R3. Under-threshold POS closeout variance must close during sync when no other closeout holds require waiting.
+- R4. Approval-required POS closeout variance must route through a single Cash Controls-owned review/approval semantic, not a second independent POS variance rule.
+- R5. Cash-affecting closeout holds must remain higher priority than variance approval; pending voids, cash-affecting item adjustments, and repairable mapping holds keep the register session unresolved.
+- R6. Legacy `register_closeout_variance` sync conflicts must remain resolvable after the change.
+- R7. Duplicate or ambiguous closeout uploads must keep their existing conflict/reject behavior and must not be mistaken for policy-approved variance.
+- R8. POS local-first continuity must remain intact: the cashier can submit closeout locally, unresolved local-only closeout still blocks the old drawer, and synced/review-owned closeout evidence must not strand replacement drawers.
+- R9. Manager review evidence must remain session-targeted and include enough closeout facts for an operator to trust the decision.
+- R10. Implementation must include focused Vitest coverage for the shared gate, Cash Controls behavior preservation, POS projection outcomes, holds priority, legacy review compatibility, and relevant presentation regressions.
+
+---
+
+## Scope Boundaries
+
+- This plan does not redesign POS closeout UI. POS can continue to save closeout locally and let sync reconcile the server decision.
+- This plan does not change sale usability for `closing`, `closeout_rejected`, or `closed` register sessions.
+- This plan does not automatically backfill or rewrite historical `register_closeout_variance` conflicts.
+- This plan does not change Daily Close completion policy except where existing register-session closeout holds already feed Daily Close readiness.
+- This plan does not broaden Terminal Health or self-heal authority to resolve business facts such as closeout variance or manager approval.
+- This plan does not import Cash Controls Convex mutations into POS projection. The shared boundary must be a pure helper.
+
+### Deferred to Follow-Up Work
+
+- A cleanup migration for old under-threshold `register_closeout_variance` conflicts, if operators report stale review queues after rollout.
+- Broader Cash Controls information-architecture changes beyond the review evidence needed for this closeout gate.
+- Any change to inline POS manager approval. The initial implementation keeps POS local-first and handles approval asynchronously through server review.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts` submits POS closeout locally and calls Cash Controls directly only for zero variance with a cloud register-session id.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts` writes the local `register.closeout_started` fact.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.ts` converts that local fact into the synced `register_closed` event.
+- `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts` owns `projectRegisterClosed`, computes expected/counted variance, applies closeout holds, currently conflicts any non-zero variance unless `allowRegisterCloseoutVarianceProjection` is true, and appends closeout records when projection closes.
+- `packages/athena-webapp/convex/cashControls/closeouts.ts` currently owns `getCashControlsConfig`, `buildRegisterSessionCloseoutReview`, manager approval requirements, closeout submission, and finalization.
+- `packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts` already provides shared cash-affecting hold facts for pending sale voids, pending item adjustments, and repairable missing mappings.
+- `packages/athena-webapp/convex/cashControls/deposits.ts` resolves legacy synced register review items and replays projection with `allowRegisterCloseoutVarianceProjection`.
+- `packages/athena-webapp/convex/pos/application/sync/types.ts` and `packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts` already expose `getStore`, so POS projection can read the same store config without a new broad repository abstraction.
+- `packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts` owns lifecycle/review classification such as `REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY`; it should remain lifecycle classification, not the store-config closeout gate.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-pos-closeout-hold-boundary-2026-07-01.md`: cash-impacting closeout holds should live in one server-side summary boundary that feeds Cash Controls finalization, deposits, register snapshots, POS drawer gates, and Daily Operations readiness.
+- `docs/solutions/logic-errors/athena-register-closeout-generic-holds-2026-06-26.md`: new closeout gates should be shared hold or policy providers, not one-off branches in closeout, deposit, or projection code.
+- `docs/solutions/architecture/athena-pos-register-lifecycle-policy-2026-06-23.md`: drawer lifecycle rules drift when local models, projection, and Cash Controls each encode their own version.
+- `docs/solutions/logic-errors/athena-pos-synced-closeout-readiness-2026-06-17.md`: local-first readiness should block only unresolved local closeout work; once the matching closeout event syncs, prior drawer state should not block the next drawer path.
+- `docs/solutions/logic-errors/athena-register-closeout-review-targeting-and-money-inputs-2026-06-27.md`: manager review actions should use session-targeted evidence, not capped store-wide scans.
+- `docs/solutions/logic-errors/athena-pos-sync-settlement-contract-2026-06-27.md`: `projected`, `conflicted`, `held`, and `rejected` sync outcomes need distinct settlement semantics.
+
+### External References
+
+- None. Existing Athena POS, Convex, Cash Controls, and institutional solution docs are the source of truth.
+
+---
+
+## Key Technical Decisions
+
+- **Extract a pure closeout gate:** Create `packages/athena-webapp/convex/operations/registerSessionCloseoutGate.ts` for store-config normalization and closeout variance review. Cash Controls and POS projection both call this helper.
+- **Keep the gate server-owned:** The frontend POS submit path remains local-first. It should not try to reimplement the threshold or manager-signoff rule in browser code.
+- **Treat holds before variance approval:** POS projection and Cash Controls should both ask for cash-affecting closeout holds before closing. Holds keep the session `closing`/submitted and defer final close, even if variance is under threshold.
+- **Close under-threshold POS variance:** When the shared gate says manager approval is not required and there are no holds, `projectRegisterClosed` should close and map the synced local closeout just like a zero-variance closeout.
+- **Use one approval semantic for required variance:** When the shared gate says approval is required, POS sync must call a Cash Controls-owned helper, such as `createOrReuseRegisterSessionVarianceReview`, for that register session. It should not create a parallel POS-only threshold rule. Legacy sync conflicts remain readable and resolvable only for historical rows.
+- **Make POS-created approval ownership durable:** A policy-required POS closeout is settled as a synced projection only after the Cash Controls review packet and register-session ownership state are persisted together. The register session remains `closing`; the local sync event is `projected` with a closeout mapping; the unresolved business state is represented by `managerApprovalRequestId`, `closeoutOwnedAt`, and `closeoutOwnershipSource: "approval_request"`.
+- **Preserve approved replay narrowly:** `allowRegisterCloseoutVarianceProjection` remains the explicit replay escape hatch used after an approved legacy `register_closeout_variance` review. It bypasses only the variance-approval decision; it must not bypass identity checks, duplicate closeout checks, stale-session checks, or cash-affecting holds.
+- **Keep lifecycle classification separate:** `shared/registerSessionLifecyclePolicy.ts` can continue naming review summaries and sale/replacement behavior, but it should not become the cash-controls config reader.
+- **Avoid schema churn unless implementation proves it necessary:** Start with existing session/store indexes and `approvalRequest.by_registerSessionId`. Add an index only if the implementation cannot query approval state safely and narrowly.
+- **No automatic historical rewrite:** Existing open `register_closeout_variance` conflicts stay in the existing manager-review path. The behavior change stops producing new conflicts when the shared gate would allow closure.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should under-threshold POS variance close during sync?** Yes. That is the parity fix; the source path should not force manager review when Cash Controls policy would not.
+- **Should POS calculate the threshold in browser code?** No. POS remains local-first and the server sync projection applies the shared gate.
+- **Should cash-affecting holds be subordinate to variance approval?** No. Holds are higher priority because expected cash can still change before final closure.
+- **Should existing legacy conflicts be rewritten?** No for this slice. They remain resolvable through the existing Cash Controls review path.
+
+### Deferred to Implementation
+
+- If current approval helpers are too mutation-specific to reuse from projection, implementation should extract a small Cash Controls-owned helper with the persistence contract below instead of importing public mutation code into POS projection.
+- Whether presentation component code needs updates depends on whether existing review copy is currently shown for all non-zero synced closeout variance or only true approval/review states; the test commands are required either way.
+
+### Approval-Required POS Sync Persistence Contract
+
+When POS projection sees no cash-affecting holds and the shared gate returns `approval_required`, implementation must persist one Cash Controls-owned review owner with these rules:
+
+- Reuse an existing pending `variance_review` for the same `registerSessionId` and identical closeout facts.
+- Never insert a second approval request when the same `localEventId` retries.
+- If a second closeout event targets the same register session with different counted cash, notes, or closeout facts, reject or conflict it before policy approval. Do not replace or cancel the existing approval in this slice.
+- Patch the register session with `status: "closing"`, `countedCash`, `variance`, `notes`, `managerApprovalRequestId`, `closeoutOwnedAt`, `closeoutOwnershipSource: "approval_request"`, and the closeout operating-date fields used by Cash Controls closeout ownership.
+- Store review metadata with `countedCash`, `expectedCash`, `variance`, `notes`, `localEventId`, `localRegisterSessionId`, `terminalId`, `closeoutOccurredAt`, `syncOrigin: "local_sync"`, and the shared gate decision/reason.
+- Return POS projection status `projected`, create the closeout mapping, and create no `posLocalSyncConflict`. The unresolved business state lives on the closing register session and its linked approval request.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["POS local closeout event"] --> B["projectRegisterClosed"]
+  C["Cash Controls submit/finalize"] --> D["Cash Controls closeout action"]
+  B --> G["Shared closeout gate"]
+  D --> G
+  G --> H{"Cash-affecting holds?"}
+  H -->|yes| I["Keep session closing/submitted"]
+  H -->|no| J{"Approval required?"}
+  J -->|no| K["Close register session"]
+  J -->|yes| L["Create/reuse Cash Controls approval review"]
+  L --> M["Approved replay closes with explicit proof"]
+```
+
+The gate should normalize facts into one decision vocabulary:
+
+| Decision | Meaning | POS sync behavior | Cash Controls behavior |
+| --- | --- | --- | --- |
+| `blocked_by_holds` | Closeout facts are submitted, but cash-impacting work can still change expected cash. | Patch session to `closing`, preserve submitted closeout evidence, do not append final closeout records. | Return submitted/unresolved state or block finalization with hold copy. |
+| `approval_required` | Counted cash variance requires manager approval by shared policy. | Persist/reuse one Cash Controls review owner, patch the session to `closing` with `managerApprovalRequestId`, return `projected`, create a closeout mapping, and create no POS sync conflict. | Create/reuse approval request or require valid manager proof. |
+| `close_allowed` | No holds and no policy-required approval. | Project as closed, map local event, record closeout evidence. | Close/finalize immediately. |
+| `projection_conflict` | Duplicate, ambiguous, stale, or identity-mismatched sync event. | Keep existing sync conflict/reject behavior. | Not applicable to direct Cash Controls closeout. |
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 shared closeout gate"] --> U2["U2 Cash Controls extraction"]
+  U1 --> U3["U3 POS sync projection"]
+  U2 --> U4["U4 legacy review compatibility"]
+  U3 --> U4
+  U4 --> U5["U5 presentation/readiness regression pass"]
+  U5 --> U6["U6 validation and docs"]
+```
+
+- U1. **Create the Shared Closeout Gate**
+
+**Goal:** Extract closeout config normalization and variance-review policy into a pure helper that can be used by Cash Controls and POS projection.
+
+**Requirements:** R1, R2, R9, R10
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/athena-webapp/convex/operations/registerSessionCloseoutGate.ts`
+- Create: `packages/athena-webapp/convex/operations/registerSessionCloseoutGate.test.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.ts` only to remove duplicated local helper ownership after U2
+
+**Approach:**
+- Move or re-create the pure parts of `getCashControlsConfig` and `buildRegisterSessionCloseoutReview` in the new operations helper.
+- Keep helper inputs plain: store document/config, expected cash, counted cash, optional submitted note/evidence context.
+- Return a typed result with normalized config, rounded variance, direction flags, threshold status, and `requiresApproval`.
+- Keep Convex mutation side effects, approval-request creation, and operator copy outside the pure helper.
+- Keep approval-review persistence out of this helper; that belongs to the Cash Controls-owned review helper in U2.
+- Preserve the exact default threshold and signoff behavior currently covered in `cashControls/closeouts.test.ts`.
+
+**Execution note:** Test this helper first with existing Cash Controls threshold cases before changing projection.
+
+**Patterns to follow:**
+- Current `getCashControlsConfig` and `buildRegisterSessionCloseoutReview` in `packages/athena-webapp/convex/cashControls/closeouts.ts`.
+- Existing pure-operation tests under `packages/athena-webapp/convex/operations`.
+
+**Test scenarios:**
+- Default config allows exact count and small non-zero variance below `5000`.
+- Variance over `varianceApprovalThreshold` requires approval.
+- `requireManagerSignoffForAnyVariance` requires approval for any non-zero variance.
+- `requireManagerSignoffForOvers` applies only to overages.
+- `requireManagerSignoffForShorts` applies only to shortages.
+- Rounded zero variance remains no-approval.
+
+**Verification:**
+- From `packages/athena-webapp`: `bun run test -- convex/operations/registerSessionCloseoutGate.test.ts`
+
+---
+
+- U2. **Wire Cash Controls to the Shared Gate**
+
+**Goal:** Preserve existing Cash Controls submit/finalize behavior while moving policy ownership out of `cashControls/closeouts.ts`.
+
+**Requirements:** R1, R2, R5, R9, R10
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/types.ts` if `SyncProjectionRepository` needs an explicit `createOrReuseRegisterSessionVarianceReview` or `ensureRegisterSessionVarianceApprovalRequest` capability
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts` if POS projection needs the repository implementation for the Cash Controls-owned helper
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.ts` only if imports or legacy review metadata need alignment
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.test.ts` only if U4 touches legacy conflict resolution
+
+**Approach:**
+- Replace local config/review helper calls with imports from `convex/operations/registerSessionCloseoutGate.ts`.
+- Extract or expose a Cash Controls-owned `createOrReuseRegisterSessionVarianceReview` helper for POS projection to call through the sync repository boundary.
+- Make that helper idempotent by `registerSessionId`, `localEventId`, and closeout facts; identical retry reuses the pending request, while changed closeout facts for the same session conflict/reject before approval.
+- Persist approval metadata and the register-session ownership patch together: `status: "closing"`, counted/variance/notes, `managerApprovalRequestId`, `closeoutOwnedAt`, `closeoutOwnershipSource: "approval_request"`, and closeout operating-date fields.
+- Keep submit and finalize semantics the same: holds block final closure, approval-required variance creates or reuses approval flow, no-approval variance closes.
+- Recompute the shared gate at finalization after holds resolve, because expected cash can change while closeout is submitted.
+- Keep manager authorization and proof validation inside Cash Controls mutations.
+- Keep approval evidence session-targeted and store-scoped.
+
+**Execution note:** This unit should be behavior-preserving. Any Cash Controls test change should be rename/import fallout or stronger assertions, not a product behavior change.
+
+**Patterns to follow:**
+- Existing submit/finalize tests in `packages/athena-webapp/convex/cashControls/closeouts.test.ts`.
+- `docs/solutions/logic-errors/athena-cash-controls-closeout-review-ia-2026-06-08.md`.
+
+**Test scenarios:**
+- Existing default threshold and signoff tests still pass through the shared helper.
+- Submitted closeout with cash-affecting holds remains submitted/unclosed.
+- Finalization recomputes closeout policy after holds resolve.
+- Approval-required closeout still requires valid manager authority or proof.
+
+**Verification:**
+- From `packages/athena-webapp`: `bun run test -- convex/cashControls/closeouts.test.ts`
+
+---
+
+- U3. **Route POS Local-Sync Closeout Projection Through the Gate**
+
+**Goal:** Make POS synced closeout projection use the same threshold/signoff policy as Cash Controls.
+
+**Requirements:** R1, R2, R3, R4, R5, R7, R8, R9, R10
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/types.ts` only if the repository contract needs a typed adjustment
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+
+**Approach:**
+- In `projectRegisterClosed`, keep duplicate closeout and identity checks ahead of policy evaluation.
+- Continue listing cash-affecting closeout holds with `listRegisterSessionCloseoutHolds`.
+- Fetch the store with the existing repository `getStore` capability and pass its cash-controls config into the shared gate.
+- If holds exist, keep the current submitted/closing behavior and do not close or create approval.
+- If no holds and the gate returns no approval required, close the register session, append closeout records, map the local event, and record `register_session_closed`.
+- If no holds and approval is required, call the Cash Controls-owned review helper, patch the session to `closing` with `managerApprovalRequestId`, set counted/variance/notes and closeout ownership fields, create the closeout mapping, return `projected`, and create no `posLocalSyncConflict`.
+- Keep the unsettled business work represented by the linked Cash Controls approval request, not by the sync-event status.
+- Keep `allowRegisterCloseoutVarianceProjection` as the explicit manager-approved replay path for legacy conflicts. It bypasses only the variance-approval branch and must still honor identity, duplicate, stale-session, and hold checks.
+
+**Execution note:** This is the behavior-changing unit. Add characterization for the current blanket non-zero variance conflict, then replace it with threshold-aware expected behavior.
+
+**Patterns to follow:**
+- Existing closeout hold branch in `projectRegisterClosed`.
+- `packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts`.
+- Existing reviewed-variance projection path using `allowRegisterCloseoutVarianceProjection`.
+
+**Test scenarios:**
+- Non-zero variance below the default threshold projects closed, creates mapping, records `register_session_closed`, and creates no `posLocalSyncConflict`.
+- Variance over threshold keeps the session unresolved and routes to Cash Controls approval semantics.
+- Approval-required POS variance returns `projected`, creates exactly one pending `variance_review` approval request, writes one `managerApprovalRequestId`, creates one closeout mapping, and creates no POS sync conflict.
+- Retrying the same `localEventId` reuses the existing approval request and does not duplicate review or timeline evidence.
+- A second closeout event for the same session with different counted cash, notes, or closeout facts conflicts/rejects before policy approval.
+- Store config requiring manager signoff for any variance is honored by POS sync.
+- Store config requiring manager signoff for overs applies to overages but not shortages.
+- Store config requiring manager signoff for shorts applies to shortages but not overages.
+- Pending completed-sale void approvals keep the closeout submitted/unfinalized even when variance is under threshold.
+- Pending cash-affecting item adjustments keep the closeout submitted/unfinalized even when variance is under threshold.
+- Repairable missing mapping holds keep the closeout submitted/unfinalized.
+- Duplicate closeout with mismatched count still conflicts/rejects as it does today.
+- Manager-approved legacy replay with `allowRegisterCloseoutVarianceProjection` still projects.
+
+**Verification:**
+- From `packages/athena-webapp`: `bun run test -- convex/pos/application/sync/projectLocalEvents.test.ts -t "closeout"`
+
+---
+
+- U4. **Preserve Legacy Review Resolution and Deposit Safety**
+
+**Goal:** Keep existing `register_closeout_variance` review rows actionable while preventing new under-threshold POS closeouts from entering that legacy path.
+
+**Requirements:** R4, R5, R6, R8, R9, R10
+
+**Dependencies:** U2, U3
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts` for replay coverage if not completed in U3
+
+**Approach:**
+- Leave historical `register_closeout_variance` conflict resolution intact.
+- Preserve the approved replay call to `projectLocalSyncEvent` with `allowRegisterCloseoutVarianceProjection`.
+- Ensure deposits remain blocked by unresolved cash-affecting closeout holds and unresolved approval-required closeout review.
+- Make deposit/read-model code consume POS-sync-created approval packets through the same session-targeted lookup used by closeouts.
+- Avoid capped store-wide conflict scans for deciding current actionability.
+
+**Execution note:** This unit is mostly compatibility. It should not resurrect the old blanket non-zero POS variance rule.
+
+**Patterns to follow:**
+- `docs/solutions/logic-errors/athena-register-closeout-review-targeting-and-money-inputs-2026-06-27.md`.
+- Existing `allowRegisterCloseoutVarianceProjection` deposit-review tests.
+
+**Test scenarios:**
+- A historical `register_closeout_variance` conflict remains approvable and replays projection.
+- Rejected historical variance conflict remains rejected and does not close.
+- Deposits cannot be recorded while closeout holds remain cash-affecting.
+- Deposits cannot treat an approval-required closeout as closed before approval.
+- Deposits remain blocked while the session is `closing` with unresolved POS-sync-created approval review.
+
+**Verification:**
+- From `packages/athena-webapp`: `bun run test -- convex/cashControls/deposits.test.ts -t "closeout"`
+
+---
+
+- U5. **Presentation, Readiness, and Continuity Regression Pass**
+
+**Goal:** Make sure the shared server decision does not create stale review copy or block replacement drawer continuity.
+
+**Requirements:** R8, R9, R10
+
+**Dependencies:** U3, U4
+
+**Files:**
+- Modify: `packages/athena-webapp/shared/registerSessionLifecyclePolicy.test.ts` only if lifecycle classification needs a narrowed review state
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts` only if closeout submit presentation changes
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.test.ts` only if sync-review copy changes
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx` only if Cash Controls review evidence display changes
+- Modify: `packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx` only if dashboard closeout status changes
+
+**Approach:**
+- Confirm under-threshold projected closeouts do not display manager-review copy after sync.
+- Confirm approval-required closeouts display one calm Cash Controls review state.
+- Confirm a newer replacement drawer remains sale-usable when the prior drawer is synced/review-owned and identities differ.
+- Keep product copy aligned with `docs/product-copy-tone.md`.
+
+**Execution note:** Do not broaden UI work unless tests reveal stale or misleading operator copy.
+
+**Patterns to follow:**
+- Existing POS continuity tests around closeout review residue.
+- `docs/product-copy-tone.md`.
+
+**Test scenarios:**
+- Under-threshold POS variance no longer appears as a manager-review sync conflict.
+- Approval-required variance still points operators to the closeout review action.
+- Replacement drawer continuity remains intact while prior closeout review is pending.
+- Daily Close/Daily Operations readiness treats under-threshold POS variance as closed after projection and approval-required POS variance as Cash Controls approval-owned, not as legacy `register_closeout_variance` sync review.
+
+**Verification:**
+- From `packages/athena-webapp`: `bun run test -- shared/registerSessionLifecyclePolicy.test.ts`
+- From `packages/athena-webapp`: `bun run test -- src/lib/pos/presentation/syncStatusPresentation.test.ts`
+- From `packages/athena-webapp`: `bun run test -- src/components/pos/register/POSRegisterView.test.tsx -t "closeout"`
+- From `packages/athena-webapp`: `bun run test -- src/components/pos/register/RegisterDrawerGate.test.tsx -t "closeout"`
+- From `packages/athena-webapp`: `bun run test -- src/components/cash-controls/RegisterSessionView.test.tsx -t "closeout"`
+- From `packages/athena-webapp`: `bun run test -- src/components/cash-controls/CashControlsDashboard.test.tsx -t "closeout"`
+- From `packages/athena-webapp`: `bun run test -- convex/operations/dailyClose.test.ts -t "closeout"`
+- From `packages/athena-webapp`: `bun run test -- convex/operations/dailyOperations.test.ts -t "closeout"`
+
+---
+
+- U6. **Validation, Graph, and Documentation**
+
+**Goal:** Prove the behavior through focused tests and capture durable knowledge for future closeout gates.
+
+**Requirements:** R10
+
+**Dependencies:** U1, U2, U3, U4, U5
+
+**Files:**
+- Add or update: `docs/solutions/logic-errors/athena-register-closeout-shared-gate-2026-07-01.md`
+- Generated as required: `packages/athena-webapp/convex/_generated/*` if Convex API shape changes
+- Generated as required: `graphify-out/*` after code changes
+
+**Approach:**
+- Run the focused Vitest files for the shared gate, Cash Controls closeouts, POS projection, deposits, and any touched presentation tests.
+- If Convex public API shape changes, regenerate from `packages/athena-webapp` using the repo-approved command.
+- Because implementation will modify code files, run `bun run graphify:rebuild` from the repo root before final delivery.
+- Add a concise solution note recording the shared gate invariant and the no-duplicate-review rule.
+
+**Verification:**
+- From `packages/athena-webapp`: `bun run test -- convex/operations/registerSessionCloseoutGate.test.ts`
+- From `packages/athena-webapp`: `bun run test -- convex/cashControls/closeouts.test.ts`
+- From `packages/athena-webapp`: `bun run test -- convex/pos/application/sync/projectLocalEvents.test.ts -t "closeout"`
+- From `packages/athena-webapp`: `bun run test -- convex/cashControls/deposits.test.ts -t "closeout"`
+- From `packages/athena-webapp`: `bun run test -- convex/operations/dailyClose.test.ts -t "closeout"`
+- From `packages/athena-webapp`: `bun run test -- convex/operations/dailyOperations.test.ts -t "closeout"`
+- From `packages/athena-webapp`: run the required U5 presentation/readiness commands listed above.
+- From repo root after code changes: `bun run graphify:rebuild`
+- From repo root before PR: `bun run pr:athena`
+
+---
+
+## Rollout Strategy
+
+1. Ship the shared gate extraction and Cash Controls import swap first inside the same PR as POS projection changes, so there is no intermediate state where two policies continue to drift.
+2. Deploy Convex and web together after tests pass. Convex should remain tolerant of older browsers because the POS browser still uploads the same local closeout event shape.
+3. Monitor Cash Controls review counts for `register_closeout_variance` after deploy. New under-threshold POS closeouts should stop entering that legacy review lane.
+4. If stale historical under-threshold conflicts remain operationally noisy, plan a separate cleanup/backfill with explicit operator sign-off.
+
+---
+
+## Risk Register
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| POS projection creates both a sync conflict and a Cash Controls approval request for the same closeout. | Duplicate review queues and inconsistent manager actions. | U3 requires one approval semantic and tests no new `posLocalSyncConflict` for policy-managed variance. |
+| Under-threshold variance closes before pending cash-affecting work resolves. | Final expected cash can be wrong. | Holds are evaluated before variance approval/closure in both paths. |
+| Shared helper accidentally changes Cash Controls defaults. | Existing stores see changed manager-review behavior. | U1/U2 preserve existing threshold/signoff tests before POS behavior changes. |
+| Legacy variance conflicts become unresolvable. | Existing review queues strand closeouts. | U4 preserves `allowRegisterCloseoutVarianceProjection` replay. |
+| Store-wide scans decide current closeout actionability. | Large sync backlogs hide or misroute reviews. | Require session-targeted reads for approval/review packets. |
+| POS continuity regresses for replacement drawers. | Cashiers cannot continue after prior drawer closeout review. | U5 includes replacement drawer continuity regression checks. |
+| Approval-required POS sync marks too little as settled and retries side effects. | Duplicate approvals, duplicate timeline evidence, or repeated closing patches. | U2/U3 require idempotent review creation, projected sync status, a closeout mapping, and retry tests. |
+
+---
+
+## Confidence
+
+- **Confidence:** High for the shared-gate extraction and POS threshold parity.
+- **Reasoning:** All three research passes converged on the same boundary: a pure server closeout gate consumed by Cash Controls and POS projection, with holds evaluated first and legacy conflict resolution preserved.
+- **Main implementation unknown:** the cleanest way to create/reuse Cash Controls approval evidence from POS sync without duplicating mutation-specific logic. This is contained to U2/U3 and should be solved by extracting a small Cash Controls-owned review builder if the existing submit path is too coupled.
+
+---
+
+## Reviewer Loop
+
+- Initial research agents:
+  - Repo research: complete.
+  - Institutional learnings: complete.
+  - Flow analysis: complete.
+- Plan reviewers:
+  - Scope review: approved initial plan.
+  - Feasibility review: requested explicit POS approval-required settlement and repository/helper boundary; incorporated.
+  - Data-integrity review: requested durable approval persistence contract and narrow legacy replay; incorporated.
+  - Testing review: requested concrete readiness/presentation commands and negative-path assertions; incorporated.
+  - Second pass: feasibility, data-integrity, testing, and scope reviewers approved unanimously.

--- a/docs/solutions/logic-errors/athena-register-closeout-shared-gate-2026-07-01.md
+++ b/docs/solutions/logic-errors/athena-register-closeout-shared-gate-2026-07-01.md
@@ -1,0 +1,99 @@
+---
+title: Athena Register Closeout Shared Gate
+date: 2026-07-01
+category: logic-errors
+module: athena-webapp
+problem_type: closeout_policy_drift
+component: cash-controls
+symptoms:
+  - "POS local-sync closeouts route every non-zero variance to manager review"
+  - "Cash Controls applies configured closeout variance threshold and manager signoff flags"
+  - "The closeout source path changes whether approval is required"
+root_cause: pos_projection_and_cash_controls_encoded_closeout_variance_policy_separately
+resolution_type: shared_closeout_gate
+severity: high
+tags:
+  - cash-controls
+  - pos
+  - closeout
+  - local-sync
+  - approval-policy
+related:
+  - docs/solutions/architecture/athena-pos-closeout-hold-boundary-2026-07-01.md
+  - docs/solutions/logic-errors/athena-register-closeout-generic-holds-2026-06-26.md
+  - docs/solutions/logic-errors/athena-register-closeout-review-targeting-and-money-inputs-2026-06-27.md
+---
+
+# Athena Register Closeout Shared Gate
+
+## Problem
+
+Register closeout variance policy must not depend on whether the count came
+from Cash Controls or POS local sync. Cash Controls uses store configuration for
+`varianceApprovalThreshold`, `requireManagerSignoffForAnyVariance`,
+`requireManagerSignoffForOvers`, and `requireManagerSignoffForShorts`. POS
+projection previously treated any non-zero synced closeout variance as a
+`register_closeout_variance` sync conflict.
+
+That split created two approval rules for one drawer closeout. A variance that
+Cash Controls would close below threshold could become manager-review work when
+submitted through POS.
+
+## Solution
+
+Keep one pure server-side closeout gate in
+`convex/operations/registerSessionCloseoutGate.ts`, then have Cash Controls and
+POS projection both ask it for the variance decision.
+
+The closeout decision order is:
+
+1. Validate sync identity, duplicate, stale-session, and permission constraints.
+2. Evaluate cash-affecting closeout holds.
+3. If holds exist, keep submitted closeout ownership in `closing` and do not
+   append final `closeoutRecords`.
+4. If no holds exist, evaluate the shared variance gate.
+5. If approval is not required, close the drawer and append final closeout
+   history.
+6. If approval is required, persist or reuse one Cash Controls-owned
+   `variance_review` approval and mark the sync event `projected` with a
+   closeout mapping. The unresolved business state lives on the closing register
+   session through `managerApprovalRequestId`, not in a second POS sync conflict.
+
+## POS Sync Approval Ownership
+
+Approval-required POS closeout projection must be idempotent:
+
+- Reuse a pending `variance_review` for the same register session and identical
+  closeout facts.
+- Do not create a second approval request when the same `localEventId` retries.
+- Conflict/reject changed closeout facts for the same session before creating a
+  new approval owner.
+- Persist counted cash, expected cash, variance, notes, local event id, local
+  register-session id, terminal id, closeout time, sync origin, and gate
+  decision/reason in review metadata.
+- Patch the register session to `closing` with `managerApprovalRequestId`,
+  closeout ownership fields, counted cash, variance, and notes before treating
+  the sync event as projected.
+
+Legacy `allowRegisterCloseoutVarianceProjection` remains only for explicitly
+approved historical `register_closeout_variance` conflicts. It bypasses the
+variance-approval decision, not identity, duplicate, stale-session, or hold
+checks.
+
+## Prevention
+
+- Add new closeout approval inputs to the shared gate, not directly to Cash
+  Controls or POS projection.
+- Keep cash-affecting holds ahead of variance approval. Holds can change
+  expected cash and must defer final closure.
+- Test every caller when the shared gate changes: Cash Controls submit/finalize,
+  POS `register_closed` projection, deposits, Daily Close/Daily Operations
+  readiness, and POS/Cash Controls presentation.
+- Historical sync conflicts may keep compatibility paths, but new
+  policy-managed closeouts should not create duplicate review queues.
+
+## Related
+
+- `docs/solutions/architecture/athena-pos-closeout-hold-boundary-2026-07-01.md`
+- `docs/solutions/logic-errors/athena-register-closeout-generic-holds-2026-06-26.md`
+- `docs/solutions/logic-errors/athena-register-closeout-review-targeting-and-money-inputs-2026-06-27.md`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2149 files · ~0 words
+- 2151 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8366 nodes · 10002 edges · 2076 communities detected
+- 8370 nodes · 10004 edges · 2078 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2086,6 +2086,8 @@
 - [[_COMMUNITY_Community 2073|Community 2073]]
 - [[_COMMUNITY_Community 2074|Community 2074]]
 - [[_COMMUNITY_Community 2075|Community 2075]]
+- [[_COMMUNITY_Community 2076|Community 2076]]
+- [[_COMMUNITY_Community 2077|Community 2077]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2350,104 +2352,104 @@ Cohesion: 0.17
 Nodes (19): assertValidEodLocalCompletionWindowMinutes(), assertValidEodThreshold(), assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getEodAutoCompletePolicyConfigWithCtx() (+11 more)
 
 ### Community 59 - "Community 59"
-Cohesion: 0.11
-Nodes (7): asBoolean(), asNumber(), asRecord(), buildRegisterCloseoutSubmittedTimelineMessage(), buildRegisterCloseoutVarianceTimelineMessage(), formatCloseoutVarianceAmount(), getCashControlsConfig()
-
-### Community 60 - "Community 60"
 Cohesion: 0.16
 Nodes (17): asRecord(), buildSnapshotHash(), buildStoreInsightsPromptFromContextBundle(), buildStoreInsightsPromptFromContextEvents(), buildUserInsightsPromptFromContextBundle(), buildUserInsightsPromptFromContextEvents(), compactContextEventsForPrompt(), compactEnvironmentForPrompt() (+9 more)
 
-### Community 61 - "Community 61"
+### Community 60 - "Community 60"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 62 - "Community 62"
+### Community 61 - "Community 61"
 Cohesion: 0.1
 Nodes (6): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onIssueTerminalRecoveryCommand(), onStartRemoteAssist(), submitUpdateApp()
 
-### Community 63 - "Community 63"
+### Community 62 - "Community 62"
 Cohesion: 0.13
 Nodes (11): dateInputToCalendarDate(), formatDateLabel(), formatNextCloseSummaryLabel(), formatNextOpenSummaryLabel(), formatScheduleSummaryLabel(), formatTimeLabel(), getCurrentOpenWindow(), getDayLabel() (+3 more)
 
-### Community 64 - "Community 64"
+### Community 63 - "Community 63"
 Cohesion: 0.21
 Nodes (21): detectFormat(), extractJsonRows(), flattenJsonRows(), inferProductName(), isRecord(), looksLikeLabel(), normalizeKey(), normalizeLegacyRow() (+13 more)
 
-### Community 65 - "Community 65"
+### Community 64 - "Community 64"
 Cohesion: 0.25
 Nodes (21): asRecord(), errorFor(), getLocalExpenseSessionId(), getOrCreateSession(), isExpenseEvent(), itemSource(), itemSourceKey(), numberField() (+13 more)
 
-### Community 66 - "Community 66"
+### Community 65 - "Community 65"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 67 - "Community 67"
+### Community 66 - "Community 66"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
-### Community 68 - "Community 68"
+### Community 67 - "Community 67"
 Cohesion: 0.21
 Nodes (18): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), formatRecoveryCode(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode() (+10 more)
 
-### Community 69 - "Community 69"
+### Community 68 - "Community 68"
 Cohesion: 0.13
 Nodes (9): asCloudOperableSession(), countPendingSyncableLocalEventsForStaff(), hasSyncedSaleLocalEventsForStaff(), hasUploadedLocalEventsForStaff(), isCloudOperableSession(), isEmptyLocalSaleShell(), selectPassiveCloseoutBlockedRegisterSession(), trimOptional() (+1 more)
 
-### Community 70 - "Community 70"
+### Community 69 - "Community 69"
 Cohesion: 0.21
 Nodes (19): getRegisterCatalogPrice(), getRegisterCatalogProjectionPrice(), isActiveProvisionalImportSkuForStore(), isDraftAllowedInTrustedRegisterCatalog(), isTrustedRegisterCatalogProjection(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailability() (+11 more)
 
-### Community 71 - "Community 71"
+### Community 70 - "Community 70"
 Cohesion: 0.11
 Nodes (3): formatMinuteOfDayLabel(), formatStoreHoursTimeLabel(), parseStoreHoursTimeLabel()
 
-### Community 72 - "Community 72"
+### Community 71 - "Community 71"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 73 - "Community 73"
+### Community 72 - "Community 72"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
 
-### Community 74 - "Community 74"
+### Community 73 - "Community 73"
 Cohesion: 0.27
 Nodes (18): assertConformsToExportedReturns(), collectReturnValidatorIssues(), decodeSerializedFloat64(), decodeSerializedInt64(), decodeSerializedLiteralValue(), describeValue(), formatReturnValidatorIssues(), isConvexValue() (+10 more)
 
-### Community 75 - "Community 75"
+### Community 74 - "Community 74"
 Cohesion: 0.22
 Nodes (15): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), classifyRegisterSessionSyncReview(), findProjectedRegisterSessionIdForRepairableMissingMapping(), findTransactionIdForSyncEvent(), hasInventoryReviewWorkItemForProjectedSale(), isNonSaleMissingRegisterSessionMappingConflict() (+7 more)
 
-### Community 76 - "Community 76"
+### Community 75 - "Community 75"
 Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
 
-### Community 77 - "Community 77"
+### Community 76 - "Community 76"
 Cohesion: 0.22
 Nodes (18): assertPrAthenaProofReady(), classifySnapshotError(), collectFilesUnder(), collectProofSnapshot(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof() (+10 more)
 
-### Community 78 - "Community 78"
+### Community 77 - "Community 77"
 Cohesion: 0.17
 Nodes (13): buildProviderRegistry(), createIntelligenceRun(), defaultFakeOutput(), failedGenerationResult(), getStoreInsightsSnapshotFallback(), isActivityTrend(), isDeviceDistribution(), isInsightGenerationInProgressError() (+5 more)
 
-### Community 79 - "Community 79"
+### Community 78 - "Community 78"
 Cohesion: 0.16
 Nodes (10): buildProductSkuSearchProjection(), buildSearchText(), hydrateCanonicalProjection(), normalizeAttributes(), normalizeLookup(), projectionsEqual(), requireProductSkuSearchAccess(), requireProductSkuSearchAdmin() (+2 more)
 
-### Community 80 - "Community 80"
+### Community 79 - "Community 79"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 81 - "Community 81"
+### Community 80 - "Community 80"
 Cohesion: 0.22
 Nodes (15): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+7 more)
 
-### Community 82 - "Community 82"
+### Community 81 - "Community 81"
 Cohesion: 0.25
 Nodes (16): buildStorefrontContextEvent(), buildStorefrontIdempotencyKey(), compactScalarPayload(), createStorefrontContextTrackingEnvelope(), createStorefrontRouteViewedContextEvent(), getCartChange(), getCartContextEventInput(), getCheckoutBlocker() (+8 more)
 
-### Community 83 - "Community 83"
+### Community 82 - "Community 82"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
+
+### Community 83 - "Community 83"
+Cohesion: 0.13
+Nodes (3): buildRegisterCloseoutSubmittedTimelineMessage(), buildRegisterCloseoutVarianceTimelineMessage(), formatCloseoutVarianceAmount()
 
 ### Community 84 - "Community 84"
 Cohesion: 0.22
@@ -2819,27 +2821,27 @@ Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger
 
 ### Community 176 - "Community 176"
 Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 177 - "Community 177"
 Cohesion: 0.39
-Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 178 - "Community 178"
+Cohesion: 0.39
+Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
+
+### Community 179 - "Community 179"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.31
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.22
 Nodes (0):
-
-### Community 181 - "Community 181"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 182 - "Community 182"
 Cohesion: 0.39
@@ -2910,12 +2912,12 @@ Cohesion: 0.22
 Nodes (0):
 
 ### Community 199 - "Community 199"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
-
-### Community 200 - "Community 200"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 200 - "Community 200"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 201 - "Community 201"
 Cohesion: 0.22
@@ -3078,296 +3080,296 @@ Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
 ### Community 241 - "Community 241"
+Cohesion: 0.43
+Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
+
+### Community 242 - "Community 242"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 0.52
 Nodes (5): getBlockingRegisterSessionIdFromConflict(), isRegisterSessionConflict(), resolveScopedRegisterSession(), resolveTerminalRegisterConflict(), resolveTerminalRegisterSessionConflict()
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.33
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 246 - "Community 246"
+### Community 247 - "Community 247"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
-
-### Community 257 - "Community 257"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 258 - "Community 258"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 259 - "Community 259"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 260 - "Community 260"
 Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 261 - "Community 261"
-Cohesion: 0.29
-Nodes (1): ResizeObserverStub
+Cohesion: 0.33
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
 ### Community 263 - "Community 263"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 264 - "Community 264"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 264 - "Community 264"
+### Community 265 - "Community 265"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 265 - "Community 265"
+### Community 266 - "Community 266"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 266 - "Community 266"
-Cohesion: 0.52
-Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 267 - "Community 267"
 Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 268 - "Community 268"
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+
+### Community 269 - "Community 269"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.52
 Nodes (6): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isDuplicatePosSessionSaleReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
-
-### Community 270 - "Community 270"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 271 - "Community 271"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 272 - "Community 272"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 273 - "Community 273"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 280 - "Community 280"
+### Community 281 - "Community 281"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
-
-### Community 282 - "Community 282"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 283 - "Community 283"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 284 - "Community 284"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 285 - "Community 285"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 285 - "Community 285"
+### Community 286 - "Community 286"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 286 - "Community 286"
+### Community 287 - "Community 287"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 287 - "Community 287"
+### Community 288 - "Community 288"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 288 - "Community 288"
+### Community 289 - "Community 289"
 Cohesion: 0.6
 Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
-### Community 289 - "Community 289"
+### Community 290 - "Community 290"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 290 - "Community 290"
+### Community 291 - "Community 291"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 291 - "Community 291"
+### Community 292 - "Community 292"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 292 - "Community 292"
+### Community 293 - "Community 293"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 293 - "Community 293"
+### Community 294 - "Community 294"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 294 - "Community 294"
+### Community 295 - "Community 295"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 295 - "Community 295"
+### Community 296 - "Community 296"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 296 - "Community 296"
+### Community 297 - "Community 297"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 297 - "Community 297"
-Cohesion: 0.4
-Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 298 - "Community 298"
 Cohesion: 0.4
-Nodes (2): moveFeaturedItem(), saveOrder()
+Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 299 - "Community 299"
+Cohesion: 0.4
+Nodes (2): moveFeaturedItem(), saveOrder()
+
+### Community 300 - "Community 300"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 300 - "Community 300"
+### Community 301 - "Community 301"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 301 - "Community 301"
+### Community 302 - "Community 302"
 Cohesion: 0.4
 Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
-### Community 302 - "Community 302"
+### Community 303 - "Community 303"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 303 - "Community 303"
+### Community 304 - "Community 304"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 304 - "Community 304"
+### Community 305 - "Community 305"
 Cohesion: 0.4
 Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
-### Community 305 - "Community 305"
+### Community 306 - "Community 306"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 306 - "Community 306"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 307 - "Community 307"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 308 - "Community 308"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 309 - "Community 309"
 Cohesion: 0.47
 Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 311 - "Community 311"
+### Community 312 - "Community 312"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 312 - "Community 312"
+### Community 313 - "Community 313"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 313 - "Community 313"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 314 - "Community 314"
 Cohesion: 0.33
@@ -3382,224 +3384,224 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 317 - "Community 317"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 318 - "Community 318"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
-
-### Community 319 - "Community 319"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 320 - "Community 320"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 321 - "Community 321"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 322 - "Community 322"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 323 - "Community 323"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 324 - "Community 324"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 322 - "Community 322"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 323 - "Community 323"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 324 - "Community 324"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
 ### Community 325 - "Community 325"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 326 - "Community 326"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 327 - "Community 327"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 328 - "Community 328"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 329 - "Community 329"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 330 - "Community 330"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 331 - "Community 331"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 332 - "Community 332"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 333 - "Community 333"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 333 - "Community 333"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 334 - "Community 334"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 335 - "Community 335"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 335 - "Community 335"
+### Community 336 - "Community 336"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 336 - "Community 336"
+### Community 337 - "Community 337"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 337 - "Community 337"
+### Community 338 - "Community 338"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 338 - "Community 338"
+### Community 339 - "Community 339"
 Cohesion: 0.53
 Nodes (5): commitFixtureRepo(), createFixtureRepo(), gitFixtureEnv(), runFixtureCommand(), write()
 
-### Community 339 - "Community 339"
+### Community 340 - "Community 340"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 340 - "Community 340"
+### Community 341 - "Community 341"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 341 - "Community 341"
+### Community 342 - "Community 342"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 342 - "Community 342"
+### Community 343 - "Community 343"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 343 - "Community 343"
+### Community 344 - "Community 344"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
-### Community 344 - "Community 344"
+### Community 345 - "Community 345"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 345 - "Community 345"
+### Community 346 - "Community 346"
 Cohesion: 0.6
 Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
-### Community 346 - "Community 346"
+### Community 347 - "Community 347"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 347 - "Community 347"
-Cohesion: 0.5
-Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 348 - "Community 348"
 Cohesion: 0.5
-Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
+Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 349 - "Community 349"
+Cohesion: 0.5
+Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
+
+### Community 350 - "Community 350"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 350 - "Community 350"
+### Community 351 - "Community 351"
 Cohesion: 0.5
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 351 - "Community 351"
+### Community 352 - "Community 352"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 352 - "Community 352"
+### Community 353 - "Community 353"
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+
+### Community 354 - "Community 354"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 353 - "Community 353"
+### Community 355 - "Community 355"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 354 - "Community 354"
+### Community 356 - "Community 356"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 355 - "Community 355"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 356 - "Community 356"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 357 - "Community 357"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 358 - "Community 358"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 359 - "Community 359"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 358 - "Community 358"
+### Community 360 - "Community 360"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
 
-### Community 359 - "Community 359"
+### Community 361 - "Community 361"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 360 - "Community 360"
-Cohesion: 0.5
-Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
-
-### Community 361 - "Community 361"
-Cohesion: 0.6
-Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
 ### Community 362 - "Community 362"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 363 - "Community 363"
-Cohesion: 0.7
-Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
+Cohesion: 0.5
+Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
 ### Community 364 - "Community 364"
 Cohesion: 0.6
-Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
+Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
 ### Community 365 - "Community 365"
-Cohesion: 0.5
-Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 366 - "Community 366"
 Cohesion: 0.7
-Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
+Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
 ### Community 367 - "Community 367"
+Cohesion: 0.6
+Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
+
+### Community 368 - "Community 368"
+Cohesion: 0.5
+Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+
+### Community 369 - "Community 369"
+Cohesion: 0.7
+Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
+
+### Community 370 - "Community 370"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
 
-### Community 368 - "Community 368"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 369 - "Community 369"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 370 - "Community 370"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 371 - "Community 371"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 372 - "Community 372"
 Cohesion: 0.4
@@ -3610,32 +3612,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 374 - "Community 374"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 375 - "Community 375"
-Cohesion: 0.5
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 376 - "Community 376"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 377 - "Community 377"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
-
-### Community 378 - "Community 378"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 378 - "Community 378"
+Cohesion: 0.5
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 379 - "Community 379"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 380 - "Community 380"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 381 - "Community 381"
 Cohesion: 0.4
@@ -3650,200 +3652,200 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 384 - "Community 384"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 385 - "Community 385"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 386 - "Community 386"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 387 - "Community 387"
+Cohesion: 0.7
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+
+### Community 388 - "Community 388"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 389 - "Community 389"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 387 - "Community 387"
+### Community 390 - "Community 390"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 388 - "Community 388"
+### Community 391 - "Community 391"
 Cohesion: 0.5
 Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
-### Community 389 - "Community 389"
+### Community 392 - "Community 392"
 Cohesion: 0.5
 Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
-### Community 390 - "Community 390"
+### Community 393 - "Community 393"
 Cohesion: 0.5
 Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
 
-### Community 391 - "Community 391"
+### Community 394 - "Community 394"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 392 - "Community 392"
+### Community 395 - "Community 395"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 393 - "Community 393"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 394 - "Community 394"
-Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
-
-### Community 395 - "Community 395"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 396 - "Community 396"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 397 - "Community 397"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 398 - "Community 398"
-Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
-
-### Community 399 - "Community 399"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 399 - "Community 399"
+Cohesion: 0.6
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+
 ### Community 400 - "Community 400"
-Cohesion: 0.7
-Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
+Cohesion: 0.6
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 401 - "Community 401"
-Cohesion: 0.5
-Nodes (2): buildAdminSkuSearchOption(), compactJoin()
+Cohesion: 0.6
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
 ### Community 402 - "Community 402"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 403 - "Community 403"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 404 - "Community 404"
+Cohesion: 0.5
+Nodes (2): buildAdminSkuSearchOption(), compactJoin()
+
+### Community 405 - "Community 405"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 405 - "Community 405"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
-
 ### Community 406 - "Community 406"
-Cohesion: 0.5
-Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 407 - "Community 407"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 408 - "Community 408"
+Cohesion: 0.5
+Nodes (2): completePendingAuthSync(), sleep()
+
+### Community 409 - "Community 409"
+Cohesion: 0.5
+Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+
+### Community 410 - "Community 410"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 411 - "Community 411"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 409 - "Community 409"
+### Community 412 - "Community 412"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 410 - "Community 410"
+### Community 413 - "Community 413"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
-### Community 411 - "Community 411"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 412 - "Community 412"
-Cohesion: 0.6
-Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
-
-### Community 413 - "Community 413"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 414 - "Community 414"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 415 - "Community 415"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+Cohesion: 0.6
+Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
 ### Community 416 - "Community 416"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 417 - "Community 417"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 418 - "Community 418"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 419 - "Community 419"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 420 - "Community 420"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 421 - "Community 421"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 420 - "Community 420"
+### Community 422 - "Community 422"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 421 - "Community 421"
+### Community 423 - "Community 423"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 422 - "Community 422"
+### Community 424 - "Community 424"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 423 - "Community 423"
+### Community 425 - "Community 425"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 424 - "Community 424"
+### Community 426 - "Community 426"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 425 - "Community 425"
+### Community 427 - "Community 427"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 426 - "Community 426"
+### Community 428 - "Community 428"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
 
-### Community 427 - "Community 427"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 428 - "Community 428"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 429 - "Community 429"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 430 - "Community 430"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 431 - "Community 431"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 432 - "Community 432"
-Cohesion: 0.67
-Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 433 - "Community 433"
 Cohesion: 0.5
@@ -3851,15 +3853,15 @@ Nodes (0):
 
 ### Community 434 - "Community 434"
 Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
+Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
 ### Community 435 - "Community 435"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 436 - "Community 436"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 437 - "Community 437"
 Cohesion: 0.5
@@ -3874,48 +3876,48 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 440 - "Community 440"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
-
-### Community 441 - "Community 441"
-Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
-
-### Community 442 - "Community 442"
-Cohesion: 0.67
-Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
-
-### Community 443 - "Community 443"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 441 - "Community 441"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 442 - "Community 442"
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+
+### Community 443 - "Community 443"
+Cohesion: 0.67
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+
 ### Community 444 - "Community 444"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
 ### Community 445 - "Community 445"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 446 - "Community 446"
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 447 - "Community 447"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 447 - "Community 447"
+### Community 448 - "Community 448"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 449 - "Community 449"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 448 - "Community 448"
+### Community 450 - "Community 450"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
-
-### Community 449 - "Community 449"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 450 - "Community 450"
-Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 451 - "Community 451"
 Cohesion: 0.5
@@ -3923,27 +3925,27 @@ Nodes (0):
 
 ### Community 452 - "Community 452"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 453 - "Community 453"
-Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
-
-### Community 454 - "Community 454"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 454 - "Community 454"
+Cohesion: 0.83
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+
 ### Community 455 - "Community 455"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 456 - "Community 456"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 457 - "Community 457"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 458 - "Community 458"
 Cohesion: 0.5
@@ -3954,24 +3956,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 460 - "Community 460"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 461 - "Community 461"
 Cohesion: 0.67
 Nodes (2): buildCtx(), buildQueryCtx()
 
-### Community 461 - "Community 461"
+### Community 462 - "Community 462"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 462 - "Community 462"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
 
 ### Community 463 - "Community 463"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 464 - "Community 464"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 465 - "Community 465"
 Cohesion: 0.5
@@ -3986,36 +3988,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 468 - "Community 468"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 469 - "Community 469"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 469 - "Community 469"
+### Community 470 - "Community 470"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 470 - "Community 470"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 471 - "Community 471"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 472 - "Community 472"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 473 - "Community 473"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 474 - "Community 474"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 475 - "Community 475"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 476 - "Community 476"
 Cohesion: 0.5
@@ -4026,36 +4028,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 478 - "Community 478"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 479 - "Community 479"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 479 - "Community 479"
+### Community 480 - "Community 480"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 480 - "Community 480"
+### Community 481 - "Community 481"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
-### Community 481 - "Community 481"
+### Community 482 - "Community 482"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 482 - "Community 482"
-Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 483 - "Community 483"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 484 - "Community 484"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 485 - "Community 485"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 486 - "Community 486"
 Cohesion: 0.5
@@ -4086,12 +4088,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 493 - "Community 493"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
-
-### Community 494 - "Community 494"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 494 - "Community 494"
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 495 - "Community 495"
 Cohesion: 0.5
@@ -4102,12 +4104,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 497 - "Community 497"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 498 - "Community 498"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 498 - "Community 498"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 499 - "Community 499"
 Cohesion: 0.5
@@ -4118,120 +4120,120 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 501 - "Community 501"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 502 - "Community 502"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 502 - "Community 502"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 503 - "Community 503"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 504 - "Community 504"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 505 - "Community 505"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 506 - "Community 506"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 507 - "Community 507"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 508 - "Community 508"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 508 - "Community 508"
+### Community 509 - "Community 509"
 Cohesion: 0.67
 Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
-### Community 509 - "Community 509"
+### Community 510 - "Community 510"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 510 - "Community 510"
+### Community 511 - "Community 511"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 511 - "Community 511"
+### Community 512 - "Community 512"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 512 - "Community 512"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 513 - "Community 513"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 514 - "Community 514"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 515 - "Community 515"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 516 - "Community 516"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 517 - "Community 517"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 517 - "Community 517"
+### Community 518 - "Community 518"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 518 - "Community 518"
+### Community 519 - "Community 519"
 Cohesion: 0.83
 Nodes (3): completedEvent(), event(), item()
 
-### Community 519 - "Community 519"
+### Community 520 - "Community 520"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 520 - "Community 520"
+### Community 521 - "Community 521"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 521 - "Community 521"
+### Community 522 - "Community 522"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
-
-### Community 522 - "Community 522"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 523 - "Community 523"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 524 - "Community 524"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 525 - "Community 525"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 525 - "Community 525"
+### Community 526 - "Community 526"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 526 - "Community 526"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 527 - "Community 527"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 528 - "Community 528"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 529 - "Community 529"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 530 - "Community 530"
 Cohesion: 0.5
@@ -4262,63 +4264,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 537 - "Community 537"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 538 - "Community 538"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 539 - "Community 539"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 540 - "Community 540"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 540 - "Community 540"
+### Community 541 - "Community 541"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 541 - "Community 541"
+### Community 542 - "Community 542"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 542 - "Community 542"
+### Community 543 - "Community 543"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 543 - "Community 543"
+### Community 544 - "Community 544"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 544 - "Community 544"
+### Community 545 - "Community 545"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 545 - "Community 545"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 546 - "Community 546"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 547 - "Community 547"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 548 - "Community 548"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 548 - "Community 548"
+### Community 549 - "Community 549"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 549 - "Community 549"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 550 - "Community 550"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 551 - "Community 551"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 552 - "Community 552"
@@ -4326,12 +4328,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 553 - "Community 553"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 554 - "Community 554"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 554 - "Community 554"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 555 - "Community 555"
 Cohesion: 0.67
@@ -4390,32 +4392,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 569 - "Community 569"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 570 - "Community 570"
 Cohesion: 1.0
-Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 571 - "Community 571"
 Cohesion: 1.0
-Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
 ### Community 572 - "Community 572"
 Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
+Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 573 - "Community 573"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 574 - "Community 574"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 575 - "Community 575"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 576 - "Community 576"
 Cohesion: 0.67
@@ -4430,12 +4432,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 579 - "Community 579"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 580 - "Community 580"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 580 - "Community 580"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 581 - "Community 581"
 Cohesion: 0.67
@@ -4458,12 +4460,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 586 - "Community 586"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 587 - "Community 587"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 587 - "Community 587"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 588 - "Community 588"
 Cohesion: 0.67
@@ -4478,16 +4480,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 591 - "Community 591"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 592 - "Community 592"
 Cohesion: 1.0
-Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 593 - "Community 593"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
 
 ### Community 594 - "Community 594"
 Cohesion: 0.67
@@ -4498,28 +4500,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 596 - "Community 596"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 597 - "Community 597"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 598 - "Community 598"
 Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 599 - "Community 599"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 600 - "Community 600"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 601 - "Community 601"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 601 - "Community 601"
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 602 - "Community 602"
 Cohesion: 0.67
@@ -4527,11 +4529,11 @@ Nodes (0):
 
 ### Community 603 - "Community 603"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 604 - "Community 604"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 605 - "Community 605"
 Cohesion: 0.67
@@ -4546,12 +4548,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 608 - "Community 608"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 609 - "Community 609"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 609 - "Community 609"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 610 - "Community 610"
 Cohesion: 0.67
@@ -4570,28 +4572,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 614 - "Community 614"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 615 - "Community 615"
 Cohesion: 1.0
 Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
-### Community 615 - "Community 615"
-Cohesion: 0.67
-Nodes (1): FadeIn()
-
 ### Community 616 - "Community 616"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 617 - "Community 617"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 618 - "Community 618"
-Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
-
-### Community 619 - "Community 619"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 619 - "Community 619"
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 620 - "Community 620"
 Cohesion: 0.67
@@ -4599,15 +4601,15 @@ Nodes (0):
 
 ### Community 621 - "Community 621"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 622 - "Community 622"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
 
 ### Community 623 - "Community 623"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 624 - "Community 624"
 Cohesion: 0.67
@@ -4618,16 +4620,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 626 - "Community 626"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 627 - "Community 627"
 Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 628 - "Community 628"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 629 - "Community 629"
 Cohesion: 0.67
@@ -4662,12 +4664,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 637 - "Community 637"
-Cohesion: 1.0
-Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
-
-### Community 638 - "Community 638"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 638 - "Community 638"
+Cohesion: 1.0
+Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
 
 ### Community 639 - "Community 639"
 Cohesion: 0.67
@@ -4687,79 +4689,79 @@ Nodes (0):
 
 ### Community 643 - "Community 643"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 644 - "Community 644"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 645 - "Community 645"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 646 - "Community 646"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 647 - "Community 647"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 648 - "Community 648"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 649 - "Community 649"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 650 - "Community 650"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 651 - "Community 651"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 651 - "Community 651"
+### Community 652 - "Community 652"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 652 - "Community 652"
+### Community 653 - "Community 653"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 653 - "Community 653"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 654 - "Community 654"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 655 - "Community 655"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 656 - "Community 656"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 657 - "Community 657"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 658 - "Community 658"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 659 - "Community 659"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 660 - "Community 660"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 661 - "Community 661"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 662 - "Community 662"
 Cohesion: 0.67
@@ -4791,11 +4793,11 @@ Nodes (0):
 
 ### Community 669 - "Community 669"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 670 - "Community 670"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 671 - "Community 671"
 Cohesion: 0.67
@@ -4826,48 +4828,48 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 678 - "Community 678"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 679 - "Community 679"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 679 - "Community 679"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 680 - "Community 680"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 681 - "Community 681"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 682 - "Community 682"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 683 - "Community 683"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 683 - "Community 683"
+### Community 684 - "Community 684"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 684 - "Community 684"
-Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 685 - "Community 685"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 686 - "Community 686"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 687 - "Community 687"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 688 - "Community 688"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 688 - "Community 688"
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 689 - "Community 689"
 Cohesion: 0.67
@@ -4894,76 +4896,76 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 695 - "Community 695"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 696 - "Community 696"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 697 - "Community 697"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 698 - "Community 698"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 699 - "Community 699"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 700 - "Community 700"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 701 - "Community 701"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 702 - "Community 702"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 703 - "Community 703"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 704 - "Community 704"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 705 - "Community 705"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 706 - "Community 706"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 707 - "Community 707"
 Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 708 - "Community 708"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 709 - "Community 709"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 710 - "Community 710"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 711 - "Community 711"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 712 - "Community 712"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 713 - "Community 713"
 Cohesion: 0.67
@@ -4978,12 +4980,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 716 - "Community 716"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 717 - "Community 717"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 717 - "Community 717"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 718 - "Community 718"
 Cohesion: 0.67
@@ -4994,12 +4996,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 720 - "Community 720"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 721 - "Community 721"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 721 - "Community 721"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 722 - "Community 722"
 Cohesion: 0.67
@@ -5066,16 +5068,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 738 - "Community 738"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 739 - "Community 739"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 740 - "Community 740"
+### Community 739 - "Community 739"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 740 - "Community 740"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 741 - "Community 741"
 Cohesion: 1.0
@@ -5090,24 +5092,24 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 744 - "Community 744"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
+
+### Community 745 - "Community 745"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 745 - "Community 745"
+### Community 746 - "Community 746"
 Cohesion: 1.0
 Nodes (2): gitFixtureEnv(), runGit()
 
-### Community 746 - "Community 746"
+### Community 747 - "Community 747"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 747 - "Community 747"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
-
 ### Community 748 - "Community 748"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 749 - "Community 749"
 Cohesion: 1.0
@@ -6223,11 +6225,11 @@ Nodes (0):
 
 ### Community 1027 - "Community 1027"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1028 - "Community 1028"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1029 - "Community 1029"
 Cohesion: 1.0
@@ -10417,366 +10419,374 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2076 - "Community 2076"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2077 - "Community 2077"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 748`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 749`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 750`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 751`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 752`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 753`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 754`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 755`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 756`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 757`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 758`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 759`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 760`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 761`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 762`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 763`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 764`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 765`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 766`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 767`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 768`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 769`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 770`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 771`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 772`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 773`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 774`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 775`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 776`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 777`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 778`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 779`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 780`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 781`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 782`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 783`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 784`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 785`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 786`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 787`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 788`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 789`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 790`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 791`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 792`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 793`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 794`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 795`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 796`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 797`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 798`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 799`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 800`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 801`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 802`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 803`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 804`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 805`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
+- **Thin community `Community 806`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 807`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 808`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 809`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 810`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 811`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 812`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 813`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 814`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 815`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 816`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 817`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 818`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 819`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 820`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 821`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 822`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 823`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 824`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 825`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 826`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 827`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 828`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 829`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 830`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 831`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 832`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 833`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 834`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 835`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 836`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 837`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 838`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 839`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 840`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 841`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 842`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 843`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 844`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 845`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 846`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 847`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 848`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 849`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 850`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 851`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 852`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 853`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 854`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 855`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 856`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 857`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 858`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 859`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 860`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 861`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 862`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 863`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 864`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 865`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 866`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 867`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 868`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 869`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 870`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 871`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 872`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 873`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 874`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 875`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 876`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 877`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 878`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 879`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 880`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 881`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 882`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 883`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 884`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 885`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 886`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 887`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 888`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 889`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 890`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 891`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 892`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 893`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 894`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 895`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `getTodayRefreshCalls()`, `DailyOperationsView.test.tsx`
+- **Thin community `Community 896`** (2 nodes): `getTodayRefreshCalls()`, `DailyOperationsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 897`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 898`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 899`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 900`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 901`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 902`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 903`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 904`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 905`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 906`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 907`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 908`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 909`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 910`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 911`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
+- **Thin community `Community 912`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 913`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 914`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 915`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 916`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 917`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 918`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 919`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 920`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 921`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 922`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 923`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 924`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 925`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 926`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 927`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -10812,2303 +10822,2305 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 928`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 929`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 930`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 931`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 932`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 933`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 934`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 935`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 936`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 937`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
+- **Thin community `Community 938`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 939`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 940`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 941`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 942`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 943`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 944`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 945`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 946`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 947`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 948`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 949`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 950`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 951`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 952`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 953`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 954`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 955`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 956`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 957`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 958`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 959`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 960`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 961`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 962`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 963`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 964`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 965`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 966`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 967`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 968`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 969`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 970`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 971`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 972`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 973`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 974`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 975`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 976`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 977`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 978`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 979`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 980`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 981`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 982`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 983`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 984`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 985`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 986`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 987`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 988`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 989`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 990`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 991`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 992`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 993`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 994`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 995`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 996`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 997`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 998`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 999`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 1000`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 1001`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1002`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1003`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1004`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1005`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1006`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1007`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1008`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1009`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1010`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1011`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1012`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1013`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1014`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1015`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1016`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1017`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1018`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1019`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1020`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1021`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1022`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1023`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1024`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1025`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1026`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1027`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1028`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1029`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1030`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1031`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1032`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1033`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1034`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1035`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1036`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1037`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1038`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1039`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1040`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1041`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1042`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1043`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1044`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1045`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1046`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
+- **Thin community `Community 1047`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1048`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1049`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1050`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1051`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
+- **Thin community `Community 1052`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1053`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1054`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1055`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1056`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1057`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1058`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1059`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1060`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1061`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1062`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1063`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1064`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `Index()`, `-index-route-view.tsx`
+- **Thin community `Community 1065`** (2 nodes): `Index()`, `-index-route-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1066`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1067`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1068`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1069`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1070`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1071`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1072`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1073`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1074`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
+- **Thin community `Community 1075`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1076`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1077`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1078`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1079`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1080`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1081`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1082`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1083`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1084`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1085`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1086`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1087`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1088`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1089`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1090`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1091`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1092`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1093`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1094`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1095`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1096`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1097`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1098`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1099`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1100`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1101`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1102`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1103`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1104`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1105`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1106`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1107`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1108`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1109`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1110`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1111`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1112`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1113`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1114`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1115`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1116`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1117`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1118`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1119`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1120`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1121`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1122`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1123`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1124`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1125`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1126`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1127`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1128`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1129`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1130`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1131`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1132`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1133`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1134`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1135`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1136`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1137`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1138`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1139`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1140`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1141`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1142`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1143`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1144`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1145`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1146`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1147`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1148`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1149`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1150`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1151`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1152`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1153`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1154`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1155`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1156`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1157`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1158`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1159`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1160`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1161`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1162`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1163`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1164`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1165`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1166`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1167`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1168`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1169`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1170`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1171`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1172`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1173`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1174`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1175`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1176`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1177`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1178`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1179`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1180`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1181`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1182`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1183`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1184`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1185`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1186`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1187`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1188`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1189`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1190`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1191`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1192`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1193`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1194`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1195`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1196`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1197`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1198`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1199`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1200`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1201`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1202`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1203`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1204`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1205`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1206`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1207`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1208`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1209`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1210`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1211`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1212`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1213`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1214`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1215`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1216`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1217`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1218`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1219`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1220`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `api.js`
+- **Thin community `Community 1221`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1222`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1223`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `server.js`
+- **Thin community `Community 1224`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `app.ts`
+- **Thin community `Community 1225`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1226`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1227`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1228`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1229`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `auth.ts`
+- **Thin community `Community 1230`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1231`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1232`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1233`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `countries.ts`
+- **Thin community `Community 1234`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `email.ts`
+- **Thin community `Community 1235`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1236`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `payment.ts`
+- **Thin community `Community 1237`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `contextEvents.test.ts`
+- **Thin community `Community 1238`** (1 nodes): `contextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1239`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `types.ts`
+- **Thin community `Community 1240`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1241`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `crons.ts`
+- **Thin community `Community 1242`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1243`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `internal.ts`
+- **Thin community `Community 1244`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1245`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1246`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1247`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1248`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1249`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1250`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1251`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1252`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1253`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1254`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1255`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `env.ts`
+- **Thin community `Community 1256`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1257`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `auth.ts`
+- **Thin community `Community 1258`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1259`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `colors.ts`
+- **Thin community `Community 1260`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `index.ts`
+- **Thin community `Community 1261`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1262`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `products.ts`
+- **Thin community `Community 1263`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1264`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `stores.ts`
+- **Thin community `Community 1265`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1266`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `bag.ts`
+- **Thin community `Community 1267`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `guest.ts`
+- **Thin community `Community 1268`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1269`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `index.ts`
+- **Thin community `Community 1270`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `me.ts`
+- **Thin community `Community 1271`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `offers.ts`
+- **Thin community `Community 1272`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1273`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1274`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1275`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1276`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1277`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1278`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1279`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1280`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1281`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `user.ts`
+- **Thin community `Community 1282`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1283`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `index.ts`
+- **Thin community `Community 1284`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1285`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `http.ts`
+- **Thin community `Community 1286`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `access.ts`
+- **Thin community `Community 1287`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1288`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1289`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1290`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `index.ts`
+- **Thin community `Community 1291`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1292`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `types.ts`
+- **Thin community `Community 1293`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1294`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `categories.ts`
+- **Thin community `Community 1295`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `colors.ts`
+- **Thin community `Community 1296`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1297`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1298`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1299`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1300`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `pos.ts`
+- **Thin community `Community 1301`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1302`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1303`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1304`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1305`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1306`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1307`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1308`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1309`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1310`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1311`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1312`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1313`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1314`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1315`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1316`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1317`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1318`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `types.ts`
+- **Thin community `Community 1319`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1320`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1321`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1322`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1323`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1324`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1325`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `dto.ts`
+- **Thin community `Community 1326`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1327`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1328`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1329`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
+- **Thin community `Community 1330`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `types.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `facts.ts`
+- **Thin community `Community 1331`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1332`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `types.ts`
+- **Thin community `Community 1333`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1334`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1335`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1336`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `customers.ts`
+- **Thin community `Community 1337`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `register.test.ts`
+- **Thin community `Community 1338`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `register.ts`
+- **Thin community `Community 1339`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `sync.ts`
+- **Thin community `Community 1340`** (1 nodes): `register.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1341`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1342`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1343`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `schema.ts`
+- **Thin community `Community 1344`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `automation.ts`
+- **Thin community `Community 1345`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1346`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1347`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `index.ts`
+- **Thin community `Community 1348`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1349`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1350`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1351`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1352`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1353`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1354`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1355`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `category.ts`
+- **Thin community `Community 1356`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `color.ts`
+- **Thin community `Community 1357`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1358`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1359`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `index.ts`
+- **Thin community `Community 1360`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1361`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1362`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1363`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1364`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `organization.ts`
+- **Thin community `Community 1365`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1366`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `product.ts`
+- **Thin community `Community 1367`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1368`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1369`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1370`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `store.ts`
+- **Thin community `Community 1371`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1372`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1373`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `index.ts`
+- **Thin community `Community 1374`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1375`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1376`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1377`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1378`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1379`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1380`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1381`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `index.ts`
+- **Thin community `Community 1382`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1383`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1384`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1385`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1386`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1387`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1388`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1389`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1390`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1391`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1392`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1393`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `customer.ts`
+- **Thin community `Community 1394`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1395`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1396`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1397`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1398`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `index.ts`
+- **Thin community `Community 1399`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1400`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1401`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1402`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1403`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1404`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1405`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1406`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1407`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1408`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1409`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1410`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1411`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1412`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1413`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1414`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1415`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1416`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1417`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1418`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `index.ts`
+- **Thin community `Community 1419`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1420`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1421`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `index.ts`
+- **Thin community `Community 1422`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1423`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1424`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1425`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1426`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1427`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1428`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `index.ts`
+- **Thin community `Community 1429`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1430`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1431`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1432`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1433`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1434`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1435`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `bag.ts`
+- **Thin community `Community 1436`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1437`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1438`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1439`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `guest.ts`
+- **Thin community `Community 1440`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `index.ts`
+- **Thin community `Community 1441`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `offer.ts`
+- **Thin community `Community 1442`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1443`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1444`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `review.ts`
+- **Thin community `Community 1445`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1446`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1447`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1448`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1449`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1450`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1451`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1452`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1453`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1454`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `bag.ts`
+- **Thin community `Community 1455`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1456`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `customer.ts`
+- **Thin community `Community 1457`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `guest.ts`
+- **Thin community `Community 1458`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1459`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1460`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1461`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1462`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1463`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1464`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1465`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `users.ts`
+- **Thin community `Community 1466`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `payment.ts`
+- **Thin community `Community 1467`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1468`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1469`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1470`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1471`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1472`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1473`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1474`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `index.ts`
+- **Thin community `Community 1475`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1476`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1477`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1478`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1479`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `auth.ts`
+- **Thin community `Community 1480`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1481`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1482`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1483`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1484`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1485`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1486`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1487`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `index.ts`
+- **Thin community `Community 1488`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1489`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1490`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1491`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1492`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1493`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1494`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1495`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1496`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1497`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1498`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1499`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1500`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1501`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1502`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1503`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1504`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1505`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1506`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1507`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1508`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1509`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `constants.ts`
+- **Thin community `Community 1510`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1511`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1512`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1513`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `types.ts`
+- **Thin community `Community 1514`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1515`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1516`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1517`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1518`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1519`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1520`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1521`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1522`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1523`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1524`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1525`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1526`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1527`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1528`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1529`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1530`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1531`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1532`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1533`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1534`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `constants.ts`
+- **Thin community `Community 1535`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1536`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1537`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1538`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `data.ts`
+- **Thin community `Community 1539`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1540`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1541`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1542`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1543`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1544`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1545`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1546`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1547`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `app-sidebar.test.tsx`
+- **Thin community `Community 1548`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1549`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `constants.ts`
+- **Thin community `Community 1550`** (1 nodes): `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1551`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1552`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1553`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `data.ts`
+- **Thin community `Community 1554`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1555`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1556`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1557`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1558`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1559`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1560`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1561`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1562`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1563`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1564`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1565`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1566`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `constants.ts`
+- **Thin community `Community 1567`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1568`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1569`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1570`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1571`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1572`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1573`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1574`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1575`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1576`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1577`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1578`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1579`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1580`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1581`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1582`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1583`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1584`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1585`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1586`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1587`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1588`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1589`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1590`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `OperationReviewItemCard.tsx`
+- **Thin community `Community 1591`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1592`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1593`** (1 nodes): `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1594`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1595`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1596`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1597`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1598`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1599`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1600`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1601`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1602`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `constants.ts`
+- **Thin community `Community 1603`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1604`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1605`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1606`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `data.ts`
+- **Thin community `Community 1607`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1608`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1609`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `constants.ts`
+- **Thin community `Community 1610`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1611`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1612`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1613`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1614`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `data.ts`
+- **Thin community `Community 1615`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1616`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `constants.ts`
+- **Thin community `Community 1617`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1618`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1619`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1620`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1621`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `data.ts`
+- **Thin community `Community 1622`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1623`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1624`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1625`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1626`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1627`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1628`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1629`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1630`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1631`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1632`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1633`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1634`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1635`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1636`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1637`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1638`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1639`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1640`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1641`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1642`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1643`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1644`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1645`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1646`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1647`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1648`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1649`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1650`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `types.ts`
+- **Thin community `Community 1651`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1652`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1653`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1654`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1655`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1656`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1657`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1658`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1659`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 1660`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1661`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1662`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1663`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1664`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1665`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1666`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1667`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1668`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1669`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `data.ts`
+- **Thin community `Community 1670`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1671`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1672`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1673`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1674`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1675`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1676`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1677`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1678`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1679`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1680`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1681`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1682`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `constants.ts`
+- **Thin community `Community 1683`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1684`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1685`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1686`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `data.ts`
+- **Thin community `Community 1687`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `types.ts`
+- **Thin community `Community 1688`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1689`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1690`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1691`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1692`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1693`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `index.ts`
+- **Thin community `Community 1694`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1695`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1696`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1697`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1698`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `index.tsx`
+- **Thin community `Community 1699`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1700`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1701`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1702`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1703`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1704`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1705`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1706`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `StoreHoursView.test.tsx`
+- **Thin community `Community 1707`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1708`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 1709`** (1 nodes): `StoreHoursView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `index.tsx`
+- **Thin community `Community 1710`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1711`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1712`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1713`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `button.tsx`
+- **Thin community `Community 1714`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1715`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `card.tsx`
+- **Thin community `Community 1716`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1717`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1718`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `command.tsx`
+- **Thin community `Community 1719`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1720`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1721`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1722`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `form.tsx`
+- **Thin community `Community 1723`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1724`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1725`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `input.tsx`
+- **Thin community `Community 1726`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1727`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1728`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1729`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1730`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1731`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1732`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `select.tsx`
+- **Thin community `Community 1733`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1734`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1735`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1736`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1737`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `table.tsx`
+- **Thin community `Community 1738`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1739`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1740`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1741`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1742`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1743`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1744`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1745`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1746`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `constants.ts`
+- **Thin community `Community 1747`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1748`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1749`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1750`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `data.ts`
+- **Thin community `Community 1751`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1752`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1753`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1754`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1755`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1756`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1757`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1758`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1759`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1760`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1761`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `index.ts`
+- **Thin community `Community 1762`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1763`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1764`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1765`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 1766`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1767`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1768`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1769`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1770`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1771`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1772`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 1773`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1774`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1775`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 1776`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 1777`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `index.ts`
+- **Thin community `Community 1778`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 1779`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1780`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 1781`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 1782`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `aws.ts`
+- **Thin community `Community 1783`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `constants.ts`
+- **Thin community `Community 1784`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `countries.ts`
+- **Thin community `Community 1785`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1786`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1787`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1788`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1789`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1790`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1791`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1792`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 1793`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `dto.ts`
+- **Thin community `Community 1794`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `ports.ts`
+- **Thin community `Community 1795`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `constants.ts`
+- **Thin community `Community 1796`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1797`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1798`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `index.ts`
+- **Thin community `Community 1799`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1800`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `types.ts`
+- **Thin community `Community 1801`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1802`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1803`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1804`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1805`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1806`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1807`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1808`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1809`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1810`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 1811`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 1812`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 1813`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 1814`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 1815`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1816`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1817`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1818`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1819`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `index.ts`
+- **Thin community `Community 1820`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1821`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `category.ts`
+- **Thin community `Community 1822`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `product.ts`
+- **Thin community `Community 1823`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `store.ts`
+- **Thin community `Community 1824`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1825`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `user.ts`
+- **Thin community `Community 1826`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1827`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1828`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1829`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1830`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1831`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `main.tsx`
+- **Thin community `Community 1832`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 1833`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1834`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1835`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1836`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1837`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1838`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `index.tsx`
+- **Thin community `Community 1839`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `index.tsx`
+- **Thin community `Community 1840`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1841`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1842`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1843`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1844`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1845`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1846`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `index.tsx`
+- **Thin community `Community 1847`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1848`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1849`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1850`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `home.tsx`
+- **Thin community `Community 1851`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1852`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1853`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1854`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `index.tsx`
+- **Thin community `Community 1855`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `review.tsx`
+- **Thin community `Community 1856`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1857`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1858`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `index.tsx`
+- **Thin community `Community 1859`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1860`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1861`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1862`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `index.tsx`
+- **Thin community `Community 1863`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1864`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1865`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1866`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1867`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1868`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1869`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 1870`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `index.tsx`
+- **Thin community `Community 1871`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1872`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1873`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1874`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1875`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1876`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1877`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1878`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1879`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1880`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `index.tsx`
+- **Thin community `Community 1881`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1882`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1883`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `new.tsx`
+- **Thin community `Community 1884`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1885`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1886`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1887`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1888`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `index.tsx`
+- **Thin community `Community 1889`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `new.tsx`
+- **Thin community `Community 1890`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1891`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1892`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1893`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1894`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1895`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `index.tsx`
+- **Thin community `Community 1896`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1897`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1898`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1899`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `index.tsx`
+- **Thin community `Community 1900`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1901`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `_authed.tsx`
+- **Thin community `Community 1902`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1903`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `index.tsx`
+- **Thin community `Community 1904`** (1 nodes): `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1905`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1906`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1907`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 1908`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1909`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 1910`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1911`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 1912`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1913`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1914`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1915`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1916`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1917`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1918`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1919`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1920`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1921`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1922`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1923`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1924`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1925`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1926`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1927`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1928`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `setup.ts`
+- **Thin community `Community 1929`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1930`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `types.ts`
+- **Thin community `Community 1931`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1932`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1933`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1934`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1935`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1936`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1937`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1938`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `types.ts`
+- **Thin community `Community 1939`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1940`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1941`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1942`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1943`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1944`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1945`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1946`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1947`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `schema.ts`
+- **Thin community `Community 1948`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1949`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1950`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1951`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1952`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1953`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1954`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1955`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1956`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1957`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `types.ts`
+- **Thin community `Community 1958`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1959`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1960`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1961`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1962`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1963`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1964`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1965`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `constants.ts`
+- **Thin community `Community 1966`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1967`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `About.tsx`
+- **Thin community `Community 1968`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1969`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1970`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1971`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1972`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1973`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1974`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1975`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1976`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1977`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1978`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `types.ts`
+- **Thin community `Community 1979`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1980`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1981`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1982`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1983`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1984`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1985`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1986`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1987`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1988`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1989`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1990`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `button.tsx`
+- **Thin community `Community 1991`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `card.tsx`
+- **Thin community `Community 1992`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1993`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `command.tsx`
+- **Thin community `Community 1994`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1995`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1996`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1997`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `form.tsx`
+- **Thin community `Community 1998`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1999`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2000`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2001`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2002`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `input.tsx`
+- **Thin community `Community 2003`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `label.tsx`
+- **Thin community `Community 2004`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2005`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2006`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2007`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `index.ts`
+- **Thin community `Community 2008`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `types.ts`
+- **Thin community `Community 2009`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2010`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2011`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2012`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2013`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `select.tsx`
+- **Thin community `Community 2014`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2015`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2016`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `table.tsx`
+- **Thin community `Community 2017`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2018`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2019`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2020`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2021`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2022`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `config.ts`
+- **Thin community `Community 2023`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2024`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2025`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2026`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2027`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2028`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `constants.ts`
+- **Thin community `Community 2029`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `countries.ts`
+- **Thin community `Community 2030`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2031`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2032`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2033`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2034`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `index.ts`
+- **Thin community `Community 2035`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2036`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `store.ts`
+- **Thin community `Community 2037`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `bag.ts`
+- **Thin community `Community 2038`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2039`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `category.ts`
+- **Thin community `Community 2040`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `organization.ts`
+- **Thin community `Community 2041`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `product.ts`
+- **Thin community `Community 2042`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `store.ts`
+- **Thin community `Community 2043`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2044`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `user.ts`
+- **Thin community `Community 2045`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `states.ts`
+- **Thin community `Community 2046`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2047`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2048`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2049`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2050`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2051`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2052`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2053`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2054`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `index.tsx`
+- **Thin community `Community 2055`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2056`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2056`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2057`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2058`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2058`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2059`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2059`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2060`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2060`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2061`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2061`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2062`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2062`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2063`** (1 nodes): `index.tsx`
+- **Thin community `Community 2063`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2064`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2064`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2065`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2065`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2066`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2066`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2067`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2067`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2068`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2068`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2069`** (1 nodes): `index.js`
+- **Thin community `Community 2069`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2070`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2070`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2071`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2071`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2072`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2072`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2073`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2073`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2074`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2074`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2075`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2075`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2076`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2077`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2149
-- Graph nodes: 8366
-- Graph edges: 10002
-- Communities: 2076
+- Code files discovered: 2151
+- Graph nodes: 8370
+- Graph edges: 10004
+- Communities: 2078
 
 ## Graph Hotspots
 - `dailyClose.ts` (90 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,8 +19,8 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 11) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 11) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 66) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `storefrontContextEvents.ts` (17 edges, Community 82) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
+- `getStoreConfigV2()` (17 edges, Community 65) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storefrontContextEvents.ts` (17 edges, Community 81) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
 - `checkoutSession.ts` (14 edges, Community 98) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 
 ## Navigation

--- a/packages/athena-webapp/convex/_generated/api.d.ts
+++ b/packages/athena-webapp/convex/_generated/api.d.ts
@@ -172,6 +172,7 @@ import type * as operations_operationalEvents from "../operations/operationalEve
 import type * as operations_operationalWorkItems from "../operations/operationalWorkItems.js";
 import type * as operations_paymentAllocations from "../operations/paymentAllocations.js";
 import type * as operations_paymentTotals from "../operations/paymentTotals.js";
+import type * as operations_registerSessionCloseoutGate from "../operations/registerSessionCloseoutGate.js";
 import type * as operations_registerSessionTracing from "../operations/registerSessionTracing.js";
 import type * as operations_registerSessions from "../operations/registerSessions.js";
 import type * as operations_serviceIntake from "../operations/serviceIntake.js";
@@ -596,6 +597,7 @@ declare const fullApi: ApiFromModules<{
   "operations/operationalWorkItems": typeof operations_operationalWorkItems;
   "operations/paymentAllocations": typeof operations_paymentAllocations;
   "operations/paymentTotals": typeof operations_paymentTotals;
+  "operations/registerSessionCloseoutGate": typeof operations_registerSessionCloseoutGate;
   "operations/registerSessionTracing": typeof operations_registerSessionTracing;
   "operations/registerSessions": typeof operations_registerSessions;
   "operations/serviceIntake": typeof operations_serviceIntake;

--- a/packages/athena-webapp/convex/cashControls/closeouts.test.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.test.ts
@@ -303,6 +303,24 @@ describe("cash control closeouts", () => {
         },
       },
     };
+    const submittedApprovalOwnedCloseoutResult = {
+      kind: "ok" as const,
+      data: {
+        action: "submitted" as const,
+        closeoutReview: {
+          hasVariance: true,
+          reason: "Manager signoff is required for any register variance (-100).",
+          requiresApproval: true,
+          variance: -100,
+        },
+        pendingVoidApprovalCount: 1,
+        registerSession: {
+          _id: "session-1",
+          managerApprovalRequestId: "approval-request-1",
+          status: "closing",
+        },
+      },
+    };
     const finalizedCloseoutResult = {
       kind: "ok" as const,
       data: {
@@ -332,6 +350,10 @@ describe("cash control closeouts", () => {
     assertConformsToExportedReturns(
       submitRegisterSessionCloseout,
       submittedCloseoutResult,
+    );
+    assertConformsToExportedReturns(
+      submitRegisterSessionCloseout,
+      submittedApprovalOwnedCloseoutResult,
     );
     assertConformsToExportedReturns(
       finalizeRegisterSessionCloseout,

--- a/packages/athena-webapp/convex/cashControls/closeouts.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.ts
@@ -15,6 +15,12 @@ import {
   reopenRejectedRegisterSessionCloseoutWithCtx,
   resolveRegisterSessionOperatingDateContext,
 } from "../operations/registerSessions";
+import {
+  buildRegisterSessionCloseoutReview,
+  getCashControlsConfig,
+  type CashControlsConfig,
+  type RegisterSessionCloseoutReview,
+} from "../operations/registerSessionCloseoutGate";
 import { recordRegisterSessionTraceBestEffort } from "../operations/registerSessionTracing";
 import { authenticateStaffCredentialWithCtx } from "../operations/staffCredentials";
 import type { OperationalRole } from "../operations/staffRoles";
@@ -40,8 +46,13 @@ import {
 import type { ApprovalRequirement } from "../../shared/approvalPolicy";
 import { formatStaffDisplayName } from "../../shared/staffDisplayName";
 
+export {
+  buildRegisterSessionCloseoutReview,
+  getCashControlsConfig,
+};
+export type { CashControlsConfig, RegisterSessionCloseoutReview };
+
 const CLOSEOUT_SESSION_LIMIT = 100;
-const DEFAULT_VARIANCE_APPROVAL_THRESHOLD = 5000;
 const REGISTER_VARIANCE_REVIEW_ACTION =
   APPROVAL_ACTIONS.registerSessionVarianceReview;
 const REGISTER_VARIANCE_REVIEW_ACTION_KEY = REGISTER_VARIANCE_REVIEW_ACTION.key;
@@ -118,13 +129,6 @@ const userErrorValidator = v.object({
   metadata: v.optional(v.record(v.string(), v.any())),
 });
 
-type CashControlsConfig = {
-  requireManagerSignoffForAnyVariance: boolean;
-  requireManagerSignoffForOvers: boolean;
-  requireManagerSignoffForShorts: boolean;
-  varianceApprovalThreshold: number;
-};
-
 type CloseoutApprovalRequestRecord = Pick<
   Doc<"approvalRequest">,
   | "_id"
@@ -146,8 +150,6 @@ type CloseoutApprovalRequestSummary = {
   requestedByStaffName: string | null;
   status: string;
 };
-
-type RegisterSessionCloseoutReview = ReturnType<typeof buildRegisterSessionCloseoutReview>;
 
 type CloseoutSnapshot = {
   config: CashControlsConfig;
@@ -357,22 +359,6 @@ const correctRegisterSessionOpeningFloatResultValidator = commandResultValidator
   }),
 );
 
-function asRecord(value: unknown): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return {};
-  }
-
-  return value as Record<string, unknown>;
-}
-
-function asBoolean(value: unknown) {
-  return typeof value === "boolean" ? value : undefined;
-}
-
-function asNumber(value: unknown) {
-  return typeof value === "number" ? value : undefined;
-}
-
 function trimOptional(value?: string | null) {
   const nextValue = value?.trim();
   return nextValue ? nextValue : undefined;
@@ -410,79 +396,6 @@ async function persistRegisterSessionWorkflowTraceIdBestEffort(
   } catch (error) {
     console.error("[workflow-trace] register.session.trace.link", error);
   }
-}
-
-export function getCashControlsConfig(store?: { config?: unknown } | null): CashControlsConfig {
-  const operations = asRecord(asRecord(store?.config).operations);
-  const cashControls = asRecord(operations.cashControls);
-  const threshold = asNumber(cashControls.varianceApprovalThreshold);
-
-  return {
-    requireManagerSignoffForAnyVariance:
-      asBoolean(cashControls.requireManagerSignoffForAnyVariance) ?? false,
-    requireManagerSignoffForOvers:
-      asBoolean(cashControls.requireManagerSignoffForOvers) ?? false,
-    requireManagerSignoffForShorts:
-      asBoolean(cashControls.requireManagerSignoffForShorts) ?? false,
-    varianceApprovalThreshold: Math.max(
-      0,
-      threshold ?? DEFAULT_VARIANCE_APPROVAL_THRESHOLD
-    ),
-  };
-}
-
-export function buildRegisterSessionCloseoutReview(args: {
-  countedCash: number;
-  expectedCash: number;
-  config: CashControlsConfig;
-}) {
-  const variance = args.countedCash - args.expectedCash;
-  const hasVariance = variance !== 0;
-  const isOver = variance > 0;
-  const isShort = variance < 0;
-  const exceedsThreshold =
-    Math.abs(variance) > args.config.varianceApprovalThreshold;
-  const requiresApproval =
-    (hasVariance && args.config.requireManagerSignoffForAnyVariance) ||
-    (isOver && args.config.requireManagerSignoffForOvers) ||
-    (isShort && args.config.requireManagerSignoffForShorts) ||
-    exceedsThreshold;
-
-  if (!requiresApproval) {
-    return {
-      hasVariance,
-      reason: undefined,
-      requiresApproval: false as const,
-      variance,
-    };
-  }
-
-  if (exceedsThreshold) {
-    return {
-      hasVariance,
-      reason: `Variance of ${variance} exceeded the closeout approval threshold.`,
-      requiresApproval: true as const,
-      variance,
-    };
-  }
-
-  if (args.config.requireManagerSignoffForAnyVariance) {
-    return {
-      hasVariance,
-      reason: `Manager signoff is required for any register variance (${variance}).`,
-      requiresApproval: true as const,
-      variance,
-    };
-  }
-
-  return {
-    hasVariance,
-    reason: isOver
-      ? `Manager signoff is required for register overages (${variance}).`
-      : `Manager signoff is required for register shortages (${variance}).`,
-    requiresApproval: true as const,
-    variance,
-  };
 }
 
 export function buildRegisterSessionVarianceApprovalRequirement(args: {

--- a/packages/athena-webapp/convex/operations/registerSessionCloseoutGate.test.ts
+++ b/packages/athena-webapp/convex/operations/registerSessionCloseoutGate.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRegisterSessionCloseoutReview,
+  getCashControlsConfig,
+} from "./registerSessionCloseoutGate";
+
+describe("register session closeout gate", () => {
+  it("uses default cash controls config when store config is absent", () => {
+    expect(getCashControlsConfig()).toEqual({
+      requireManagerSignoffForAnyVariance: false,
+      requireManagerSignoffForOvers: false,
+      requireManagerSignoffForShorts: false,
+      varianceApprovalThreshold: 5000,
+    });
+  });
+
+  it("allows exact counts and under-threshold variances by default", () => {
+    expect(
+      buildRegisterSessionCloseoutReview({
+        config: getCashControlsConfig(),
+        countedCash: 10000,
+        expectedCash: 10000,
+      }),
+    ).toEqual({
+      hasVariance: false,
+      reason: undefined,
+      requiresApproval: false,
+      variance: 0,
+    });
+
+    expect(
+      buildRegisterSessionCloseoutReview({
+        config: getCashControlsConfig(),
+        countedCash: 9800,
+        expectedCash: 10000,
+      }),
+    ).toEqual({
+      hasVariance: true,
+      reason: undefined,
+      requiresApproval: false,
+      variance: -200,
+    });
+  });
+
+  it("requires approval when variance exceeds the configured threshold", () => {
+    expect(
+      buildRegisterSessionCloseoutReview({
+        config: getCashControlsConfig({
+          config: {
+            operations: {
+              cashControls: {
+                varianceApprovalThreshold: 250,
+              },
+            },
+          },
+        }),
+        countedCash: 10300,
+        expectedCash: 10000,
+      }),
+    ).toEqual({
+      hasVariance: true,
+      reason: "Variance of 300 exceeded the closeout approval threshold.",
+      requiresApproval: true,
+      variance: 300,
+    });
+  });
+
+  it("requires approval for any variance when configured", () => {
+    expect(
+      buildRegisterSessionCloseoutReview({
+        config: {
+          ...getCashControlsConfig(),
+          requireManagerSignoffForAnyVariance: true,
+        },
+        countedCash: 9999,
+        expectedCash: 10000,
+      }),
+    ).toEqual({
+      hasVariance: true,
+      reason: "Manager signoff is required for any register variance (-1).",
+      requiresApproval: true,
+      variance: -1,
+    });
+  });
+
+  it("requires approval only for configured overage direction", () => {
+    const config = {
+      ...getCashControlsConfig(),
+      requireManagerSignoffForOvers: true,
+    };
+
+    expect(
+      buildRegisterSessionCloseoutReview({
+        config,
+        countedCash: 10001,
+        expectedCash: 10000,
+      }),
+    ).toEqual({
+      hasVariance: true,
+      reason: "Manager signoff is required for register overages (1).",
+      requiresApproval: true,
+      variance: 1,
+    });
+
+    expect(
+      buildRegisterSessionCloseoutReview({
+        config,
+        countedCash: 9999,
+        expectedCash: 10000,
+      }),
+    ).toEqual({
+      hasVariance: true,
+      reason: undefined,
+      requiresApproval: false,
+      variance: -1,
+    });
+  });
+
+  it("requires approval only for configured shortage direction", () => {
+    const config = {
+      ...getCashControlsConfig(),
+      requireManagerSignoffForShorts: true,
+    };
+
+    expect(
+      buildRegisterSessionCloseoutReview({
+        config,
+        countedCash: 9999,
+        expectedCash: 10000,
+      }),
+    ).toEqual({
+      hasVariance: true,
+      reason: "Manager signoff is required for register shortages (-1).",
+      requiresApproval: true,
+      variance: -1,
+    });
+
+    expect(
+      buildRegisterSessionCloseoutReview({
+        config,
+        countedCash: 10001,
+        expectedCash: 10000,
+      }),
+    ).toEqual({
+      hasVariance: true,
+      reason: undefined,
+      requiresApproval: false,
+      variance: 1,
+    });
+  });
+
+  it("treats rounded zero variance as no-approval", () => {
+    expect(
+      buildRegisterSessionCloseoutReview({
+        config: {
+          ...getCashControlsConfig(),
+          requireManagerSignoffForAnyVariance: true,
+        },
+        countedCash: 10000.4,
+        expectedCash: 10000.49,
+      }),
+    ).toEqual({
+      hasVariance: false,
+      reason: undefined,
+      requiresApproval: false,
+      variance: 0,
+    });
+  });
+});

--- a/packages/athena-webapp/convex/operations/registerSessionCloseoutGate.ts
+++ b/packages/athena-webapp/convex/operations/registerSessionCloseoutGate.ts
@@ -1,0 +1,137 @@
+export const DEFAULT_VARIANCE_APPROVAL_THRESHOLD = 5000;
+
+export type CashControlsConfig = {
+  requireManagerSignoffForAnyVariance: boolean;
+  requireManagerSignoffForOvers: boolean;
+  requireManagerSignoffForShorts: boolean;
+  varianceApprovalThreshold: number;
+};
+
+export type RegisterSessionCloseoutReview = {
+  hasVariance: boolean;
+  reason?: string;
+  requiresApproval: boolean;
+  variance: number;
+};
+
+export type RegisterSessionCloseoutReviewFacts = {
+  countedCash: number;
+  expectedCash: number;
+  localEventId: string;
+  localRegisterSessionId?: string;
+  notes?: string;
+  terminalId: string;
+  variance: number;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function asBoolean(value: unknown) {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function asNumber(value: unknown) {
+  return typeof value === "number" ? value : undefined;
+}
+
+export function getCashControlsConfig(store?: {
+  config?: unknown;
+} | null): CashControlsConfig {
+  const operations = asRecord(asRecord(store?.config).operations);
+  const cashControls = asRecord(operations.cashControls);
+  const threshold = asNumber(cashControls.varianceApprovalThreshold);
+
+  return {
+    requireManagerSignoffForAnyVariance:
+      asBoolean(cashControls.requireManagerSignoffForAnyVariance) ?? false,
+    requireManagerSignoffForOvers:
+      asBoolean(cashControls.requireManagerSignoffForOvers) ?? false,
+    requireManagerSignoffForShorts:
+      asBoolean(cashControls.requireManagerSignoffForShorts) ?? false,
+    varianceApprovalThreshold: Math.max(
+      0,
+      threshold ?? DEFAULT_VARIANCE_APPROVAL_THRESHOLD,
+    ),
+  };
+}
+
+export function buildRegisterSessionCloseoutReview(args: {
+  countedCash: number;
+  expectedCash: number;
+  config: CashControlsConfig;
+}): RegisterSessionCloseoutReview {
+  const roundedVariance = Math.round(args.countedCash - args.expectedCash);
+  const variance = Object.is(roundedVariance, -0) ? 0 : roundedVariance;
+  const hasVariance = variance !== 0;
+  const isOver = variance > 0;
+  const isShort = variance < 0;
+  const exceedsThreshold =
+    Math.abs(variance) > args.config.varianceApprovalThreshold;
+  const requiresApproval =
+    (hasVariance && args.config.requireManagerSignoffForAnyVariance) ||
+    (isOver && args.config.requireManagerSignoffForOvers) ||
+    (isShort && args.config.requireManagerSignoffForShorts) ||
+    exceedsThreshold;
+
+  if (!requiresApproval) {
+    return {
+      hasVariance,
+      reason: undefined,
+      requiresApproval: false,
+      variance,
+    };
+  }
+
+  if (exceedsThreshold) {
+    return {
+      hasVariance,
+      reason: `Variance of ${variance} exceeded the closeout approval threshold.`,
+      requiresApproval: true,
+      variance,
+    };
+  }
+
+  if (args.config.requireManagerSignoffForAnyVariance) {
+    return {
+      hasVariance,
+      reason: `Manager signoff is required for any register variance (${variance}).`,
+      requiresApproval: true,
+      variance,
+    };
+  }
+
+  return {
+    hasVariance,
+    reason: isOver
+      ? `Manager signoff is required for register overages (${variance}).`
+      : `Manager signoff is required for register shortages (${variance}).`,
+    requiresApproval: true,
+    variance,
+  };
+}
+
+export function areRegisterSessionCloseoutReviewFactsEquivalent(
+  metadata: unknown,
+  facts: RegisterSessionCloseoutReviewFacts,
+) {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return false;
+  }
+
+  const record = metadata as Record<string, unknown>;
+  return (
+    record.countedCash === facts.countedCash &&
+    record.expectedCash === facts.expectedCash &&
+    record.variance === facts.variance &&
+    record.notes === facts.notes &&
+    record.localEventId === facts.localEventId &&
+    record.localRegisterSessionId === facts.localRegisterSessionId &&
+    record.terminalId === facts.terminalId
+  );
+}

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
@@ -4250,6 +4250,32 @@ function createFakeSyncRepository(
         ? (existing as never)
         : null;
     },
+    async getApprovalRequest() {
+      return null;
+    },
+    async createOrReuseRegisterSessionVarianceReview(input) {
+      return {
+        status: "ready",
+        approvalRequest: {
+          _id: "approval-request-1",
+          _creationTime: input.closeoutOccurredAt,
+          actionKey: "cash_controls.register_session.variance_review",
+          createdAt: input.closeoutOccurredAt,
+          createdByStaffProfileId: input.requestedByStaffProfileId,
+          metadata: {
+            countedCash: input.countedCash,
+            expectedCash: input.expectedCash,
+            variance: input.variance,
+          },
+          reason: input.gateDecisionReason,
+          registerSessionId: input.registerSessionId,
+          requestType: "variance_review",
+          status: "pending",
+          storeId: input.storeId,
+        } as never,
+        created: true,
+      };
+    },
     async getActiveHeldQuantity() {
       return 0;
     },

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -4656,7 +4656,7 @@ describe("projectLocalSyncEvent", () => {
     ]);
   });
 
-  it("conflicts non-zero offline closeout variance for manager review", async () => {
+  it("projects under-threshold offline closeout variance without manager review", async () => {
     const repository = createProjectionRepository();
 
     const result = await projectLocalSyncEvent(repository, {
@@ -4679,55 +4679,624 @@ describe("projectLocalSyncEvent", () => {
       now: 100,
     });
 
-    expect(result.status).toBe("conflicted");
-    expect(repository.registerSessionPatches).toEqual([
-      {
-        registerSessionId: "register-session-1",
-        patch: {
-          closeoutOwnedAt: 30,
-          closeoutOwnershipSource: "closeout_submission",
-          countedCash: 90,
-          notes: "Short drawer",
-          status: "closing",
-          variance: -10,
-        },
-      },
-    ]);
-    const registerSessionPatch = repository.registerSessionPatches[0] as
-      | { patch: Record<string, unknown> }
-      | undefined;
-    expect(registerSessionPatch?.patch).not.toHaveProperty(
-      "closeoutRecords",
-    );
-    expect(result.conflicts).toEqual([
+    expect(result.status).toBe("projected");
+    expect(result.conflicts).toEqual([]);
+    expect(result.mappings).toEqual([
       expect.objectContaining({
-        conflictType: "permission",
-        details: expect.objectContaining({
-          notes: "Short drawer",
-        }),
-        summary:
-          "Register closeout variance requires manager review before synced closeout can be applied.",
+        cloudId: "register-session-1",
+        cloudTable: "registerSession",
+        localId: "event-register-closed-1",
+        localIdKind: "closeout",
       }),
     ]);
+    expect(repository.registerSessionPatches).toEqual(
+      expect.arrayContaining([
+        {
+          registerSessionId: "register-session-1",
+          patch: expect.objectContaining({
+            closedAt: 30,
+            closedByStaffProfileId: "staff-1",
+            countedCash: 90,
+            notes: "Short drawer",
+            status: "closed",
+            variance: -10,
+          }),
+        },
+      ]),
+    );
+    expect(repository.createdConflicts).toEqual([]);
     expect(repository.createdOperationalEvents).toEqual([
       expect.objectContaining({
         actorStaffProfileId: "staff-1",
         createdAt: 30,
-        eventType: "register_session_sync_closeout_review_requested",
+        eventType: "register_session_closed",
         localEventId: "event-register-closed-1",
         message:
-          "Front counter / Register 1 closeout submitted with a cash variance of GH₵-0.1. Review before applying it.",
+          "Front counter / Register 1 closeout recorded with a cash variance of GH₵-0.1.",
         metadata: expect.objectContaining({
           countedCash: 90,
           expectedCash: 100,
           localEventId: "event-register-closed-1",
-          notes: "Short drawer",
-          reviewConflictId: "conflict-1",
           syncOrigin: "local_sync",
           variance: -10,
         }),
         registerSessionId: "register-session-1",
         terminalId: "terminal-1",
+      }),
+    ]);
+  });
+
+  it("projects approval-required offline closeout variance with Cash Controls approval ownership", async () => {
+    const repository = createProjectionRepository({
+      storeConfig: {
+        operations: {
+          cashControls: {
+            varianceApprovalThreshold: 5,
+          },
+        },
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-closed-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 3,
+        eventType: "register_closed",
+        occurredAt: 30,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: {
+          countedCash: 90,
+          notes: "Short drawer",
+        },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("projected");
+    expect(result.conflicts).toEqual([]);
+    expect(repository.createdConflicts).toEqual([]);
+    expect(result.mappings).toEqual([
+      expect.objectContaining({
+        cloudId: "register-session-1",
+        cloudTable: "registerSession",
+        localId: "event-register-closed-1",
+        localIdKind: "closeout",
+      }),
+    ]);
+    expect(repository.approvalRequests).toEqual([
+      expect.objectContaining({
+        _id: "approval-request-1",
+        metadata: expect.objectContaining({
+          countedCash: 90,
+          expectedCash: 100,
+          gateDecision: "approval_required",
+          localEventId: "event-register-closed-1",
+          localRegisterSessionId: "local-register-1",
+          notes: "Short drawer",
+          syncOrigin: "local_sync",
+          terminalId: "terminal-1",
+          variance: -10,
+        }),
+        registerSessionId: "register-session-1",
+        requestType: "variance_review",
+        status: "pending",
+      }),
+    ]);
+    expect(repository.registerSessionPatches).toEqual([
+      {
+        registerSessionId: "register-session-1",
+        patch: expect.objectContaining({
+          closeoutOwnedAt: 30,
+          closeoutOwnershipSource: "approval_request",
+          countedCash: 90,
+          managerApprovalRequestId: "approval-request-1",
+          notes: "Short drawer",
+          status: "closing",
+          variance: -10,
+        }),
+      },
+    ]);
+    expect(repository.createdOperationalEvents).toEqual([
+      expect.objectContaining({
+        actorStaffProfileId: "staff-1",
+        approvalRequestId: "approval-request-1",
+        createdAt: 30,
+        eventType: "register_session_variance_review_requested",
+        localEventId: "event-register-closed-1",
+        metadata: expect.objectContaining({
+          approvalRequestId: "approval-request-1",
+          countedCash: 90,
+          expectedCash: 100,
+          gateDecision: "approval_required",
+          localEventId: "event-register-closed-1",
+          syncOrigin: "local_sync",
+          variance: -10,
+        }),
+        registerSessionId: "register-session-1",
+        terminalId: "terminal-1",
+      }),
+    ]);
+  });
+
+  it("honors store manager-signoff variance policy during offline closeout projection", async () => {
+    const repository = createProjectionRepository({
+      storeConfig: {
+        operations: {
+          cashControls: {
+            requireManagerSignoffForAnyVariance: true,
+            varianceApprovalThreshold: 5000,
+          },
+        },
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-closed-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 3,
+        eventType: "register_closed",
+        occurredAt: 30,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: {
+          countedCash: 90,
+          notes: "Short drawer",
+        },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("projected");
+    expect(result.conflicts).toEqual([]);
+    expect(repository.approvalRequests).toEqual([
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          gateDecisionReason:
+            "Manager signoff is required for any register variance (-10).",
+          variance: -10,
+        }),
+        requestType: "variance_review",
+        status: "pending",
+      }),
+    ]);
+    expect(repository.createdConflicts).toEqual([]);
+  });
+
+  it("conflicts approval-required closeout sync when a pending review has different facts", async () => {
+    const repository = createProjectionRepository({
+      approvalRequests: [
+        ...Array.from({ length: 25 }, (_, index) => ({
+          _id: `approval-request-unrelated-${index}`,
+          createdAt: index,
+          registerSessionId: "register-session-1",
+          requestType: index % 2 === 0 ? "void_review" : "variance_review",
+          status: index % 2 === 0 ? ("pending" as const) : ("approved" as const),
+        })),
+        {
+          _id: "approval-request-existing",
+          createdAt: 25,
+          metadata: {
+            countedCash: 80,
+            expectedCash: 100,
+            localEventId: "event-register-closed-previous",
+            localRegisterSessionId: "local-register-1",
+            notes: "Earlier count",
+            terminalId: "terminal-1",
+            variance: -20,
+          },
+          notes: "Earlier count",
+          reason: "Variance of -20 exceeded the closeout approval threshold.",
+          registerSessionId: "register-session-1",
+          requestType: "variance_review",
+          status: "pending",
+        },
+      ],
+      storeConfig: {
+        operations: {
+          cashControls: {
+            varianceApprovalThreshold: 5,
+          },
+        },
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-closed-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 3,
+        eventType: "register_closed",
+        occurredAt: 30,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: {
+          countedCash: 90,
+          notes: "Short drawer",
+        },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("conflicted");
+    expect(result.mappings).toEqual([]);
+    expect(result.conflicts).toEqual([
+      expect.objectContaining({
+        conflictType: "permission",
+        details: expect.objectContaining({
+          existingApprovalRequestId: "approval-request-existing",
+          localEventId: "event-register-closed-1",
+          registerSessionId: "register-session-1",
+        }),
+        summary:
+          "Register closeout already has a pending variance review with different closeout facts.",
+      }),
+    ]);
+    expect(repository.approvalRequests).toHaveLength(26);
+    expect(
+      repository.approvalRequests.filter(
+        (approvalRequest) =>
+          approvalRequest.status === "pending" &&
+          approvalRequest.requestType === "variance_review",
+      ),
+    ).toHaveLength(1);
+    expect(repository.approvalRequests).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ _id: "approval-request-27" }),
+      ]),
+    );
+    expect(repository.registerSessionPatches).toEqual([]);
+    expect(repository.createdOperationalEvents).toEqual([]);
+  });
+
+  it("conflicts approval-required closeout sync when multiple pending variance reviews exist", async () => {
+    const repository = createProjectionRepository({
+      approvalRequests: [
+        {
+          _id: "approval-request-one",
+          createdAt: 25,
+          metadata: {
+            countedCash: 90,
+            expectedCash: 100,
+            localEventId: "event-register-closed-1",
+            localRegisterSessionId: "local-register-1",
+            notes: "Short drawer",
+            terminalId: "terminal-1",
+            variance: -10,
+          },
+          notes: "Short drawer",
+          reason: "Variance of -10 exceeded the closeout approval threshold.",
+          registerSessionId: "register-session-1",
+          requestType: "variance_review",
+          status: "pending",
+        },
+        {
+          _id: "approval-request-two",
+          createdAt: 26,
+          metadata: {
+            countedCash: 80,
+            expectedCash: 100,
+            localEventId: "event-register-closed-previous",
+            localRegisterSessionId: "local-register-1",
+            notes: "Earlier count",
+            terminalId: "terminal-1",
+            variance: -20,
+          },
+          notes: "Earlier count",
+          reason: "Variance of -20 exceeded the closeout approval threshold.",
+          registerSessionId: "register-session-1",
+          requestType: "variance_review",
+          status: "pending",
+        },
+      ],
+      storeConfig: {
+        operations: {
+          cashControls: {
+            varianceApprovalThreshold: 5,
+          },
+        },
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-closed-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 3,
+        eventType: "register_closed",
+        occurredAt: 30,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: {
+          countedCash: 90,
+          notes: "Short drawer",
+        },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("conflicted");
+    expect(result.mappings).toEqual([]);
+    expect(result.conflicts).toEqual([
+      expect.objectContaining({
+        conflictType: "permission",
+        details: expect.objectContaining({
+          existingApprovalRequestIds: [
+            "approval-request-one",
+            "approval-request-two",
+          ],
+          localEventId: "event-register-closed-1",
+          registerSessionId: "register-session-1",
+        }),
+        summary:
+          "Register closeout already has multiple pending variance reviews.",
+      }),
+    ]);
+    expect(repository.approvalRequests).toHaveLength(2);
+    expect(repository.registerSessionPatches).toEqual([]);
+    expect(repository.createdOperationalEvents).toEqual([]);
+  });
+
+  it("reuses approval ownership when approval-required closeout sync retries", async () => {
+    const repository = createProjectionRepository({
+      approvalRequests: [
+        ...Array.from({ length: 25 }, (_, index) => ({
+          _id: `approval-request-unrelated-${index}`,
+          createdAt: index,
+          registerSessionId: "register-session-1",
+          requestType: index % 2 === 0 ? "void_review" : "variance_review",
+          status: index % 2 === 0 ? ("pending" as const) : ("approved" as const),
+        })),
+        {
+          _id: "approval-request-existing",
+          createdAt: 30,
+          metadata: {
+            countedCash: 90,
+            expectedCash: 100,
+            localEventId: "event-register-closed-1",
+            localRegisterSessionId: "local-register-1",
+            notes: "Short drawer",
+            terminalId: "terminal-1",
+            variance: -10,
+          },
+          notes: "Short drawer",
+          reason: "Variance of -10 exceeded the closeout approval threshold.",
+          registerSessionId: "register-session-1",
+          requestType: "variance_review",
+          status: "pending",
+        },
+      ],
+      registerSession: {
+        _id: "register-session-1",
+        closeoutRecords: [],
+        countedCash: 90,
+        expectedCash: 100,
+        managerApprovalRequestId: "approval-request-existing" as never,
+        registerNumber: "1",
+        status: "closing",
+        variance: -10,
+      },
+      storeConfig: {
+        operations: {
+          cashControls: {
+            varianceApprovalThreshold: 5,
+          },
+        },
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-closed-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 3,
+        eventType: "register_closed",
+        occurredAt: 30,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: {
+          countedCash: 90,
+          notes: "Short drawer",
+        },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("projected");
+    expect(result.conflicts).toEqual([]);
+    expect(repository.approvalRequests).toHaveLength(26);
+    expect(
+      repository.approvalRequests.filter(
+        (approvalRequest) =>
+          approvalRequest.status === "pending" &&
+          approvalRequest.requestType === "variance_review",
+      ),
+    ).toHaveLength(1);
+    expect(repository.approvalRequests).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ _id: "approval-request-27" }),
+      ]),
+    );
+    expect(repository.createdOperationalEvents).toEqual([]);
+    expect(result.mappings).toEqual([
+      expect.objectContaining({
+        cloudId: "register-session-1",
+        cloudTable: "registerSession",
+        localId: "event-register-closed-1",
+        localIdKind: "closeout",
+      }),
+    ]);
+  });
+
+  it("conflicts approval-owned closeout retry when the submitted notes changed", async () => {
+    const repository = createProjectionRepository({
+      approvalRequests: [
+        {
+          _id: "approval-request-existing",
+          createdAt: 30,
+          metadata: {
+            countedCash: 90,
+            expectedCash: 100,
+            localEventId: "event-register-closed-1",
+            localRegisterSessionId: "local-register-1",
+            notes: "Short drawer",
+            terminalId: "terminal-1",
+            variance: -10,
+          },
+          notes: "Short drawer",
+          reason: "Variance of -10 exceeded the closeout approval threshold.",
+          registerSessionId: "register-session-1",
+          requestType: "variance_review",
+          status: "pending",
+        },
+      ],
+      registerSession: {
+        _id: "register-session-1",
+        closeoutRecords: [],
+        countedCash: 90,
+        expectedCash: 100,
+        managerApprovalRequestId: "approval-request-existing" as never,
+        registerNumber: "1",
+        status: "closing",
+        variance: -10,
+      },
+      storeConfig: {
+        operations: {
+          cashControls: {
+            varianceApprovalThreshold: 5,
+          },
+        },
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-closed-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 3,
+        eventType: "register_closed",
+        occurredAt: 30,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: {
+          countedCash: 90,
+          notes: "Adjusted drawer note",
+        },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("conflicted");
+    expect(result.mappings).toEqual([]);
+    expect(result.conflicts).toEqual([
+      expect.objectContaining({
+        conflictType: "permission",
+        details: expect.objectContaining({
+          approvalRequestId: "approval-request-existing",
+          localEventId: "event-register-closed-1",
+          registerSessionId: "register-session-1",
+        }),
+        summary:
+          "Register closeout approval ownership no longer matches the synced closeout facts.",
+      }),
+    ]);
+    expect(repository.approvalRequests).toHaveLength(1);
+    expect(repository.createdOperationalEvents).toEqual([]);
+  });
+
+  it("replays an approved approval-owned closeout without creating a second review", async () => {
+    const repository = createProjectionRepository({
+      approvalRequests: [
+        {
+          _id: "approval-request-approved",
+          createdAt: 30,
+          decidedAt: 40,
+          metadata: {
+            countedCash: 90,
+            expectedCash: 100,
+            localEventId: "event-register-closed-1",
+            localRegisterSessionId: "local-register-1",
+            notes: "Short drawer",
+            terminalId: "terminal-1",
+            variance: -10,
+          },
+          notes: "Short drawer",
+          reason: "Variance of -10 exceeded the closeout approval threshold.",
+          registerSessionId: "register-session-1",
+          requestType: "variance_review",
+          status: "approved",
+        },
+      ],
+      registerSession: {
+        _id: "register-session-1",
+        closeoutRecords: [],
+        countedCash: 90,
+        expectedCash: 100,
+        managerApprovalRequestId: "approval-request-approved" as never,
+        registerNumber: "1",
+        status: "closing",
+        variance: -10,
+      },
+      storeConfig: {
+        operations: {
+          cashControls: {
+            varianceApprovalThreshold: 5,
+          },
+        },
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-closed-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 3,
+        eventType: "register_closed",
+        occurredAt: 30,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: {
+          countedCash: 90,
+          notes: "Short drawer",
+        },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("projected");
+    expect(result.conflicts).toEqual([]);
+    expect(repository.approvalRequests).toHaveLength(1);
+    expect(repository.registerSessionPatches).toEqual([]);
+    expect(repository.createdOperationalEvents).toEqual([]);
+    expect(result.mappings).toEqual([
+      expect.objectContaining({
+        cloudId: "register-session-1",
+        cloudTable: "registerSession",
+        localId: "event-register-closed-1",
+        localIdKind: "closeout",
       }),
     ]);
   });
@@ -6066,6 +6635,7 @@ function createProjectionRepository(
       closedAt?: number;
       closedByStaffProfileId?: string;
       countedCash?: number;
+      managerApprovalRequestId?: string;
       notes?: string;
       registerNumber?: string;
       status: string;
@@ -6190,8 +6760,31 @@ function createProjectionRepository(
         | "repairable_missing_register_session_mapping_sales";
     }>;
     validStaffProof: boolean;
+    storeConfig: unknown;
+    approvalRequests: Array<{
+      _id: string;
+      createdAt: number;
+      decidedAt?: number;
+      metadata?: Record<string, unknown>;
+      notes?: string;
+      reason?: string;
+      registerSessionId?: string;
+      requestType: string;
+      status: "pending" | "approved" | "rejected" | "cancelled";
+    }>;
   }> = {},
 ): SyncProjectionRepository & {
+  approvalRequests: Array<{
+    _id: string;
+    createdAt: number;
+    decidedAt?: number;
+    metadata?: Record<string, unknown>;
+    notes?: string;
+    reason?: string;
+    registerSessionId?: string;
+    requestType: string;
+    status: "pending" | "approved" | "rejected" | "cancelled";
+  }>;
   createdConflicts: LocalSyncConflictRecord[];
   consumedHoldRequests: unknown[];
   releasedHoldRequests: unknown[];
@@ -6264,6 +6857,7 @@ function createProjectionRepository(
   const registerSessionPatches: unknown[] = [];
   const consumedHoldRequests: unknown[] = [];
   const releasedHoldRequests: unknown[] = [];
+  const approvalRequests = [...(overrides.approvalRequests ?? [])];
   const sku = overrides.sku ?? {
     _id: "sku-1",
     storeId: "store-1",
@@ -6339,6 +6933,7 @@ function createProjectionRepository(
     registerSessionPatches,
     consumedHoldRequests,
     releasedHoldRequests,
+    approvalRequests,
     mappings,
     async getTerminal(terminalId) {
       return terminalId === "terminal-1" ? (terminal as never) : null;
@@ -6391,6 +6986,7 @@ function createProjectionRepository(
     async getStore() {
       return {
         _id: "store-1",
+        config: overrides.storeConfig,
         organizationId: "org-1",
       } as never;
     },
@@ -6682,6 +7278,106 @@ function createProjectionRepository(
     async patchRegisterSession(registerSessionId, patch) {
       registerSessionPatches.push({ registerSessionId, patch });
       if (registerSession) Object.assign(registerSession, patch);
+    },
+    async getApprovalRequest(approvalRequestId) {
+      return (
+        (approvalRequests.find(
+          (approvalRequest) => approvalRequest._id === approvalRequestId,
+        ) as never) ?? null
+      );
+    },
+    async createOrReuseRegisterSessionVarianceReview(input) {
+      const notes = input.notes?.trim() || undefined;
+      const pendingVarianceReviews = approvalRequests.filter(
+        (approvalRequest) =>
+          approvalRequest.status === "pending" &&
+          approvalRequest.requestType === "variance_review" &&
+          approvalRequest.registerSessionId === input.registerSessionId,
+      );
+      if (pendingVarianceReviews.length > 1) {
+        return {
+          details: {
+            existingApprovalRequestIds: pendingVarianceReviews.map(
+              (approvalRequest) => approvalRequest._id,
+            ),
+            localEventId: input.localEventId,
+            registerSessionId: input.registerSessionId,
+          },
+          status: "conflict",
+          summary:
+            "Register closeout already has multiple pending variance reviews.",
+        };
+      }
+      const matchingApprovalRequest = pendingVarianceReviews.find(
+        (approvalRequest) =>
+          approvalRequest.metadata?.countedCash === input.countedCash &&
+          approvalRequest.metadata?.expectedCash === input.expectedCash &&
+          approvalRequest.metadata?.variance === input.variance &&
+          approvalRequest.metadata?.notes === notes &&
+          approvalRequest.metadata?.localEventId === input.localEventId &&
+          approvalRequest.metadata?.localRegisterSessionId ===
+            input.localRegisterSessionId &&
+          approvalRequest.metadata?.terminalId === input.terminalId,
+      );
+
+      if (matchingApprovalRequest) {
+        return {
+          approvalRequest: matchingApprovalRequest as never,
+          created: false,
+          status: "ready",
+        };
+      }
+
+      if (pendingVarianceReviews[0]) {
+        return {
+          details: {
+            existingApprovalRequestId: pendingVarianceReviews[0]._id,
+            localEventId: input.localEventId,
+            registerSessionId: input.registerSessionId,
+          },
+          status: "conflict",
+          summary:
+            "Register closeout already has a pending variance review with different closeout facts.",
+        };
+      }
+
+      const approvalRequest = {
+        _id: `approval-request-${approvalRequests.length + 1}`,
+        createdAt: input.closeoutOccurredAt,
+        metadata: {
+          countedCash: input.countedCash,
+          expectedCash: input.expectedCash,
+          gateDecision: "approval_required",
+          gateDecisionReason: input.gateDecisionReason,
+          localEventId: input.localEventId,
+          localRegisterSessionId: input.localRegisterSessionId,
+          notes,
+          closeoutOccurredAt: input.closeoutOccurredAt,
+          syncOrigin: "local_sync",
+          terminalId: input.terminalId,
+          variance: input.variance,
+        },
+        notes,
+        reason: input.gateDecisionReason,
+        registerSessionId: input.registerSessionId,
+        requestType: "variance_review",
+        status: "pending" as const,
+      };
+      approvalRequests.push(approvalRequest);
+      await this.patchRegisterSession(input.registerSessionId, {
+        countedCash: input.countedCash,
+        variance: input.variance,
+        notes,
+        status: "closing",
+        managerApprovalRequestId: approvalRequest._id as never,
+        closeoutOwnedAt: approvalRequest.createdAt,
+        closeoutOwnershipSource: "approval_request",
+      });
+      return {
+        approvalRequest: approvalRequest as never,
+        created: true,
+        status: "ready",
+      };
     },
     async createPosSession(input) {
       const id = `pos-session-${input.localPosSessionId ?? nextId++}`;

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -1,6 +1,11 @@
 import type { Id } from "../../../_generated/dataModel";
 import { normalizeInStorePayments } from "../../../cashControls/paymentAllocationAttribution";
 import { toDisplayAmount } from "../../../lib/currency";
+import {
+  areRegisterSessionCloseoutReviewFactsEquivalent,
+  buildRegisterSessionCloseoutReview,
+  getCashControlsConfig,
+} from "../../../operations/registerSessionCloseoutGate";
 import { currencyFormatter, generateTransactionNumber } from "../../../utils";
 import {
   canReuseCloudRegisterSessionForLocalOpen as canReuseCloudRegisterSessionForLocalOpenPolicy,
@@ -3637,6 +3642,55 @@ async function projectRegisterClosed(
           conflicts: [existingVarianceConflict],
         };
       }
+
+      if (registerSession.managerApprovalRequestId) {
+        const approvalRequest = await repository.getApprovalRequest(
+          registerSession.managerApprovalRequestId,
+        );
+        const factsMatch =
+          approvalRequest?.requestType === "variance_review" &&
+          approvalRequest.registerSessionId === registerSession._id &&
+          areRegisterSessionCloseoutReviewFactsEquivalent(
+            approvalRequest.metadata,
+            {
+              countedCash,
+              expectedCash: registerSession.expectedCash,
+              localEventId: args.event.localEventId,
+              localRegisterSessionId: args.event.localRegisterSessionId,
+              notes: payload.notes?.trim() || undefined,
+              terminalId: args.terminalId,
+              variance,
+            },
+          );
+
+        if (
+          !approvalRequest ||
+          !factsMatch ||
+          (approvalRequest.status !== "pending" &&
+            approvalRequest.status !== "approved")
+        ) {
+          const conflict = await createConflict(repository, args, {
+            conflictType: "permission",
+            summary:
+              "Register closeout approval ownership no longer matches the synced closeout facts.",
+            details: {
+              approvalRequestId: registerSession.managerApprovalRequestId,
+              approvalRequestStatus: approvalRequest?.status,
+              localEventId: args.event.localEventId,
+              registerSessionId: registerSession._id,
+            },
+          });
+          return { status: "conflicted", mappings: [], conflicts: [conflict] };
+        }
+
+        const mapping = await createMapping(repository, args, {
+          localIdKind: "closeout",
+          localId: args.event.localEventId,
+          cloudTable: "registerSession",
+          cloudId: registerSession._id,
+        });
+        return { status: "projected", mappings: [mapping], conflicts: [] };
+      }
     }
 
     const conflict = await createConflict(repository, args, {
@@ -3721,53 +3775,89 @@ async function projectRegisterClosed(
       repository.getStore(args.storeId),
       repository.getTerminal(args.terminalId),
     ]);
-    const conflict = await createConflict(repository, args, {
-      conflictType: "permission",
-      summary: REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY,
-      details: {
-        closeoutOccurredAt: args.event.occurredAt,
-        countedCash,
-        expectedCash: registerSession.expectedCash,
-        notes: payload.notes,
-        variance,
-      },
-    });
-    const registerLabel = formatTerminalRegisterLabel({
-      registerNumber: registerSession.registerNumber,
-      terminalName: terminal?.displayName,
-    });
-    await repository.createOperationalEvent({
-      storeId: args.storeId,
-      organizationId: store?.organizationId,
-      eventType: "register_session_sync_closeout_review_requested",
-      subjectType: "register_session",
-      subjectId: registerSession._id,
-      message: `${registerLabel} closeout submitted with a cash variance of ${formatSaleTotal(store?.currency, variance)}. Review before applying it.`,
-      metadata: {
-        countedCash,
-        expectedCash: registerSession.expectedCash,
-        localEventId: args.event.localEventId,
-        notes: payload.notes,
-        registerNumber: registerSession.registerNumber,
-        reviewConflictId: conflict._id,
-        syncOrigin: "local_sync",
-        variance,
-      },
-      createdAt: args.event.occurredAt,
-      actorStaffProfileId: args.event.staffProfileId,
-      registerSessionId: registerSession._id,
-      terminalId: args.terminalId,
-      localEventId: args.event.localEventId,
-    });
-    await repository.patchRegisterSession(registerSession._id, {
-      status: "closing",
+    const closeoutReview = buildRegisterSessionCloseoutReview({
+      config: getCashControlsConfig(store),
       countedCash,
-      variance,
-      closeoutOwnedAt: args.event.occurredAt,
-      closeoutOwnershipSource: "closeout_submission",
-      notes: payload.notes,
+      expectedCash: registerSession.expectedCash,
     });
-    return { status: "conflicted", mappings: [], conflicts: [conflict] };
+
+    if (!closeoutReview.requiresApproval) {
+      // The shared Cash Controls gate allows this variance; project it below.
+    } else {
+      const reviewResult =
+        await repository.createOrReuseRegisterSessionVarianceReview({
+          closeoutOccurredAt: args.event.occurredAt,
+          countedCash,
+          expectedCash: registerSession.expectedCash,
+          gateDecisionReason: closeoutReview.reason,
+          localEventId: args.event.localEventId,
+          localRegisterSessionId: args.event.localRegisterSessionId,
+          notes: payload.notes,
+          organizationId: store?.organizationId,
+          registerNumber: registerSession.registerNumber,
+          registerSessionId: registerSession._id,
+          requestedByStaffProfileId: args.event.staffProfileId,
+          requestedByUserId: args.submittedByUserId,
+          storeId: args.storeId,
+          terminalId: args.terminalId,
+          variance: closeoutReview.variance,
+        });
+
+      if (reviewResult.status === "conflict") {
+        const conflict = await createConflict(repository, args, {
+          conflictType: "permission",
+          summary: reviewResult.summary,
+          details: reviewResult.details,
+        });
+        return { status: "conflicted", mappings: [], conflicts: [conflict] };
+      }
+
+      const registerLabel = formatTerminalRegisterLabel({
+        registerNumber: registerSession.registerNumber,
+        terminalName: terminal?.displayName,
+      });
+
+      if (reviewResult.created) {
+        await repository.createOperationalEvent({
+          storeId: args.storeId,
+          organizationId: store?.organizationId,
+          eventType: "register_session_variance_review_requested",
+          subjectType: "register_session",
+          subjectId: registerSession._id,
+          message: `${registerLabel} closeout submitted with a cash variance of ${formatSaleTotal(store?.currency, closeoutReview.variance)}. Review before finalizing it.`,
+          metadata: {
+            actionKey: "cash_controls.register_session.variance_review",
+            approvalMode: "async_approval",
+            approvalRequestId: reviewResult.approvalRequest._id,
+            countedCash,
+            expectedCash: registerSession.expectedCash,
+            gateDecision: "approval_required",
+            gateDecisionReason: closeoutReview.reason,
+            localEventId: args.event.localEventId,
+            localRegisterSessionId: args.event.localRegisterSessionId,
+            notes: payload.notes,
+            registerNumber: registerSession.registerNumber,
+            syncOrigin: "local_sync",
+            variance: closeoutReview.variance,
+          },
+          createdAt: args.event.occurredAt,
+          actorStaffProfileId: args.event.staffProfileId,
+          actorUserId: args.submittedByUserId,
+          approvalRequestId: reviewResult.approvalRequest._id,
+          registerSessionId: registerSession._id,
+          terminalId: args.terminalId,
+          localEventId: args.event.localEventId,
+        });
+      }
+
+      const mapping = await createMapping(repository, args, {
+        localIdKind: "closeout",
+        localId: args.event.localEventId,
+        cloudTable: "registerSession",
+        cloudId: registerSession._id,
+      });
+      return { status: "projected", mappings: [mapping], conflicts: [] };
+    }
   }
 
   const [store, terminal] = await Promise.all([

--- a/packages/athena-webapp/convex/pos/application/sync/types.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/types.ts
@@ -443,6 +443,37 @@ export type SyncProjectionRepository = {
     registerSessionId: Id<"registerSession">,
     patch: Partial<Omit<Doc<"registerSession">, "_id" | "_creationTime">>,
   ): Promise<void>;
+  getApprovalRequest(
+    approvalRequestId: Id<"approvalRequest">,
+  ): Promise<Doc<"approvalRequest"> | null>;
+  createOrReuseRegisterSessionVarianceReview(input: {
+    closeoutOccurredAt: number;
+    countedCash: number;
+    expectedCash: number;
+    gateDecisionReason?: string;
+    localEventId: string;
+    localRegisterSessionId?: string;
+    notes?: string;
+    organizationId?: Id<"organization">;
+    registerNumber?: string;
+    registerSessionId: Id<"registerSession">;
+    requestedByStaffProfileId?: Id<"staffProfile">;
+    requestedByUserId?: Id<"athenaUser">;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+    variance: number;
+  }): Promise<
+    | {
+        approvalRequest: Doc<"approvalRequest">;
+        created: boolean;
+        status: "ready";
+      }
+    | {
+        details: Record<string, unknown>;
+        status: "conflict";
+        summary: string;
+      }
+  >;
   createPosSession(input: {
     localPosSessionId?: string;
     sessionNumber: string;
@@ -715,6 +746,7 @@ export type SyncProjectionRepository = {
     registerSessionId?: Id<"registerSession">;
     terminalId?: Id<"posTerminal">;
     localEventId?: string;
+    approvalRequestId?: Id<"approvalRequest">;
     paymentAllocationId?: Id<"paymentAllocation">;
     posTransactionId?: Id<"posTransaction">;
   }): Promise<Id<"operationalEvent">>;

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.test.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.test.ts
@@ -23,4 +23,28 @@ describe("createConvexLocalSyncRepository", () => {
     expect(financialSyncSource).toContain(".collect()");
     expect(financialSyncSource).not.toContain(".paginate(");
   });
+
+  it("queries pending register variance reviews through the exact duplicate-prevention index", () => {
+    const source = readProjectFile(
+      "convex",
+      "pos",
+      "infrastructure",
+      "repositories",
+      "localSyncRepository.ts",
+    );
+    const varianceReviewSource = source.slice(
+      source.indexOf("async createOrReuseRegisterSessionVarianceReview(input)"),
+      source.indexOf("async createPosSession(input)"),
+    );
+
+    expect(varianceReviewSource).toContain(
+      '.withIndex("by_registerSessionId_status_requestType"',
+    );
+    expect(varianceReviewSource).toContain('.eq("registerSessionId", input.registerSessionId)');
+    expect(varianceReviewSource).toContain('.eq("status", "pending")');
+    expect(varianceReviewSource).toContain('.eq("requestType", "variance_review")');
+    expect(varianceReviewSource).toContain(".take(2)");
+    expect(varianceReviewSource).not.toContain(".collect()");
+    expect(varianceReviewSource).not.toContain(".take(20)");
+  });
 });

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
@@ -1,6 +1,8 @@
 import type { Id, TableNames } from "../../../_generated/dataModel";
 import type { MutationCtx } from "../../../_generated/server";
 import { isRegisterSessionConflictBlockingStatus } from "../../../../shared/registerSessionStatus";
+import { buildApprovalRequest } from "../../../operations/approvalRequestHelpers";
+import { areRegisterSessionCloseoutReviewFactsEquivalent } from "../../../operations/registerSessionCloseoutGate";
 import { recordRegisterSessionTraceBestEffort } from "../../../operations/registerSessionTracing";
 import {
   buildRegisterSessionDateDerivationPatch,
@@ -68,6 +70,11 @@ function areConflictDetailsEquivalent(left: unknown, right: unknown): boolean {
       key === rightKeys[index] &&
       areConflictDetailsEquivalent(leftRecord[key], rightRecord[key]),
   );
+}
+
+function trimOptional(value?: string | null) {
+  const nextValue = value?.trim();
+  return nextValue ? nextValue : undefined;
 }
 
 export function createConvexLocalSyncRepository(
@@ -679,6 +686,117 @@ export function createConvexLocalSyncRepository(
         ...patch,
         ...datePatch,
       });
+    },
+    async getApprovalRequest(approvalRequestId) {
+      return ctx.db.get("approvalRequest", approvalRequestId);
+    },
+    async createOrReuseRegisterSessionVarianceReview(input) {
+      const notes = trimOptional(input.notes);
+      const pendingVarianceReviews = await ctx.db
+        .query("approvalRequest")
+        .withIndex("by_registerSessionId_status_requestType", (q) =>
+          q
+            .eq("registerSessionId", input.registerSessionId)
+            .eq("status", "pending")
+            .eq("requestType", "variance_review"),
+        )
+        .take(2);
+      if (pendingVarianceReviews.length > 1) {
+        return {
+          details: {
+            existingApprovalRequestIds: pendingVarianceReviews.map(
+              (approvalRequest) => approvalRequest._id,
+            ),
+            localEventId: input.localEventId,
+            registerSessionId: input.registerSessionId,
+          },
+          status: "conflict" as const,
+          summary:
+            "Register closeout already has multiple pending variance reviews.",
+        };
+      }
+      const matchingApprovalRequest = pendingVarianceReviews.find((approvalRequest) =>
+        areRegisterSessionCloseoutReviewFactsEquivalent(approvalRequest.metadata, {
+          countedCash: input.countedCash,
+          expectedCash: input.expectedCash,
+          localEventId: input.localEventId,
+          localRegisterSessionId: input.localRegisterSessionId,
+          notes,
+          terminalId: input.terminalId,
+          variance: input.variance,
+        }),
+      );
+
+      if (matchingApprovalRequest) {
+        return {
+          approvalRequest: matchingApprovalRequest,
+          created: false,
+          status: "ready" as const,
+        };
+      }
+
+      const conflictingApprovalRequest = pendingVarianceReviews[0];
+      if (conflictingApprovalRequest) {
+        return {
+          details: {
+            existingApprovalRequestId: conflictingApprovalRequest._id,
+            localEventId: input.localEventId,
+            registerSessionId: input.registerSessionId,
+          },
+          status: "conflict" as const,
+          summary:
+            "Register closeout already has a pending variance review with different closeout facts.",
+        };
+      }
+
+      const approvalRequestId = await ctx.db.insert(
+        "approvalRequest",
+        buildApprovalRequest({
+          metadata: {
+            countedCash: input.countedCash,
+            expectedCash: input.expectedCash,
+            gateDecision: "approval_required",
+            gateDecisionReason: input.gateDecisionReason,
+            localEventId: input.localEventId,
+            localRegisterSessionId: input.localRegisterSessionId,
+            notes,
+            closeoutOccurredAt: input.closeoutOccurredAt,
+            syncOrigin: "local_sync",
+            terminalId: input.terminalId,
+            variance: input.variance,
+          },
+          notes,
+          organizationId: input.organizationId,
+          reason: input.gateDecisionReason,
+          registerSessionId: input.registerSessionId,
+          requestType: "variance_review",
+          requestedByStaffProfileId: input.requestedByStaffProfileId,
+          requestedByUserId: input.requestedByUserId,
+          storeId: input.storeId,
+          subjectId: input.registerSessionId,
+          subjectType: "register_session",
+        }),
+      );
+      const approvalRequest = await ctx.db.get("approvalRequest", approvalRequestId);
+      if (!approvalRequest) {
+        throw new Error("Created approval request could not be read.");
+      }
+
+      await this.patchRegisterSession(input.registerSessionId, {
+        countedCash: input.countedCash,
+        variance: input.variance,
+        notes,
+        status: "closing",
+        managerApprovalRequestId: approvalRequestId,
+        closeoutOwnedAt: input.closeoutOccurredAt,
+        closeoutOwnershipSource: "approval_request",
+      });
+
+      return {
+        approvalRequest,
+        created: true,
+        status: "ready" as const,
+      };
     },
     async createPosSession(input) {
       return ctx.db.insert("posSession", {

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -161,7 +161,12 @@ const schema = defineSchema({
       "posTransactionId",
     ])
     .index("by_workItemId", ["workItemId"])
-    .index("by_registerSessionId", ["registerSessionId"]),
+    .index("by_registerSessionId", ["registerSessionId"])
+    .index("by_registerSessionId_status_requestType", [
+      "registerSessionId",
+      "status",
+      "requestType",
+    ]),
   automationPolicy: defineTable(automationPolicySchema)
     .index("by_storeId_domain_action", ["storeId", "domain", "action"])
     .index("by_domain_action_mode", ["domain", "action", "mode"])

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 16 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, cycleCountDrafts.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 8 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCaseTracing.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 19 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 614 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 616 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 9 file(s); key children: README.md, SUMMARY.md, pos, prod.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -100,6 +100,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/operations/operationalWorkItems.test.ts`](../../convex/operations/operationalWorkItems.test.ts)
 - [`convex/operations/operationsQueryIndexes.test.ts`](../../convex/operations/operationsQueryIndexes.test.ts)
 - [`convex/operations/paymentAllocations.test.ts`](../../convex/operations/paymentAllocations.test.ts)
+- [`convex/operations/registerSessionCloseoutGate.test.ts`](../../convex/operations/registerSessionCloseoutGate.test.ts)
 - [`convex/operations/registerSessionTracing.test.ts`](../../convex/operations/registerSessionTracing.test.ts)
 - [`convex/operations/registerSessions.trace.test.ts`](../../convex/operations/registerSessions.trace.test.ts)
 - [`convex/operations/serviceIntake.test.ts`](../../convex/operations/serviceIntake.test.ts)


### PR DESCRIPTION
## Summary
- Extracts the register closeout variance gate into a shared Convex helper used by Cash Controls and POS sync.
- Routes approval-required POS closeouts into Cash Controls approval ownership instead of a divergent POS-only conflict path.
- Adds exact indexed duplicate prevention for pending variance reviews, approved-held replay handling, and conflict coverage for mismatched or duplicate approval ownership.
- Adds the approved plan and solution note, plus refreshed generated API, Graphify, and agent docs.

## Validation
- `bun run pr:athena` passed and recorded proof.
- Focused closeout suites passed, including shared gate, Cash Controls closeouts, POS sync closeouts, and repository query guards.
- Changed Convex lint, TypeScript, Graphify check, harness review, inferential review, and scorecard delivery-run proof passed.
- Reviewer loop unanimous: correctness, data integrity, testing, and project standards approved.

## Linear
- V26-912
- V26-913
- V26-914
- V26-915