### PR TITLE
Validate solution doc links from agent docs

### DIFF
--- a/docs/solutions/harness/compound-solution-gate-2026-05-05.md
+++ b/docs/solutions/harness/compound-solution-gate-2026-05-05.md
@@ -12,6 +12,7 @@ symptoms:
 root_cause: missing_validation
 resolution_type: guardrail
 severity: medium
+last_updated: 2026-07-02
 tags:
   - compound
   - docs-solutions
@@ -45,6 +46,8 @@ repo-local invariants:
 - Foundational architecture solution notes must be linked from a relevant
   package agent doc under
   `packages/*/docs/agent/{architecture.md,code-map.md,testing.md}`.
+- Solution-doc links in package agent docs are resolved relative to the
+  markdown file and must point to an existing `docs/solutions/**/*.md` file.
 
 The source threshold intentionally ignores generated files, test files, and
 docs-only changes. The goal is to catch meaningful implementation deliveries,
@@ -77,9 +80,12 @@ same command that would otherwise accept them.
 The discoverability check keeps architecture foundations from becoming isolated
 archive entries. If a solution note describes a foundation, primitive,
 aggregate, contract, policy, or architecture pattern, at least one package
-agent doc must point to it. That makes the package architecture and code-map
-docs the entrypoint for future agents while `docs/solutions/` remains the
-durable knowledge store.
+agent doc must point to it with a real link. The checker resolves relative
+markdown links such as `../../../../docs/solutions/...` from the agent doc's
+location, so a raw substring or an off-by-one `../` path does not satisfy
+discoverability. That makes the package architecture and code-map docs the
+entrypoint for future agents while `docs/solutions/` remains the durable
+knowledge store.
 
 ## Prevention
 
@@ -94,6 +100,8 @@ durable knowledge store.
   need.
 - When a note captures foundational architecture, add a direct reference from
   the relevant package agent architecture, code-map, or testing doc.
+- Prefer normal markdown links in package agent docs and let `compound:check`
+  verify that the relative path resolves to the intended solution note.
 - Treat the final integration branch as the unit of compounding. Parallel
   subagent work is evaluated in aggregate, so the final branch needs the durable
   learning artifact even if no single worker owned the note.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8402 nodes · 10063 edges · 2081 communities detected
+- 8403 nodes · 10066 edges · 2081 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2243,20 +2243,20 @@ Cohesion: 0.12
 Nodes (26): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildInventorySnapshotRowsForProductSkusWithCtx(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle() (+18 more)
 
 ### Community 31 - "Community 31"
+Cohesion: 0.16
+Nodes (29): assertCompoundSolutionCheck(), collectAgentDocContents(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSolutionDocContents(), collectSourceLineChanges() (+21 more)
+
+### Community 32 - "Community 32"
 Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.11
 Nodes (24): buildGitProcessEnv(), buildProviderSkip(), collectCommandsForChangedFiles(), commandDisplayName(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs() (+16 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.14
 Nodes (25): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+17 more)
-
-### Community 34 - "Community 34"
-Cohesion: 0.16
-Nodes (28): assertCompoundSolutionCheck(), collectAgentDocContents(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSolutionDocContents(), collectSourceLineChanges() (+20 more)
 
 ### Community 35 - "Community 35"
 Cohesion: 0.13
@@ -2907,24 +2907,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 197 - "Community 197"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 198 - "Community 198"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 200 - "Community 200"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
 ### Community 201 - "Community 201"
 Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 202 - "Community 202"
 Cohesion: 0.39
@@ -3535,76 +3535,76 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 354 - "Community 354"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
-### Community 355 - "Community 355"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 356 - "Community 356"
+### Community 355 - "Community 355"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 357 - "Community 357"
+### Community 356 - "Community 356"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
+
+### Community 357 - "Community 357"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 358 - "Community 358"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 359 - "Community 359"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 360 - "Community 360"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 361 - "Community 361"
+### Community 360 - "Community 360"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
+
+### Community 361 - "Community 361"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 362 - "Community 362"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 363 - "Community 363"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 364 - "Community 364"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 365 - "Community 365"
+### Community 364 - "Community 364"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 366 - "Community 366"
+### Community 365 - "Community 365"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 367 - "Community 367"
+### Community 366 - "Community 366"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 368 - "Community 368"
+### Community 367 - "Community 367"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 369 - "Community 369"
+### Community 368 - "Community 368"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 370 - "Community 370"
+### Community 369 - "Community 369"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 371 - "Community 371"
+### Community 370 - "Community 370"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
+
+### Community 371 - "Community 371"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 372 - "Community 372"
 Cohesion: 0.4
@@ -3619,12 +3619,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 375 - "Community 375"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 376 - "Community 376"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 376 - "Community 376"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 377 - "Community 377"
 Cohesion: 0.4
@@ -3635,20 +3635,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 379 - "Community 379"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 380 - "Community 380"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 381 - "Community 381"
+### Community 380 - "Community 380"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 382 - "Community 382"
+### Community 381 - "Community 381"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+
+### Community 382 - "Community 382"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 383 - "Community 383"
 Cohesion: 0.4
@@ -3667,80 +3667,80 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 387 - "Community 387"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 388 - "Community 388"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 389 - "Community 389"
+### Community 388 - "Community 388"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 390 - "Community 390"
+### Community 389 - "Community 389"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 391 - "Community 391"
+### Community 390 - "Community 390"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 392 - "Community 392"
+### Community 391 - "Community 391"
 Cohesion: 0.5
 Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
-### Community 393 - "Community 393"
+### Community 392 - "Community 392"
 Cohesion: 0.5
 Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
-### Community 394 - "Community 394"
+### Community 393 - "Community 393"
 Cohesion: 0.5
 Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
 
-### Community 395 - "Community 395"
+### Community 394 - "Community 394"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 396 - "Community 396"
+### Community 395 - "Community 395"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 397 - "Community 397"
+### Community 396 - "Community 396"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 398 - "Community 398"
+### Community 397 - "Community 397"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 399 - "Community 399"
+### Community 398 - "Community 398"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 400 - "Community 400"
+### Community 399 - "Community 399"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 401 - "Community 401"
+### Community 400 - "Community 400"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 402 - "Community 402"
+### Community 401 - "Community 401"
 Cohesion: 0.6
 Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
-### Community 403 - "Community 403"
+### Community 402 - "Community 402"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 404 - "Community 404"
+### Community 403 - "Community 403"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 405 - "Community 405"
+### Community 404 - "Community 404"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
+
+### Community 405 - "Community 405"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 406 - "Community 406"
 Cohesion: 0.4
@@ -3751,44 +3751,44 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 408 - "Community 408"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 409 - "Community 409"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 410 - "Community 410"
+### Community 409 - "Community 409"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 411 - "Community 411"
+### Community 410 - "Community 410"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 412 - "Community 412"
+### Community 411 - "Community 411"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 413 - "Community 413"
+### Community 412 - "Community 412"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 414 - "Community 414"
+### Community 413 - "Community 413"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
-### Community 415 - "Community 415"
+### Community 414 - "Community 414"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 416 - "Community 416"
+### Community 415 - "Community 415"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 417 - "Community 417"
+### Community 416 - "Community 416"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 417 - "Community 417"
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 418 - "Community 418"
 Cohesion: 0.7

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2154
-- Graph nodes: 8402
-- Graph edges: 10063
+- Graph nodes: 8403
+- Graph edges: 10066
 - Communities: 2081
 
 ## Graph Hotspots

--- a/scripts/compound-solution-check.test.ts
+++ b/scripts/compound-solution-check.test.ts
@@ -139,6 +139,17 @@ describe("extractSolutionReferences", () => {
       )
     ).toEqual(["docs/solutions/harness/compound-solution-gate-2026-05-05.md"]);
   });
+
+  it("resolves package-agent relative solution doc links to repo paths", () => {
+    expect(
+      extractSolutionReferences(
+        "See [context primitives](../../../../docs/solutions/architecture/athena-intelligence-context-primitives-2026-06-21.md).",
+        "packages/storefront-webapp/docs/agent/architecture.md"
+      )
+    ).toEqual([
+      "docs/solutions/architecture/athena-intelligence-context-primitives-2026-06-21.md",
+    ]);
+  });
 });
 
 describe("isConsiderableSourcePath", () => {
@@ -242,6 +253,52 @@ describe("collectCompoundSolutionFindings", () => {
     });
 
     expect(findings).toEqual([]);
+  });
+
+  it("fails when changed agent docs contain a relative solution link that does not resolve", () => {
+    const findings = collectCompoundSolutionFindings({
+      changedFiles: ["packages/athena-webapp/docs/agent/architecture.md"],
+      existingFiles: new Set(["packages/athena-webapp/docs/agent/architecture.md"]),
+      markdownContents: new Map([
+        [
+          "packages/athena-webapp/docs/agent/architecture.md",
+          "See [missing](../../../../docs/solutions/architecture/missing-foundation.md).",
+        ],
+      ]),
+      sourceLineChanges: lineChanges([]),
+    });
+
+    expect(findings).toEqual([
+      {
+        message:
+          "packages/athena-webapp/docs/agent/architecture.md references docs/solutions/architecture/missing-foundation.md, but that solution doc does not exist.",
+      },
+    ]);
+  });
+
+  it("fails when existing agent docs contain a relative solution link that does not resolve", () => {
+    const findings = collectCompoundSolutionFindings({
+      changedFiles: ["docs/harness.md"],
+      existingFiles: new Set([
+        "docs/harness.md",
+        "packages/athena-webapp/docs/agent/architecture.md",
+      ]),
+      markdownContents: new Map([["docs/harness.md", "# Harness\n"]]),
+      agentDocContents: new Map([
+        [
+          "packages/athena-webapp/docs/agent/architecture.md",
+          "See [missing](../../../../docs/solutions/architecture/missing-foundation.md).",
+        ],
+      ]),
+      sourceLineChanges: lineChanges([]),
+    });
+
+    expect(findings).toEqual([
+      {
+        message:
+          "packages/athena-webapp/docs/agent/architecture.md references docs/solutions/architecture/missing-foundation.md, but that solution doc does not exist.",
+      },
+    ]);
   });
 
   it("fails substantial source changes without a changed solution doc", () => {
@@ -441,13 +498,53 @@ describe("collectCompoundSolutionFindings", () => {
       agentDocContents: new Map([
         [
           "packages/athena-webapp/docs/agent/architecture.md",
-          "See docs/solutions/architecture/terminal-boundary.md.\n",
+          "See [terminal boundary](../../../../docs/solutions/architecture/terminal-boundary.md).\n",
         ],
       ]),
       sourceLineChanges: lineChanges([]),
     });
 
     expect(findings).toEqual([]);
+  });
+
+  it("does not accept a broken relative agent-doc link as foundational discoverability", () => {
+    const findings = collectCompoundSolutionFindings({
+      changedFiles: ["docs/solutions/architecture/terminal-boundary.md"],
+      existingFiles: new Set([
+        "docs/solutions/architecture/terminal-boundary.md",
+        "packages/athena-webapp/docs/agent/architecture.md",
+      ]),
+      markdownContents: new Map([
+        [
+          "docs/solutions/architecture/terminal-boundary.md",
+          architectureSolutionNote(),
+        ],
+      ]),
+      solutionDocContents: new Map([
+        [
+          "docs/solutions/architecture/terminal-boundary.md",
+          architectureSolutionNote(),
+        ],
+      ]),
+      agentDocContents: new Map([
+        [
+          "packages/athena-webapp/docs/agent/architecture.md",
+          "See [terminal boundary](../../../docs/solutions/architecture/terminal-boundary.md).\n",
+        ],
+      ]),
+      sourceLineChanges: lineChanges([]),
+    });
+
+    expect(findings).toEqual([
+      {
+        message:
+          "packages/athena-webapp/docs/agent/architecture.md references packages/docs/solutions/architecture/terminal-boundary.md, but that solution doc does not exist.",
+      },
+      {
+        message:
+          "Foundational architecture solution note docs/solutions/architecture/terminal-boundary.md is missing an agent-doc discovery reference. Link it from packages/*/docs/agent/{architecture.md,code-map.md,testing.md} so future agents can find the durable concept.",
+      },
+    ]);
   });
 
   it("fails existing foundational architecture notes that are not agent-discoverable", () => {

--- a/scripts/compound-solution-check.ts
+++ b/scripts/compound-solution-check.ts
@@ -62,7 +62,7 @@ const COMPOUND_SENSITIVE_PATTERNS = [
   /^package\.json$/,
 ] as const;
 const SOLUTION_REFERENCE_PATTERN =
-  /(?:^|[\s('"`])((?:\.\/)?docs\/solutions\/[A-Za-z0-9._/-]+\.md)(?=$|[\s)'"`,.])/g;
+  /(?:^|[\s('"`])((?:(?:\.\.?\/)+)?docs\/solutions\/[A-Za-z0-9._/-]+\.md)(?=$|[\s)'"`,.])/g;
 
 function normalizeRepoPath(repoPath: string) {
   return repoPath.replaceAll("\\", "/").replace(/^\.\//, "");
@@ -112,9 +112,32 @@ export function isCompoundSensitiveWorkflowPath(repoPath: string) {
   return COMPOUND_SENSITIVE_PATTERNS.some((pattern) => pattern.test(normalizedPath));
 }
 
-export function extractSolutionReferences(markdown: string) {
+function normalizeSolutionReference(reference: string, markdownFilePath?: string) {
+  const normalizedReference = normalizeRepoPath(reference);
+
+  if (
+    normalizedReference.startsWith("docs/solutions/") ||
+    normalizedReference.startsWith("./docs/solutions/")
+  ) {
+    return normalizeRepoPath(normalizedReference);
+  }
+
+  if (!markdownFilePath) {
+    return normalizeRepoPath(path.posix.normalize(normalizedReference));
+  }
+
+  return normalizeRepoPath(
+    path.posix.normalize(
+      path.posix.join(path.posix.dirname(normalizeRepoPath(markdownFilePath)), normalizedReference)
+    )
+  );
+}
+
+export function extractSolutionReferences(markdown: string, markdownFilePath?: string) {
   return sortUniquePaths(
-    [...markdown.matchAll(SOLUTION_REFERENCE_PATTERN)].map((match) => match[1])
+    [...markdown.matchAll(SOLUTION_REFERENCE_PATTERN)].map((match) =>
+      normalizeSolutionReference(match[1], markdownFilePath)
+    )
   );
 }
 
@@ -181,7 +204,7 @@ function hasAgentDocSolutionReference(
       continue;
     }
 
-    if (markdown.includes(solutionDocPath)) {
+    if (extractSolutionReferences(markdown, filePath).includes(solutionDocPath)) {
       return true;
     }
   }
@@ -223,8 +246,13 @@ export function collectCompoundSolutionFindings({
     isCompoundSensitiveWorkflowPath(filePath)
   );
 
-  for (const [filePath, markdown] of markdownContents) {
-    const references = extractSolutionReferences(markdown);
+  const referenceMarkdownContents = new Map([
+    ...agentDocContents,
+    ...markdownContents,
+  ]);
+
+  for (const [filePath, markdown] of referenceMarkdownContents) {
+    const references = extractSolutionReferences(markdown, filePath);
 
     for (const reference of references) {
       if (!existingFiles.has(reference)) {


### PR DESCRIPTION
## Summary
- resolve `docs/solutions/**/*.md` references relative to the markdown file that contains them
- require foundational architecture discoverability to be a real resolved solution-doc link, not just a raw substring
- validate existing agent discovery docs on every `compound:check` run so broken links are caught even when those docs are not in the changed file set
- refresh the compound gate solution note and graphify artifacts for the new invariant

## Validation
- `bun test scripts/compound-solution-check.test.ts`
- `bun run compound:check`
- `git diff --check`
- `bun run graphify:rebuild`
- `bun run harness:check`
- `bun run pr:athena` (pass; delivery run recorded 2026-07-02T02:19:06Z)
