### PR TITLE
Fix POS terminal register recovery loops

### DIFF
--- a/docs/solutions/logic-errors/athena-pos-terminal-register-recovery-and-review-cleanup-2026-07-01.md
+++ b/docs/solutions/logic-errors/athena-pos-terminal-register-recovery-and-review-cleanup-2026-07-01.md
@@ -1,0 +1,79 @@
+---
+title: Athena POS Terminal Register Recovery And Review Cleanup
+date: 2026-07-01
+category: logic-errors
+module: athena-webapp
+problem_type: terminal_state_reconciliation
+component: pos-terminal-recovery
+symptoms:
+  - "A terminal can loop on the drawer-open gate when runtime active drawer evidence points at a local register session that was reused or conflicted with a different synced cloud register session"
+  - "Support cleanup for terminal-local review backlogs can become unsafe if it clears by count instead of by exact local event ids"
+  - "Already-seeded register sessions can appear usable while the local-to-cloud register-session mapping remains missing"
+root_cause: terminal_recovery_commands_were_not_bound_to_exact_runtime_evidence
+resolution_type: evidence_bound_terminal_recovery
+severity: high
+tags:
+  - pos
+  - terminal-recovery
+  - local-sync
+  - register-session
+  - indexeddb
+---
+
+# Athena POS Terminal Register Recovery And Review Cleanup
+
+## Problem
+
+Terminal recovery sits between server-owned support commands and terminal-local
+IndexedDB state. That boundary is dangerous when the server preview is broad
+but the terminal mutation is specific. A support action that says "clear all
+review items" can be useful for terminal repair, but it must not become a
+generic count-based delete of whatever review rows happen to exist locally when
+the command runs.
+
+The same evidence boundary applies to register-session repair. If a terminal
+already has the target local drawer projected, idempotent seeding should still
+repair the local-to-cloud register-session mapping. Otherwise later read models
+can keep treating the drawer as local-only, which can feed the drawer gate loop
+or make runtime active-session reconciliation ambiguous.
+
+## Solution
+
+Bind terminal repair commands to the exact runtime evidence that made the
+server preview safe:
+
+- Build clear-all local review actions only from fresh runtime evidence, not
+  stale count-only snapshots or stale collected evidence.
+- Include the exact `localReviewEventIds` in `commandContext` and the matching
+  `localReviewClearedEventIds` in `expectedEvidence`.
+- Keep the action visibly dangerous in the UI, but hide it unless the command
+  ids and expected cleared ids are present, unique, and matching.
+- On the terminal, reject clear-all execution if the current scoped local review
+  rows differ from the evidenced id set or include non-clearable business facts.
+  The safe repair set is uploaded `register.opened` review rows; sale,
+  payment, inventory, and closeout facts stay in review.
+- Keep explicit-id cleanup idempotent by accepting ids that were already
+  cleared by the same terminal recovery command reason.
+- When register-session seeding resolves to `already_seeded`, still write the
+  local-to-cloud register-session mapping when the cloud id is available.
+
+For drawer-gate loop fixes, do not suppress server active-register directives
+just because some runtime local drawer exists. Resolve the runtime drawer to a
+cloud register session when possible, then only suppress the directive when the
+runtime cloud session is sale-usable or already matches the directive target.
+
+## Prevention
+
+- Never issue terminal-local repair commands that mutate IndexedDB by count
+  alone. Carry exact ids and make the executor re-check current local state
+  before mutating.
+- Keep support cleanup actions out of generic "safe action" groups when they
+  discard local review state. Render a separate dangerous affordance with calm,
+  explicit operator copy.
+- Treat local/cloud mapping repair as part of idempotent register-session
+  seeding, not only first-time seeding.
+- Add paired tests at the policy, public command, UI, and local executor
+  boundaries whenever a recovery action crosses from server evidence into
+  terminal-local mutation.
+- Include stale evidence, duplicate ids, business-fact review rows, and
+  already-cleared retries in the regression set.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8386 nodes · 10028 edges · 2081 communities detected
+- 8394 nodes · 10045 edges · 2081 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2102,7 +2102,7 @@
 7. `submitTerminalRuntimeStatus()` - 17 edges
 8. `getStoreConfigV2()` - 17 edges
 9. `createConflict()` - 16 edges
-10. `DataTableViewOptions()` - 16 edges
+10. `buildTerminalOperationalState()` - 16 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `getAmountPaidForOrder()` --calls--> `getDiscountValue()`  [EXTRACTED]
@@ -2159,16 +2159,16 @@ Cohesion: 0.09
 Nodes (48): buildFinalTrustedQuantitiesByRowNumber(), buildProductPageFinalizationMetadata(), buildProductPageFinalizationPayloadHash(), buildProvisionalSkuPatch(), buildSaleEvidenceFingerprint(), buildSkuInsert(), buildSkuPatch(), buildTrustedSkuFingerprint() (+40 more)
 
 ### Community 10 - "Community 10"
+Cohesion: 0.11
+Nodes (42): completed(), executeCallbackCommand(), executeClearLocalReviewItems(), executeClearStaleDrawerAuthority(), executeCollectLocalReview(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand() (+34 more)
+
+### Community 11 - "Community 11"
 Cohesion: 0.08
 Nodes (42): addDaysToOperatingDate(), automationErrorMessage(), automationIdempotencyKey(), configuredEodAutoCompleteStoreDayContext(), configuredOpeningOperatingDate(), eodAutoCompleteDecision(), eodAutoCompletePolicyCronWindow(), eodAutoCompleteTiming() (+34 more)
 
-### Community 11 - "Community 11"
+### Community 12 - "Community 12"
 Cohesion: 0.09
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
-
-### Community 12 - "Community 12"
-Cohesion: 0.12
-Nodes (40): completed(), executeCallbackCommand(), executeClearLocalReviewItems(), executeClearStaleDrawerAuthority(), executeCollectLocalReview(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand() (+32 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.06
@@ -2215,16 +2215,16 @@ Cohesion: 0.07
 Nodes (10): arrayDetail(), buildCashControlsDashboardSnapshot(), buildReviewedSaleProjectionEvent(), getCompletedTransactionForRegisterMappingRepair(), normalizeReviewedNonCashOverpaymentPayload(), numberDetail(), recordDetail(), roundCurrencyAmount() (+2 more)
 
 ### Community 24 - "Community 24"
+Cohesion: 0.12
+Nodes (27): buildDiagnosticEvidence(), buildTerminalOperationalExplanation(), buildTerminalOperationalState(), buildTerminalRecoveryActions(), buildTerminalRecoveryManualReview(), buildTerminalSupportCleanupActions(), classifySalesReadiness(), classifySupportRecovery() (+19 more)
+
+### Community 25 - "Community 25"
 Cohesion: 0.07
 Nodes (11): formatCompactTextList(), formatPaymentMethods(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary(), formatReviewTypeSummary(), formatTimestamp() (+3 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
-
-### Community 26 - "Community 26"
-Cohesion: 0.12
-Nodes (25): buildDiagnosticEvidence(), buildTerminalOperationalExplanation(), buildTerminalOperationalState(), buildTerminalRecoveryActions(), buildTerminalRecoveryManualReview(), classifySalesReadiness(), classifySupportRecovery(), classifyTerminalHealth() (+17 more)
 
 ### Community 27 - "Community 27"
 Cohesion: 0.11
@@ -2279,8 +2279,8 @@ Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
 ### Community 40 - "Community 40"
-Cohesion: 0.19
-Nodes (23): assertRegisterNumberIsAvailable(), buildRuntimeActiveRegisterSessionDirective(), buildRuntimeDrawerAuthorityDirective(), cleanActiveRegisterSession(), cleanAppSessionRecovery(), cleanAppShell(), cleanAppUpdate(), cleanBrowserInfo() (+15 more)
+Cohesion: 0.18
+Nodes (24): assertRegisterNumberIsAvailable(), buildRuntimeActiveRegisterSessionDirective(), buildRuntimeDrawerAuthorityDirective(), cleanActiveRegisterSession(), cleanAppSessionRecovery(), cleanAppShell(), cleanAppUpdate(), cleanBrowserInfo() (+16 more)
 
 ### Community 41 - "Community 41"
 Cohesion: 0.16
@@ -2824,27 +2824,27 @@ Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger
 
 ### Community 176 - "Community 176"
 Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 177 - "Community 177"
 Cohesion: 0.39
-Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 178 - "Community 178"
+Cohesion: 0.39
+Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
+
+### Community 179 - "Community 179"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.31
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.22
 Nodes (0):
-
-### Community 181 - "Community 181"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 182 - "Community 182"
 Cohesion: 0.39
@@ -3619,12 +3619,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 375 - "Community 375"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 376 - "Community 376"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 376 - "Community 376"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 377 - "Community 377"
 Cohesion: 0.4
@@ -3635,20 +3635,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 379 - "Community 379"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 380 - "Community 380"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 380 - "Community 380"
+### Community 381 - "Community 381"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 381 - "Community 381"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 382 - "Community 382"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 383 - "Community 383"
 Cohesion: 0.4
@@ -3667,80 +3667,80 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 387 - "Community 387"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 388 - "Community 388"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 388 - "Community 388"
+### Community 389 - "Community 389"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 389 - "Community 389"
+### Community 390 - "Community 390"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 390 - "Community 390"
+### Community 391 - "Community 391"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 391 - "Community 391"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 392 - "Community 392"
 Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 393 - "Community 393"
 Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
 ### Community 394 - "Community 394"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 395 - "Community 395"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 395 - "Community 395"
+### Community 396 - "Community 396"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 396 - "Community 396"
+### Community 397 - "Community 397"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 397 - "Community 397"
+### Community 398 - "Community 398"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 398 - "Community 398"
+### Community 399 - "Community 399"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 399 - "Community 399"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 400 - "Community 400"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 401 - "Community 401"
 Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 402 - "Community 402"
+Cohesion: 0.6
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+
+### Community 403 - "Community 403"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 403 - "Community 403"
+### Community 404 - "Community 404"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 404 - "Community 404"
+### Community 405 - "Community 405"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
-
-### Community 405 - "Community 405"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 406 - "Community 406"
 Cohesion: 0.4
@@ -3751,48 +3751,48 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 408 - "Community 408"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 409 - "Community 409"
 Cohesion: 0.5
-Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 410 - "Community 410"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
 ### Community 411 - "Community 411"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 412 - "Community 412"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 413 - "Community 413"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 414 - "Community 414"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 415 - "Community 415"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 415 - "Community 415"
+### Community 416 - "Community 416"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 416 - "Community 416"
+### Community 417 - "Community 417"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 417 - "Community 417"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 418 - "Community 418"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 419 - "Community 419"
 Cohesion: 0.4
@@ -3803,72 +3803,72 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 421 - "Community 421"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 422 - "Community 422"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 422 - "Community 422"
+### Community 423 - "Community 423"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 423 - "Community 423"
+### Community 424 - "Community 424"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 424 - "Community 424"
+### Community 425 - "Community 425"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 425 - "Community 425"
+### Community 426 - "Community 426"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 426 - "Community 426"
+### Community 427 - "Community 427"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 427 - "Community 427"
+### Community 428 - "Community 428"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 428 - "Community 428"
+### Community 429 - "Community 429"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 429 - "Community 429"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 430 - "Community 430"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 431 - "Community 431"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
-
-### Community 432 - "Community 432"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 432 - "Community 432"
+Cohesion: 0.67
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 433 - "Community 433"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 434 - "Community 434"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 435 - "Community 435"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 435 - "Community 435"
+### Community 436 - "Community 436"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 436 - "Community 436"
-Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 437 - "Community 437"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 438 - "Community 438"
 Cohesion: 0.5
@@ -3887,76 +3887,76 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 442 - "Community 442"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 443 - "Community 443"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 443 - "Community 443"
+### Community 444 - "Community 444"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 444 - "Community 444"
+### Community 445 - "Community 445"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 445 - "Community 445"
+### Community 446 - "Community 446"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 446 - "Community 446"
+### Community 447 - "Community 447"
 Cohesion: 0.83
 Nodes (3): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), formatOnlineOrderLabel()
 
-### Community 447 - "Community 447"
+### Community 448 - "Community 448"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 448 - "Community 448"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 449 - "Community 449"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 450 - "Community 450"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 451 - "Community 451"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 451 - "Community 451"
+### Community 452 - "Community 452"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 452 - "Community 452"
+### Community 453 - "Community 453"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 453 - "Community 453"
+### Community 454 - "Community 454"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 454 - "Community 454"
+### Community 455 - "Community 455"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 455 - "Community 455"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 456 - "Community 456"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 457 - "Community 457"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 458 - "Community 458"
-Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
-
-### Community 459 - "Community 459"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 459 - "Community 459"
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 460 - "Community 460"
 Cohesion: 0.5
@@ -3967,24 +3967,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 462 - "Community 462"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 463 - "Community 463"
 Cohesion: 0.67
 Nodes (2): buildCtx(), buildQueryCtx()
 
-### Community 463 - "Community 463"
+### Community 464 - "Community 464"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 464 - "Community 464"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
 
 ### Community 465 - "Community 465"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 466 - "Community 466"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 467 - "Community 467"
 Cohesion: 0.5
@@ -3999,36 +3999,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 470 - "Community 470"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 471 - "Community 471"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 471 - "Community 471"
+### Community 472 - "Community 472"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 472 - "Community 472"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 473 - "Community 473"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 474 - "Community 474"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 475 - "Community 475"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 476 - "Community 476"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 477 - "Community 477"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 478 - "Community 478"
 Cohesion: 0.5
@@ -4039,20 +4039,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 480 - "Community 480"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 481 - "Community 481"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 481 - "Community 481"
+### Community 482 - "Community 482"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 482 - "Community 482"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 483 - "Community 483"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 484 - "Community 484"
 Cohesion: 0.67

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,14 +8,14 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2154
-- Graph nodes: 8386
-- Graph edges: 10028
+- Graph nodes: 8394
+- Graph edges: 10045
 - Communities: 2081
 
 ## Graph Hotspots
 - `dailyClose.ts` (90 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-inferential-review.ts` (86 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `terminalHealthPresentation.ts` (75 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
+- `terminalHealthPresentation.ts` (76 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (71 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `DailyCloseView.tsx` (65 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `projectLocalEvents.ts` (65 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -18,7 +18,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 
 ## Graph Hotspots
 - `dailyClose.ts` (90 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `terminalHealthPresentation.ts` (75 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
+- `terminalHealthPresentation.ts` (76 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (71 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `DailyCloseView.tsx` (65 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `projectLocalEvents.ts` (65 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -17,8 +17,8 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - [validation-map.json](../../../packages/storefront-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `storefrontJourneyEvents.ts` (45 edges, Community 11) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `createJourneyEvent()` (40 edges, Community 11) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `storefrontJourneyEvents.ts` (45 edges, Community 12) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 12) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 65) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `storefrontContextEvents.ts` (17 edges, Community 81) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
 - `checkoutSession.ts` (14 edges, Community 98) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)

--- a/packages/athena-webapp/convex/pos/application/commands/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/terminals.ts
@@ -594,7 +594,6 @@ async function buildRuntimeActiveRegisterSessionDirective(
   },
 ): Promise<ActiveRegisterSessionDirective | undefined> {
   if (
-    args.activeRegisterSession ||
     !args.runtimeStatus.localStore.available ||
     !args.runtimeStatus.localStore.terminalSeedReady
   ) {
@@ -612,6 +611,22 @@ async function buildRuntimeActiveRegisterSessionDirective(
   if (!cloudRegisterSession) {
     return undefined;
   }
+  if (args.activeRegisterSession) {
+    const runtimeCloudRegisterSession =
+      await getRuntimeActiveCloudRegisterSession(ctx, {
+        activeRegisterSession: args.activeRegisterSession,
+        storeId: args.storeId,
+      });
+    if (
+      !runtimeCloudRegisterSession ||
+      isRegisterSessionSaleUsable(runtimeCloudRegisterSession)
+    ) {
+      return undefined;
+    }
+    if (runtimeCloudRegisterSession._id === cloudRegisterSession._id) {
+      return undefined;
+    }
+  }
 
   return omitUndefined({
     cloudRegisterSessionId: cloudRegisterSession._id,
@@ -624,6 +639,32 @@ async function buildRuntimeActiveRegisterSessionDirective(
     staffProfileId: cloudRegisterSession.openedByStaffProfileId,
     status: "active" as const,
   });
+}
+
+async function getRuntimeActiveCloudRegisterSession(
+  ctx: MutationCtx,
+  args: {
+    activeRegisterSession: NonNullable<
+      ReturnType<typeof cleanActiveRegisterSession>
+    >;
+    storeId: Id<"store">;
+  },
+): Promise<Doc<"registerSession"> | null> {
+  const registerSessionId = ctx.db.normalizeId(
+    "registerSession",
+    args.activeRegisterSession.cloudRegisterSessionId ??
+      args.activeRegisterSession.localRegisterSessionId,
+  );
+  if (!registerSessionId) {
+    return null;
+  }
+
+  const registerSession = await ctx.db.get("registerSession", registerSessionId);
+  if (!registerSession || registerSession.storeId !== args.storeId) {
+    return null;
+  }
+
+  return registerSession;
 }
 
 async function getSaleUsableRegisterSessionForTerminal(

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts
@@ -442,6 +442,16 @@ describe("terminal operational state policy", () => {
       commandType: "collect_local_review",
       expectedEvidence: { localReviewDetailsCollected: true },
     });
+    expect(state.recoveryPreview.terminalActions).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          commandContext: expect.objectContaining({
+            expectedBlockerType: "local_review_clear_all",
+          }),
+          commandType: "clear_local_review_items",
+        }),
+      ]),
+    );
   });
 
   it("does not replay stale collected local review evidence after the runtime count clears", () => {
@@ -625,6 +635,67 @@ describe("terminal operational state policy", () => {
         syncStatus: "idle",
       },
     });
+  });
+
+  it("adds bounded clear-all cleanup to the preview without changing primary recovery", () => {
+    const state = buildTerminalOperationalState(
+      baseInput({
+        runtimeStatus: buildRuntimeStatus({
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 2,
+            reviewEvents: [
+              {
+                createdAt: now - 1_000,
+                localEventId: "event-review-1",
+                sequence: 12,
+                status: "needs_review",
+                type: "register.opened",
+                uploaded: true,
+                uploadSequence: 12,
+              },
+              {
+                createdAt: now - 500,
+                localEventId: "event-review-2",
+                sequence: 13,
+                status: "needs_review",
+                type: "register.opened",
+                uploaded: true,
+                uploadSequence: 13,
+              },
+            ],
+            status: "needs_review",
+            uploadableEventCount: 0,
+          },
+        }),
+      }),
+    );
+
+    expect(state.recoveryEvidence.terminalActions[0]).toMatchObject({
+      commandContext: {
+        expectedBlockerType: "local_review_replay",
+      },
+      commandType: "retry_sync",
+    });
+    expect(state.recoveryPreview.terminalActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          commandContext: expect.objectContaining({
+            expectedBlockerType: "local_review_clear_all",
+            localReviewClearAll: true,
+            localReviewClearLimit: 2,
+            localReviewEventIds: ["event-review-1", "event-review-2"],
+          }),
+          commandType: "clear_local_review_items",
+          expectedEvidence: {
+            localReviewClearedEventIds: ["event-review-1", "event-review-2"],
+            localReviewEventCount: 0,
+          },
+        }),
+      ]),
+    );
   });
 
   it("keeps collecting local review evidence when any reported local review item was not uploaded", () => {

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.ts
@@ -49,6 +49,10 @@ export function buildTerminalOperationalState(
     effectiveRuntimeStatus,
     input.commandStatus,
   );
+  const terminalPreviewActions = dedupeTerminalActions([
+    ...terminalActions,
+    ...buildTerminalSupportCleanupActions(effectiveRuntimeStatus, input.runtimeFresh),
+  ]);
   const manualReview = buildTerminalRecoveryManualReview({
     attentionReasons,
     safeConflictIds: input.cloudRepair.safeConflictIds,
@@ -123,7 +127,7 @@ export function buildTerminalOperationalState(
       },
       cloudRepair: input.cloudRepair,
       commandStatus: input.commandStatus,
-      terminalActions,
+      terminalActions: terminalPreviewActions,
       manualReview,
     },
     registerEvidence: {
@@ -737,6 +741,66 @@ function buildTerminalRecoveryActions(
     });
   }
   return dedupeTerminalActions(actions);
+}
+
+function buildTerminalSupportCleanupActions(
+  status: TerminalOperationalPolicyInput["runtimeStatus"],
+  runtimeFresh: boolean,
+): TerminalOperationalState["recoveryEvidence"]["terminalActions"] {
+  const clearableReviewIds = getClearableLocalReviewIds(status, runtimeFresh);
+  if (!clearableReviewIds) {
+    return [];
+  }
+
+  return [
+    {
+      commandType: "clear_local_review_items",
+      expectedEvidence: {
+        localReviewClearedEventIds: clearableReviewIds,
+        localReviewEventCount: 0,
+      },
+      commandContext: {
+        expectedBlockerType: "local_review_clear_all",
+        localReviewClearAll: true,
+        localReviewClearLimit: clearableReviewIds.length,
+        localReviewEventIds: clearableReviewIds,
+        reason: "Dangerous cleanup for local review items.",
+      },
+      reason:
+        "Dangerous cleanup can clear all local review items from this terminal.",
+    },
+  ];
+}
+
+function getClearableLocalReviewIds(
+  status: TerminalOperationalPolicyInput["runtimeStatus"],
+  runtimeFresh: boolean,
+) {
+  const sync = status?.sync;
+  if (!sync) {
+    return null;
+  }
+  if (!runtimeFresh) {
+    return null;
+  }
+  if (
+    sync.reviewEventCount <= 0 ||
+    sync.reviewEventCount > LOCAL_REVIEW_COMMAND_EVENT_LIMIT
+  ) {
+    return null;
+  }
+
+  const reviewEvents = sync.reviewEvents ?? [];
+  if (
+    reviewEvents.length >= sync.reviewEventCount &&
+    reviewEvents.every(isReplayableLocalReviewEvent)
+  ) {
+    return reviewEvents
+      .slice(0, sync.reviewEventCount)
+      .map((event) => event.localEventId);
+  }
+
+  return null;
 }
 
 function getReplayableRuntimeLocalReviewEvents(

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts
@@ -103,26 +103,49 @@ describe("terminal command service", () => {
     expect(repository.insertCommand).not.toHaveBeenCalled();
   });
 
-  it("rejects local review cleanup commands without bounded explicit ids", async () => {
+  it("issues bounded local review clear-all commands", async () => {
     const repository = buildRepository();
 
-    await expect(
-      issueTerminalRecoveryCommand(repository, {
-        commandType: "clear_local_review_items",
-        expectedEvidence: { localReviewEventCount: 0 },
-        issuedAt: now,
-        issuedByUserId: "user-1" as Id<"athenaUser">,
-        commandContext: {
-          localReviewClearAll: true,
-          reason: "Clear all local review items.",
-        },
-        storeId,
-        terminalId,
-      }),
-    ).resolves.toMatchObject({
-      error: { code: "validation_failed" },
-      kind: "user_error",
+    const result = await issueTerminalRecoveryCommand(repository, {
+      commandType: "clear_local_review_items",
+      expectedEvidence: {
+        localReviewClearedEventIds: ["event-review-1", "event-review-2"],
+        localReviewEventCount: 0,
+      },
+      issuedAt: now,
+      issuedByUserId: "user-1" as Id<"athenaUser">,
+      commandContext: {
+        expectedBlockerType: "local_review_clear_all",
+        localReviewClearAll: true,
+        localReviewClearLimit: 2,
+        localReviewEventIds: ["event-review-1", "event-review-2"],
+        reason: "Clear all local review items.",
+      },
+      storeId,
+      terminalId,
     });
+
+    expect(result).toMatchObject({
+      data: {
+        commandContext: {
+          expectedBlockerType: "local_review_clear_all",
+          localReviewClearAll: true,
+          localReviewClearLimit: 2,
+          localReviewEventIds: ["event-review-1", "event-review-2"],
+        },
+        commandType: "clear_local_review_items",
+        expectedEvidence: {
+          localReviewClearedEventIds: ["event-review-1", "event-review-2"],
+          localReviewEventCount: 0,
+        },
+      },
+      kind: "ok",
+    });
+    expect(repository.insertCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects local review cleanup commands without bounded explicit ids or clear-all scope", async () => {
+    const repository = buildRepository();
 
     await expect(
       issueTerminalRecoveryCommand(repository, {
@@ -154,6 +177,101 @@ describe("terminal command service", () => {
         commandContext: {
           localReviewEventIds: ["event-review-1"],
           reason: "Clear reviewed local review items.",
+        },
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toMatchObject({
+      error: { code: "validation_failed" },
+      kind: "user_error",
+    });
+
+    expect(repository.insertCommand).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed local review clear-all commands", async () => {
+    const repository = buildRepository();
+
+    await expect(
+      issueTerminalRecoveryCommand(repository, {
+        commandType: "clear_local_review_items",
+        expectedEvidence: { localReviewEventCount: 0 },
+        issuedAt: now,
+        issuedByUserId: "user-1" as Id<"athenaUser">,
+        commandContext: {
+          localReviewClearAll: true,
+          localReviewClearLimit: 101,
+          localReviewEventIds: Array.from(
+            { length: 101 },
+            (_, index) => `event-review-${index}`,
+          ),
+          reason: "Clear all local review items.",
+        },
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toMatchObject({
+      error: { code: "validation_failed" },
+      kind: "user_error",
+    });
+
+    await expect(
+      issueTerminalRecoveryCommand(repository, {
+        commandType: "clear_local_review_items",
+        expectedEvidence: {
+          localReviewClearedEventIds: ["event-review-2"],
+          localReviewEventCount: 0,
+        },
+        issuedAt: now,
+        issuedByUserId: "user-1" as Id<"athenaUser">,
+        commandContext: {
+          localReviewClearAll: true,
+          localReviewEventIds: ["event-review-1"],
+          reason: "Clear all local review items.",
+        },
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toMatchObject({
+      error: { code: "validation_failed" },
+      kind: "user_error",
+    });
+
+    await expect(
+      issueTerminalRecoveryCommand(repository, {
+        commandType: "clear_local_review_items",
+        expectedEvidence: { localReviewEventCount: 0 },
+        issuedAt: now,
+        issuedByUserId: "user-1" as Id<"athenaUser">,
+        commandContext: {
+          localReviewClearAll: true,
+          localReviewEventIds: ["event-review-1"],
+          reason: "Clear all local review items.",
+        },
+        storeId,
+        terminalId,
+      }),
+    ).resolves.toMatchObject({
+      error: { code: "validation_failed" },
+      kind: "user_error",
+    });
+
+    expect(repository.insertCommand).not.toHaveBeenCalled();
+  });
+
+  it("rejects local review clear-all commands without evidenced ids", async () => {
+    const repository = buildRepository();
+
+    await expect(
+      issueTerminalRecoveryCommand(repository, {
+        commandType: "clear_local_review_items",
+        expectedEvidence: { localReviewEventCount: 0 },
+        issuedAt: now,
+        issuedByUserId: "user-1" as Id<"athenaUser">,
+        commandContext: {
+          localReviewClearAll: true,
+          localReviewClearLimit: 2,
+          reason: "Clear all local review items.",
         },
         storeId,
         terminalId,

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts
@@ -539,6 +539,40 @@ function validateTerminalRecoveryCommandShape(input: {
   }
 
   const eventIds = input.commandContext.localReviewEventIds ?? [];
+  if (input.commandContext.localReviewClearAll === true) {
+    if (eventIds.length === 0) {
+      return "Local review clear-all commands require evidenced local review item ids.";
+    }
+    if (eventIds.length > LOCAL_REVIEW_CLEAR_COMMAND_EVENT_LIMIT) {
+      return `Local review clear-all commands can include at most ${LOCAL_REVIEW_CLEAR_COMMAND_EVENT_LIMIT} item ids.`;
+    }
+    if (uniqueStrings(eventIds).length !== eventIds.length) {
+      return "Local review clear-all commands require unique local review item ids.";
+    }
+    if (
+      input.commandContext.localReviewClearLimit !== undefined &&
+      (!Number.isInteger(input.commandContext.localReviewClearLimit) ||
+        input.commandContext.localReviewClearLimit <= 0 ||
+        input.commandContext.localReviewClearLimit >
+          LOCAL_REVIEW_CLEAR_COMMAND_EVENT_LIMIT)
+    ) {
+      return `Local review clear-all commands can include at most ${LOCAL_REVIEW_CLEAR_COMMAND_EVENT_LIMIT} items.`;
+    }
+    if (input.expectedEvidence.localReviewEventCount === undefined) {
+      return "Local review clear-all commands require expected local review count evidence.";
+    }
+    const expectedClearedIds =
+      input.expectedEvidence.localReviewClearedEventIds ?? [];
+    if (uniqueStrings(expectedClearedIds).length !== expectedClearedIds.length) {
+      return "Local review clear-all commands require unique cleared item evidence.";
+    }
+    if (!arraysEqualAsSets(eventIds, expectedClearedIds)) {
+      return "Local review clear-all commands require matching evidenced item ids.";
+    }
+
+    return null;
+  }
+
   if (eventIds.length === 0) {
     return "Local review cleanup commands require explicit local review item ids.";
   }
@@ -549,7 +583,6 @@ function validateTerminalRecoveryCommandShape(input: {
     return "Local review cleanup commands require unique local review item ids.";
   }
   if (
-    input.commandContext.localReviewClearAll === true ||
     input.commandContext.localReviewClearLimit !== undefined
   ) {
     return "Local review cleanup commands must target explicit reviewed item ids.";

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -675,6 +675,96 @@ describe("submitTerminalRuntimeStatus", () => {
     });
   });
 
+  it("returns an active register session directive when runtime is stuck on a closed cloud drawer", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
+      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    );
+    const registerSessions = [
+      {
+        _creationTime: 300,
+        _id: "cloud-register-active",
+        expectedCash: 10_000,
+        openedAt: 180,
+        openingFloat: 10_000,
+        openedByStaffProfileId: "staff-2",
+        registerNumber: "A1",
+        status: "active",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      },
+      {
+        _creationTime: 200,
+        _id: "cloud-register-closed",
+        expectedCash: 9_000,
+        openedAt: 100,
+        openingFloat: 9_000,
+        registerNumber: "A1",
+        status: "closed",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      },
+    ];
+    const db = {
+      get: vi.fn(async (tableName: string, id: string) =>
+        tableName === "registerSession"
+          ? (registerSessions.find((session) => session._id === id) ?? null)
+          : null,
+      ),
+      normalizeId: vi.fn((tableName: string, value: string) =>
+        tableName === "registerSession" &&
+        registerSessions.some((session) => session._id === value)
+          ? value
+          : null,
+      ),
+      query: vi.fn(() => buildTerminalHealthQuery(registerSessions)),
+    };
+
+    const result = await submitTerminalRuntimeStatus(
+      { db } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        status: {
+          ...buildRuntimeStatus(),
+          activeRegisterSession: {
+            localRegisterSessionId: "cloud-register-closed",
+            observedAt: 190,
+            openedAt: 100,
+            registerNumber: "A1",
+            status: "active",
+          },
+          localStore: {
+            available: true,
+            schemaVersion: 1,
+            terminalSeedReady: true,
+          },
+        },
+      },
+    );
+
+    expect(db.get).toHaveBeenCalledWith(
+      "registerSession",
+      "cloud-register-closed",
+    );
+    expect(result).toEqual({
+      kind: "ok",
+      data: expect.objectContaining({
+        activeRegisterSessionDirective: {
+          cloudRegisterSessionId: "cloud-register-active",
+          expectedCash: 10_000,
+          localRegisterSessionId: "cloud-register-active",
+          observedAt: 200,
+          openedAt: 180,
+          openingFloat: 10_000,
+          registerNumber: "A1",
+          staffProfileId: "staff-2",
+          status: "active",
+        },
+      }),
+    });
+  });
+
   it("returns a cloud-closed drawer authority directive for closing local runtime evidence", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
     vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -1659,6 +1659,67 @@ describe("POS terminal public mutations", () => {
     expect(result.kind).toBe("ok");
   });
 
+  it("issues preview-matched local review clear-all commands", async () => {
+    const ctx = buildCtx();
+    const clearAllAction = {
+      commandType: "clear_local_review_items",
+      commandContext: {
+        expectedBlockerType: "local_review_clear_all",
+        localReviewClearAll: true,
+        localReviewClearLimit: 2,
+        localReviewEventIds: ["event-review-1", "event-review-2"],
+        reason: "Dangerous cleanup for local review items.",
+      },
+      expectedEvidence: {
+        localReviewClearedEventIds: ["event-review-1", "event-review-2"],
+        localReviewEventCount: 0,
+      },
+      reason:
+        "Dangerous cleanup can clear all local review items from this terminal.",
+    };
+    mocks.previewTerminalRecoveryQuery.mockResolvedValue({
+      appUpdate: {
+        description: "Current",
+        status: "current",
+      },
+      readiness: "needs_terminal_action",
+      runtimeFresh: true,
+      evidence: {
+        activeRegisterSession: false,
+        freshRuntimeRequiredForAbleToTransactNow: true,
+      },
+      cloudRepair: {
+        preconditionHash: "hash",
+        safeConflictIds: [],
+        skippedConflictIds: [],
+      },
+      commandStatus: null,
+      terminalActions: [clearAllAction],
+      manualReview: [],
+    });
+
+    const result = await getHandler(issueTerminalRecoveryCommand)(ctx as never, {
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      commandType: "clear_local_review_items",
+      commandContext: clearAllAction.commandContext,
+      expectedEvidence: clearAllAction.expectedEvidence,
+    });
+
+    expect(mocks.issueTerminalRecoveryCommandService).toHaveBeenCalledWith(
+      { repository: "write" },
+      expect.objectContaining({
+        commandContext: clearAllAction.commandContext,
+        commandType: "clear_local_review_items",
+        expectedEvidence: clearAllAction.expectedEvidence,
+        issuedByUserId: "athena-user-1",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    );
+    expect(result.kind).toBe("ok");
+  });
+
   it("rejects terminal recovery commands that are not in the current server preview", async () => {
     const ctx = buildCtx();
     mocks.previewTerminalRecoveryQuery.mockResolvedValue({

--- a/packages/athena-webapp/src/components/app-sidebar.test.tsx
+++ b/packages/athena-webapp/src/components/app-sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import React, { type ReactElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -10,6 +10,8 @@ const mocks = vi.hoisted(() => ({
   useGetActiveOrganization: vi.fn(),
   usePermissions: vi.fn(),
   useQuery: vi.fn(),
+  useSidebar: vi.fn(),
+  toggleSidebar: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -142,6 +144,7 @@ vi.mock("@/components/ui/sidebar", () => {
     SidebarMenuSub: Passthrough,
     SidebarMenuSubItem: Passthrough,
     SidebarRail: () => null,
+    useSidebar: mocks.useSidebar,
   };
 });
 
@@ -161,6 +164,10 @@ describe("AppSidebar capability gates", () => {
       activeOrganization: { _id: "org-1", slug: "org" },
     });
     mocks.useQuery.mockReturnValue([]);
+    mocks.useSidebar.mockReturnValue({
+      state: "expanded",
+      toggleSidebar: mocks.toggleSidebar,
+    });
   });
 
   it("lets POS-only accounts open store-day surfaces without admin surfaces", () => {
@@ -262,5 +269,32 @@ describe("AppSidebar capability gates", () => {
       "data-sidebar-variant",
       "contained",
     );
+  });
+
+  it("places a collapse toggle under the contained desktop sidebar", () => {
+    mocks.usePermissions.mockReturnValue({
+      canAccessAdmin: () => true,
+      canAccessFullAdminSurfaces: () => true,
+      canAccessPOS: () => true,
+      canAccessOperations: () => true,
+      canAccessStoreDaySurfaces: () => true,
+      hasFullAdminAccess: true,
+      hasStoreDaySurfaceAccess: true,
+      isLoading: false,
+      role: "admin",
+    });
+
+    render(<AppSidebar shellVariant="contained" />);
+
+    const toggle = screen.getByRole("button", { name: "Collapse sidebar" });
+
+    expect(toggle).toHaveClass(
+      "mt-layout-xs",
+      "w-[var(--sidebar-width-icon)]",
+      "self-start",
+      "md:flex",
+    );
+    fireEvent.click(toggle);
+    expect(mocks.toggleSidebar).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/athena-webapp/src/components/app-sidebar.tsx
+++ b/packages/athena-webapp/src/components/app-sidebar.tsx
@@ -10,6 +10,7 @@ import {
   SidebarMenuSub,
   SidebarMenuSubItem,
   SidebarRail,
+  useSidebar,
 } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
 import * as Collapsible from "@radix-ui/react-collapsible";
@@ -39,6 +40,8 @@ import {
   Layers,
   Banknote,
   ChevronRight,
+  PanelLeftClose,
+  PanelLeftOpen,
   Workflow,
 } from "lucide-react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
@@ -58,6 +61,28 @@ type SidebarOrderSummary = {
 };
 
 type AppSidebarShellVariant = "classic" | "contained";
+
+function ContainedSidebarToggle() {
+  const { state, toggleSidebar } = useSidebar();
+  const isCollapsed = state === "collapsed";
+  const label = isCollapsed ? "Expand sidebar" : "Collapse sidebar";
+  const Icon = isCollapsed ? PanelLeftOpen : PanelLeftClose;
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={toggleSidebar}
+      className={cn(
+        "mt-layout-xs hidden h-9 w-[var(--sidebar-width-icon)] shrink-0 items-center justify-center self-start rounded-lg border border-sidebar-border/70 bg-sidebar text-sidebar-foreground shadow-surface transition-[background-color,border-color,color,transform] duration-fast ease-standard hover:border-sidebar-border hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring active:scale-[0.96] md:flex",
+      )}
+    >
+      <Icon aria-hidden="true" className="h-4 w-4" />
+      <span className="sr-only">{label}</span>
+    </button>
+  );
+}
 
 function SidebarMenuCollapsible({
   icon: Icon,
@@ -165,7 +190,7 @@ export function AppSidebar({
       className={cn(
         "top-16 bottom-auto h-[calc(100svh-4rem)]",
         isContainedShell &&
-          "md:top-20 md:bottom-auto md:h-auto md:max-h-[calc(100svh-6rem)] md:px-layout-sm",
+          "md:top-20 md:bottom-auto md:h-auto md:max-h-[calc(100svh-6rem)] md:flex-col md:px-layout-sm",
       )}
     >
       <SidebarContent
@@ -946,7 +971,7 @@ export function AppSidebar({
           </SidebarGroup>
         </PermissionGate>
       </SidebarContent>
-      {isContainedShell ? null : <SidebarRail />}
+      {isContainedShell ? <ContainedSidebarToggle /> : <SidebarRail />}
     </Sidebar>
   );
 }

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -1157,6 +1157,204 @@ describe("POSTerminalDetailViewContent", () => {
     expect(mocks.toastSuccess).toHaveBeenCalledWith("Terminal command queued.");
   });
 
+  it("lets support send the dangerous clear-all local review command from the review table", async () => {
+    const onIssueTerminalRecoveryCommand = vi.fn(async () => ({
+      data: { _id: "command-clear-all" },
+      kind: "ok" as const,
+    }));
+
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          runtimeStatus: {
+            ...detail.runtimeStatus!,
+            sync: {
+              ...detail.runtimeStatus!.sync,
+              reviewEventCount: 2,
+              reviewEvents: [
+                {
+                  createdAt: Date.now() - 6 * 60_000,
+                  localEventId: "local-review-1",
+                  localRegisterSessionId: "local-session-2",
+                  sequence: 5,
+                  status: "needs_review",
+                  type: "register.opened",
+                  uploaded: true,
+                  uploadSequence: 1,
+                },
+                {
+                  createdAt: Date.now() - 5 * 60_000,
+                  localEventId: "local-review-2",
+                  localRegisterSessionId: "local-session-2",
+                  sequence: 9,
+                  status: "needs_review",
+                  type: "register.opened",
+                  uploaded: true,
+                  uploadSequence: 2,
+                },
+              ],
+              status: "needs_review",
+            },
+          },
+          recovery: {
+            readiness: "needs_terminal_action",
+            terminalActions: [
+              {
+                commandContext: {
+                  expectedBlockerType: "local_review_clear_all",
+                  localReviewClearAll: true,
+                  localReviewClearLimit: 2,
+                  localReviewEventIds: ["local-review-1", "local-review-2"],
+                  reason: "Dangerous cleanup for local review items.",
+                },
+                commandType: "clear_local_review_items",
+                expectedEvidence: {
+                  localReviewClearedEventIds: [
+                    "local-review-1",
+                    "local-review-2",
+                  ],
+                  localReviewEventCount: 0,
+                },
+                reason:
+                  "Dangerous cleanup can clear all local review items from this terminal.",
+              },
+            ],
+          },
+        }}
+        isLoading={false}
+        onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+      />,
+    );
+
+    expect(screen.getByText("Dangerous action")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Clears all local review items reported by this terminal\.\s+Use only after confirming the review state is safe to discard\./i,
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /clear all review items/i }),
+    );
+
+    await waitFor(() => {
+      expect(onIssueTerminalRecoveryCommand).toHaveBeenCalledWith({
+        action: expect.objectContaining({
+          commandContext: expect.objectContaining({
+            expectedBlockerType: "local_review_clear_all",
+            localReviewClearAll: true,
+            localReviewClearLimit: 2,
+            localReviewEventIds: ["local-review-1", "local-review-2"],
+          }),
+          commandType: "clear_local_review_items",
+          expectedEvidence: {
+            localReviewClearedEventIds: ["local-review-1", "local-review-2"],
+            localReviewEventCount: 0,
+          },
+          kind: "terminal_command",
+        }),
+        terminalId: "terminal-1",
+      });
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Terminal command queued.");
+  });
+
+  it("hides dangerous clear-all when the action lacks evidenced review ids", () => {
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          runtimeStatus: {
+            ...detail.runtimeStatus!,
+            sync: {
+              ...detail.runtimeStatus!.sync,
+              reviewEventCount: 2,
+              reviewEvents: [],
+              status: "needs_review",
+            },
+          },
+          recovery: {
+            readiness: "needs_terminal_action",
+            terminalActions: [
+              {
+                commandContext: {
+                  expectedBlockerType: "local_review_clear_all",
+                  localReviewClearAll: true,
+                  localReviewClearLimit: 2,
+                  reason: "Dangerous cleanup for local review items.",
+                },
+                commandType: "clear_local_review_items",
+                expectedEvidence: {
+                  localReviewEventCount: 0,
+                },
+                reason:
+                  "Dangerous cleanup can clear all local review items from this terminal.",
+              },
+            ],
+          },
+        }}
+        isLoading={false}
+        onIssueTerminalRecoveryCommand={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Dangerous action")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /clear all review items/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides dangerous clear-all when evidenced review ids do not match", () => {
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          runtimeStatus: {
+            ...detail.runtimeStatus!,
+            sync: {
+              ...detail.runtimeStatus!.sync,
+              reviewEventCount: 2,
+              reviewEvents: [],
+              status: "needs_review",
+            },
+          },
+          recovery: {
+            readiness: "needs_terminal_action",
+            terminalActions: [
+              {
+                commandContext: {
+                  expectedBlockerType: "local_review_clear_all",
+                  localReviewClearAll: true,
+                  localReviewClearLimit: 2,
+                  localReviewEventIds: ["local-review-1", "local-review-1"],
+                  reason: "Dangerous cleanup for local review items.",
+                },
+                commandType: "clear_local_review_items",
+                expectedEvidence: {
+                  localReviewClearedEventIds: [
+                    "local-review-1",
+                    "local-review-2",
+                  ],
+                  localReviewEventCount: 0,
+                },
+                reason:
+                  "Dangerous cleanup can clear all local review items from this terminal.",
+              },
+            ],
+          },
+        }}
+        isLoading={false}
+        onIssueTerminalRecoveryCommand={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Dangerous action")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /clear all review items/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("issues Update app from active terminals even when update readiness is unknown", async () => {
     const onIssueTerminalRecoveryCommand = vi.fn(async () => ({
       data: { _id: "command-update" },

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
@@ -10,6 +10,7 @@ import {
   MonitorUp,
   Send,
   ShieldCheck,
+  Trash2,
   Wrench,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -1115,6 +1116,8 @@ function ConflictSection({
   const hasLocalReviewTableAction = Boolean(
     getAttentionReasonRecoveryAction(localReviewActionReason, detail),
   );
+  const localReviewClearAllAction =
+    getLocalReviewClearAllAction(recoveryPreview);
 
   return (
     <DetailPanel
@@ -1230,6 +1233,14 @@ function ConflictSection({
                 />
               </div>
             ) : null}
+            {localReviewClearAllAction && detail ? (
+              <LocalReviewClearAllAction
+                action={localReviewClearAllAction}
+                onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+                reviewCount={runtimeReviewCount}
+                terminalId={detail.terminal._id}
+              />
+            ) : null}
           </div>
         ) : null}
 
@@ -1262,6 +1273,157 @@ function ConflictSection({
       </div>
     </DetailPanel>
   );
+}
+
+function LocalReviewClearAllAction({
+  action,
+  onIssueTerminalRecoveryCommand,
+  reviewCount,
+  terminalId,
+}: {
+  action: TerminalRecoveryAction;
+  onIssueTerminalRecoveryCommand?: POSTerminalDetailViewContentProps["onIssueTerminalRecoveryCommand"];
+  reviewCount: number;
+  terminalId: Id<"posTerminal"> | string;
+}) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+  const canIssue = isRecoveryActionIssuable(action);
+
+  const submitClearAll = async () => {
+    if (!canIssue || !onIssueTerminalRecoveryCommand || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage("");
+    const result = await onIssueTerminalRecoveryCommand({ action, terminalId });
+    setIsSubmitting(false);
+
+    if (result.kind === "ok") {
+      toast.success("Terminal command queued.");
+      return;
+    }
+
+    const message = normalizeRecoveryActionError(result.error.message);
+    setErrorMessage(message);
+    toast.error(message);
+  };
+
+  return (
+    <div className="grid gap-layout-sm rounded-md border border-danger/25 bg-danger/10 px-layout-md py-layout-sm md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
+      <div className="min-w-0">
+        <div className="flex items-center gap-layout-xs">
+          <AlertTriangle className="h-4 w-4 text-danger" aria-hidden="true" />
+          <p className="text-sm font-medium text-foreground">
+            Dangerous action
+          </p>
+        </div>
+        <p className="mt-1 max-w-2xl text-xs text-muted-foreground">
+          Clears all local review items reported by this terminal. Use only
+          after confirming the review state is safe to discard.
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {reviewCount} local review{" "}
+          {reviewCount === 1 ? "item is" : "items are"} currently reported.
+        </p>
+        {action.status && action.status !== "available" ? (
+          <p className="mt-1 text-xs text-muted-foreground">
+            {getRecoveryActionStatusCopy(action)}
+          </p>
+        ) : null}
+        {errorMessage ? (
+          <p className="mt-1 text-xs text-danger">{errorMessage}</p>
+        ) : null}
+      </div>
+      <Button
+        disabled={!canIssue || !onIssueTerminalRecoveryCommand || isSubmitting}
+        onClick={() => {
+          void submitClearAll();
+        }}
+        size="sm"
+        type="button"
+        variant="destructive"
+      >
+        <Trash2 aria-hidden="true" />
+        {isSubmitting ? "Sending..." : "Clear all review items"}
+      </Button>
+    </div>
+  );
+}
+
+function getLocalReviewClearAllAction(
+  recoveryPreview: TerminalHealthDetail["recoveryPreview"] | null | undefined,
+): TerminalRecoveryAction | null {
+  const action = recoveryPreview?.terminalActions?.find(
+    (candidate) =>
+      candidate.commandType === "clear_local_review_items" &&
+      isValidLocalReviewClearAllAction(candidate),
+  );
+  if (!action) {
+    return null;
+  }
+
+  return {
+    commandContext: action.commandContext,
+    commandType: action.commandType,
+    expectedEvidence: action.expectedEvidence,
+    kind: "terminal_command",
+    label: "Clear all review items",
+    status: getLocalReviewClearAllStatus(recoveryPreview),
+  };
+}
+
+function isValidLocalReviewClearAllAction(
+  action: NonNullable<
+    NonNullable<TerminalHealthDetail["recoveryPreview"]>["terminalActions"]
+  >[number],
+) {
+  if (action.commandContext.localReviewClearAll !== true) {
+    return false;
+  }
+  const eventIds = action.commandContext.localReviewEventIds ?? [];
+  const clearedEventIds = action.expectedEvidence.localReviewClearedEventIds ?? [];
+  return (
+    eventIds.length > 0 &&
+    action.commandContext.localReviewClearLimit === eventIds.length &&
+    arraysEqualAsSets(eventIds, clearedEventIds)
+  );
+}
+
+function arraysEqualAsSets(left: string[], right: string[]) {
+  if (left.length !== right.length) {
+    return false;
+  }
+  const leftIds = new Set(left);
+  const rightIds = new Set(right);
+  return (
+    leftIds.size === left.length &&
+    rightIds.size === right.length &&
+    left.every((id) => rightIds.has(id))
+  );
+}
+
+function getLocalReviewClearAllStatus(
+  recoveryPreview: TerminalHealthDetail["recoveryPreview"] | null | undefined,
+) {
+  const commandStatus = recoveryPreview?.commandStatus;
+  if (commandStatus?.commandType !== "clear_local_review_items") {
+    return "available";
+  }
+  if (commandStatus.verificationStatus === "verified") {
+    return "verified";
+  }
+  if (commandStatus.verificationStatus === "runtime_verification_ready") {
+    return "waiting_for_check_in";
+  }
+  if (
+    commandStatus.status === "precondition_failed" ||
+    commandStatus.status === "superseded"
+  ) {
+    return "failed";
+  }
+  return commandStatus.status ?? "available";
 }
 
 function OperationalExplanationReviewSummary({

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
@@ -1053,6 +1053,56 @@ describe("terminal health presentation", () => {
     );
   });
 
+  it("keeps clear-all local review cleanup out of safe actions", () => {
+    const presentation = buildTerminalRecoveryPresentation({
+      recovery: {
+        terminalActions: [
+          {
+            commandContext: {
+              expectedBlockerType: "local_review_clear_all",
+              localReviewClearAll: true,
+              localReviewClearLimit: 2,
+              reason: "Dangerous cleanup for local review items.",
+            },
+            commandType: "clear_local_review_items",
+            expectedEvidence: {
+              localReviewEventCount: 0,
+            },
+            reason:
+              "Dangerous cleanup can clear all local review items from this terminal.",
+          },
+        ],
+      },
+      runtimeStatus: {
+        receivedAt: Date.now(),
+        sync: {
+          failedEventCount: 0,
+          localOnlyEventCount: 0,
+          pendingEventCount: 0,
+          reviewEventCount: 2,
+          reviewEvents: [
+            {
+              createdAt: Date.now() - 1_000,
+              localEventId: "event-review-1",
+              sequence: 12,
+              status: "needs_review",
+              type: "register.opened",
+              uploaded: true,
+              uploadSequence: 12,
+            },
+          ],
+          status: "needs_review",
+          uploadableEventCount: 0,
+        },
+      },
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    expect(presentation.safeActions).toEqual([]);
+    expect(presentation.groups.terminalRequired).toEqual([]);
+  });
+
   it("allows recovery actions after the latest command expires", () => {
     const presentation = buildTerminalRecoveryPresentation({
       recovery: {

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
@@ -1498,6 +1498,10 @@ function buildRecoveryBlockersFromPreview(
   }
 
   preview.terminalActions?.forEach((action, index) => {
+    if (isDangerousLocalReviewClearAllAction(action)) {
+      return;
+    }
+
     const actionStatus = getTerminalActionStatusForCurrentRuntime(
       summary,
       preview,
@@ -1542,6 +1546,15 @@ function buildRecoveryBlockersFromPreview(
   });
 
   return blockers;
+}
+
+function isDangerousLocalReviewClearAllAction(
+  action: NonNullable<TerminalRecoveryPreview["terminalActions"]>[number],
+) {
+  return (
+    action.commandType === "clear_local_review_items" &&
+    action.commandContext.localReviewClearAll === true
+  );
 }
 
 function getTerminalActionStatusForCurrentRuntime(

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
@@ -339,6 +339,7 @@ export type TerminalRecoveryExpectedEvidence = {
   localRegisterSessionId?: string;
   localStoreAvailable?: boolean;
   localReviewDetailsCollected?: boolean;
+  localReviewClearedEventIds?: string[];
   localReviewEventCount?: number;
   saleAuthorityStatus?: "ready" | "missing" | "blocked" | "unknown";
   staffAuthorityStatus?: "ready" | "missing" | "expired" | "unknown";

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
@@ -1496,6 +1496,7 @@ describe("createLocalCommandGateway", () => {
         terminalId: "terminal-1",
         storeId: "store-1",
         registerNumber: "1",
+        cloudRegisterSessionId: "cloud-drawer-1",
         localRegisterSessionId: "cloud-drawer-1",
         staffProfileId: "staff-1",
         openingFloat: 100,
@@ -1510,10 +1511,118 @@ describe("createLocalCommandGateway", () => {
       value: expect.arrayContaining([
         expect.objectContaining({
           localRegisterSessionId: "cloud-drawer-1",
+          sync: { status: "synced" },
           type: "register.opened",
         }),
       ]),
     });
+    const events = await store.listEvents();
+    expect(events.ok).toBe(true);
+    if (events.ok) {
+      const seededEvent = events.value.find(
+        (event) => event.localRegisterSessionId === "cloud-drawer-1",
+      );
+      expect(seededEvent).not.toHaveProperty("uploadSequence");
+    }
+  });
+
+  it("does not duplicate runtime directive register seeding once the drawer is active", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    const gateway = createLocalCommandGateway({
+      allowExplicitRegisterSessionWithoutProjection: true,
+      allowRegisterSessionSeedFromRuntimeDirective: true,
+      store,
+    });
+    const seedInput = {
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      cloudRegisterSessionId: "cloud-drawer-1",
+      localRegisterSessionId: "cloud-drawer-1",
+      staffProfileId: "staff-1",
+      openingFloat: 100,
+      expectedCash: 100,
+      runtimeDirectiveRepair: true,
+      status: "active" as const,
+    };
+
+    await expect(gateway.seedRegisterSession(seedInput)).resolves.toBe(true);
+    await expect(gateway.seedRegisterSession(seedInput)).resolves.toBe(true);
+
+    const events = await store.listEvents();
+    expect(events).toMatchObject({ ok: true });
+    if (!events.ok) throw new Error(events.error.message);
+    expect(
+      events.value.filter(
+        (event) =>
+          event.type === "register.opened" &&
+          event.localRegisterSessionId === "cloud-drawer-1",
+      ),
+    ).toHaveLength(1);
+    expect(events.value[0]).toMatchObject({
+      sync: { status: "synced" },
+    });
+    expect(events.value[0]).not.toHaveProperty("uploadSequence");
+    await expect(store.readLocalCloudMapping({
+      entity: "registerSession",
+      localId: "cloud-drawer-1",
+    })).resolves.toMatchObject({
+      ok: true,
+      value: {
+        cloudId: "cloud-drawer-1",
+        localId: "cloud-drawer-1",
+      },
+    });
+  });
+
+  it("writes a missing cloud mapping when runtime directive seeding is already active", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    await appendOpenDrawer(store);
+    const gateway = createLocalCommandGateway({
+      allowExplicitRegisterSessionWithoutProjection: true,
+      allowRegisterSessionSeedFromRuntimeDirective: true,
+      store,
+    });
+
+    await expect(
+      gateway.seedRegisterSession({
+        terminalId: "terminal-1",
+        storeId: "store-1",
+        registerNumber: "1",
+        cloudRegisterSessionId: "cloud-drawer-1",
+        localRegisterSessionId: "drawer-1",
+        staffProfileId: "staff-1",
+        openingFloat: 100,
+        expectedCash: 100,
+        runtimeDirectiveRepair: true,
+        status: "active",
+      }),
+    ).resolves.toBe(true);
+
+    await expect(store.readLocalCloudMapping({
+      entity: "registerSession",
+      localId: "drawer-1",
+    })).resolves.toMatchObject({
+      ok: true,
+      value: {
+        cloudId: "cloud-drawer-1",
+        localId: "drawer-1",
+      },
+    });
+    const events = await store.listEvents();
+    expect(events).toMatchObject({ ok: true });
+    if (!events.ok) throw new Error(events.error.message);
+    expect(
+      events.value.filter(
+        (event) =>
+          event.type === "register.opened" &&
+          event.localRegisterSessionId === "drawer-1",
+      ),
+    ).toHaveLength(1);
   });
 
   it("rejects runtime directive register seeding when a different local drawer is already operable", async () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
@@ -29,6 +29,9 @@ type PosLocalCommandStore = {
   ): Promise<PosLocalStoreResult<PosLocalEventRecord>>;
   listEvents(): Promise<PosLocalStoreResult<PosLocalEventRecord[]>>;
   listLocalCloudMappings?(): Promise<PosLocalStoreResult<PosLocalCloudMapping[]>>;
+  writeLocalCloudMapping?(
+    mapping: PosLocalCloudMapping,
+  ): Promise<PosLocalStoreResult<PosLocalCloudMapping>>;
   readDrawerAuthorityState?(input: {
     localRegisterSessionId: string;
     storeId: string;
@@ -53,6 +56,8 @@ type CreateLocalCommandGatewayOptions = {
   onEventAppended?: () => void;
   staffProofToken?: string | ((staffProfileId: string) => string | undefined);
 };
+
+type RegisterSessionSeedDecision = "append" | "already_seeded" | "blocked";
 
 export type LocalOpenDrawerResult = CommandResult<{
   localRegisterSessionId: string;
@@ -259,17 +264,21 @@ export function createLocalCommandGateway(
     return !blocker;
   }
 
-  async function canSeedRegisterSession(input: SeedLocalRegisterSessionInput) {
-    if (!hasCommandIdentity(input)) return false;
+  async function resolveRegisterSessionSeedDecision(
+    input: SeedLocalRegisterSessionInput,
+  ): Promise<RegisterSessionSeedDecision> {
+    if (!hasCommandIdentity(input)) return "blocked";
     const model = await readModel({
       storeId: input.storeId,
       terminalId: input.terminalId,
     });
-    if (!model.ok) return false;
+    if (!model.ok) return "blocked";
     if (model.value.canSell) {
       return (
         model.value.activeRegisterSession?.localRegisterSessionId ===
         input.localRegisterSessionId
+          ? "already_seeded"
+          : "blocked"
       );
     }
     const hasSettledCloseoutSession =
@@ -288,13 +297,13 @@ export function createLocalCommandGateway(
     const canSeedAfterExistingHistory =
       canSeedAfterSettledHistory || canSeedFromRuntimeDirective;
     if (model.value.saleBlockReason && !canSeedAfterExistingHistory) {
-      return false;
+      return "blocked";
     }
     if (
       !options.allowExplicitRegisterSessionWithoutProjection ||
       (model.eventCount > 0 && !canSeedAfterExistingHistory)
     ) {
-      return false;
+      return "blocked";
     }
 
     const drawerAuthority = await readDrawerAuthorityBlock({
@@ -302,7 +311,9 @@ export function createLocalCommandGateway(
       storeId: input.storeId,
       terminalId: input.terminalId,
     });
-    return drawerAuthority.ok && !drawerAuthority.blocked;
+    return drawerAuthority.ok && !drawerAuthority.blocked
+      ? "append"
+      : "blocked";
   }
 
   async function appendWithResult(input: PosLocalAppendEventInput) {
@@ -310,6 +321,22 @@ export function createLocalCommandGateway(
     if (!result.ok) return toLocalUserError(result.error.message);
     options.onEventAppended?.();
     return ok({ event: result.value });
+  }
+
+  async function writeSeedRegisterSessionMapping(
+    input: SeedLocalRegisterSessionInput,
+  ) {
+    if (!input.cloudRegisterSessionId || !options.store.writeLocalCloudMapping) {
+      return true;
+    }
+
+    const result = await options.store.writeLocalCloudMapping({
+      entity: "registerSession",
+      localId: input.localRegisterSessionId,
+      cloudId: input.cloudRegisterSessionId,
+      mappedAt: clock(),
+    });
+    return result.ok;
   }
 
   return {
@@ -555,7 +582,12 @@ export function createLocalCommandGateway(
     },
 
     async seedRegisterSession(input: SeedLocalRegisterSessionInput) {
-      if (!(await canSeedRegisterSession(input))) return false;
+      const seedDecision = await resolveRegisterSessionSeedDecision(input);
+      if (seedDecision === "blocked") return false;
+      if (seedDecision === "already_seeded") {
+        return writeSeedRegisterSessionMapping(input);
+      }
+      if (!(await writeSeedRegisterSessionMapping(input))) return false;
       return appendBoolean({
         type: "register.opened",
         terminalId: input.terminalId,
@@ -568,6 +600,7 @@ export function createLocalCommandGateway(
           input.staffProfileId,
         ),
         validationMetadata: input.validationMetadata,
+        initialSyncStatus: "synced",
         payload: {
           localRegisterSessionId: input.localRegisterSessionId,
           openingFloat: input.openingFloat,
@@ -848,6 +881,7 @@ type ReopenLocalRegisterInput = LocalCommandContext & {
 };
 
 type SeedLocalRegisterSessionInput = LocalCommandContext & {
+  cloudRegisterSessionId?: string;
   expectedCash: number;
   notes?: string | null;
   openingFloat: number;

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts
@@ -606,7 +606,7 @@ describe("terminalRecoveryCommands", () => {
       payload: {},
       storeId: "store-1",
       terminalId: "local-terminal-1",
-      type: "register.opened",
+      type: "transaction.completed",
     });
     await store.writeDrawerAuthorityState({
       cloudRegisterSessionId: "register-cloud-1",
@@ -1003,7 +1003,7 @@ describe("terminalRecoveryCommands", () => {
       staffProofToken: "proof-token-1",
       storeId: "store-1",
       terminalId: "local-terminal-1",
-      type: "transaction.completed",
+      type: "register.opened",
     });
     await store.markEventsNeedsReview(["event-review-1"], undefined, {
       uploaded: true,
@@ -1193,7 +1193,7 @@ describe("terminalRecoveryCommands", () => {
       staffProofToken: "proof-token-1",
       storeId: "store-1",
       terminalId: "local-terminal-1",
-      type: "transaction.completed",
+      type: "register.opened",
     });
 
     const result = await executeTerminalRecoveryCommand({
@@ -1223,21 +1223,50 @@ describe("terminalRecoveryCommands", () => {
     });
   });
 
-  it("fails clear-all local review cleanup commands without explicit ids", async () => {
+  it("clears all terminal-local review items", async () => {
+    let nextLocalId = 1;
     const store = createPosLocalStore({
       adapter: createMemoryPosLocalStorageAdapter(),
-      createLocalId: () => "event-review-1",
+      clock: () => 4_500,
+      createLocalId: () => `event-review-${nextLocalId++}`,
     });
     await store.appendEvent({
       initialSyncStatus: "needs_review",
       localRegisterSessionId: "register-local-1",
       payload: { total: 1000 },
       staffProfileId: "staff-1",
+      staffProofToken: "proof-token-1",
       storeId: "store-1",
       terminalId: "local-terminal-1",
-      type: "transaction.completed",
+      type: "register.opened",
     });
     await store.markEventsNeedsReview(["event-review-1"], undefined, {
+      uploaded: true,
+    });
+    await store.appendEvent({
+      initialSyncStatus: "needs_review",
+      localRegisterSessionId: "register-local-1",
+      payload: { total: 2000 },
+      staffProfileId: "staff-1",
+      staffProofToken: "proof-token-2",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+      type: "register.opened",
+    });
+    await store.markEventsNeedsReview(["event-review-2"], undefined, {
+      uploaded: true,
+    });
+    await store.appendEvent({
+      initialSyncStatus: "needs_review",
+      localRegisterSessionId: "register-local-1",
+      payload: { total: 3000 },
+      staffProfileId: "staff-1",
+      staffProofToken: "proof-token-3",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+      type: "register.opened",
+    });
+    await store.markEventsNeedsReview(["event-review-3"], undefined, {
       uploaded: true,
     });
 
@@ -1245,6 +1274,112 @@ describe("terminalRecoveryCommands", () => {
       command: buildCommand({
         commandContext: {
           localReviewClearAll: true,
+          localReviewClearLimit: 3,
+          localReviewEventIds: [
+            "event-review-1",
+            "event-review-2",
+            "event-review-3",
+          ],
+        },
+        type: "clear_local_review_items",
+      }),
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(result).toEqual({
+      clearedLocalReviewEventIds: [
+        "event-review-1",
+        "event-review-2",
+        "event-review-3",
+      ],
+      commandId: "command-1",
+      diagnostics: {
+        clearedReviewEventCount: 3,
+        remainingReviewEventCount: 0,
+        terminalId: "terminal-cloud-1",
+      },
+      message: "3 local review items were cleared on this terminal.",
+      status: "completed",
+      type: "clear_local_review_items",
+    });
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: [
+        expect.objectContaining({
+          localEventId: "event-review-1",
+          sync: expect.objectContaining({
+            localResolution: {
+              reason: "terminal_recovery_command",
+              resolvedAt: 4_500,
+              status: "local_review_cleared",
+            },
+            status: "locally_resolved",
+          }),
+        }),
+        expect.objectContaining({
+          localEventId: "event-review-2",
+          sync: expect.objectContaining({
+            localResolution: {
+              reason: "terminal_recovery_command",
+              resolvedAt: 4_500,
+              status: "local_review_cleared",
+            },
+            status: "locally_resolved",
+          }),
+        }),
+        expect.objectContaining({
+          localEventId: "event-review-3",
+          sync: expect.objectContaining({
+            localResolution: {
+              reason: "terminal_recovery_command",
+              resolvedAt: 4_500,
+              status: "local_review_cleared",
+            },
+            status: "locally_resolved",
+          }),
+        }),
+      ],
+    });
+    expect(JSON.stringify(result)).not.toMatch(/staff|proof-token|payload/i);
+  });
+
+  it("rejects clear-all local review commands when terminal review state drifted", async () => {
+    let nextLocalId = 1;
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 4_500,
+      createLocalId: () => `event-review-${nextLocalId++}`,
+    });
+    await store.appendEvent({
+      initialSyncStatus: "needs_review",
+      localRegisterSessionId: "register-local-1",
+      payload: { total: 1000 },
+      staffProfileId: "staff-1",
+      staffProofToken: "proof-token-1",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+      type: "transaction.completed",
+    });
+    await store.appendEvent({
+      initialSyncStatus: "needs_review",
+      localRegisterSessionId: "register-local-1",
+      payload: { total: 2000 },
+      staffProfileId: "staff-2",
+      staffProofToken: "proof-token-2",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+      type: "register.opened",
+    });
+
+    const result = await executeTerminalRecoveryCommand({
+      command: buildCommand({
+        commandContext: {
+          localReviewClearAll: true,
+          localReviewClearLimit: 1,
+          localReviewEventIds: ["event-review-1"],
         },
         type: "clear_local_review_items",
       }),
@@ -1266,7 +1401,11 @@ describe("terminalRecoveryCommands", () => {
       value: [
         expect.objectContaining({
           localEventId: "event-review-1",
-          sync: expect.objectContaining({ status: "needs_review" }),
+          sync: { status: "needs_review" },
+        }),
+        expect.objectContaining({
+          localEventId: "event-review-2",
+          sync: { status: "needs_review" },
         }),
       ],
     });

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts
@@ -134,7 +134,9 @@ type ClearStaleDrawerAuthorityPreconditions = {
   localRegisterSessionId: string;
 };
 
-type ClearLocalReviewItemsRequest = { localEventIds: string[] };
+type ClearLocalReviewItemsRequest =
+  | { clearAll: true; limit: number; localEventIds: string[] }
+  | { clearAll: false; localEventIds: string[] };
 
 const CLEAR_LOCAL_REVIEW_ITEMS_HARD_CAP = 100;
 const COLLECT_LOCAL_REVIEW_ITEMS_HARD_CAP = 100;
@@ -381,7 +383,9 @@ async function executeClearLocalReviewItems(
     });
   }
 
-  const reviewEvents = getScopedUploadedLocalReviewEvents(events.value, context);
+  const reviewEvents = request.clearAll
+    ? getScopedLocalReviewEvents(events.value, context)
+    : getScopedUploadedLocalReviewEvents(events.value, context);
   const previouslyClearedEvents = getScopedTerminalRecoveryClearedReviewEvents(
     events.value,
     context,
@@ -410,13 +414,13 @@ async function executeClearLocalReviewItems(
   }
 
   const clearedReviewEventCount = clear.value.length;
-  const remainingReviewEventCount = getScopedUploadedLocalReviewEvents(
-    remainingEvents.value,
-    context,
-  ).length;
+  const remainingReviewEventCount = (request.clearAll
+    ? getScopedLocalReviewEvents
+    : getScopedUploadedLocalReviewEvents)(remainingEvents.value, context)
+    .length;
 
   return completed(context.command, {
-    clearedLocalReviewEventIds: request.localEventIds,
+    clearedLocalReviewEventIds: selection.idsForAcknowledgement,
     diagnostics: {
       clearedReviewEventCount,
       remainingReviewEventCount,
@@ -714,6 +718,41 @@ function selectLocalReviewEventIdsForClear(
   reviewEvents: PosLocalEventRecord[],
   previouslyClearedEvents: PosLocalEventRecord[],
 ) {
+  if (request.clearAll) {
+    const scopedReviewIds = new Set(
+      reviewEvents.map((event) => event.localEventId),
+    );
+    const scopedPreviouslyClearedIds = new Set(
+      previouslyClearedEvents.map((event) => event.localEventId),
+    );
+    const requestedIds = request.localEventIds.slice(
+      0,
+      Math.min(request.limit, CLEAR_LOCAL_REVIEW_ITEMS_HARD_CAP),
+    );
+    const idsToClear = requestedIds.filter((localEventId) =>
+      reviewEvents.some(
+        (event) =>
+          event.localEventId === localEventId &&
+          isClearableLocalReviewEvent(event),
+      ),
+    );
+    return {
+      allRequestedIdsAccountedFor:
+        request.localEventIds.length <= request.limit &&
+        request.localEventIds.every(
+          (localEventId) =>
+            scopedReviewIds.has(localEventId) ||
+            scopedPreviouslyClearedIds.has(localEventId),
+        ) &&
+        reviewEvents.every((event) =>
+          request.localEventIds.includes(event.localEventId) &&
+          isClearableLocalReviewEvent(event),
+        ),
+      idsForAcknowledgement: request.localEventIds,
+      idsToClear,
+    };
+  }
+
   const scopedReviewIds = new Set(
     reviewEvents.map((event) => event.localEventId),
   );
@@ -729,6 +768,7 @@ function selectLocalReviewEventIdsForClear(
         scopedReviewIds.has(localEventId) ||
         scopedPreviouslyClearedIds.has(localEventId),
     ),
+    idsForAcknowledgement: request.localEventIds,
     idsToClear,
   };
 }
@@ -757,6 +797,10 @@ function isDrawerAuthorityLifecycleEvent(event: PosLocalEventRecord) {
     event.type === "register.reopened" ||
     event.type === "transaction.completed"
   );
+}
+
+function isClearableLocalReviewEvent(event: PosLocalEventRecord) {
+  return event.sync.uploaded === true && event.type === "register.opened";
 }
 
 function toRepairTerminalSeedPayload(
@@ -808,13 +852,45 @@ function toClearLocalReviewItemsRequest(
 ): ClearLocalReviewItemsRequest | null {
   const candidates = [command.commandContext, command.payload];
   for (const candidate of candidates) {
+    if (isClearAllLocalReviewRequest(candidate)) {
+      const ids = firstLocalReviewEventIds(candidate);
+      if (ids.length === 0) {
+        return null;
+      }
+      return {
+        clearAll: true,
+        localEventIds: ids,
+        limit: getLocalReviewClearLimit(candidate),
+      };
+    }
+
     const ids = firstLocalReviewEventIds(candidate);
     if (ids.length > 0) {
-      return { localEventIds: ids };
+      return { clearAll: false, localEventIds: ids };
     }
   }
 
   return null;
+}
+
+function isClearAllLocalReviewRequest(value: unknown) {
+  return isRecord(value) && value.localReviewClearAll === true;
+}
+
+function getLocalReviewClearLimit(value: unknown) {
+  if (
+    isRecord(value) &&
+    typeof value.localReviewClearLimit === "number" &&
+    Number.isFinite(value.localReviewClearLimit) &&
+    value.localReviewClearLimit > 0
+  ) {
+    return Math.min(
+      Math.floor(value.localReviewClearLimit),
+      CLEAR_LOCAL_REVIEW_ITEMS_HARD_CAP,
+    );
+  }
+
+  return CLEAR_LOCAL_REVIEW_ITEMS_HARD_CAP;
 }
 
 function firstLocalReviewEventIds(value: unknown): string[] {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -3574,7 +3574,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
           ...event,
           localEventId: "event-seeded-open",
           sequence: events.length + 1,
-          sync: { status: "pending" },
+          sync: { status: event.initialSyncStatus ?? "pending" },
         });
         events.push(localEvent);
         return { ok: true, value: localEvent };
@@ -3600,6 +3600,10 @@ describe("usePosLocalSyncRuntimeStatus", () => {
           terminalId: "local-terminal-1",
         },
       })),
+      writeLocalCloudMapping: vi.fn(async (mapping) => ({
+        ok: true,
+        value: mapping,
+      })),
     };
 
     const { result } = renderHook(() =>
@@ -3621,6 +3625,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
           storeId: "store-1",
           terminalId: "terminal-cloud-1",
           type: "register.opened",
+          initialSyncStatus: "synced",
           payload: expect.objectContaining({
             expectedCash: 13_000,
             localRegisterSessionId: "cloud-register-1",
@@ -3630,6 +3635,12 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         }),
       ),
     );
+    expect(store.writeLocalCloudMapping).toHaveBeenCalledWith({
+      entity: "registerSession",
+      localId: "cloud-register-1",
+      cloudId: "cloud-register-1",
+      mappedAt: expect.any(Number),
+    });
     expect(onLocalEventsChanged).toHaveBeenCalled();
     await waitFor(() =>
       expect(result.current?.debug?.activeRegisterSessionRepair).toMatchObject({

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -1746,6 +1746,7 @@ async function seedRuntimeActiveRegisterSessionDirective(input: {
   });
 
   const seeded = await gateway.seedRegisterSession({
+    cloudRegisterSessionId: input.directive.cloudRegisterSessionId,
     expectedCash: input.directive.expectedCash,
     localRegisterSessionId: input.directive.localRegisterSessionId,
     openingFloat: input.directive.openingFloat,

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -4849,7 +4849,13 @@ describe("useRegisterViewModel", () => {
       }),
     );
     expect(mockAddItem).not.toHaveBeenCalled();
-    expect(mockWriteLocalCloudMapping).not.toHaveBeenCalled();
+    expect(mockWriteLocalCloudMapping).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cloudId: "drawer-1",
+        entity: "registerSession",
+        localId: "drawer-1",
+      }),
+    );
   });
 
   it("durably clears an empty local sale when voiding it", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -2170,6 +2170,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         terminalId: terminal._id,
         storeId: activeStoreId!,
         registerNumber,
+        cloudRegisterSessionId: usableActiveRegisterSession._id,
         localRegisterSessionId,
         staffProfileId: actingStaffProfileId,
         validationMetadata: localSaleValidationMetadata,


### PR DESCRIPTION
## Summary
- Fix terminal active-register directive reconciliation so stale/conflicted local drawer state does not keep the POS stuck behind the open-drawer gate.
- Make local register session seeding idempotently repair the local-to-cloud register-session mapping.
- Add a dangerous support-only clear-all review action that is bound to fresh, exact local review ids and rejected locally when evidence drifts or includes business review facts.
- Add terminal detail UI affordance, presentation filtering, graphify updates, and a reusable docs/solutions note.

## Validation
- Reviewer subagent quorum: correctness, reliability, data integrity, adversarial, testing, TypeScript, and project standards all approved after fixes.
- bun run pr:athena
- Focused POS recovery/register tests during review: terminal recovery command service, operational policy, public terminals, local command gateway, local recovery commands, local sync runtime, register view model, terminal detail UI.
