### PR TITLE
Fix approval requester attribution

### DIFF
--- a/docs/plans/2026-07-02-001-fix-approval-requester-attribution-plan.html
+++ b/docs/plans/2026-07-02-001-fix-approval-requester-attribution-plan.html
@@ -1,0 +1,284 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>fix: Separate approval requester attribution</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #172033;
+      --muted: #5e6a7d;
+      --line: #d9dee8;
+      --panel: #f7f9fc;
+      --accent: #315f8f;
+      --risk: #8f3d31;
+      --ok: #28684a;
+    }
+    body {
+      margin: 0;
+      background: #ffffff;
+      color: var(--ink);
+      font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 40px 28px 56px;
+    }
+    header {
+      border-bottom: 1px solid var(--line);
+      margin-bottom: 28px;
+      padding-bottom: 22px;
+    }
+    h1 {
+      font-size: 32px;
+      line-height: 1.15;
+      margin: 0 0 12px;
+      letter-spacing: 0;
+    }
+    h2 {
+      border-top: 1px solid var(--line);
+      font-size: 21px;
+      margin: 30px 0 12px;
+      padding-top: 24px;
+      letter-spacing: 0;
+    }
+    h3 {
+      font-size: 16px;
+      margin: 18px 0 8px;
+      letter-spacing: 0;
+    }
+    a {
+      color: var(--accent);
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    .meta {
+      color: var(--muted);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px 18px;
+      margin: 0;
+    }
+    .summary {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 18px 20px;
+    }
+    .grid {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+    .card {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px;
+    }
+    .card h3 {
+      margin-top: 0;
+    }
+    .tag {
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      color: var(--muted);
+      display: inline-block;
+      font-size: 12px;
+      margin: 2px 5px 2px 0;
+      padding: 2px 8px;
+    }
+    code {
+      background: #eef2f7;
+      border-radius: 4px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.92em;
+      padding: 1px 4px;
+    }
+    ul {
+      padding-left: 21px;
+    }
+    li {
+      margin: 5px 0;
+    }
+    table {
+      border-collapse: collapse;
+      margin: 12px 0;
+      width: 100%;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 9px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th {
+      background: var(--panel);
+    }
+    .risk {
+      border-left: 4px solid var(--risk);
+    }
+    .ok {
+      border-left: 4px solid var(--ok);
+    }
+    @media (max-width: 720px) {
+      main {
+        padding: 28px 18px 44px;
+      }
+      h1 {
+        font-size: 27px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>fix: Separate approval requester attribution</h1>
+      <p class="meta">
+        <span>Type: fix</span>
+        <span>Status: active</span>
+        <span>Date: 2026-07-02</span>
+        <span>Source: <a href="2026-07-02-001-fix-approval-requester-attribution-plan.md">markdown plan</a></span>
+      </p>
+    </header>
+
+    <section class="summary">
+      <h2>Summary</h2>
+      <p>Approval proof minting should stop treating every <code>requestedByStaffProfileId</code> as a staff profile linked to the signed-in Athena account. The plan keeps the anti-spoofing guard for signed-in requester claims, while adding a first-class, server-held requester challenge for POS and Cash Controls workflows where the requester is an operational staff actor.</p>
+    </section>
+
+    <section>
+      <h2>Problem</h2>
+      <p>Valid manager credentials can fail with <code>Requested staff profile does not match the signed-in user.</code> The failure is in proof minting, not manager credential validation. Current POS and Cash Controls workflows can send an operational requester staff profile through a field now interpreted as signed-in-user staff attribution.</p>
+    </section>
+
+    <section>
+      <h2>Core Requirements</h2>
+      <ul>
+        <li>Valid manager credentials must not fail solely because the operational requester staff profile is unlinked.</li>
+        <li>The linked-user guard remains for direct signed-in requester claims.</li>
+        <li>Proof creation and consumption keep exact requester binding.</li>
+        <li>POS corrections, POS opening-float correction, and Cash Controls register workflows are fixed together.</li>
+        <li>Operations Queue, Daily Close, and Daily Opening are characterized for non-regression.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Key Decisions</h2>
+      <div class="grid">
+        <article class="card ok">
+          <h3>First-Class Binding</h3>
+          <p>Add an <code>ApprovalRequesterBinding</code> shape in shared approval policy and matching Convex validation instead of carrying requester data through untyped metadata.</p>
+        </article>
+        <article class="card ok">
+          <h3>Server-Held Challenge</h3>
+          <p>Operational requester binding uses a short-lived Convex challenge that stores requester, action, store, subject, role, expiry, and proof-minting state.</p>
+        </article>
+        <article class="card ok">
+          <h3>Preserve Proof Consumption</h3>
+          <p><code>consumeApprovalProofWithCtx</code> keeps exact action, store, subject, role, requester, expiry, and one-use checks.</p>
+        </article>
+        <article class="card risk">
+          <h3>No React-Trusted Fallback</h3>
+          <p>Protected operational flows must use a server challenge or mint with no requester; caller-provided staff ids are not trusted fallbacks.</p>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <h2>Implementation Units</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>U1. Requester Binding Foundation</h3>
+          <p>Add the shared requester-binding type and Convex-backed requester challenge used by proof minting.</p>
+          <span class="tag">staffCredentials</span><span class="tag">approval challenges</span>
+        </article>
+        <article class="card">
+          <h3>U2. Shared Runner Contract</h3>
+          <p>Update <code>useApprovedCommand</code> and <code>CommandApprovalDialog</code> to pass first-class requester bindings and remove React-trusted operational fallback.</p>
+          <span class="tag">React</span><span class="tag">approval UI</span>
+        </article>
+        <article class="card">
+          <h3>U3. POS Corrections</h3>
+          <p>Fix payment correction, item adjustment, void, and opening-float correction with Staff A requester and Manager Staff B approval coverage.</p>
+          <span class="tag">POS</span><span class="tag">financial correction</span>
+        </article>
+        <article class="card">
+          <h3>U4. Cash Controls</h3>
+          <p>Fix closeout submit, finalize, reopen, reopened submit, opening-float correction, and sync-review requester binding.</p>
+          <span class="tag">cash controls</span><span class="tag">closeout</span>
+        </article>
+        <article class="card">
+          <h3>U5. Adjacent Characterization</h3>
+          <p>Characterize Operations Queue, Daily Close, and Daily Opening so the shared helper changes do not broaden authority.</p>
+          <span class="tag">daily ops</span><span class="tag">queue</span>
+        </article>
+        <article class="card">
+          <h3>U6. Docs and Validation</h3>
+          <p>Add durable solution guidance, run focused approval/POS/cash-control tests, and rebuild graphify after code changes.</p>
+          <span class="tag">docs</span><span class="tag">validation</span>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <h2>Primary Files</h2>
+      <ul>
+        <li><code>packages/athena-webapp/convex/operations/staffCredentials.ts</code></li>
+        <li><code>packages/athena-webapp/convex/operations/approvalProofs.ts</code></li>
+        <li><code>packages/athena-webapp/src/components/operations/useApprovedCommand.tsx</code></li>
+        <li><code>packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx</code></li>
+        <li><code>packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts</code></li>
+        <li><code>packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx</code></li>
+        <li><code>packages/athena-webapp/convex/cashControls/closeouts.ts</code></li>
+        <li><code>packages/athena-webapp/convex/cashControls/deposits.ts</code></li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Risk Summary</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Risk</th>
+            <th>Mitigation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Requester validation relaxes into spoofing.</td>
+            <td>Make requester source explicit and keep linked-user validation for signed-in requester claims.</td>
+          </tr>
+          <tr>
+            <td>UI forwards stale requester ids.</td>
+            <td>Use server-returned requester context in shared runners and test mismatches.</td>
+          </tr>
+          <tr>
+            <td>Manager elevation becomes approval.</td>
+            <td>Add non-regression coverage that elevation cannot satisfy command approval.</td>
+          </tr>
+          <tr>
+            <td>Scope expands into full approval refactor.</td>
+            <td>Defer broader audit normalization to the existing July 1 standard plan.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Verification Focus</h2>
+      <ul>
+        <li>Staff A requester unlinked to signed-in user plus Manager Staff B valid credentials succeeds through a server-held requester challenge for affected POS and Cash Controls workflows.</li>
+        <li>Direct signed-in requester mismatch still fails.</li>
+        <li>Wrong requester, action, store, subject, role, forged challenge, stale challenge, expired proof, and consumed proof fail closed.</li>
+        <li>Operations Queue records reviewer account and approving manager separately.</li>
+        <li>Daily Opening remains free of a manager approval start-day blocker.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-07-02-001-fix-approval-requester-attribution-plan.md
+++ b/docs/plans/2026-07-02-001-fix-approval-requester-attribution-plan.md
@@ -1,0 +1,483 @@
+---
+title: "fix: Separate approval requester attribution"
+type: fix
+status: active
+date: 2026-07-02
+---
+
+# fix: Separate approval requester attribution
+
+## Summary
+
+Approval proof minting should stop treating every `requestedByStaffProfileId` as a staff profile linked to the signed-in Athena account. This plan keeps the July 1 anti-spoofing guard for signed-in requester claims, but adds a server-owned requester-binding path for POS and Cash Controls workflows where the requester is an operational staff actor validated by staff credentials or the domain command.
+
+---
+
+## Problem Frame
+
+Valid manager credentials can currently fail before proof creation with `Requested staff profile does not match the signed-in user.` The failure happens in `packages/athena-webapp/convex/operations/staffCredentials.ts`, where proof minting validates `requestedByStaffProfileId` against `staffProfile.linkedUserId`. That is correct when the client claims "this requester is the signed-in user's linked staff profile", but wrong when POS or Cash Controls passes the cashier/operator staff profile that initiated the business command.
+
+The fix should not weaken manager approval. The approving manager remains `approvalProof.approvedByStaffProfileId`; the requester remains bound to the proof and command; the signed-in Athena user remains account/session/reviewer evidence.
+
+---
+
+## Assumptions
+
+- Staff profile linking is supported but is not the live source of truth for many POS and Cash Controls actors, so this plan does not rely on broad `linkedUserId` cleanup.
+- The implementation should prefer server-derived requester binding from the initial protected command over trusting a requester id supplied only by React state.
+- Operations Queue, Daily Close, and Daily Opening are in scope for characterization because they share approval primitives, but they should not be rewritten unless tests show they pass the failing requester field.
+
+---
+
+## Requirements
+
+- R1. Valid manager credentials must not be rejected only because the operational requester staff profile is unlinked to the signed-in Athena user.
+- R2. The existing linked-user guard must remain for flows that explicitly claim a requester staff profile as the signed-in Athena user's staff identity.
+- R3. Approval proofs must keep exact requester binding for workflows with a validated requester; no-requester workflows must mint and consume proofs with no requester rather than falling back to caller state.
+- R4. POS transaction corrections, POS opening-float correction, and Cash Controls register closeout workflows must all use the corrected requester-binding behavior.
+- R5. Raw `staffProfileId`, `managerElevationId`, and signed-in `athenaUser` identity must not become manager approval authority.
+- R6. Affected domain records and read models must preserve requester/operator, approving manager, proof id, and reviewer/account evidence as distinct lanes where those facts already exist.
+- R7. Operations Queue, Daily Close, and Daily Opening must retain their current authority semantics unless characterization reveals the same linked-user requester failure.
+- R8. Regression coverage must prove invalid store, inactive requester, wrong action, wrong subject, wrong requester, forged requester challenge, stale/replayed challenge, expired proof, consumed proof, and manager-elevation spoof attempts fail closed.
+
+---
+
+## Scope Boundaries
+
+- This plan does not change approval actions, thresholds, required roles, proof TTL, or self-approval policy.
+- This plan does not auto-link Athena users to staff profiles.
+- This plan does not replace `approvalProof` or `CommandApprovalDialog`.
+- This plan does not introduce offline manager approval.
+- This plan does not change Operations Queue's full-admin reviewer gate.
+- This plan does not make Daily Opening require manager approval to start the day.
+- This plan does not backfill historical approval records.
+
+### Deferred to Follow-Up Work
+
+- Broader execution of `docs/plans/2026-07-01-002-refactor-manager-approval-standard-plan.md` beyond the requester-link failure.
+- Historical audit normalization for old records that lack typed approval evidence.
+- Product/security reconsideration of self-approval by approval action.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/convex/operations/staffCredentials.ts` authenticates staff credentials and currently rejects unlinked `requestedByStaffProfileId` in `validateApprovalRequesterStaffProfileWithCtx`.
+- `packages/athena-webapp/convex/operations/approvalProofs.ts` creates one-use approval proofs and already enforces exact requester matching during consumption.
+- `packages/athena-webapp/src/components/operations/useApprovedCommand.tsx` is the shared UI runner that forwards requester ids into `authenticateStaffCredentialForApproval`.
+- `packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx` is the shared fallback approval dialog.
+- `packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx` passes requester staff ids for payment correction, item adjustment, and completed-sale void approval.
+- `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts` and `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx` pass the active POS staff actor for opening-float correction approval.
+- `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx` passes operational staff ids through closeout submit, finalize, reopen, reopened submit, and sync-review approval paths.
+- `packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts`, `packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts`, and `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts` consume requester-bound proofs for POS corrections.
+- `packages/athena-webapp/convex/cashControls/closeouts.ts` and `packages/athena-webapp/convex/cashControls/deposits.ts` consume requester-bound proofs for register closeout and sync-review actions.
+- `packages/athena-webapp/convex/operations/approvalRequests.ts`, `packages/athena-webapp/src/components/operations/OperationsQueueView.tsx`, `packages/athena-webapp/convex/operations/dailyClose.ts`, and `packages/athena-webapp/convex/operations/dailyOpening.ts` are adjacent surfaces to characterize for non-regression.
+
+### Institutional Learnings
+
+- `packages/athena-webapp/docs/agent/architecture.md` says manager approval authority must stay separate from the signed-in Athena session, and requester, reviewer, decision proof, approving manager, and automation fields are distinct lanes.
+- `docs/solutions/architecture/athena-manager-approval-authority-standard-2026-07-01.md` records the durable approval evidence standard this plan should follow.
+- `docs/solutions/logic-errors/athena-command-approval-manager-fast-path-2026-05-02.md` says the command boundary owns action, subject, role, reason, and resolution modes; staff profile ids are requester identity, not approval.
+- `docs/solutions/logic-errors/athena-command-approval-policy-boundary-2026-05-01.md` says protected commands should return `approval_required`, mint a server-validated one-use proof, then retry the same command.
+- `docs/solutions/logic-errors/athena-terminal-manager-elevation-command-boundary-2026-05-10.md` makes manager elevation a surface capability, not command approval.
+- `docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md` separates local POS staff authority from global Athena access and approval authority.
+- `docs/solutions/logic-errors/athena-register-closeout-correction-approval-boundary-2026-06-25.md` separates closeout staff identity, manager reopen/correction authority, and async variance approval.
+
+### Prior Session Evidence
+
+- July 1 manager approval work established that account session identity and staff/PIN identity are separate lanes, and proof authority comes from consumed proof fields.
+- July 1 security review accepted the strict linked-user guard for signed-in requester attribution and rejected caller-controlled requester spoofing.
+- The closeout mismatch investigation traced the current browser failure to proof minting in `staffCredentials.ts`, not invalid manager credentials.
+
+### External References
+
+- None. Existing Athena code, package-local Convex guidance, and project solution docs are the source of truth.
+
+---
+
+## Key Technical Decisions
+
+- **Use a first-class requester-binding contract:** Add an `ApprovalRequesterBinding` shape to `packages/athena-webapp/shared/approvalPolicy.ts` and the matching Convex validator in `packages/athena-webapp/convex/operations/staffCredentials.ts`. Do not carry requester binding through untyped `metadata`.
+- **Use a short-lived server-held requester challenge for operational staff:** Protected domain commands that need manager approval and have an operational requester should create a server-side approval requester challenge before returning `approval_required`. The challenge stores action, store, subject, required role, requester staff profile, expiry, and consumed/minted state. `authenticateStaffCredentialForApproval` validates the challenge against the caller's action/store/subject/role and uses the stored requester id; it does not trust a client-provided requester id or mode flag.
+- **Keep signed-in requester validation separate:** Signed-in requester claims keep the current `linkedUserId` check and do not use the operational requester challenge path.
+- **Keep proof consumption unchanged:** `consumeApprovalProofWithCtx` should continue exact matching on action, store, subject, role, requester, expiry, and consumption state.
+- **Remove React-trusted operational fallbacks:** `useApprovedCommand` should pass the server-returned requester binding from the `approval_required` result. For protected operational workflows, caller-provided `requestedByStaffProfileId` is not a fallback. If no requester binding is present, proof creation must mint without requester and the retry must consume without requester.
+- **Do not make approval proof creation a raw active-staff lookup:** Accepting any active staff profile for proof requester attribution would recreate the spoofing concern. The implementation should make the requester source explicit enough that reviewers can tell which validation path ran.
+- **Keep affected workflow changes narrow:** POS corrections, POS opening-float correction, and Cash Controls closeout paths need behavior changes and regression tests. Operations Queue, Daily Close, and Daily Opening need characterization/non-regression unless implementation reveals the same faulty requester path.
+- **Preserve authority lane vocabulary:** Account user, operational requester, approving manager, reviewer account, manager elevation, and automation evidence remain separate in names, tests, and durable records.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should the fix auto-link staff profiles to Athena users?** No. Prior sessions show staff linking is not a reliable live assumption, and auto-linking would couple account session and staff/PIN identity.
+- **Should manager proof creation simply stop validating requester ids?** No. The requester still needs store/status validation and a clear source; proof consumption still enforces exact requester matching.
+- **Should Operations Queue be rewritten as part of this fix?** No. It does not pass `requestedByStaffProfileId` into proof creation for the decision unlock today, so it is a characterization surface for this plan.
+- **Should Daily Opening gain a manager gate?** No. Starting the day should not require manager approval just to unblock POS.
+
+### Deferred to Implementation
+
+- Exact helper and table names for the short-lived requester challenge are implementation-owned, but the plan requires a first-class shared requester-binding type and a server-verifiable challenge, not metadata echoing.
+- If a specific workflow lacks server-side requester validation today, implementation must add that validation before it can return an operational requester challenge. Otherwise it must omit requester binding and consume the resulting proof with no requester.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  A["Protected domain command"] --> B{"Needs manager approval?"}
+  B -->|no| C["Apply command with actor/requester evidence"]
+  B -->|yes| D["Return approval_required with server-validated subject and requester context"]
+  D --> E["Create short-lived requester challenge when operational requester exists"]
+  E --> F["useApprovedCommand / CommandApprovalDialog passes first-class binding"]
+  F --> G["Manager credential authentication"]
+  G --> H["Requester binding policy"]
+  H -->|signed-in requester| I["Require staffProfile.linkedUserId == athenaUser"]
+  H -->|operational requester| N["Load challenge and verify action/store/subject/role/expiry"]
+  H -->|none| O["Mint proof with no requester"]
+  I --> J["Create requester-bound approvalProof"]
+  N --> J
+  O --> K
+  J --> K["Retry same command with approvalProofId"]
+  K --> L["consumeApprovalProof exact action/store/subject/role/requester match"]
+  L --> M["Apply command and persist requester plus approver evidence"]
+```
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 requester binding foundation"] --> U2["U2 shared runner contract"]
+  U1 --> U3["U3 POS correction workflows"]
+  U2 --> U3
+  U1 --> U4["U4 Cash Controls workflows"]
+  U2 --> U4
+  U1 --> U5["U5 adjacent workflow characterization"]
+  U2 --> U5
+  U3 --> U6["U6 docs and validation"]
+  U4 --> U6
+  U5 --> U6
+```
+
+- U1. **Define approval requester binding at proof creation**
+
+**Goal:** Separate signed-in staff requester claims from operational staff requester binding without weakening approval proof consumption.
+
+**Requirements:** R1, R2, R3, R5, R8
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/staffCredentials.ts`
+- Modify: `packages/athena-webapp/convex/operations/staffCredentials.test.ts`
+- Modify: `packages/athena-webapp/convex/operations/approvalProofs.test.ts`
+- Modify: `packages/athena-webapp/convex/operations/approvalProofs.ts` only if return data needs to expose challenge consumption evidence
+- Modify: `packages/athena-webapp/convex/schema.ts`
+- Create: `packages/athena-webapp/convex/operations/approvalRequesterChallenges.ts`
+- Create: `packages/athena-webapp/convex/operations/approvalRequesterChallenges.test.ts`
+- Modify: `packages/athena-webapp/convex/lib/commandResultValidators.ts`
+- Modify: `packages/athena-webapp/shared/approvalPolicy.ts`
+
+**Approach:**
+- Replace `validateApprovalRequesterStaffProfileWithCtx` with a policy that distinguishes requester source.
+- Add a first-class `ApprovalRequesterBinding` to the shared approval policy. It should cover `none`, `signed_in_staff_profile`, and `operational_staff_challenge`.
+- Update the central Convex approval requirement validator so returned `approval_required` results validate the first-class requester binding.
+- Add a small Convex-backed requester challenge helper that creates short-lived records for operational requester binding. Challenge records must store requester staff profile, action key, store, subject type/id, required role, expiry, and whether the challenge has already minted a proof.
+- Keep the existing linked-user check for signed-in requester attribution.
+- For operational requester binding, have proof creation load the challenge server-side, validate action/store/subject/role/expiry, validate the stored requester staff profile is active and in-store, mark the challenge as used for proof minting, and then create the proof with the stored requester id.
+- For no-requester binding, mint proof with `requestedByStaffProfileId` omitted and require the retry command to consume with no requester.
+- Leave `consumeApprovalProofWithCtx` requester matching unchanged.
+- Keep `approvedByStaffProfileId` and `approvedByCredentialId` as the only manager approval authority evidence.
+
+**Execution note:** Start with failing `staffCredentials.test.ts` coverage for an unlinked requester with valid manager credentials, then add the source-specific rejection cases.
+
+**Patterns to follow:**
+- `packages/athena-webapp/docs/agent/architecture.md` approval authority lanes.
+- `packages/athena-webapp/convex/operations/approvalProofs.ts` one-use proof binding.
+
+**Test scenarios:**
+- Happy path: unlinked active in-store Staff A can be bound as operational requester when valid Manager Staff B credentials mint the proof.
+- Happy path: requester Staff A linked to a different Athena user can still be bound through the operational requester path when the workflow source is valid.
+- Error path: direct signed-in requester mode rejects Staff A when `linkedUserId` does not match the signed-in Athena user.
+- Error path: inactive requester staff profile is rejected.
+- Error path: requester staff profile from another store is rejected.
+- Error path: direct calls to `authenticateStaffCredentialForApproval` with a forged operational requester binding fail when no matching server challenge exists.
+- Error path: tampered challenge/action/store/subject/role values fail before proof creation.
+- Error path: stale or reused requester challenges cannot mint proofs for a new approval attempt.
+- Error path: proof created for Staff A cannot be consumed by a command retried for Staff B.
+- Error path: expired, consumed, wrong-store, wrong-action, wrong-role, and wrong-subject proofs still fail closed.
+- Error path: passing a manager elevation id or equivalent capability evidence cannot mint approval proof.
+
+**Verification:**
+- Proof creation accepts operational requester binding without accepting arbitrary signed-in requester spoofing.
+- Existing approval proof replay protections are unchanged.
+
+---
+
+- U2. **Move shared UI runners to server-derived requester context**
+
+**Goal:** Ensure `useApprovedCommand` and shared approval dialogs do not blindly forward caller-provided operational staff ids as signed-in requester claims.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/operations/useApprovedCommand.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/useApprovedCommand.test.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/CommandApprovalDialog.test.tsx`
+- Modify: `packages/athena-webapp/shared/approvalPolicy.ts`
+
+**Approach:**
+- Teach the runner to pass the first-class requester binding returned by the server's `approval_required` result.
+- Remove operational requester fallback from caller-provided `requestedByStaffProfileId`. For protected operational flows, the fallback is either the server challenge or no requester binding.
+- Allow signed-in requester fallback only when the caller explicitly uses the signed-in requester binding mode and the backend can enforce the linked-user check.
+- Keep same-submission manager credentials as an inline proof attempt after the command returns `approval_required`; do not precompute policy in React.
+- Ensure dialog approval and same-submission approval pass the same requester binding to proof creation and command retry.
+
+**Patterns to follow:**
+- `docs/solutions/logic-errors/athena-command-approval-manager-fast-path-2026-05-02.md`.
+- Existing `buildApprovalRetryArgs` behavior in `useApprovedCommand.tsx`.
+
+**Test scenarios:**
+- Happy path: runner uses server-returned requester binding when caller args and approval binding disagree.
+- Happy path: same-submission inline manager proof passes the same requester binding that the retry command consumes.
+- Error path: runner does not pass an unvalidated requester fallback when the approval requirement lacks a server challenge.
+- Error path: tampered approval requester binding sent directly to the public proof-minting mutation fails server validation.
+- Error path: a requester challenge created for one action/store/subject cannot be replayed through another approval dialog.
+- Integration: `CommandApprovalDialog` sends requester context consistently with `useApprovedCommand`.
+
+**Verification:**
+- Shared approval UI no longer converts operational staff ids into signed-in requester claims by default.
+
+---
+
+- U3. **Fix POS protected correction workflows**
+
+**Goal:** Make POS payment correction, item adjustment, completed-sale void, and opening-float correction approve with valid manager credentials even when the requester staff profile is unlinked to the signed-in Athena account.
+
+**Requirements:** R1, R3, R4, R5, R6, R8
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Modify: `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/correctTransactionPaymentMethod.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/adjustTransactionItems.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/completeTransaction.test.ts`
+
+**Approach:**
+- Have each protected POS command create a requester challenge and return approval requirements with the challenge binding for the requester staff profile that the command already validated.
+- For item adjustment and void, preserve the local staff proof requirement; do not let manager proof replace cashier/operator authentication.
+- For payment correction, characterize the current actor validation and add the missing validation if the command only receives a raw staff id today.
+- For opening-float correction, bind the active POS staff requester through the same server-derived requester path before proof minting.
+- Preserve existing durable correction evidence such as requester staff, approval request id, decision proof id, and approved manager staff profile.
+
+**Execution note:** Add characterization coverage for current actor validation before changing payment correction semantics.
+
+**Patterns to follow:**
+- `docs/solutions/logic-errors/athena-pos-ledger-safe-corrections-2026-04-30.md`.
+- `docs/solutions/logic-errors/athena-pos-completed-transaction-void-reversal-2026-05-21.md`.
+- `docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md`.
+
+**Test scenarios:**
+- Happy path: Staff A requests payment correction and Manager Staff B approves inline, with Staff A unlinked to the signed-in Athena user.
+- Happy path: Staff A requests item adjustment with valid local staff proof and Manager Staff B approves inline.
+- Happy path: Staff A requests completed-sale void with valid local staff proof and Manager Staff B approves inline.
+- Happy path: active POS staff requests opening-float correction and a different manager approves.
+- Integration: async approval request and inline proof paths record equivalent requester and approver evidence.
+- Error path: manager proof without required local staff proof does not apply item adjustment or void.
+- Error path: proof requester mismatch fails without mutating transaction/register-session facts.
+- Error path: manager elevation or a forged requester challenge cannot approve a POS correction.
+
+**Verification:**
+- POS protected workflows no longer fail because operational requester staff is unlinked, and they still fail when requester proof binding or local staff authority is invalid.
+
+---
+
+- U4. **Fix Cash Controls register workflows**
+
+**Goal:** Make Cash Controls closeout submit, finalize, reopen, reopened submit, opening-float correction, and sync-review approvals use explicit requester binding instead of the signed-in-user staff link assumption.
+
+**Requirements:** R1, R3, R4, R5, R6, R8
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.auth.test.tsx`
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.test.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+
+**Approach:**
+- Ensure closeout submit/finalize paths create requester challenges for the staff actor resolved by `resolveCloseoutActorStaffProfileId`, not for the signed-in account's staff profile.
+- Ensure reopened closeout and closeout-reopen commands keep manager approver and operational requester distinct.
+- For sync review, keep the approving manager from proof data and bind requester only when the requester source is validated.
+- Remove or replace UI plumbing that forwards `result.staffProfileId` or `actorStaffProfileId` into proof minting without source context.
+- Preserve closeout evidence fields used by register-session history, deposits, and review display.
+
+**Execution note:** Characterize closeout submit/finalize behavior first because this is the browser manifestation that triggered the plan.
+
+**Patterns to follow:**
+- `docs/solutions/logic-errors/athena-register-closeout-correction-approval-boundary-2026-06-25.md`.
+- `docs/solutions/architecture/athena-pos-closeout-hold-boundary-2026-07-01.md`.
+- `docs/solutions/logic-errors/athena-cash-controls-closeout-review-ia-2026-06-08.md`.
+
+**Test scenarios:**
+- Happy path: cashier Staff A submits closeout with variance and Manager Staff B approves inline; Staff A is unlinked to signed-in user.
+- Happy path: manager Staff B finalizes a submitted closeout while requester Staff A remains distinct.
+- Happy path: closeout reopen and reopened submit preserve requester and approving manager evidence separately.
+- Happy path: sync-review approval uses manager proof approver as reviewer authority and does not require requester staff to be linked to the signed-in user.
+- Error path: invalid requester store/status fails before proof creation.
+- Error path: proof minted for one register session or requester cannot approve another closeout command.
+- Error path: manager elevation or a forged requester challenge cannot approve closeout, reopen, or sync-review commands.
+- Integration: register-session and deposit read models show requester/operator and manager approver without inferring from raw ids.
+
+**Verification:**
+- The selected browser closeout workflow can finalize with valid manager credentials, and the original linked-user error no longer appears for a validated operational requester.
+
+---
+
+- U5. **Characterize adjacent approval workflows**
+
+**Goal:** Prevent regressions in shared approval surfaces that do not currently trigger the exact linked-user failure.
+
+**Requirements:** R5, R6, R7, R8
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/operations/OperationsQueueView.tsx` only if characterization finds requester drift
+- Modify: `packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx`
+- Modify: `packages/athena-webapp/convex/operations/approvalRequests.ts` only if characterization finds evidence drift
+- Modify: `packages/athena-webapp/convex/operations/approvalRequests.test.ts`
+- Modify: `packages/athena-webapp/src/components/operations/DailyCloseView.tsx` only if characterization finds requester drift
+- Modify: `packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx`
+- Modify: `packages/athena-webapp/convex/operations/dailyClose.ts` only if characterization finds requester drift
+- Modify: `packages/athena-webapp/convex/operations/dailyClose.test.ts`
+- Modify: `packages/athena-webapp/src/components/operations/DailyOpeningView.tsx` only if characterization finds requester drift
+- Modify: `packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx`
+- Modify: `packages/athena-webapp/convex/operations/dailyOpening.ts` only if characterization finds requester drift
+- Modify: `packages/athena-webapp/convex/operations/dailyOpening.test.ts`
+
+**Approach:**
+- Prove Operations Queue decision unlock still mints proof without requester binding and records full-admin reviewer account separately from manager proof approver.
+- Prove Daily Close completion/reopen do not pass an unlinked operational requester into proof minting unless the requester has been validated.
+- Prove Daily Opening does not require manager approval for start-day continuity.
+- If any adjacent surface does pass `requestedByStaffProfileId` into proof creation, move it to the same source-specific requester binding model as U3/U4.
+
+**Patterns to follow:**
+- `docs/plans/2026-07-01-002-refactor-manager-approval-standard-plan.md`.
+- `docs/plans/2026-06-22-004-feat-eod-review-automation-plan.md`.
+
+**Test scenarios:**
+- Operations Queue: signed-in full-admin User X uses Manager Staff B credentials; decision records reviewer account and approving manager separately.
+- Operations Queue: unlinked manager credential still approves only after valid manager proof, not by account identity alone.
+- Daily Close: completion/reopen proof behavior remains valid when requester is omitted or validated.
+- Daily Opening: start-day flow remains free of a manager approval blocker.
+- Error path: manager elevation cannot satisfy any command approval in these adjacent flows.
+- Error path: automation evidence does not fabricate human manager proof fields.
+
+**Verification:**
+- Shared approval changes do not accidentally broaden manager authority or introduce new start-day/closeout blockers.
+
+---
+
+- U6. **Document, validate, and refresh generated context**
+
+**Goal:** Update durable project guidance and run the focused validation ladder for approval-sensitive workflows.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R8
+
+**Dependencies:** U1, U2, U3, U4, U5
+
+**Files:**
+- Modify: `packages/athena-webapp/docs/agent/architecture.md` if the requester-binding helper adds a new durable convention
+- Create or modify: `docs/solutions/logic-errors/athena-approval-requester-binding-2026-07-02.md`
+- Modify generated graph output through `bun run graphify:rebuild` after code changes
+
+**Approach:**
+- Add a solution note explaining the difference between signed-in requester attribution and operational requester binding.
+- Keep package docs concise: name the helper/pattern and the authority lanes, not the implementation internals.
+- Run focused approval, POS, cash-controls, and adjacent workflow tests before broader package validation.
+- Rebuild graphify because implementation will modify code files.
+
+**Patterns to follow:**
+- `docs/solutions/architecture/athena-manager-approval-authority-standard-2026-07-01.md`.
+- `packages/athena-webapp/docs/agent/testing.md` command approval and cash-controls validation guidance.
+
+**Test scenarios:**
+- Test expectation: none for documentation-only changes, beyond confirming links and references are accurate.
+
+**Verification:**
+- Focused tests cover approval proof minting/consumption, POS corrections, Cash Controls closeout, Operations Queue characterization, Daily Close characterization, and Daily Opening continuity.
+- Broader validation includes Convex audit/lint, TypeScript build checks, graphify rebuild, and diff hygiene.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** The change spans proof minting, proof consumption, shared approval UI runners, POS protected commands, Cash Controls register commands, and adjacent Operations/Daily workflows.
+- **Error propagation:** The user-facing linked-user error should disappear only for validated operational requester paths; direct signed-in requester spoofing should still return an authorization failure.
+- **State lifecycle risks:** Proofs remain one-use. If subject state changes between proof minting and command retry, the command must fail closed and require fresh approval when the proof has been consumed.
+- **API surface parity:** Same-submission inline manager approval and dialog-based approval must use the same requester binding.
+- **Integration coverage:** Browser tests need to verify that requester context passed to `authenticateStaffCredentialForApproval` matches the server-approved command requirement, not only that a mutation was called.
+- **Unchanged invariants:** Manager elevation is not proof. Signed-in user is not approving manager. Automation is not human manager approval. `consumeApprovalProofWithCtx` requester matching remains exact.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Relaxing requester validation reopens spoofing | Make requester source explicit; keep linked-user validation for signed-in claims; require server/credential validation for operational requester binding. |
+| UI keeps forwarding stale requester ids | Update `useApprovedCommand` and `CommandApprovalDialog` tests to prefer server-returned requester context. |
+| POS payment correction lacks actor validation | Characterize first; add workflow-specific actor validation before binding requester if needed. |
+| Proof consumed before stale command failure | Validate subject/requester/payload freshness before proof consumption where possible; otherwise persist failure evidence and require fresh approval. |
+| Adjacent workflows regress through shared helper changes | Add Operations Queue, Daily Close, and Daily Opening characterization coverage. |
+| Scope expands into full approval standard refactor | Keep this plan limited to requester attribution failure and affected workflows; defer broader audit normalization. |
+
+---
+
+## Documentation / Operational Notes
+
+- Product copy should avoid saying the signed-in user approved an action when the manager credential did.
+- Support/debugging should distinguish invalid manager credentials from invalid requester binding; the current browser manifestation is the latter.
+- Because this touches Convex code and graph-guided docs, implementation should run `bun run graphify:rebuild` after code changes.
+
+---
+
+## Sources & References
+
+- Existing plan: `docs/plans/2026-07-01-002-refactor-manager-approval-standard-plan.md`
+- Existing plan: `docs/plans/2026-07-01-001-fix-register-closeout-gate-policy-plan.md`
+- Solution note: `docs/solutions/architecture/athena-manager-approval-authority-standard-2026-07-01.md`
+- Solution note: `docs/solutions/logic-errors/athena-command-approval-manager-fast-path-2026-05-02.md`
+- Solution note: `docs/solutions/logic-errors/athena-command-approval-policy-boundary-2026-05-01.md`
+- Solution note: `docs/solutions/logic-errors/athena-terminal-manager-elevation-command-boundary-2026-05-10.md`
+- Package guide: `packages/athena-webapp/docs/agent/architecture.md`
+- Package guide: `packages/athena-webapp/docs/agent/testing.md`
+- Root cause: `packages/athena-webapp/convex/operations/staffCredentials.ts`
+- Proof binding: `packages/athena-webapp/convex/operations/approvalProofs.ts`
+- Shared runner: `packages/athena-webapp/src/components/operations/useApprovedCommand.tsx`

--- a/docs/solutions/logic-errors/athena-approval-requester-binding-2026-07-02.md
+++ b/docs/solutions/logic-errors/athena-approval-requester-binding-2026-07-02.md
@@ -1,0 +1,57 @@
+---
+title: "Athena approval requester binding"
+date: "2026-07-02"
+category: logic-errors
+module: athena-webapp
+problem_type: approval_requester_identity_confusion
+component: command-approval
+symptoms:
+  - "Valid manager credentials are rejected because requested staff profile does not match the signed-in Athena user"
+  - "A POS or Cash Controls approval flow passes requestedByStaffProfileId from React into proof minting"
+  - "Operational requester identity is confused with signed-in account identity"
+root_cause: operational_staff_requester_attribution_reused_signed_in_user_linkage_validation
+resolution_type: server_held_requester_challenge
+severity: high
+tags:
+  - athena
+  - command-approval
+  - manager-approval
+  - requester-binding
+  - convex
+related:
+  - ./athena-command-approval-manager-fast-path-2026-05-02.md
+---
+
+# Athena approval requester binding
+
+## Problem
+
+Approval proof minting has three distinct requester modes:
+
+1. **No requester**: the command intentionally has no operational staff requester.
+2. **Direct signed-in requester**: `requestedByStaffProfileId` must belong to the signed-in Athena account through `linkedUserId`.
+3. **Operational staff requester**: the command has already server-validated a staff actor for the store/action/subject, so proof minting must consume a short-lived server-held requester binding instead of revalidating against `linkedUserId`.
+
+Do not use React state as the bridge between mode 2 and mode 3. If a workflow passes a UI-selected or locally authenticated `requestedByStaffProfileId` directly into `authenticateStaffCredentialForApproval`, proof minting will either reject valid operational staff who are not linked to the signed-in user or tempt a dangerous relaxation that would allow requester spoofing.
+
+## Solution
+
+The server command that returns `approval_required` owns requester binding. After it validates the operational actor, it creates a short-lived single-use `approvalRequesterChallenge` for the exact store, action key, subject, required role, and requester staff profile. The returned `ApprovalRequirement.requesterBinding` is then forwarded unchanged by `useApprovedCommand` or `CommandApprovalDialog` when manager credentials mint the approval proof.
+
+The proof remains the only manager approval authority. The requester challenge only establishes who requested the command; it does not authorize the command and it is consumed before proof creation.
+
+## Prevention
+
+- Add `requesterBinding` to the server-returned `ApprovalRequirement` when a workflow needs operational requester attribution.
+- Keep direct `requestedByStaffProfileId` proof-minting validation strict against `staffProfile.linkedUserId`.
+- In React approval runners, pass `approval.requesterBinding` back to proof minting and send no requester when the server returned no binding.
+- Reject calls that supply both direct `requestedByStaffProfileId` and `requesterBinding`.
+- Bind the requester challenge to action key, store, subject type/id, required role, requester staff profile, expiration, and single-use consumption.
+- Preserve requester/approver separation in approval proof audit events and domain evidence.
+
+## Tests to include
+
+- Unlinked Staff A requests a protected command, Manager Staff B approves through a matching requester binding, and the proof records Staff A as requester and Staff B as approver.
+- Direct proof minting with unlinked Staff A still fails with the signed-in-user mismatch.
+- Forged, stale, replayed, wrong-action, wrong-store, wrong-subject, and mixed direct-plus-binding evidence fail closed.
+- Shared UI tests assert that React-supplied requester fallbacks are not sent to proof minting.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2154 files · ~0 words
+- 2156 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8403 nodes · 10066 edges · 2081 communities detected
+- 8411 nodes · 10077 edges · 2083 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2091,6 +2091,8 @@
 - [[_COMMUNITY_Community 2078|Community 2078]]
 - [[_COMMUNITY_Community 2079|Community 2079]]
 - [[_COMMUNITY_Community 2080|Community 2080]]
+- [[_COMMUNITY_Community 2081|Community 2081]]
+- [[_COMMUNITY_Community 2082|Community 2082]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2195,7 +2197,7 @@ Cohesion: 0.11
 Nodes (33): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+25 more)
 
 ### Community 19 - "Community 19"
-Cohesion: 0.12
+Cohesion: 0.13
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
 ### Community 20 - "Community 20"
@@ -2331,7 +2333,7 @@ Cohesion: 0.21
 Nodes (23): buildCartChange(), buildLegacyContextPayload(), buildLegacyProductId(), compactPayload(), compileLegacyStorefrontAnalyticsRow(), compileLegacyStorefrontAnalyticsRows(), compileLegacyStorefrontAnalyticsRowsWithReport(), containsSensitiveText() (+15 more)
 
 ### Community 53 - "Community 53"
-Cohesion: 0.19
+Cohesion: 0.2
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
 ### Community 54 - "Community 54"
@@ -2427,32 +2429,32 @@ Cohesion: 0.22
 Nodes (18): assertPrAthenaProofReady(), classifySnapshotError(), collectFilesUnder(), collectProofSnapshot(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof() (+10 more)
 
 ### Community 77 - "Community 77"
+Cohesion: 0.13
+Nodes (5): buildRegisterCloseoutSubmittedTimelineMessage(), buildRegisterCloseoutVarianceTimelineMessage(), cancelPendingApprovalIfNeeded(), formatCloseoutVarianceAmount(), omitUndefined()
+
+### Community 78 - "Community 78"
 Cohesion: 0.17
 Nodes (13): buildProviderRegistry(), createIntelligenceRun(), defaultFakeOutput(), failedGenerationResult(), getStoreInsightsSnapshotFallback(), isActivityTrend(), isDeviceDistribution(), isInsightGenerationInProgressError() (+5 more)
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.16
 Nodes (10): buildProductSkuSearchProjection(), buildSearchText(), hydrateCanonicalProjection(), normalizeAttributes(), normalizeLookup(), projectionsEqual(), requireProductSkuSearchAccess(), requireProductSkuSearchAdmin() (+2 more)
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.22
 Nodes (15): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+7 more)
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.25
 Nodes (16): buildStorefrontContextEvent(), buildStorefrontIdempotencyKey(), compactScalarPayload(), createStorefrontContextTrackingEnvelope(), createStorefrontRouteViewedContextEvent(), getCartChange(), getCartContextEventInput(), getCheckoutBlocker() (+8 more)
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
-
-### Community 83 - "Community 83"
-Cohesion: 0.14
-Nodes (5): buildRegisterCloseoutSubmittedTimelineMessage(), buildRegisterCloseoutVarianceTimelineMessage(), cancelPendingApprovalIfNeeded(), formatCloseoutVarianceAmount(), omitUndefined()
 
 ### Community 84 - "Community 84"
 Cohesion: 0.22
@@ -2828,27 +2830,27 @@ Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger
 
 ### Community 177 - "Community 177"
 Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 178 - "Community 178"
 Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
-
-### Community 179 - "Community 179"
-Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 180 - "Community 180"
+### Community 179 - "Community 179"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 181 - "Community 181"
+### Community 180 - "Community 180"
 Cohesion: 0.31
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 182 - "Community 182"
+### Community 181 - "Community 181"
 Cohesion: 0.22
 Nodes (0):
+
+### Community 182 - "Community 182"
+Cohesion: 0.39
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 183 - "Community 183"
 Cohesion: 0.39
@@ -3535,80 +3537,80 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 354 - "Community 354"
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+
+### Community 355 - "Community 355"
+Cohesion: 0.6
+Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
+
+### Community 356 - "Community 356"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 355 - "Community 355"
+### Community 357 - "Community 357"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 356 - "Community 356"
+### Community 358 - "Community 358"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 357 - "Community 357"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 358 - "Community 358"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 359 - "Community 359"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 360 - "Community 360"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 361 - "Community 361"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 360 - "Community 360"
+### Community 362 - "Community 362"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
 
-### Community 361 - "Community 361"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 362 - "Community 362"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 363 - "Community 363"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 364 - "Community 364"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 365 - "Community 365"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 364 - "Community 364"
+### Community 366 - "Community 366"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 365 - "Community 365"
+### Community 367 - "Community 367"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 366 - "Community 366"
+### Community 368 - "Community 368"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 367 - "Community 367"
+### Community 369 - "Community 369"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 368 - "Community 368"
+### Community 370 - "Community 370"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 369 - "Community 369"
+### Community 371 - "Community 371"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 370 - "Community 370"
+### Community 372 - "Community 372"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
-
-### Community 371 - "Community 371"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 372 - "Community 372"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 373 - "Community 373"
 Cohesion: 0.4
@@ -3619,24 +3621,24 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 375 - "Community 375"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 376 - "Community 376"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 377 - "Community 377"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 378 - "Community 378"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 379 - "Community 379"
-Cohesion: 0.5
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 380 - "Community 380"
 Cohesion: 0.4
@@ -3644,15 +3646,15 @@ Nodes (0):
 
 ### Community 381 - "Community 381"
 Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 382 - "Community 382"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 383 - "Community 383"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 384 - "Community 384"
 Cohesion: 0.4
@@ -3667,48 +3669,48 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 387 - "Community 387"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 388 - "Community 388"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 389 - "Community 389"
-Cohesion: 0.8
-Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+Cohesion: 0.7
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 390 - "Community 390"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 391 - "Community 391"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
+Cohesion: 0.8
+Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
 ### Community 392 - "Community 392"
-Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
-
-### Community 393 - "Community 393"
-Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
-
-### Community 394 - "Community 394"
-Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
-
-### Community 395 - "Community 395"
-Cohesion: 0.4
-Nodes (1): MockImage
-
-### Community 396 - "Community 396"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 393 - "Community 393"
+Cohesion: 0.5
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
+
+### Community 394 - "Community 394"
+Cohesion: 0.5
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
+
+### Community 395 - "Community 395"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 396 - "Community 396"
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+
 ### Community 397 - "Community 397"
-Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
+Cohesion: 0.4
+Nodes (1): MockImage
 
 ### Community 398 - "Community 398"
 Cohesion: 0.4
@@ -3716,71 +3718,71 @@ Nodes (0):
 
 ### Community 399 - "Community 399"
 Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 400 - "Community 400"
-Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 401 - "Community 401"
 Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 402 - "Community 402"
+Cohesion: 0.6
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+
+### Community 403 - "Community 403"
+Cohesion: 0.6
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+
+### Community 404 - "Community 404"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 403 - "Community 403"
+### Community 405 - "Community 405"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 404 - "Community 404"
+### Community 406 - "Community 406"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
-
-### Community 405 - "Community 405"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 406 - "Community 406"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 407 - "Community 407"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 408 - "Community 408"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 409 - "Community 409"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 410 - "Community 410"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 409 - "Community 409"
+### Community 411 - "Community 411"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 410 - "Community 410"
+### Community 412 - "Community 412"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 411 - "Community 411"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
-
-### Community 412 - "Community 412"
-Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 413 - "Community 413"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 414 - "Community 414"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 415 - "Community 415"
-Cohesion: 0.6
-Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 416 - "Community 416"
 Cohesion: 0.4
@@ -3788,15 +3790,15 @@ Nodes (0):
 
 ### Community 417 - "Community 417"
 Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
 ### Community 418 - "Community 418"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
-
-### Community 419 - "Community 419"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 419 - "Community 419"
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 420 - "Community 420"
 Cohesion: 0.4
@@ -3807,72 +3809,72 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 422 - "Community 422"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 423 - "Community 423"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 423 - "Community 423"
+### Community 424 - "Community 424"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 424 - "Community 424"
+### Community 425 - "Community 425"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 425 - "Community 425"
+### Community 426 - "Community 426"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 426 - "Community 426"
+### Community 427 - "Community 427"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 427 - "Community 427"
+### Community 428 - "Community 428"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 428 - "Community 428"
+### Community 429 - "Community 429"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 429 - "Community 429"
+### Community 430 - "Community 430"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 430 - "Community 430"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 431 - "Community 431"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 432 - "Community 432"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
-
-### Community 433 - "Community 433"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 433 - "Community 433"
+Cohesion: 0.67
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 434 - "Community 434"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 435 - "Community 435"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 436 - "Community 436"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 436 - "Community 436"
+### Community 437 - "Community 437"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 437 - "Community 437"
-Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 438 - "Community 438"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 439 - "Community 439"
 Cohesion: 0.5
@@ -3891,76 +3893,76 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 443 - "Community 443"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 444 - "Community 444"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 444 - "Community 444"
+### Community 445 - "Community 445"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 445 - "Community 445"
+### Community 446 - "Community 446"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 446 - "Community 446"
+### Community 447 - "Community 447"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 447 - "Community 447"
+### Community 448 - "Community 448"
 Cohesion: 0.83
 Nodes (3): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), formatOnlineOrderLabel()
 
-### Community 448 - "Community 448"
+### Community 449 - "Community 449"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 449 - "Community 449"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 450 - "Community 450"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 451 - "Community 451"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 452 - "Community 452"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 452 - "Community 452"
+### Community 453 - "Community 453"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 453 - "Community 453"
+### Community 454 - "Community 454"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 454 - "Community 454"
+### Community 455 - "Community 455"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 455 - "Community 455"
+### Community 456 - "Community 456"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 456 - "Community 456"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 457 - "Community 457"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 458 - "Community 458"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 459 - "Community 459"
-Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
-
-### Community 460 - "Community 460"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 460 - "Community 460"
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 461 - "Community 461"
 Cohesion: 0.5
@@ -3971,24 +3973,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 463 - "Community 463"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 464 - "Community 464"
 Cohesion: 0.67
 Nodes (2): buildCtx(), buildQueryCtx()
 
-### Community 464 - "Community 464"
+### Community 465 - "Community 465"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 465 - "Community 465"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
 
 ### Community 466 - "Community 466"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 467 - "Community 467"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 468 - "Community 468"
 Cohesion: 0.5
@@ -4003,36 +4005,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 471 - "Community 471"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 472 - "Community 472"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 472 - "Community 472"
+### Community 473 - "Community 473"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 473 - "Community 473"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 474 - "Community 474"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 475 - "Community 475"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 476 - "Community 476"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 477 - "Community 477"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 478 - "Community 478"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 479 - "Community 479"
 Cohesion: 0.5
@@ -4043,32 +4045,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 481 - "Community 481"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 482 - "Community 482"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 482 - "Community 482"
+### Community 483 - "Community 483"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 483 - "Community 483"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 484 - "Community 484"
 Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 485 - "Community 485"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 486 - "Community 486"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 487 - "Community 487"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 488 - "Community 488"
 Cohesion: 0.5
@@ -4099,12 +4101,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 495 - "Community 495"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
-
-### Community 496 - "Community 496"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 496 - "Community 496"
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 497 - "Community 497"
 Cohesion: 0.5
@@ -4115,12 +4117,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 499 - "Community 499"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 500 - "Community 500"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 500 - "Community 500"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 501 - "Community 501"
 Cohesion: 0.5
@@ -4131,120 +4133,120 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 503 - "Community 503"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 504 - "Community 504"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 504 - "Community 504"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 505 - "Community 505"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 506 - "Community 506"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 507 - "Community 507"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 508 - "Community 508"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 509 - "Community 509"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 510 - "Community 510"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 510 - "Community 510"
+### Community 511 - "Community 511"
 Cohesion: 0.67
 Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
-### Community 511 - "Community 511"
+### Community 512 - "Community 512"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 512 - "Community 512"
+### Community 513 - "Community 513"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 513 - "Community 513"
+### Community 514 - "Community 514"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 514 - "Community 514"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 515 - "Community 515"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 516 - "Community 516"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 517 - "Community 517"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 518 - "Community 518"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 519 - "Community 519"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 519 - "Community 519"
+### Community 520 - "Community 520"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 520 - "Community 520"
+### Community 521 - "Community 521"
 Cohesion: 0.83
 Nodes (3): completedEvent(), event(), item()
 
-### Community 521 - "Community 521"
+### Community 522 - "Community 522"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 522 - "Community 522"
+### Community 523 - "Community 523"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 523 - "Community 523"
+### Community 524 - "Community 524"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
-
-### Community 524 - "Community 524"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 525 - "Community 525"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 526 - "Community 526"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 527 - "Community 527"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 527 - "Community 527"
+### Community 528 - "Community 528"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 528 - "Community 528"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 529 - "Community 529"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 530 - "Community 530"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 531 - "Community 531"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 532 - "Community 532"
 Cohesion: 0.5
@@ -4275,63 +4277,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 539 - "Community 539"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 540 - "Community 540"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 541 - "Community 541"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 542 - "Community 542"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 542 - "Community 542"
+### Community 543 - "Community 543"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 543 - "Community 543"
+### Community 544 - "Community 544"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 544 - "Community 544"
+### Community 545 - "Community 545"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 545 - "Community 545"
+### Community 546 - "Community 546"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 546 - "Community 546"
+### Community 547 - "Community 547"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 547 - "Community 547"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 548 - "Community 548"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 549 - "Community 549"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 550 - "Community 550"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 550 - "Community 550"
+### Community 551 - "Community 551"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 551 - "Community 551"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 552 - "Community 552"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 553 - "Community 553"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 554 - "Community 554"
@@ -4339,12 +4341,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 555 - "Community 555"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 556 - "Community 556"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 556 - "Community 556"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 557 - "Community 557"
 Cohesion: 0.67
@@ -4403,32 +4405,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 571 - "Community 571"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 572 - "Community 572"
 Cohesion: 1.0
-Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 573 - "Community 573"
 Cohesion: 1.0
-Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
 ### Community 574 - "Community 574"
 Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
+Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 575 - "Community 575"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 576 - "Community 576"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 577 - "Community 577"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 578 - "Community 578"
 Cohesion: 0.67
@@ -4443,12 +4445,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 581 - "Community 581"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 582 - "Community 582"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 582 - "Community 582"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 583 - "Community 583"
 Cohesion: 0.67
@@ -4471,12 +4473,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 588 - "Community 588"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 589 - "Community 589"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 589 - "Community 589"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 590 - "Community 590"
 Cohesion: 0.67
@@ -4491,16 +4493,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 593 - "Community 593"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 594 - "Community 594"
 Cohesion: 1.0
-Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 595 - "Community 595"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
 
 ### Community 596 - "Community 596"
 Cohesion: 0.67
@@ -4511,28 +4513,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 598 - "Community 598"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 599 - "Community 599"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 600 - "Community 600"
 Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 601 - "Community 601"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 602 - "Community 602"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 603 - "Community 603"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 603 - "Community 603"
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 604 - "Community 604"
 Cohesion: 0.67
@@ -4540,11 +4542,11 @@ Nodes (0):
 
 ### Community 605 - "Community 605"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 606 - "Community 606"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 607 - "Community 607"
 Cohesion: 0.67
@@ -4559,12 +4561,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 610 - "Community 610"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 611 - "Community 611"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 611 - "Community 611"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 612 - "Community 612"
 Cohesion: 0.67
@@ -4583,28 +4585,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 616 - "Community 616"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 617 - "Community 617"
 Cohesion: 1.0
 Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
-### Community 617 - "Community 617"
-Cohesion: 0.67
-Nodes (1): FadeIn()
-
 ### Community 618 - "Community 618"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 619 - "Community 619"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 620 - "Community 620"
-Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
-
-### Community 621 - "Community 621"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 621 - "Community 621"
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 622 - "Community 622"
 Cohesion: 0.67
@@ -4612,15 +4614,15 @@ Nodes (0):
 
 ### Community 623 - "Community 623"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 624 - "Community 624"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
 
 ### Community 625 - "Community 625"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 626 - "Community 626"
 Cohesion: 0.67
@@ -4631,16 +4633,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 628 - "Community 628"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 629 - "Community 629"
 Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 630 - "Community 630"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 631 - "Community 631"
 Cohesion: 0.67
@@ -4675,12 +4677,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 639 - "Community 639"
-Cohesion: 1.0
-Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
-
-### Community 640 - "Community 640"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 640 - "Community 640"
+Cohesion: 1.0
+Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
 
 ### Community 641 - "Community 641"
 Cohesion: 0.67
@@ -4700,79 +4702,79 @@ Nodes (0):
 
 ### Community 645 - "Community 645"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 646 - "Community 646"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 647 - "Community 647"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 648 - "Community 648"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 649 - "Community 649"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 650 - "Community 650"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 651 - "Community 651"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 652 - "Community 652"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 653 - "Community 653"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 653 - "Community 653"
+### Community 654 - "Community 654"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 654 - "Community 654"
+### Community 655 - "Community 655"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 655 - "Community 655"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 656 - "Community 656"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 657 - "Community 657"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 658 - "Community 658"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 659 - "Community 659"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 660 - "Community 660"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 661 - "Community 661"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 662 - "Community 662"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 663 - "Community 663"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 664 - "Community 664"
 Cohesion: 0.67
@@ -4804,11 +4806,11 @@ Nodes (0):
 
 ### Community 671 - "Community 671"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 672 - "Community 672"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 673 - "Community 673"
 Cohesion: 0.67
@@ -4839,52 +4841,52 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 680 - "Community 680"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 681 - "Community 681"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 681 - "Community 681"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 682 - "Community 682"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 683 - "Community 683"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 684 - "Community 684"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 685 - "Community 685"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 685 - "Community 685"
+### Community 686 - "Community 686"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 686 - "Community 686"
-Cohesion: 1.0
-Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
 ### Community 687 - "Community 687"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
 ### Community 688 - "Community 688"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 689 - "Community 689"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 690 - "Community 690"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 691 - "Community 691"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 691 - "Community 691"
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 692 - "Community 692"
 Cohesion: 0.67
@@ -4911,76 +4913,76 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 698 - "Community 698"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 699 - "Community 699"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 700 - "Community 700"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 701 - "Community 701"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 702 - "Community 702"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 703 - "Community 703"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 704 - "Community 704"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 705 - "Community 705"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 706 - "Community 706"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 707 - "Community 707"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 708 - "Community 708"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 709 - "Community 709"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 710 - "Community 710"
 Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 711 - "Community 711"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 712 - "Community 712"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 713 - "Community 713"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 714 - "Community 714"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 715 - "Community 715"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 716 - "Community 716"
 Cohesion: 0.67
@@ -4995,12 +4997,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 719 - "Community 719"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 720 - "Community 720"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 720 - "Community 720"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 721 - "Community 721"
 Cohesion: 0.67
@@ -5011,12 +5013,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 723 - "Community 723"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 724 - "Community 724"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 724 - "Community 724"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 725 - "Community 725"
 Cohesion: 0.67
@@ -5083,16 +5085,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 741 - "Community 741"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 742 - "Community 742"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 743 - "Community 743"
+### Community 742 - "Community 742"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 743 - "Community 743"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 744 - "Community 744"
 Cohesion: 1.0
@@ -5107,24 +5109,24 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 747 - "Community 747"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
+
+### Community 748 - "Community 748"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 748 - "Community 748"
+### Community 749 - "Community 749"
 Cohesion: 1.0
 Nodes (2): gitFixtureEnv(), runGit()
 
-### Community 749 - "Community 749"
+### Community 750 - "Community 750"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 750 - "Community 750"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
-
 ### Community 751 - "Community 751"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 752 - "Community 752"
 Cohesion: 1.0
@@ -6236,7 +6238,7 @@ Nodes (0):
 
 ### Community 1029 - "Community 1029"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1030 - "Community 1030"
 Cohesion: 1.0
@@ -6244,7 +6246,7 @@ Nodes (0):
 
 ### Community 1031 - "Community 1031"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1032 - "Community 1032"
 Cohesion: 1.0
@@ -10442,364 +10444,374 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2081 - "Community 2081"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2082 - "Community 2082"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 751`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 752`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 753`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 754`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 755`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 756`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 757`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 758`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 759`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 760`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 761`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 762`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 763`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 764`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 765`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 766`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 767`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 768`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 769`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 770`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 771`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 772`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 773`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 774`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 775`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 776`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 777`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 778`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 779`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 780`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 781`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 782`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 783`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 784`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 785`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 786`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 787`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 788`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 789`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 790`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 791`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 792`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 793`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 794`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 795`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 796`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 797`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 798`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 799`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 800`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 801`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 802`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 803`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 804`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 805`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 806`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 807`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
+- **Thin community `Community 808`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 809`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 810`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 811`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 812`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 813`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 814`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 815`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 816`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 817`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 818`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 819`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 820`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 821`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 822`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 823`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 824`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 825`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 826`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 827`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 828`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 829`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 830`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 831`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 832`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 833`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 834`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 835`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 836`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 837`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 838`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 839`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 840`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 841`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 842`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 843`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 844`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 845`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 846`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 847`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 848`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 849`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 850`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 851`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 852`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 853`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 854`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 855`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 856`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 857`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 858`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 859`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 860`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 861`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 862`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 863`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 864`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 865`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 866`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 867`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 868`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 869`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 870`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 871`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 872`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 873`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 874`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 875`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 876`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 877`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 878`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 879`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 880`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 881`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 882`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 883`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 884`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 885`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 886`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 887`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 888`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 889`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 890`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 891`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 892`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 893`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 894`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 895`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 896`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 897`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `getTodayRefreshCalls()`, `DailyOperationsView.test.tsx`
+- **Thin community `Community 898`** (2 nodes): `getTodayRefreshCalls()`, `DailyOperationsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 899`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 900`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 901`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 902`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 903`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 904`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 905`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 906`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 907`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 908`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 909`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 910`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 911`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 912`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 913`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
+- **Thin community `Community 914`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 915`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 916`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 917`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 918`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 919`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 920`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 921`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 922`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 923`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 924`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 925`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 926`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 927`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 928`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 929`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 930`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -10835,2309 +10847,2309 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 931`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 932`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 933`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 934`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 935`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 936`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 937`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 938`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 939`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 940`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
+- **Thin community `Community 941`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 942`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 943`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 944`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 945`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 946`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 947`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 948`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 949`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 950`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 951`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 952`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 953`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 954`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 955`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 956`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 957`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 958`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 959`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 960`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 961`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 962`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 963`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 964`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 965`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 966`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 967`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 968`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 969`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 970`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 971`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 972`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 973`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 974`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 975`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 976`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 977`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 978`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 979`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 980`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 981`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 982`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 983`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 984`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 985`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 986`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 987`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 988`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 989`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 990`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 991`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 992`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 993`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 994`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 995`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 996`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 997`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 998`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 999`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 1000`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 1001`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 1002`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 1003`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 1004`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1005`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1006`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1007`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1008`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1009`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1010`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1011`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1012`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1013`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1014`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1015`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1016`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1017`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1018`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1019`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1020`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1021`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1022`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1023`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1024`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1025`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1026`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1027`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1028`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1029`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1030`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1031`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1032`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1033`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1034`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1035`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1036`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1037`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1038`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1039`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1040`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1041`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1042`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1043`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1044`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1045`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1046`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1047`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1048`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1049`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1050`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1051`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1052`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1053`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
+- **Thin community `Community 1054`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1055`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1056`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1057`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1058`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1059`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1060`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1061`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1062`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1063`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1064`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1065`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1066`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `Index()`, `-index-route-view.tsx`
+- **Thin community `Community 1067`** (2 nodes): `Index()`, `-index-route-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1068`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1069`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1070`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1071`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1072`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1073`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1074`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1075`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1076`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
+- **Thin community `Community 1077`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1078`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1079`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1080`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1081`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1082`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1083`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1084`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1085`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1086`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1087`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1088`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1089`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1090`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1091`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1092`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1093`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1094`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1095`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1096`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1097`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1098`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1099`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1100`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1101`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1102`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1103`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1104`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1105`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1106`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1107`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1108`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1109`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1110`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1111`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1112`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1113`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1114`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1115`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1116`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1117`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1118`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1119`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1120`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1121`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1122`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1123`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1124`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1125`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1126`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1127`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1128`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1129`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1130`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1131`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1132`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1133`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1134`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1135`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1136`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1137`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1138`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1139`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1140`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1141`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1142`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1143`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1144`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1145`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1146`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1147`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1148`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1149`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1150`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1151`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1152`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1153`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1154`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1155`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1156`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1157`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1158`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1159`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1160`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1161`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1162`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1163`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1164`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1165`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1166`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1167`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1168`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1169`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1170`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1171`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1172`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1173`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1174`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1175`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1176`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1177`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1178`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1179`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1180`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1181`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1182`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1183`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1184`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1185`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1186`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1187`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1188`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1189`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1190`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1191`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1192`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1193`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1194`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1195`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1196`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1197`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1198`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1199`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1200`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1201`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1202`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1203`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1204`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1205`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1206`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1207`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1208`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1209`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1210`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1211`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1212`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1213`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1214`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1215`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1216`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1217`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1218`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1219`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1220`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1221`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1222`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `api.js`
+- **Thin community `Community 1223`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1224`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1225`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `server.js`
+- **Thin community `Community 1226`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `app.ts`
+- **Thin community `Community 1227`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1228`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1229`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1230`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1231`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `auth.ts`
+- **Thin community `Community 1232`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1233`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1234`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1235`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `countries.ts`
+- **Thin community `Community 1236`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `email.ts`
+- **Thin community `Community 1237`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1238`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `payment.ts`
+- **Thin community `Community 1239`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `contextEvents.test.ts`
+- **Thin community `Community 1240`** (1 nodes): `contextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1241`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `types.ts`
+- **Thin community `Community 1242`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1243`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `crons.ts`
+- **Thin community `Community 1244`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1245`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `internal.ts`
+- **Thin community `Community 1246`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1247`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1248`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1249`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1250`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1251`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1252`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1253`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1254`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1255`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1256`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1257`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `env.ts`
+- **Thin community `Community 1258`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1259`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `auth.ts`
+- **Thin community `Community 1260`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1261`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `colors.ts`
+- **Thin community `Community 1262`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `index.ts`
+- **Thin community `Community 1263`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1264`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `products.ts`
+- **Thin community `Community 1265`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1266`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `stores.ts`
+- **Thin community `Community 1267`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1268`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `bag.ts`
+- **Thin community `Community 1269`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `guest.ts`
+- **Thin community `Community 1270`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1271`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `index.ts`
+- **Thin community `Community 1272`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `me.ts`
+- **Thin community `Community 1273`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `offers.ts`
+- **Thin community `Community 1274`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1275`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1276`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1277`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1278`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1279`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1280`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1281`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1282`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1283`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `user.ts`
+- **Thin community `Community 1284`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1285`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `index.ts`
+- **Thin community `Community 1286`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1287`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `http.ts`
+- **Thin community `Community 1288`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `access.ts`
+- **Thin community `Community 1289`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1290`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1291`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1292`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `index.ts`
+- **Thin community `Community 1293`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1294`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `types.ts`
+- **Thin community `Community 1295`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1296`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `categories.ts`
+- **Thin community `Community 1297`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `colors.ts`
+- **Thin community `Community 1298`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1299`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1300`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1301`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1302`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `pos.ts`
+- **Thin community `Community 1303`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1304`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1305`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1306`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1307`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1308`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1309`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1310`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1311`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1312`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1313`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1314`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1315`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1316`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1317`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1318`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1319`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1320`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `types.ts`
+- **Thin community `Community 1321`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1322`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `eventBuilders.test.ts`
+- **Thin community `Community 1323`** (1 nodes): `eventBuilders.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1324`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `registerSessionCloseoutGate.test.ts`
+- **Thin community `Community 1325`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1326`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1327`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1328`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1329`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `dto.ts`
+- **Thin community `Community 1330`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1331`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1332`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1333`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `types.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `facts.ts`
+- **Thin community `Community 1334`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1335`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `types.ts`
+- **Thin community `Community 1336`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1337`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1338`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1339`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `customers.ts`
+- **Thin community `Community 1340`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `register.test.ts`
+- **Thin community `Community 1341`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `register.ts`
+- **Thin community `Community 1342`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `sync.ts`
+- **Thin community `Community 1343`** (1 nodes): `register.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1344`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1345`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1346`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `schema.ts`
+- **Thin community `Community 1347`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `automation.ts`
+- **Thin community `Community 1348`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1349`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1350`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `index.ts`
+- **Thin community `Community 1351`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1352`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1353`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1354`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1355`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1356`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1357`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1358`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `category.ts`
+- **Thin community `Community 1359`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `color.ts`
+- **Thin community `Community 1360`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1361`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1362`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `index.ts`
+- **Thin community `Community 1363`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1364`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1365`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1366`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1367`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `organization.ts`
+- **Thin community `Community 1368`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1369`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `product.ts`
+- **Thin community `Community 1370`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1371`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1372`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1373`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `store.ts`
+- **Thin community `Community 1374`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1375`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1376`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `index.ts`
+- **Thin community `Community 1377`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1378`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1379`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1380`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1381`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1382`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1383`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1384`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `index.ts`
+- **Thin community `Community 1385`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1386`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1387`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1388`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1389`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1390`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1391`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1392`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1393`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1394`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1395`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1396`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `customer.ts`
+- **Thin community `Community 1397`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1398`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1399`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1400`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1401`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `index.ts`
+- **Thin community `Community 1402`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1403`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1404`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1405`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1406`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1407`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1408`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1409`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1410`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1411`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1412`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1413`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1414`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1415`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1416`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1417`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1418`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1419`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1420`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1421`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `index.ts`
+- **Thin community `Community 1422`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1423`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1424`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `index.ts`
+- **Thin community `Community 1425`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1426`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1427`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1428`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1429`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1430`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1431`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `index.ts`
+- **Thin community `Community 1432`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1433`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1434`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1435`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1436`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1437`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1438`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `bag.ts`
+- **Thin community `Community 1439`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1440`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1441`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1442`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `guest.ts`
+- **Thin community `Community 1443`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `index.ts`
+- **Thin community `Community 1444`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `offer.ts`
+- **Thin community `Community 1445`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1446`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1447`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `review.ts`
+- **Thin community `Community 1448`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1449`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1450`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1451`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1452`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1453`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1454`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1455`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1456`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1457`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `bag.ts`
+- **Thin community `Community 1458`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1459`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `customer.ts`
+- **Thin community `Community 1460`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `guest.ts`
+- **Thin community `Community 1461`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1462`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1463`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1464`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1465`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1466`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1467`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1468`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `users.ts`
+- **Thin community `Community 1469`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `payment.ts`
+- **Thin community `Community 1470`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1471`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1472`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1473`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1474`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1475`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1476`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1477`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `index.ts`
+- **Thin community `Community 1478`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1479`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1480`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1481`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1482`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `auth.ts`
+- **Thin community `Community 1483`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1484`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1485`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1486`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1487`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1488`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1489`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1490`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `index.ts`
+- **Thin community `Community 1491`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1492`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1493`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1494`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1495`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1496`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1497`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1498`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1499`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1500`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `Navbar.test.tsx`
+- **Thin community `Community 1501`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1502`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1503`** (1 nodes): `Navbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1504`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1505`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1506`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1507`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1508`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1509`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1510`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1511`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1512`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1513`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `constants.ts`
+- **Thin community `Community 1514`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1515`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1516`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1517`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `types.ts`
+- **Thin community `Community 1518`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1519`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1520`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1521`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1522`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1523`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1524`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1525`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1526`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1527`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1528`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1529`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1530`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1531`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1532`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1533`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1534`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1535`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1536`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1537`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1538`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `constants.ts`
+- **Thin community `Community 1539`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1540`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1541`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1542`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `data.ts`
+- **Thin community `Community 1543`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1544`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1545`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1546`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1547`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1548`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1549`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1550`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1551`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `app-sidebar.test.tsx`
+- **Thin community `Community 1552`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1553`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `constants.ts`
+- **Thin community `Community 1554`** (1 nodes): `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1555`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1556`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1557`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `data.ts`
+- **Thin community `Community 1558`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1559`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1560`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1561`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1562`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1563`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1564`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1565`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1566`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1567`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1568`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1569`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1570`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `constants.ts`
+- **Thin community `Community 1571`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1572`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1573`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 1574`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1575`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1576`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1577`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1578`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1579`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1580`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1581`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1582`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1583`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1584`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1585`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1586`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1587`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1588`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1589`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1590`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1591`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1592`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1593`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1594`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1595`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `OperationReviewItemCard.tsx`
+- **Thin community `Community 1596`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1597`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1598`** (1 nodes): `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1599`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1600`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1601`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1602`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1603`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1604`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1605`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1606`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1607`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `constants.ts`
+- **Thin community `Community 1608`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1609`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1610`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1611`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `data.ts`
+- **Thin community `Community 1612`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1613`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1614`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `constants.ts`
+- **Thin community `Community 1615`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1616`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1617`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1618`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1619`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `data.ts`
+- **Thin community `Community 1620`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1621`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `constants.ts`
+- **Thin community `Community 1622`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1623`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1624`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1625`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1626`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `data.ts`
+- **Thin community `Community 1627`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1628`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1629`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1630`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1631`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1632`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1633`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1634`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1635`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1636`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1637`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1638`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1639`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1640`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1641`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1642`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1643`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1644`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1645`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1646`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1647`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1648`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1649`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1650`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1651`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1652`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1653`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1654`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1655`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `types.ts`
+- **Thin community `Community 1656`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1657`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1658`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1659`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1660`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1661`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1662`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1663`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1664`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 1665`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1666`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1667`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1668`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1669`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1670`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1671`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1672`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1673`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1674`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `data.ts`
+- **Thin community `Community 1675`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1676`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1677`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1678`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1679`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1680`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1681`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1682`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1683`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1684`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1685`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1686`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1687`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `constants.ts`
+- **Thin community `Community 1688`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1689`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1690`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1691`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `data.ts`
+- **Thin community `Community 1692`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `types.ts`
+- **Thin community `Community 1693`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1694`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1695`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1696`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1697`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1698`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `index.ts`
+- **Thin community `Community 1699`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1700`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1701`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1702`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1703`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `index.tsx`
+- **Thin community `Community 1704`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1705`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1706`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1707`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1708`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1709`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1710`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1711`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `StoreHoursView.test.tsx`
+- **Thin community `Community 1712`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1713`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 1714`** (1 nodes): `StoreHoursView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `index.tsx`
+- **Thin community `Community 1715`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1716`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1717`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1718`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `button.tsx`
+- **Thin community `Community 1719`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1720`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `card.tsx`
+- **Thin community `Community 1721`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1722`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1723`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `command.tsx`
+- **Thin community `Community 1724`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1725`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1726`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1727`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `form.tsx`
+- **Thin community `Community 1728`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1729`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1730`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `input.tsx`
+- **Thin community `Community 1731`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1732`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1733`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1734`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1735`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1736`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1737`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `select.tsx`
+- **Thin community `Community 1738`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1739`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1740`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1741`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1742`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `table.tsx`
+- **Thin community `Community 1743`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1744`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1745`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1746`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1747`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1748`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1749`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1750`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1751`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `constants.ts`
+- **Thin community `Community 1752`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1753`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1754`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1755`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `data.ts`
+- **Thin community `Community 1756`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1757`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1758`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1759`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1760`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1761`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1762`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1763`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1764`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1765`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1766`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `index.ts`
+- **Thin community `Community 1767`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1768`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1769`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1770`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 1771`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1772`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1773`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1774`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1775`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1776`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1777`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 1778`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1779`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1780`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 1781`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 1782`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `index.ts`
+- **Thin community `Community 1783`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 1784`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1785`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 1786`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 1787`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `aws.ts`
+- **Thin community `Community 1788`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `constants.ts`
+- **Thin community `Community 1789`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `countries.ts`
+- **Thin community `Community 1790`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1791`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1792`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1793`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1794`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1795`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1796`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1797`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 1798`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `dto.ts`
+- **Thin community `Community 1799`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `ports.ts`
+- **Thin community `Community 1800`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `constants.ts`
+- **Thin community `Community 1801`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1802`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1803`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `index.ts`
+- **Thin community `Community 1804`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1805`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `types.ts`
+- **Thin community `Community 1806`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1807`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1808`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1809`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1810`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1811`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1812`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1813`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1814`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1815`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 1816`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 1817`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 1818`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 1819`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 1820`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1821`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1822`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1823`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1824`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `index.ts`
+- **Thin community `Community 1825`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1826`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `category.ts`
+- **Thin community `Community 1827`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `product.ts`
+- **Thin community `Community 1828`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `store.ts`
+- **Thin community `Community 1829`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1830`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `user.ts`
+- **Thin community `Community 1831`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1832`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1833`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1834`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1835`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1836`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `main.tsx`
+- **Thin community `Community 1837`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 1838`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1839`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1840`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1841`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1842`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1843`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `index.tsx`
+- **Thin community `Community 1844`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `index.tsx`
+- **Thin community `Community 1845`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1846`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1847`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1848`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1849`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1850`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1851`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `index.tsx`
+- **Thin community `Community 1852`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1853`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1854`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1855`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `home.tsx`
+- **Thin community `Community 1856`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1857`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1858`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1859`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `index.tsx`
+- **Thin community `Community 1860`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `review.tsx`
+- **Thin community `Community 1861`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1862`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1863`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `index.tsx`
+- **Thin community `Community 1864`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1865`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1866`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1867`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `index.tsx`
+- **Thin community `Community 1868`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1869`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1870`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1871`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1872`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1873`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1874`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 1875`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `index.tsx`
+- **Thin community `Community 1876`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1877`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1878`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1879`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1880`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1881`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1882`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1883`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1884`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1885`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `index.tsx`
+- **Thin community `Community 1886`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1887`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1888`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `new.tsx`
+- **Thin community `Community 1889`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1890`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1891`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1892`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1893`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `index.tsx`
+- **Thin community `Community 1894`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `new.tsx`
+- **Thin community `Community 1895`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1896`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1897`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1898`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1899`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1900`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `index.tsx`
+- **Thin community `Community 1901`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1902`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1903`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1904`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `index.tsx`
+- **Thin community `Community 1905`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1906`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `_authed.tsx`
+- **Thin community `Community 1907`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1908`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `index.tsx`
+- **Thin community `Community 1909`** (1 nodes): `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1910`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1911`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1912`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 1913`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1914`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 1915`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1916`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 1917`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1918`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1919`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1920`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1921`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1922`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1923`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1924`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1925`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1926`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1927`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1928`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1929`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1930`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1931`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1932`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1933`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `setup.ts`
+- **Thin community `Community 1934`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1935`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `types.ts`
+- **Thin community `Community 1936`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1937`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1938`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1939`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1940`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1941`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1942`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1943`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `types.ts`
+- **Thin community `Community 1944`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1945`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1946`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1947`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1948`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1949`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1950`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1951`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1952`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `schema.ts`
+- **Thin community `Community 1953`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1954`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1955`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1956`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1957`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1958`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1959`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1960`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1961`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1962`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `types.ts`
+- **Thin community `Community 1963`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1964`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1965`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1966`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1967`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1968`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1969`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1970`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `constants.ts`
+- **Thin community `Community 1971`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1972`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `About.tsx`
+- **Thin community `Community 1973`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1974`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1975`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1976`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1977`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1978`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1979`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1980`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1981`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1982`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1983`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `types.ts`
+- **Thin community `Community 1984`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1985`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1986`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1987`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1988`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1989`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1990`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1991`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1992`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1993`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1994`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1995`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `button.tsx`
+- **Thin community `Community 1996`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `card.tsx`
+- **Thin community `Community 1997`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1998`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `command.tsx`
+- **Thin community `Community 1999`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2000`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2001`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2002`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `form.tsx`
+- **Thin community `Community 2003`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2004`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2005`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2006`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2007`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `input.tsx`
+- **Thin community `Community 2008`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `label.tsx`
+- **Thin community `Community 2009`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2010`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2011`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2012`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `index.ts`
+- **Thin community `Community 2013`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `types.ts`
+- **Thin community `Community 2014`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2015`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2016`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2017`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2018`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `select.tsx`
+- **Thin community `Community 2019`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2020`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2021`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `table.tsx`
+- **Thin community `Community 2022`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2023`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2024`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2025`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2026`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2027`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `config.ts`
+- **Thin community `Community 2028`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2029`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2030`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2031`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2032`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2033`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `constants.ts`
+- **Thin community `Community 2034`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `countries.ts`
+- **Thin community `Community 2035`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2036`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2037`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2038`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2039`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `index.ts`
+- **Thin community `Community 2040`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2041`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `store.ts`
+- **Thin community `Community 2042`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `bag.ts`
+- **Thin community `Community 2043`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2044`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `category.ts`
+- **Thin community `Community 2045`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `organization.ts`
+- **Thin community `Community 2046`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `product.ts`
+- **Thin community `Community 2047`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `store.ts`
+- **Thin community `Community 2048`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2049`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `user.ts`
+- **Thin community `Community 2050`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `states.ts`
+- **Thin community `Community 2051`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2052`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2053`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2054`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2055`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2056`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2056`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2057`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2057`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2058`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2058`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2059`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2059`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2060`** (1 nodes): `index.tsx`
+- **Thin community `Community 2060`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2061`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2061`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2062`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2063`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2063`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2064`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2064`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2065`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2065`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2066`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2066`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2067`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2067`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2068`** (1 nodes): `index.tsx`
+- **Thin community `Community 2068`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2069`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2069`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2070`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2070`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2071`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2071`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2072`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2072`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2073`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2073`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2074`** (1 nodes): `index.js`
+- **Thin community `Community 2074`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2075`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2075`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2076`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2076`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2077`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2077`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2078`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2078`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2079`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2079`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2080`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2080`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2081`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2082`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2154
-- Graph nodes: 8403
-- Graph edges: 10066
-- Communities: 2081
+- Code files discovered: 2156
+- Graph nodes: 8411
+- Graph edges: 10077
+- Communities: 2083
 
 ## Graph Hotspots
 - `dailyClose.ts` (90 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 12) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 12) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 65) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `storefrontContextEvents.ts` (17 edges, Community 81) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
+- `storefrontContextEvents.ts` (17 edges, Community 82) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
 - `checkoutSession.ts` (14 edges, Community 98) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 
 ## Navigation

--- a/packages/athena-webapp/convex/_generated/api.d.ts
+++ b/packages/athena-webapp/convex/_generated/api.d.ts
@@ -158,6 +158,7 @@ import type * as operations_approvalActions from "../operations/approvalActions.
 import type * as operations_approvalAuditEvents from "../operations/approvalAuditEvents.js";
 import type * as operations_approvalProofs from "../operations/approvalProofs.js";
 import type * as operations_approvalRequestHelpers from "../operations/approvalRequestHelpers.js";
+import type * as operations_approvalRequesterChallenges from "../operations/approvalRequesterChallenges.js";
 import type * as operations_approvalRequests from "../operations/approvalRequests.js";
 import type * as operations_customerProfiles from "../operations/customerProfiles.js";
 import type * as operations_dailyClose from "../operations/dailyClose.js";
@@ -583,6 +584,7 @@ declare const fullApi: ApiFromModules<{
   "operations/approvalAuditEvents": typeof operations_approvalAuditEvents;
   "operations/approvalProofs": typeof operations_approvalProofs;
   "operations/approvalRequestHelpers": typeof operations_approvalRequestHelpers;
+  "operations/approvalRequesterChallenges": typeof operations_approvalRequesterChallenges;
   "operations/approvalRequests": typeof operations_approvalRequests;
   "operations/customerProfiles": typeof operations_customerProfiles;
   "operations/dailyClose": typeof operations_dailyClose;

--- a/packages/athena-webapp/convex/cashControls/closeouts.test.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.test.ts
@@ -1070,7 +1070,9 @@ describe("cash control closeouts", () => {
   it("requires the same manager to submit a reopened closeout correction", async () => {
     const runMutation = vi.fn();
     const patch = vi.fn();
-    const insert = vi.fn();
+    const insert = vi.fn(async (table: string) =>
+      table === "approvalRequesterChallenge" ? "requester-challenge-1" : "event-1",
+    );
     const registerSession = {
       _id: "session-1",
       closeoutRecords: [
@@ -1101,7 +1103,6 @@ describe("cash control closeouts", () => {
               actionKey: "cash_controls.register_session.submit_reopened_closeout",
               approvedByStaffProfileId: "manager-2",
               expiresAt: Date.now() + 60_000,
-              requestedByStaffProfileId: "staff-1",
               requiredRole: "manager",
               storeId: "store-1",
               subjectId: "session-1",
@@ -1173,7 +1174,9 @@ describe("cash control closeouts", () => {
       countedCash: 20000,
       status: "closing",
     }));
-    const insert = vi.fn();
+    const insert = vi.fn(async (table: string) =>
+      table === "approvalRequesterChallenge" ? "requester-challenge-1" : "event-1",
+    );
     const ctx = {
       db: {
         get: vi.fn(async (table: string) => {
@@ -1228,6 +1231,11 @@ describe("cash control closeouts", () => {
           key: "cash_controls.register_session.review_variance",
         },
         requiredRole: "manager",
+        requesterBinding: {
+          challengeId: "requester-challenge-1",
+          kind: "operational_staff_challenge",
+          requestedByStaffProfileId: "staff-1",
+        },
         resolutionModes: [{ kind: "inline_manager_proof" }],
         subject: {
           id: "session-1",
@@ -1238,7 +1246,21 @@ describe("cash control closeouts", () => {
     expect(result.approval.resolutionModes).not.toContainEqual(
       expect.objectContaining({ kind: "async_request" }),
     );
-    expect(insert).not.toHaveBeenCalled();
+    expect(insert).toHaveBeenCalledWith(
+      "approvalRequesterChallenge",
+      expect.objectContaining({
+        actionKey: "cash_controls.register_session.review_variance",
+        requestedByStaffProfileId: "staff-1",
+        requiredRole: "manager",
+        storeId: "store-1",
+        subjectId: "session-1",
+        subjectType: "register_session",
+      }),
+    );
+    expect(insert).not.toHaveBeenCalledWith(
+      "approvalRequest",
+      expect.anything(),
+    );
   });
 
   it("submits closeout without final closure when pending void approvals exist", async () => {
@@ -1530,6 +1552,134 @@ describe("cash control closeouts", () => {
     );
   });
 
+  it("returns an operational requester binding for unlinked staff variance closeout submissions", async () => {
+    const registerSession = {
+      _id: "session-1",
+      expectedCash: 70000,
+      openedAt: 1,
+      organizationId: "org-1",
+      registerNumber: "A1",
+      status: "active",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    };
+    const runMutation = vi.fn(async () => ({
+      ...registerSession,
+      countedCash: 60000,
+      status: "closing",
+    }));
+    const patch = vi.fn();
+    const insert = vi.fn(async (table: string) => {
+      if (table === "approvalRequest") return "approval-1";
+      if (table === "approvalRequesterChallenge") return "requester-challenge-1";
+      return "event-1";
+    });
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string, id?: string) => {
+          if (table === "store") {
+            return { _id: "store-1", currency: "GHS", organizationId: "org-1" };
+          }
+          if (table === "registerSession") {
+            return registerSession;
+          }
+          if (table === "approvalRequest" && id === "approval-1") {
+            return {
+              _id: "approval-1",
+              createdAt: 1234,
+              requestedByStaffProfileId: "cashier-1",
+            };
+          }
+          if (table === "staffProfile") {
+            return {
+              _id: "cashier-1",
+              linkedUserId: "other-user-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+          return null;
+        }),
+        insert,
+        patch,
+        query: vi.fn((table: string) => ({
+          withIndex: vi.fn(() => ({
+            collect: vi.fn(async () => []),
+            order: vi.fn(() => ({
+              first: vi.fn(async () => null),
+              take: vi.fn(async () => []),
+            })),
+            take: vi.fn(async () => {
+              if (table === "staffCredential") {
+                return [
+                  {
+                    _id: "credential-1",
+                    organizationId: "org-1",
+                    pinHash: "hashed-pin",
+                    staffProfileId: "cashier-1",
+                    status: "active",
+                    storeId: "store-1",
+                    username: "cashier",
+                  },
+                ];
+              }
+              if (table === "staffRoleAssignment") {
+                return [
+                  {
+                    organizationId: "org-1",
+                    role: "cashier",
+                    status: "active",
+                    storeId: "store-1",
+                  },
+                ];
+              }
+              return [];
+            }),
+            unique: vi.fn(async () => null),
+          })),
+        })),
+      },
+      runMutation,
+      runQuery: vi.fn(async () => ({ _id: "store-1" })),
+    };
+
+    const result = await getHandler(submitRegisterSessionCloseout)(ctx, {
+      actorStaffProfileId: "cashier-1",
+      countedCash: 60000,
+      registerSessionId: "session-1",
+      staffPinHash: "hashed-pin",
+      staffUsername: "cashier",
+      storeId: "store-1",
+    });
+
+    expect(result).toMatchObject({
+      kind: "approval_required",
+      approval: {
+        requesterBinding: {
+          challengeId: "requester-challenge-1",
+          kind: "operational_staff_challenge",
+          requestedByStaffProfileId: "cashier-1",
+        },
+      },
+    });
+    expect(insert).toHaveBeenCalledWith(
+      "approvalRequesterChallenge",
+      expect.objectContaining({
+        actionKey: "cash_controls.register_session.review_variance",
+        requestedByStaffProfileId: "cashier-1",
+        requiredRole: "manager",
+        storeId: "store-1",
+        subjectId: "session-1",
+      }),
+    );
+    expect(patch).toHaveBeenCalledWith("staffCredential", "credential-1", {
+      authenticationLockedUntil: undefined,
+      failedAuthenticationAttempts: 0,
+      lastAuthenticatedAt: expect.any(Number),
+    });
+  });
+
   it("rejects closeout submit when staff credentials authenticate a different actor", async () => {
     const runMutation = vi.fn();
     const patch = vi.fn();
@@ -1664,7 +1814,9 @@ describe("cash control closeouts", () => {
   });
 
   it("returns the existing pending approval for duplicate variance closeout submissions", async () => {
-    const insert = vi.fn();
+    const insert = vi.fn(async (table: string) =>
+      table === "approvalRequesterChallenge" ? "requester-challenge-1" : "event-1",
+    );
     const patch = vi.fn();
     const runMutation = vi.fn();
     const ctx = {
@@ -1749,6 +1901,11 @@ describe("cash control closeouts", () => {
           expectedCash: 70000,
           variance: -70000,
         },
+        requesterBinding: {
+          challengeId: "requester-challenge-1",
+          kind: "operational_staff_challenge",
+          requestedByStaffProfileId: "cashier-1",
+        },
       },
     });
     expect(result.kind === "approval_required" && result.approval.resolutionModes).toContainEqual({
@@ -1757,8 +1914,169 @@ describe("cash control closeouts", () => {
       requestType: "variance_review",
     });
     expect(runMutation).not.toHaveBeenCalled();
-    expect(insert).not.toHaveBeenCalled();
+    expect(insert).toHaveBeenCalledWith(
+      "approvalRequesterChallenge",
+      expect.objectContaining({
+        actionKey: "cash_controls.register_session.review_variance",
+        requestedByStaffProfileId: "cashier-1",
+        storeId: "store-1",
+        subjectId: "session-1",
+      }),
+    );
+    expect(insert).not.toHaveBeenCalledWith(
+      "approvalRequest",
+      expect.anything(),
+    );
     expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("marks matched pending variance approvals approved on inline proof retry", async () => {
+    const closedSession = {
+      _id: "session-1",
+      closedAt: 2,
+      countedCash: 0,
+      expectedCash: 70000,
+      status: "closed",
+      storeId: "store-1",
+    };
+    const patch = vi.fn();
+    const runMutation = vi.fn(async (_mutation, args) =>
+      "closedByStaffProfileId" in args
+        ? closedSession
+        : {
+            _id: "session-1",
+            countedCash: 0,
+            expectedCash: 70000,
+            status: "closing",
+            storeId: "store-1",
+          },
+    );
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string, id?: string) => {
+          if (table === "store") {
+            return { _id: "store-1", currency: "GHS", organizationId: "org-1" };
+          }
+          if (table === "registerSession") {
+            return {
+              _id: "session-1",
+              expectedCash: 70000,
+              managerApprovalRequestId: "approval-1",
+              openedAt: 1,
+              organizationId: "org-1",
+              registerNumber: "A1",
+              status: "closing",
+              storeId: "store-1",
+              terminalId: "terminal-1",
+            };
+          }
+          if (table === "approvalRequest" && id === "approval-1") {
+            return {
+              _id: "approval-1",
+              createdAt: 1,
+              metadata: {
+                countedCash: 0,
+                expectedCash: 70000,
+                variance: -70000,
+              },
+              notes: "Recounted drawer.",
+              registerSessionId: "session-1",
+              requestType: "variance_review",
+              requestedByStaffProfileId: "cashier-1",
+              status: "pending",
+              storeId: "store-1",
+            };
+          }
+          if (table === "approvalProof") {
+            return {
+              _id: "proof-1",
+              actionKey: "cash_controls.register_session.review_variance",
+              approvedByStaffProfileId: "manager-1",
+              expiresAt: Date.now() + 60_000,
+              requestedByStaffProfileId: "cashier-1",
+              requiredRole: "manager",
+              storeId: "store-1",
+              subjectId: "session-1",
+              subjectLabel: "A1",
+              subjectType: "register_session",
+            };
+          }
+          if (table === "staffProfile" && id === "cashier-1") {
+            return {
+              _id: "cashier-1",
+              linkedUserId: "manager-user-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+          if (table === "staffProfile" && id === "manager-1") {
+            return {
+              _id: "manager-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+          return null;
+        }),
+        insert: vi.fn(async () => "event-1"),
+        patch,
+        query: vi.fn((table: string) => ({
+          withIndex: vi.fn(() => ({
+            collect: vi.fn(async () => []),
+            order: vi.fn(() => ({
+              first: vi.fn(async () => null),
+              take: vi.fn(async () => []),
+            })),
+            take: vi.fn(async () =>
+              table === "staffRoleAssignment"
+                ? [
+                    {
+                      organizationId: "org-1",
+                      role: "manager",
+                      status: "active",
+                      storeId: "store-1",
+                    },
+                  ]
+                : [],
+            ),
+          })),
+        })),
+      },
+      runMutation,
+      runQuery: vi.fn(async () => ({ _id: "store-1" })),
+    };
+
+    const result = await getHandler(submitRegisterSessionCloseout)(ctx, {
+      actorStaffProfileId: "cashier-1",
+      approvalProofId: "proof-1",
+      countedCash: 0,
+      notes: "Recounted drawer.",
+      registerSessionId: "session-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "closed",
+        registerSession: closedSession,
+      },
+    });
+    expect(patch).toHaveBeenCalledWith("approvalRequest", "approval-1", {
+      status: "approved",
+      decisionApprovedByStaffProfileId: "manager-1",
+      decisionApprovalProofId: "proof-1",
+      reviewedByStaffProfileId: "manager-1",
+      reviewedByUserId: "manager-user-1",
+      decidedAt: expect.any(Number),
+    });
+    expect(patch).not.toHaveBeenCalledWith(
+      "approvalRequest",
+      "approval-1",
+      expect.objectContaining({ status: "cancelled" }),
+    );
   });
 
   it("replaces pending variance approval when a corrected closeout count changes before review", async () => {
@@ -2448,6 +2766,9 @@ describe("cash control closeouts", () => {
       storeId: "store-1",
       terminalId: "terminal-1",
     };
+    const insert = vi.fn(async (table: string) =>
+      table === "approvalRequesterChallenge" ? "requester-challenge-1" : "event-1",
+    );
     const ctx = {
       db: {
         get: vi.fn(async (table: string) => {
@@ -2471,6 +2792,7 @@ describe("cash control closeouts", () => {
             collect: vi.fn(async () => []),
           })),
         })),
+        insert,
       },
       runMutation: vi.fn(),
       runQuery: vi.fn(async () => ({ _id: "store-1" })),
@@ -2490,8 +2812,21 @@ describe("cash control closeouts", () => {
           key: "cash_controls.register_session.review_variance",
         },
         requiredRole: "manager",
+        requesterBinding: {
+          challengeId: "requester-challenge-1",
+          kind: "operational_staff_challenge",
+          requestedByStaffProfileId: "manager-1",
+        },
       },
     });
+    expect(insert).toHaveBeenCalledWith(
+      "approvalRequesterChallenge",
+      expect.objectContaining({
+        actionKey: "cash_controls.register_session.review_variance",
+        requestedByStaffProfileId: "manager-1",
+        subjectId: "session-1",
+      }),
+    );
   });
 
   it("allows managers to finalize variance closeout after pending void approvals clear", async () => {
@@ -2799,6 +3134,82 @@ describe("cash control closeouts", () => {
         },
       },
     });
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("binds opening float approval to the active staff requester", async () => {
+    const insert = vi.fn(async (table: string) =>
+      table === "approvalRequesterChallenge" ? "requester-challenge-1" : "event-1",
+    );
+    const runMutation = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string) => {
+          if (table === "registerSession") {
+            return {
+              _id: "session-1",
+              expectedCash: 30000,
+              openingFloat: 30000,
+              openedAt: 1,
+              organizationId: "org-1",
+              registerNumber: "A1",
+              status: "open",
+              storeId: "store-1",
+            };
+          }
+
+          if (table === "store") {
+            return { _id: "store-1", currency: "GHS", organizationId: "org-1" };
+          }
+
+          if (table === "staffProfile") {
+            return {
+              _id: "staff-1",
+              linkedUserId: "manager-user-1",
+              organizationId: "org-1",
+              status: "active",
+              storeId: "store-1",
+            };
+          }
+
+          return null;
+        }),
+        insert,
+      },
+      runMutation,
+    };
+
+    const result = await getHandler(correctRegisterSessionOpeningFloat)(ctx, {
+      actorStaffProfileId: "staff-1",
+      correctedOpeningFloat: 20000,
+      reason: "Drawer counted wrong at open.",
+      registerSessionId: "session-1",
+      storeId: "store-1",
+    });
+
+    expect(result).toMatchObject({
+      kind: "approval_required",
+      approval: {
+        requesterBinding: {
+          kind: "operational_staff_challenge",
+          challengeId: "requester-challenge-1",
+          requestedByStaffProfileId: "staff-1",
+        },
+      },
+    });
+    expect(insert).toHaveBeenCalledWith(
+      "approvalRequesterChallenge",
+      expect.objectContaining({
+        actionKey: "cash_controls.register_session.correct_opening_float",
+        organizationId: "org-1",
+        requestedByStaffProfileId: "staff-1",
+        requiredRole: "manager",
+        storeId: "store-1",
+        subjectId: "session-1",
+        subjectLabel: "A1",
+        subjectType: "register_session",
+      }),
+    );
     expect(runMutation).not.toHaveBeenCalled();
   });
 

--- a/packages/athena-webapp/convex/cashControls/closeouts.ts
+++ b/packages/athena-webapp/convex/cashControls/closeouts.ts
@@ -22,6 +22,7 @@ import {
   type RegisterSessionCloseoutReview,
 } from "../operations/registerSessionCloseoutGate";
 import { recordRegisterSessionTraceBestEffort } from "../operations/registerSessionTracing";
+import { createApprovalRequesterChallengeWithCtx } from "../operations/approvalRequesterChallenges";
 import { authenticateStaffCredentialWithCtx } from "../operations/staffCredentials";
 import type { OperationalRole } from "../operations/staffRoles";
 import { commandResultValidator } from "../lib/commandResultValidators";
@@ -43,7 +44,10 @@ import {
   type ApprovalCommandResult,
   type CommandResult,
 } from "../../shared/commandResult";
-import type { ApprovalRequirement } from "../../shared/approvalPolicy";
+import type {
+  ApprovalRequirement,
+  ApprovalRequesterBinding,
+} from "../../shared/approvalPolicy";
 import { formatStaffDisplayName } from "../../shared/staffDisplayName";
 
 export {
@@ -76,6 +80,35 @@ function formatCloseoutVarianceAmount(
   } catch {
     return currencyFormatter("GHS").format(toDisplayAmount(amount));
   }
+}
+
+async function createApprovalRequesterBindingForCloseout(
+  ctx: MutationCtx,
+  args: {
+    actionKey: string;
+    organizationId?: Id<"organization">;
+    registerSession: Pick<Doc<"registerSession">, "_id" | "registerNumber">;
+    requestedByStaffProfileId?: Id<"staffProfile">;
+    requiredRole: "manager";
+    storeId: Id<"store">;
+  },
+): Promise<CommandResult<{ requesterBinding?: ApprovalRequesterBinding }>> {
+  if (!args.requestedByStaffProfileId) {
+    return ok({});
+  }
+
+  return createApprovalRequesterChallengeWithCtx(ctx, {
+    actionKey: args.actionKey,
+    organizationId: args.organizationId,
+    requestedByStaffProfileId: args.requestedByStaffProfileId,
+    requiredRole: args.requiredRole,
+    storeId: args.storeId,
+    subject: {
+      id: args.registerSession._id,
+      label: args.registerSession.registerNumber,
+      type: "register_session",
+    },
+  });
 }
 
 function buildRegisterCloseoutVarianceTimelineMessage(args: {
@@ -252,6 +285,7 @@ function buildOpeningFloatCorrectionApprovalRequirement(args: {
   previousOpeningFloat: number;
   reason: string;
   registerSession: Doc<"registerSession">;
+  requesterBinding?: ApprovalRequesterBinding;
 }) {
   return {
     action: {
@@ -275,6 +309,7 @@ function buildOpeningFloatCorrectionApprovalRequirement(args: {
       secondaryActionLabel: "Cancel",
     },
     resolutionModes: [{ kind: "inline_manager_proof" as const }],
+    ...(args.requesterBinding ? { requesterBinding: args.requesterBinding } : {}),
     metadata: {
       correctedOpeningFloat: args.correctedOpeningFloat,
       previousOpeningFloat: args.previousOpeningFloat,
@@ -404,6 +439,7 @@ export function buildRegisterSessionVarianceApprovalRequirement(args: {
   countedCash: number;
   expectedCash: number;
   registerSession: Pick<Doc<"registerSession">, "_id" | "registerNumber">;
+  requesterBinding?: ApprovalRequesterBinding;
 }): ApprovalRequirement {
   return {
     action: REGISTER_VARIANCE_REVIEW_ACTION,
@@ -440,6 +476,7 @@ export function buildRegisterSessionVarianceApprovalRequirement(args: {
             kind: "inline_manager_proof",
           },
         ],
+    ...(args.requesterBinding ? { requesterBinding: args.requesterBinding } : {}),
     selfApproval: "allowed",
     subject: {
       id: args.registerSession._id,
@@ -859,6 +896,10 @@ export const submitRegisterSessionCloseout = mutation({
     const latestReopenedCloseout = getLatestReopenedCloseoutRecord(registerSession);
     let closeoutSubmitActorStaffProfileId = submitActorStaffProfileId;
     let approvedByStaffProfileId: Id<"staffProfile"> | undefined;
+    let hasMatchingPendingVarianceApprovalRequest = false;
+    let pendingVarianceApprovalRequesterStaffProfileId:
+      | Id<"staffProfile">
+      | undefined;
 
     if (
       registerSession.status === "closing" &&
@@ -895,15 +936,36 @@ export const submitRegisterSessionCloseout = mutation({
           pendingVariance === closeoutReview.variance &&
           pendingNotes === submittedNotes
         ) {
-          return approvalRequired(
-            buildRegisterSessionVarianceApprovalRequirement({
-              approvalRequestId: pendingApprovalRequest._id,
-              closeoutReview,
-              countedCash: args.countedCash,
-              expectedCash: registerSession.expectedCash,
-              registerSession,
-            }),
-          );
+          hasMatchingPendingVarianceApprovalRequest = true;
+          pendingVarianceApprovalRequesterStaffProfileId =
+            pendingApprovalRequest.requestedByStaffProfileId;
+
+          if (!args.approvalProofId) {
+            const requesterBindingResult =
+              await createApprovalRequesterBindingForCloseout(ctx, {
+                actionKey: REGISTER_VARIANCE_REVIEW_ACTION_KEY,
+                organizationId: registerSession.organizationId,
+                registerSession,
+                requestedByStaffProfileId:
+                  pendingApprovalRequest.requestedByStaffProfileId,
+                requiredRole: "manager",
+                storeId: args.storeId,
+              });
+            if (requesterBindingResult.kind !== "ok") {
+              return requesterBindingResult;
+            }
+
+            return approvalRequired(
+              buildRegisterSessionVarianceApprovalRequirement({
+                approvalRequestId: pendingApprovalRequest._id,
+                closeoutReview,
+                countedCash: args.countedCash,
+                expectedCash: registerSession.expectedCash,
+                registerSession,
+                requesterBinding: requesterBindingResult.data.requesterBinding,
+              }),
+            );
+          }
         }
 
         // A changed count or note is a correction before review. Let the
@@ -929,7 +991,6 @@ export const submitRegisterSessionCloseout = mutation({
         action: REGISTER_CLOSEOUT_MODIFICATION_SUBMIT_ACTION,
         approvalProofId: args.closeoutModificationApprovalProofId,
         requiredRole: "manager",
-        requestedByStaffProfileId: closeoutSubmitActorStaffProfileId,
         storeId: args.storeId,
         subject: {
           type: "register_session",
@@ -973,7 +1034,10 @@ export const submitRegisterSessionCloseout = mutation({
         action: REGISTER_VARIANCE_REVIEW_ACTION,
         approvalProofId: args.approvalProofId,
         requiredRole: "manager",
-        requestedByStaffProfileId: closeoutSubmitActorStaffProfileId,
+        requestedByStaffProfileId:
+          hasMatchingPendingVarianceApprovalRequest
+            ? pendingVarianceApprovalRequesterStaffProfileId
+            : closeoutSubmitActorStaffProfileId,
         storeId: args.storeId,
         subject: {
           type: "register_session",
@@ -1020,12 +1084,26 @@ export const submitRegisterSessionCloseout = mutation({
       );
 
       if (actorCanReviewVariance) {
+        const requesterBindingResult =
+          await createApprovalRequesterBindingForCloseout(ctx, {
+            actionKey: REGISTER_VARIANCE_REVIEW_ACTION_KEY,
+            organizationId: registerSession.organizationId,
+            registerSession,
+            requestedByStaffProfileId: closeoutSubmitActorStaffProfileId,
+            requiredRole: "manager",
+            storeId: args.storeId,
+          });
+        if (requesterBindingResult.kind !== "ok") {
+          return requesterBindingResult;
+        }
+
         return approvalRequired(
           buildRegisterSessionVarianceApprovalRequirement({
             closeoutReview,
             countedCash: args.countedCash,
             expectedCash: registerSession.expectedCash,
             registerSession,
+            requesterBinding: requesterBindingResult.data.requesterBinding,
           }),
         );
       }
@@ -1103,14 +1181,30 @@ export const submitRegisterSessionCloseout = mutation({
     }
 
     if (closeoutReview.requiresApproval) {
-      await cancelPendingApprovalIfNeeded({
-        approvalRequestId: registerSession.managerApprovalRequestId,
-        ctx,
-        registerSessionId: registerSession._id,
-        reviewedByStaffProfileId: closeoutSubmitActorStaffProfileId,
-        reviewedByUserId: actorUserId,
-        storeId: args.storeId,
-      });
+      if (
+        approvedByStaffProfileId &&
+        hasMatchingPendingVarianceApprovalRequest &&
+        registerSession.managerApprovalRequestId &&
+        args.approvalProofId
+      ) {
+        await ctx.db.patch("approvalRequest", registerSession.managerApprovalRequestId, {
+          status: "approved",
+          decisionApprovedByStaffProfileId: approvedByStaffProfileId,
+          decisionApprovalProofId: args.approvalProofId,
+          reviewedByStaffProfileId: approvedByStaffProfileId,
+          reviewedByUserId: actorUserId,
+          decidedAt: Date.now(),
+        });
+      } else {
+        await cancelPendingApprovalIfNeeded({
+          approvalRequestId: registerSession.managerApprovalRequestId,
+          ctx,
+          registerSessionId: registerSession._id,
+          reviewedByStaffProfileId: closeoutSubmitActorStaffProfileId,
+          reviewedByUserId: actorUserId,
+          storeId: args.storeId,
+        });
+      }
 
       if (approvedByStaffProfileId) {
         const closedSession = await ctx.runMutation(
@@ -1213,6 +1307,21 @@ export const submitRegisterSessionCloseout = mutation({
         })
       );
       const approvalRequest = await ctx.db.get("approvalRequest", approvalRequestId);
+      const requesterBindingResult = await createApprovalRequesterBindingForCloseout(
+        ctx,
+        {
+          actionKey: REGISTER_VARIANCE_REVIEW_ACTION_KEY,
+          organizationId: registerSession.organizationId,
+          registerSession,
+          requestedByStaffProfileId: closeoutSubmitActorStaffProfileId,
+          requiredRole: "manager",
+          storeId: args.storeId,
+        },
+      );
+      if (requesterBindingResult.kind !== "ok") {
+        return requesterBindingResult;
+      }
+
       const approvalRequirement =
         buildRegisterSessionVarianceApprovalRequirement({
           approvalRequestId,
@@ -1220,6 +1329,7 @@ export const submitRegisterSessionCloseout = mutation({
           countedCash: args.countedCash,
           expectedCash: registerSession.expectedCash,
           registerSession,
+          requesterBinding: requesterBindingResult.data.requesterBinding,
         });
       const approvalRequestCreatedAt = approvalRequest?.createdAt ?? Date.now();
       const closeoutContext = await resolveRegisterSessionOperatingDateContext(ctx, {
@@ -1481,12 +1591,25 @@ export const finalizeRegisterSessionCloseout = mutation({
     }
 
     if (closeoutReview.requiresApproval && !args.approvalProofId) {
+      const requesterBindingResult = await createApprovalRequesterBindingForCloseout(ctx, {
+        actionKey: REGISTER_VARIANCE_REVIEW_ACTION_KEY,
+        organizationId: registerSession.organizationId,
+        registerSession,
+        requestedByStaffProfileId,
+        requiredRole: "manager",
+        storeId: args.storeId,
+      });
+      if (requesterBindingResult.kind !== "ok") {
+        return requesterBindingResult;
+      }
+
       return approvalRequired(
         buildRegisterSessionVarianceApprovalRequirement({
           closeoutReview,
           countedCash: registerSession.countedCash,
           expectedCash: registerSession.expectedCash,
           registerSession,
+          requesterBinding: requesterBindingResult.data.requesterBinding,
         }),
       );
     }
@@ -1495,12 +1618,26 @@ export const finalizeRegisterSessionCloseout = mutation({
       const approvalProofId = args.approvalProofId;
 
       if (!approvalProofId) {
+        const requesterBindingResult =
+          await createApprovalRequesterBindingForCloseout(ctx, {
+            actionKey: REGISTER_VARIANCE_REVIEW_ACTION_KEY,
+            organizationId: registerSession.organizationId,
+            registerSession,
+            requestedByStaffProfileId,
+            requiredRole: "manager",
+            storeId: args.storeId,
+          });
+        if (requesterBindingResult.kind !== "ok") {
+          return requesterBindingResult;
+        }
+
         return approvalRequired(
           buildRegisterSessionVarianceApprovalRequirement({
             closeoutReview,
             countedCash: registerSession.countedCash,
             expectedCash: registerSession.expectedCash,
             registerSession,
+            requesterBinding: requesterBindingResult.data.requesterBinding,
           }),
         );
       }
@@ -1947,12 +2084,25 @@ export const correctRegisterSessionOpeningFloat = mutation({
     const previousOpeningFloat = registerSession.openingFloat;
 
     if (!args.approvalProofId) {
+      const requesterBindingResult = await createApprovalRequesterBindingForCloseout(ctx, {
+        actionKey: REGISTER_OPENING_FLOAT_CORRECTION_ACTION_KEY,
+        organizationId: registerSession.organizationId,
+        registerSession,
+        requestedByStaffProfileId: actorStaffProfileId,
+        requiredRole: "manager",
+        storeId: args.storeId,
+      });
+      if (requesterBindingResult.kind !== "ok") {
+        return requesterBindingResult;
+      }
+
       return approvalRequired(
         buildOpeningFloatCorrectionApprovalRequirement({
           correctedOpeningFloat: args.correctedOpeningFloat,
           previousOpeningFloat,
           reason,
           registerSession,
+          requesterBinding: requesterBindingResult.data.requesterBinding,
         }),
       );
     }

--- a/packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts
+++ b/packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts
@@ -187,6 +187,10 @@ function createMutationCtx(seed?: {
       return null;
     }),
     insert: vi.fn(async (table: string, value: Record<string, unknown>) => {
+      if (table === "approvalRequesterChallenge") {
+        return "requester-challenge-1" as Id<"approvalRequesterChallenge">;
+      }
+
       if (table !== "approvalRequest") {
         throw new Error(`Unsupported insert into ${table}`);
       }

--- a/packages/athena-webapp/convex/lib/commandResultValidators.test.ts
+++ b/packages/athena-webapp/convex/lib/commandResultValidators.test.ts
@@ -59,6 +59,7 @@ describe("command result validators", () => {
                 reason: expect.objectContaining({ optional: false }),
                 copy: expect.objectContaining({ optional: false }),
                 resolutionModes: expect.objectContaining({ optional: false }),
+                requesterBinding: expect.objectContaining({ optional: true }),
               }),
             }),
           }),
@@ -67,6 +68,10 @@ describe("command result validators", () => {
     );
 
     expect(JSON.stringify(approvalVariant)).toContain("inline_manager_proof");
+    expect(JSON.stringify(approvalVariant)).toContain(
+      "operational_staff_challenge",
+    );
+    expect(JSON.stringify(approvalVariant)).toContain("challengeId");
   });
 
   it("accepts approval-required results with async request resolution", () => {

--- a/packages/athena-webapp/convex/lib/commandResultValidators.ts
+++ b/packages/athena-webapp/convex/lib/commandResultValidators.ts
@@ -45,6 +45,12 @@ export const approvalOperatorCopyValidator = v.object({
   secondaryActionLabel: v.optional(v.string()),
 });
 
+export const approvalRequesterBindingValidator = v.object({
+  kind: v.literal("operational_staff_challenge"),
+  challengeId: v.string(),
+  requestedByStaffProfileId: v.string(),
+});
+
 export const approvalResolutionModeValidator = v.union(
   v.object({
     kind: v.literal("inline_manager_proof"),
@@ -64,6 +70,7 @@ export const approvalRequirementValidator = v.object({
   reason: v.string(),
   copy: approvalOperatorCopyValidator,
   resolutionModes: v.array(approvalResolutionModeValidator),
+  requesterBinding: v.optional(approvalRequesterBindingValidator),
   selfApproval: v.optional(
     v.union(v.literal("allowed"), v.literal("disallowed")),
   ),

--- a/packages/athena-webapp/convex/operations/approvalRequesterChallenges.ts
+++ b/packages/athena-webapp/convex/operations/approvalRequesterChallenges.ts
@@ -1,0 +1,179 @@
+import { v } from "convex/values";
+import type { Doc, Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+import type {
+  ApprovalRequesterBinding,
+  ApprovalSubjectIdentity,
+} from "../../shared/approvalPolicy";
+import { ok, userError, type CommandResult } from "../../shared/commandResult";
+import { operationalRoleValidator, type OperationalRole } from "./staffRoles";
+
+export const APPROVAL_REQUESTER_CHALLENGE_TTL_MS = 5 * 60 * 1000;
+
+type ApprovalRequesterChallengeId = Id<"approvalRequesterChallenge">;
+
+type CreateApprovalRequesterChallengeArgs = {
+  actionKey: string;
+  organizationId?: Id<"organization">;
+  requestedByStaffProfileId: Id<"staffProfile">;
+  requiredRole: OperationalRole;
+  storeId: Id<"store">;
+  subject: ApprovalSubjectIdentity;
+  ttlMs?: number;
+};
+
+type ConsumeApprovalRequesterChallengeArgs = {
+  actionKey: string;
+  binding: {
+    challengeId: ApprovalRequesterChallengeId;
+    kind: "operational_staff_challenge";
+    requestedByStaffProfileId: Id<"staffProfile">;
+  };
+  requiredRole: OperationalRole;
+  storeId: Id<"store">;
+  subject: ApprovalSubjectIdentity;
+};
+
+function invalidApprovalRequesterChallengeResult(message: string) {
+  return userError({
+    code: "precondition_failed",
+    message,
+  });
+}
+
+function toRequesterBinding(
+  challengeId: ApprovalRequesterChallengeId,
+  requestedByStaffProfileId: Id<"staffProfile">,
+): ApprovalRequesterBinding {
+  return {
+    kind: "operational_staff_challenge",
+    challengeId: String(challengeId),
+    requestedByStaffProfileId: String(requestedByStaffProfileId),
+  };
+}
+
+export async function createApprovalRequesterChallengeWithCtx(
+  ctx: MutationCtx,
+  args: CreateApprovalRequesterChallengeArgs,
+): Promise<CommandResult<{ requesterBinding: ApprovalRequesterBinding }>> {
+  const staffProfile = await ctx.db.get(
+    "staffProfile",
+    args.requestedByStaffProfileId,
+  );
+
+  if (
+    !staffProfile ||
+    staffProfile.storeId !== args.storeId ||
+    staffProfile.status !== "active"
+  ) {
+    return userError({
+      code: "authorization_failed",
+      message: "Requested staff profile is not valid for this approval.",
+    });
+  }
+
+  const now = Date.now();
+  const challengeId = await ctx.db.insert("approvalRequesterChallenge", {
+    storeId: args.storeId,
+    organizationId: args.organizationId,
+    actionKey: args.actionKey,
+    subjectType: args.subject.type,
+    subjectId: args.subject.id,
+    subjectLabel: args.subject.label,
+    requiredRole: args.requiredRole,
+    requestedByStaffProfileId: args.requestedByStaffProfileId,
+    createdAt: now,
+    expiresAt: now + (args.ttlMs ?? APPROVAL_REQUESTER_CHALLENGE_TTL_MS),
+  });
+
+  return ok({
+    requesterBinding: toRequesterBinding(
+      challengeId,
+      args.requestedByStaffProfileId,
+    ),
+  });
+}
+
+export async function consumeApprovalRequesterChallengeWithCtx(
+  ctx: MutationCtx,
+  args: ConsumeApprovalRequesterChallengeArgs,
+): Promise<CommandResult<{ requestedByStaffProfileId: Id<"staffProfile"> }>> {
+  const challenge = await ctx.db.get(
+    "approvalRequesterChallenge",
+    args.binding.challengeId,
+  );
+
+  if (!challenge) {
+    return invalidApprovalRequesterChallengeResult(
+      "Approval requester challenge was not found.",
+    );
+  }
+
+  if (
+    challenge.storeId !== args.storeId ||
+    challenge.actionKey !== args.actionKey ||
+    challenge.subjectType !== args.subject.type ||
+    challenge.subjectId !== args.subject.id ||
+    challenge.requiredRole !== args.requiredRole ||
+    challenge.requestedByStaffProfileId !== args.binding.requestedByStaffProfileId
+  ) {
+    return invalidApprovalRequesterChallengeResult(
+      "Approval requester challenge does not match this approval.",
+    );
+  }
+
+  if (challenge.consumedAt !== undefined) {
+    return invalidApprovalRequesterChallengeResult(
+      "Approval requester challenge has already been used.",
+    );
+  }
+
+  const now = Date.now();
+
+  if (challenge.expiresAt <= now) {
+    return invalidApprovalRequesterChallengeResult(
+      "Approval requester challenge has expired.",
+    );
+  }
+
+  const staffProfile = await ctx.db.get(
+    "staffProfile",
+    challenge.requestedByStaffProfileId,
+  );
+  if (
+    !staffProfile ||
+    staffProfile.storeId !== args.storeId ||
+    staffProfile.status !== "active"
+  ) {
+    return userError({
+      code: "authorization_failed",
+      message: "Requested staff profile is not valid for this approval.",
+    });
+  }
+
+  await ctx.db.patch("approvalRequesterChallenge", challenge._id, {
+    consumedAt: now,
+  });
+
+  return ok({
+    requestedByStaffProfileId: challenge.requestedByStaffProfileId,
+  });
+}
+
+export const approvalRequesterBindingArgValidator = v.object({
+  kind: v.literal("operational_staff_challenge"),
+  challengeId: v.id("approvalRequesterChallenge"),
+  requestedByStaffProfileId: v.id("staffProfile"),
+});
+
+export const approvalRequesterChallengeArgsValidator = {
+  actionKey: v.string(),
+  requestedByStaffProfileId: v.id("staffProfile"),
+  requiredRole: operationalRoleValidator,
+  storeId: v.id("store"),
+  subject: v.object({
+    type: v.string(),
+    id: v.string(),
+    label: v.optional(v.string()),
+  }),
+};

--- a/packages/athena-webapp/convex/operations/staffCredentials.test.ts
+++ b/packages/athena-webapp/convex/operations/staffCredentials.test.ts
@@ -32,10 +32,12 @@ import {
   validateRestoredPosLocalStaffProof,
   validateRestoredPosLocalStaffProofWithCtx,
 } from "./staffCredentials";
+import { createApprovalRequesterChallengeWithCtx } from "./approvalRequesterChallenges";
 import { hashPosLocalStaffProofToken } from "../pos/application/sync/staffProof";
 
 type TableName =
   | "approvalProof"
+  | "approvalRequesterChallenge"
   | "expenseSession"
   | "operationalEvent"
   | "posTerminal"
@@ -57,6 +59,7 @@ const localPinVerifier = {
 
 function createStaffCredentialsMutationCtx(seed?: {
   approvalProofs?: Row[];
+  approvalRequesterChallenges?: Row[];
   expenseSessions?: Row[];
   operationalEvents?: Row[];
   posTerminals?: Row[];
@@ -70,6 +73,9 @@ function createStaffCredentialsMutationCtx(seed?: {
   const tables: Record<TableName, Map<string, Row>> = {
     approvalProof: new Map(
       (seed?.approvalProofs ?? []).map((row) => [row._id, row])
+    ),
+    approvalRequesterChallenge: new Map(
+      (seed?.approvalRequesterChallenges ?? []).map((row) => [row._id, row])
     ),
     expenseSession: new Map(
       (seed?.expenseSessions ?? []).map((row) => [row._id, row])
@@ -121,6 +127,7 @@ function createStaffCredentialsMutationCtx(seed?: {
   };
   const insertCounters: Record<TableName, number> = {
     approvalProof: 0,
+    approvalRequesterChallenge: 0,
     expenseSession: 0,
     operationalEvent: 0,
     posTerminal: 0,
@@ -2590,6 +2597,282 @@ describe("staff credential operations", () => {
     });
   });
 
+  it("creates an approval proof for an unlinked operational requester through a server challenge", async () => {
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      credentials: [
+        {
+          _id: "credential-1",
+          staffProfileId: "manager-1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "manager",
+          pinHash: "hash-1",
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "manager-1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+        {
+          _id: "cashier-1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Cashier One",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "manager-1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "manager",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+
+    const subject = {
+      type: "pos_transaction",
+      id: "transaction-1",
+      label: "Receipt 1001",
+    };
+    const challenge = await createApprovalRequesterChallengeWithCtx(ctx, {
+      actionKey: "pos.transaction.payment_method.correct",
+      requestedByStaffProfileId: "cashier-1" as Id<"staffProfile">,
+      requiredRole: "manager",
+      storeId: "store_1" as Id<"store">,
+      subject,
+    });
+
+    expect(challenge).toEqual({
+      kind: "ok",
+      data: {
+        requesterBinding: {
+          kind: "operational_staff_challenge",
+          challengeId: "approvalRequesterChallenge-1",
+          requestedByStaffProfileId: "cashier-1",
+        },
+      },
+    });
+
+    if (challenge.kind !== "ok") {
+      throw new Error("Expected requester challenge to be created.");
+    }
+
+    const result = await authenticateStaffCredentialForApprovalWithCtx(ctx, {
+      actionKey: "pos.transaction.payment_method.correct",
+      pinHash: "hash-1",
+      reason: "Completed transactions require manager approval.",
+      requiredRole: "manager",
+      requesterBinding: challenge.data.requesterBinding as {
+        challengeId: Id<"approvalRequesterChallenge">;
+        kind: "operational_staff_challenge";
+        requestedByStaffProfileId: Id<"staffProfile">;
+      },
+      storeId: "store_1" as Id<"store">,
+      subject,
+      username: "manager",
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: expect.objectContaining({
+        approvalProofId: "approvalProof-1",
+        approvedByStaffProfileId: "manager-1",
+        requestedByStaffProfileId: "cashier-1",
+      }),
+    });
+    assertConformsToExportedReturns(authenticateStaffCredentialForApproval, result);
+    expect(tables.approvalRequesterChallenge.get("approvalRequesterChallenge-1"))
+      .toMatchObject({
+        actionKey: "pos.transaction.payment_method.correct",
+        consumedAt: expect.any(Number),
+        requestedByStaffProfileId: "cashier-1",
+        storeId: "store_1",
+        subjectId: "transaction-1",
+        subjectType: "pos_transaction",
+      });
+    expect(tables.approvalProof.get("approvalProof-1")).toMatchObject({
+      actionKey: "pos.transaction.payment_method.correct",
+      approvedByStaffProfileId: "manager-1",
+      requestedByStaffProfileId: "cashier-1",
+      storeId: "store_1",
+      subjectId: "transaction-1",
+      subjectType: "pos_transaction",
+    });
+  });
+
+  it.each([
+    {
+      name: "missing requester profile",
+      profiles: [],
+    },
+    {
+      name: "inactive requester profile",
+      profiles: [
+        {
+          _id: "cashier-1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "inactive",
+          fullName: "Cashier One",
+        },
+      ],
+    },
+    {
+      name: "wrong-store requester profile",
+      profiles: [
+        {
+          _id: "cashier-1",
+          storeId: "store_2",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Cashier One",
+        },
+      ],
+    },
+  ])("rejects requester challenge creation for $name", async (scenario) => {
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      profiles: scenario.profiles,
+    });
+
+    const result = await createApprovalRequesterChallengeWithCtx(ctx, {
+      actionKey: "pos.transaction.payment_method.correct",
+      requestedByStaffProfileId: "cashier-1" as Id<"staffProfile">,
+      requiredRole: "manager",
+      storeId: "store_1" as Id<"store">,
+      subject: {
+        type: "pos_transaction",
+        id: "transaction-1",
+      },
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "authorization_failed",
+        message: "Requested staff profile is not valid for this approval.",
+      },
+    });
+    expect(tables.approvalRequesterChallenge.size).toBe(0);
+  });
+
+  it.each([
+    {
+      name: "missing requester profile",
+      requesterProfile: null,
+    },
+    {
+      name: "inactive requester profile",
+      requesterProfile: {
+        _id: "cashier-1",
+        storeId: "store_1",
+        organizationId: "org_1",
+        status: "inactive",
+        fullName: "Cashier One",
+      },
+    },
+    {
+      name: "wrong-store requester profile",
+      requesterProfile: {
+        _id: "cashier-1",
+        storeId: "store_2",
+        organizationId: "org_1",
+        status: "active",
+        fullName: "Cashier One",
+      },
+    },
+  ])("rejects requester challenge consumption for $name", async (scenario) => {
+    const requesterProfiles =
+      scenario.requesterProfile === null ? [] : [scenario.requesterProfile];
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      approvalRequesterChallenges: [
+        {
+          _id: "challenge-1",
+          actionKey: "pos.transaction.payment_method.correct",
+          createdAt: 1,
+          expiresAt: Date.now() + 60_000,
+          requestedByStaffProfileId: "cashier-1",
+          requiredRole: "manager",
+          storeId: "store_1",
+          subjectId: "transaction-1",
+          subjectType: "pos_transaction",
+        },
+      ],
+      credentials: [
+        {
+          _id: "credential-1",
+          staffProfileId: "manager-1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "manager",
+          pinHash: "hash-1",
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "manager-1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+        ...requesterProfiles,
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "manager-1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "manager",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+
+    const result = await authenticateStaffCredentialForApprovalWithCtx(ctx, {
+      actionKey: "pos.transaction.payment_method.correct",
+      pinHash: "hash-1",
+      requiredRole: "manager",
+      requesterBinding: {
+        challengeId: "challenge-1" as Id<"approvalRequesterChallenge">,
+        kind: "operational_staff_challenge",
+        requestedByStaffProfileId: "cashier-1" as Id<"staffProfile">,
+      },
+      storeId: "store_1" as Id<"store">,
+      subject: {
+        type: "pos_transaction",
+        id: "transaction-1",
+      },
+      username: "manager",
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "authorization_failed",
+        message: "Requested staff profile is not valid for this approval.",
+      },
+    });
+    expect(tables.approvalRequesterChallenge.get("challenge-1")).not.toHaveProperty(
+      "consumedAt",
+    );
+    expect(tables.approvalProof.size).toBe(0);
+  });
+
   it("rejects approval proof requester attribution for unlinked staff profiles", async () => {
     const { ctx, tables } = createStaffCredentialsMutationCtx({
       credentials: [
@@ -2654,6 +2937,339 @@ describe("staff credential operations", () => {
         message: "Requested staff profile does not match the signed-in user.",
       },
     });
+    expect(tables.approvalProof.size).toBe(0);
+  });
+
+  it("rejects replayed operational requester challenges", async () => {
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      approvalRequesterChallenges: [
+        {
+          _id: "challenge-1",
+          actionKey: "pos.transaction.payment_method.correct",
+          consumedAt: 100,
+          createdAt: 1,
+          expiresAt: Date.now() + 60_000,
+          requestedByStaffProfileId: "cashier-1",
+          requiredRole: "manager",
+          storeId: "store_1",
+          subjectId: "transaction-1",
+          subjectType: "pos_transaction",
+        },
+      ],
+      credentials: [
+        {
+          _id: "credential-1",
+          staffProfileId: "manager-1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "manager",
+          pinHash: "hash-1",
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "manager-1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+        {
+          _id: "cashier-1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Cashier One",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "manager-1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "manager",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+
+    const result = await authenticateStaffCredentialForApprovalWithCtx(ctx, {
+      actionKey: "pos.transaction.payment_method.correct",
+      pinHash: "hash-1",
+      requiredRole: "manager",
+      requesterBinding: {
+        challengeId: "challenge-1" as Id<"approvalRequesterChallenge">,
+        kind: "operational_staff_challenge",
+        requestedByStaffProfileId: "cashier-1" as Id<"staffProfile">,
+      },
+      storeId: "store_1" as Id<"store">,
+      subject: {
+        type: "pos_transaction",
+        id: "transaction-1",
+      },
+      username: "manager",
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Approval requester challenge has already been used.",
+      },
+    });
+    expect(tables.approvalProof.size).toBe(0);
+  });
+
+  it("rejects mixed direct requester and operational requester binding evidence", async () => {
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      approvalRequesterChallenges: [
+        {
+          _id: "challenge-1",
+          actionKey: "pos.transaction.payment_method.correct",
+          createdAt: 1,
+          expiresAt: Date.now() + 60_000,
+          requestedByStaffProfileId: "cashier-1",
+          requiredRole: "manager",
+          storeId: "store_1",
+          subjectId: "transaction-1",
+          subjectType: "pos_transaction",
+        },
+      ],
+      credentials: [
+        {
+          _id: "credential-1",
+          staffProfileId: "manager-1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "manager",
+          pinHash: "hash-1",
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "manager-1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+        {
+          _id: "cashier-1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          linkedUserId: "athena-user-1",
+          status: "active",
+          fullName: "Cashier One",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "manager-1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "manager",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+
+    const result = await authenticateStaffCredentialForApprovalWithCtx(ctx, {
+      actionKey: "pos.transaction.payment_method.correct",
+      pinHash: "hash-1",
+      requiredRole: "manager",
+      requesterBinding: {
+        challengeId: "challenge-1" as Id<"approvalRequesterChallenge">,
+        kind: "operational_staff_challenge",
+        requestedByStaffProfileId: "cashier-1" as Id<"staffProfile">,
+      },
+      requestedByStaffProfileId: "cashier-1" as Id<"staffProfile">,
+      storeId: "store_1" as Id<"store">,
+      subject: {
+        type: "pos_transaction",
+        id: "transaction-1",
+      },
+      username: "manager",
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message:
+          "Approval requester must use either a direct staff profile or a requester binding.",
+      },
+    });
+    const storedChallenge = tables.approvalRequesterChallenge.get("challenge-1");
+    if (storedChallenge) {
+      expect(storedChallenge).not.toHaveProperty("consumedAt");
+    }
+    expect(tables.approvalProof.size).toBe(0);
+  });
+
+  it.each([
+    {
+      name: "missing challenge",
+      challenges: [],
+      binding: {
+        challengeId: "challenge-1" as Id<"approvalRequesterChallenge">,
+        kind: "operational_staff_challenge" as const,
+        requestedByStaffProfileId: "cashier-1" as Id<"staffProfile">,
+      },
+      message: "Approval requester challenge was not found.",
+    },
+    {
+      name: "wrong requester",
+      binding: {
+        challengeId: "challenge-1" as Id<"approvalRequesterChallenge">,
+        kind: "operational_staff_challenge" as const,
+        requestedByStaffProfileId: "cashier-2" as Id<"staffProfile">,
+      },
+      message: "Approval requester challenge does not match this approval.",
+    },
+    {
+      name: "wrong action",
+      args: { actionKey: "pos.transaction.void" },
+      message: "Approval requester challenge does not match this approval.",
+    },
+    {
+      name: "wrong subject id",
+      args: { subject: { type: "pos_transaction", id: "transaction-2" } },
+      message: "Approval requester challenge does not match this approval.",
+    },
+    {
+      name: "wrong subject type",
+      args: { subject: { type: "register_session", id: "transaction-1" } },
+      message: "Approval requester challenge does not match this approval.",
+    },
+    {
+      name: "wrong store",
+      challenge: { storeId: "store_2" as Id<"store"> },
+      message: "Approval requester challenge does not match this approval.",
+    },
+    {
+      name: "wrong required role",
+      args: { requiredRole: "cashier" as const },
+      message: "Approval requester challenge does not match this approval.",
+    },
+    {
+      name: "expired challenge",
+      challenge: { expiresAt: Date.now() - 1 },
+      message: "Approval requester challenge has expired.",
+    },
+  ])("rejects forged operational requester binding evidence: $name", async (scenario) => {
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      approvalRequesterChallenges:
+        scenario.challenges ??
+        [
+          {
+            _id: "challenge-1",
+            actionKey: "pos.transaction.payment_method.correct",
+            createdAt: 1,
+            expiresAt: Date.now() + 60_000,
+            requestedByStaffProfileId: "cashier-1",
+            requiredRole: "manager",
+            storeId: "store_1",
+            subjectId: "transaction-1",
+            subjectType: "pos_transaction",
+            ...scenario.challenge,
+          },
+        ],
+      credentials: [
+        {
+          _id: "credential-1",
+          staffProfileId: "manager-1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "manager",
+          pinHash: "hash-1",
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "manager-1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+        {
+          _id: "cashier-1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Cashier One",
+        },
+        {
+          _id: "cashier-2",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Cashier Two",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "manager-1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "manager",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+        {
+          _id: "role_2",
+          staffProfileId: "manager-1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "cashier",
+          isPrimary: false,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+
+    const result = await authenticateStaffCredentialForApprovalWithCtx(ctx, {
+      actionKey: "pos.transaction.payment_method.correct",
+      pinHash: "hash-1",
+      requiredRole: "manager",
+      requesterBinding:
+        scenario.binding ?? {
+          challengeId: "challenge-1" as Id<"approvalRequesterChallenge">,
+          kind: "operational_staff_challenge",
+          requestedByStaffProfileId: "cashier-1" as Id<"staffProfile">,
+        },
+      storeId: "store_1" as Id<"store">,
+      subject: {
+        type: "pos_transaction",
+        id: "transaction-1",
+      },
+      username: "manager",
+      ...scenario.args,
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: scenario.message,
+      },
+    });
+    const storedChallenge = tables.approvalRequesterChallenge.get("challenge-1");
+    if (storedChallenge) {
+      expect(storedChallenge).not.toHaveProperty("consumedAt");
+    }
     expect(tables.approvalProof.size).toBe(0);
   });
 

--- a/packages/athena-webapp/convex/operations/staffCredentials.ts
+++ b/packages/athena-webapp/convex/operations/staffCredentials.ts
@@ -12,6 +12,10 @@ import { commandResultValidator } from "../lib/commandResultValidators";
 import type { ApprovalSubjectIdentity } from "../../shared/approvalPolicy";
 import { createApprovalProofWithCtx } from "./approvalProofs";
 import {
+  approvalRequesterBindingArgValidator,
+  consumeApprovalRequesterChallengeWithCtx,
+} from "./approvalRequesterChallenges";
+import {
   createPosLocalStaffProofToken,
   hashPosLocalStaffProofToken,
   POS_LOCAL_STAFF_PROOF_TTL_MS,
@@ -234,10 +238,36 @@ async function requireStaffAuthenticationStoreAccessWithCtx(
 async function validateApprovalRequesterStaffProfileWithCtx(
   ctx: MutationCtx,
   args: {
+    requesterBinding?: {
+      challengeId: Id<"approvalRequesterChallenge">;
+      kind: "operational_staff_challenge";
+      requestedByStaffProfileId: Id<"staffProfile">;
+    };
     requestedByStaffProfileId?: Id<"staffProfile">;
+    actionKey: string;
+    requiredRole: OperationalRole;
     storeId: Id<"store">;
+    subject: ApprovalSubjectIdentity;
   },
 ): Promise<CommandResult<{ requestedByStaffProfileId?: Id<"staffProfile"> }>> {
+  if (args.requesterBinding && args.requestedByStaffProfileId) {
+    return userError({
+      code: "validation_failed",
+      message:
+        "Approval requester must use either a direct staff profile or a requester binding.",
+    });
+  }
+
+  if (args.requesterBinding) {
+    return consumeApprovalRequesterChallengeWithCtx(ctx, {
+      actionKey: args.actionKey,
+      binding: args.requesterBinding,
+      requiredRole: args.requiredRole,
+      storeId: args.storeId,
+      subject: args.subject,
+    });
+  }
+
   if (!args.requestedByStaffProfileId) {
     return ok({});
   }
@@ -1035,6 +1065,11 @@ export async function authenticateStaffCredentialForApprovalWithCtx(
     pinHash: string;
     reason?: string;
     requiredRole: OperationalRole;
+    requesterBinding?: {
+      challengeId: Id<"approvalRequesterChallenge">;
+      kind: "operational_staff_challenge";
+      requestedByStaffProfileId: Id<"staffProfile">;
+    };
     requestedByStaffProfileId?: Id<"staffProfile">;
     storeId: Id<"store">;
     subject: ApprovalSubjectIdentity;
@@ -1053,8 +1088,12 @@ export async function authenticateStaffCredentialForApprovalWithCtx(
   }
 
   const requester = await validateApprovalRequesterStaffProfileWithCtx(ctx, {
+    actionKey: args.actionKey,
+    requesterBinding: args.requesterBinding,
     requestedByStaffProfileId: args.requestedByStaffProfileId,
+    requiredRole: args.requiredRole,
     storeId: args.storeId,
+    subject: args.subject,
   });
 
   if (requester.kind !== "ok") {
@@ -1409,6 +1448,7 @@ export const authenticateStaffCredentialForApproval = mutation({
     pinHash: v.string(),
     reason: v.optional(v.string()),
     requiredRole: operationalRoleValidator,
+    requesterBinding: v.optional(approvalRequesterBindingArgValidator),
     requestedByStaffProfileId: v.optional(v.id("staffProfile")),
     storeId: v.id("store"),
     subject: v.object({

--- a/packages/athena-webapp/convex/pos/application/adjustTransactionItems.test.ts
+++ b/packages/athena-webapp/convex/pos/application/adjustTransactionItems.test.ts
@@ -7,6 +7,7 @@ import {
   type TransactionItemAdjustmentPayload,
 } from "./commands/adjustTransactionItems";
 import { consumeCommandApprovalProofWithCtx } from "../../operations/approvalActions";
+import { createApprovalRequesterChallengeWithCtx } from "../../operations/approvalRequesterChallenges";
 import { recordInventoryMovementWithCtx } from "../../operations/inventoryMovements";
 import { recordOperationalEventWithCtx } from "../../operations/operationalEvents";
 import { recordPaymentAllocationWithCtx } from "../../operations/paymentAllocations";
@@ -42,6 +43,21 @@ vi.mock("../../operations/approvalActions", () => ({
   },
   consumeCommandApprovalProofWithCtx: vi.fn(),
 }));
+
+vi.mock(
+  "../../operations/approvalRequesterChallenges",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../operations/approvalRequesterChallenges")
+      >();
+
+    return {
+      ...actual,
+      createApprovalRequesterChallengeWithCtx: vi.fn(),
+    };
+  },
+);
 
 vi.mock("../../operations/inventoryMovements", () => ({
   recordInventoryMovementWithCtx: vi.fn(),
@@ -343,6 +359,16 @@ beforeEach(() => {
     traceCreated: true,
     traceId: "register_session:register-session-1",
   } as never);
+  vi.mocked(createApprovalRequesterChallengeWithCtx).mockResolvedValue({
+    kind: "ok",
+    data: {
+      requesterBinding: {
+        kind: "operational_staff_challenge",
+        challengeId: "requester-challenge-1",
+        requestedByStaffProfileId: "cashier-1",
+      },
+    },
+  } as never);
 });
 
 describe("adjustTransactionItems", () => {
@@ -376,6 +402,11 @@ describe("adjustTransactionItems", () => {
         subject: {
           type: "pos_transaction_item_adjustment",
         },
+        requesterBinding: {
+          kind: "operational_staff_challenge",
+          challengeId: "requester-challenge-1",
+          requestedByStaffProfileId: "cashier-1",
+        },
       },
       transactionId: "txn-1",
     });
@@ -391,6 +422,18 @@ describe("adjustTransactionItems", () => {
         transactionId: "txn-1",
       }),
     });
+    expect(createApprovalRequesterChallengeWithCtx).toHaveBeenCalledWith(
+      ctx as never,
+      expect.objectContaining({
+        actionKey: "pos.transaction.adjust_items",
+        requestedByStaffProfileId: "cashier-1",
+        requiredRole: "manager",
+        storeId: "store-1",
+        subject: expect.objectContaining({
+          type: "pos_transaction_item_adjustment",
+        }),
+      }),
+    );
     expect(tables.posTransactionAdjustment.size).toBe(0);
     expect(tables.posTransactionAdjustmentLine.size).toBe(0);
     expect(recordInventoryMovementWithCtx).not.toHaveBeenCalled();
@@ -457,7 +500,7 @@ describe("adjustTransactionItems", () => {
     } as never);
 
     const result = await adjustTransactionItems(ctx as never, {
-      actorStaffProfileId: "cashier-1" as Id<"staffProfile">,
+      actorStaffProfileId: "cashier-2" as Id<"staffProfile">,
       approvalProofId: "proof-1" as Id<"approvalProof">,
       approvalRequestId,
       payload: basePayload(),
@@ -472,6 +515,7 @@ describe("adjustTransactionItems", () => {
           key: "pos.transaction.adjust_items",
         }),
         approvalProofId: "proof-1",
+        requestedByStaffProfileId: "cashier-1",
         requiredRole: "manager",
         storeId: "store-1",
         subject: expect.objectContaining({
@@ -571,6 +615,55 @@ describe("adjustTransactionItems", () => {
     });
   });
 
+  it("keeps no-requester pending adjustment approvals unbound on proof retry", async () => {
+    const { ctx } = createFakeCtx();
+    const first = await adjustTransactionItems(ctx as never, {
+      payload: basePayload(),
+      reason: "Customer was charged for two instead of one",
+      transactionId: "txn-1" as Id<"posTransaction">,
+    });
+    const approvalRequestId =
+      "action" in first && first.action === "approval_required"
+        ? (first.approval.resolutionModes[1] as { approvalRequestId?: Id<"approvalRequest"> })
+            .approvalRequestId
+        : undefined;
+    vi.mocked(consumeCommandApprovalProofWithCtx).mockResolvedValue({
+      kind: "ok",
+      data: {
+        approvalProofId: "proof-1" as Id<"approvalProof">,
+        approvedByStaffProfileId: "manager-1" as Id<"staffProfile">,
+      },
+    } as never);
+
+    await adjustTransactionItems(ctx as never, {
+      actorStaffProfileId: "cashier-2" as Id<"staffProfile">,
+      approvalProofId: "proof-1" as Id<"approvalProof">,
+      approvalRequestId,
+      payload: basePayload(),
+      reason: "Customer was charged for two instead of one",
+      transactionId: "txn-1" as Id<"posTransaction">,
+    });
+
+    expect(first).toMatchObject({
+      action: "approval_required",
+      approval: expect.not.objectContaining({
+        requesterBinding: expect.anything(),
+      }),
+    });
+    expect(consumeCommandApprovalProofWithCtx).toHaveBeenCalledWith(
+      ctx as never,
+      expect.objectContaining({
+        action: expect.objectContaining({
+          key: "pos.transaction.adjust_items",
+        }),
+        approvalProofId: "proof-1",
+        requestedByStaffProfileId: undefined,
+        requiredRole: "manager",
+        storeId: "store-1",
+      }),
+    );
+  });
+
   it("records collection allocations for higher corrected totals", async () => {
     const { ctx } = createFakeCtx();
     vi.mocked(consumeCommandApprovalProofWithCtx).mockResolvedValue({
@@ -660,7 +753,7 @@ describe("adjustTransactionItems", () => {
       transactionId: "txn-1" as Id<"posTransaction">,
     });
     const second = await adjustTransactionItems(ctx as never, {
-      actorStaffProfileId: "cashier-1" as Id<"staffProfile">,
+      actorStaffProfileId: "cashier-2" as Id<"staffProfile">,
       payload: basePayload(),
       reason: "Customer was charged for two instead of one",
       transactionId: "txn-1" as Id<"posTransaction">,
@@ -679,6 +772,24 @@ describe("adjustTransactionItems", () => {
 
     expect(firstApprovalRequestId).toBe("approvalRequest-1");
     expect(secondApprovalRequestId).toBe(firstApprovalRequestId);
+    expect(second).toMatchObject({
+      action: "approval_required",
+      approval: {
+        requesterBinding: {
+          kind: "operational_staff_challenge",
+          requestedByStaffProfileId: "cashier-1",
+        },
+      },
+    });
+    expect(createApprovalRequesterChallengeWithCtx).toHaveBeenLastCalledWith(
+      ctx as never,
+      expect.objectContaining({
+        actionKey: "pos.transaction.adjust_items",
+        requestedByStaffProfileId: "cashier-1",
+        requiredRole: "manager",
+        storeId: "store-1",
+      }),
+    );
     expect(tables.approvalRequest.size).toBe(1);
   });
 

--- a/packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts
@@ -2,6 +2,7 @@ import type { Id } from "../../../_generated/dataModel";
 import type { MutationCtx } from "../../../_generated/server";
 import type { ApprovalRequirement } from "../../../../shared/approvalPolicy";
 import { buildApprovalRequest } from "../../../operations/approvalRequestHelpers";
+import { createApprovalRequesterChallengeWithCtx } from "../../../operations/approvalRequesterChallenges";
 import {
   APPROVAL_ACTIONS,
   consumeCommandApprovalProofWithCtx,
@@ -258,6 +259,7 @@ async function buildServerAdjustmentPlan(
 function buildAdjustmentApprovalRequirement(args: {
   approvalRequestId?: Id<"approvalRequest">;
   plan: AdjustmentPlan;
+  requesterBinding?: ApprovalRequirement["requesterBinding"];
   transaction: {
     _id: Id<"posTransaction">;
     transactionNumber: string;
@@ -289,6 +291,9 @@ function buildAdjustmentApprovalRequirement(args: {
         approvalRequestId: args.approvalRequestId,
       },
     ],
+    ...(args.requesterBinding
+      ? { requesterBinding: args.requesterBinding }
+      : {}),
     metadata: {
       correctedTotal: args.plan.correctedTotal,
       deltaTotal: args.plan.deltaTotal,
@@ -448,6 +453,25 @@ async function createApprovalRequestForAdjustment(
   },
 ) {
   const store = await getStoreById(ctx, args.transaction.storeId);
+  const requesterBindingResult = args.actorStaffProfileId
+    ? await createApprovalRequesterChallengeWithCtx(ctx, {
+        actionKey: ITEM_ADJUSTMENT_ACTION_KEY,
+        organizationId: store?.organizationId,
+        requestedByStaffProfileId: args.actorStaffProfileId,
+        requiredRole: "manager",
+        storeId: args.transaction.storeId,
+        subject: {
+          id: args.plan.payloadSubject,
+          label: `${transactionLabel(args.transaction)} item adjustment`,
+          type: ITEM_ADJUSTMENT_SUBJECT_TYPE,
+        },
+      })
+    : null;
+
+  if (requesterBindingResult?.kind === "user_error") {
+    throw new Error(requesterBindingResult.error.message);
+  }
+
   const approvalRequestId = await ctx.db.insert(
     "approvalRequest",
     buildApprovalRequest({
@@ -507,7 +531,10 @@ async function createApprovalRequestForAdjustment(
     transaction: args.transaction,
   });
 
-  return approvalRequestId;
+  return {
+    approvalRequestId,
+    requesterBinding: requesterBindingResult?.data.requesterBinding,
+  };
 }
 
 async function findPendingItemAdjustmentApprovalRequest(
@@ -632,13 +659,14 @@ async function consumeItemAdjustmentApprovalProof(
     actorStaffProfileId?: Id<"staffProfile">;
     approvalProofId: Id<"approvalProof">;
     plan: AdjustmentPlan;
+    requestedByStaffProfileId?: Id<"staffProfile">;
     storeId: Id<"store">;
   },
 ) {
   const proof = await consumeCommandApprovalProofWithCtx(ctx, {
     action: ITEM_ADJUSTMENT_ACTION,
     approvalProofId: args.approvalProofId,
-    requestedByStaffProfileId: args.actorStaffProfileId,
+    requestedByStaffProfileId: args.requestedByStaffProfileId,
     requiredRole: "manager",
     storeId: args.storeId,
     subject: {
@@ -1121,21 +1149,45 @@ export async function adjustTransactionItems(
       });
     }
 
-    const approvalRequestId =
-      pendingApprovalRequest?._id ??
-      (await createApprovalRequestForAdjustment(ctx, {
+    const pendingRequesterBindingResult =
+      pendingApprovalRequest?.requestedByStaffProfileId
+        ? await createApprovalRequesterChallengeWithCtx(ctx, {
+            actionKey: ITEM_ADJUSTMENT_ACTION_KEY,
+            requestedByStaffProfileId:
+              pendingApprovalRequest.requestedByStaffProfileId,
+            requiredRole: "manager",
+            storeId: transaction.storeId,
+            subject: {
+              id: plan.payloadSubject,
+              label: `${transactionLabel(transaction)} item adjustment`,
+              type: ITEM_ADJUSTMENT_SUBJECT_TYPE,
+            },
+          })
+        : null;
+
+    if (pendingRequesterBindingResult?.kind === "user_error") {
+      throw new Error(pendingRequesterBindingResult.error.message);
+    }
+
+    const createdApprovalRequest = pendingApprovalRequest
+      ? null
+      : await createApprovalRequestForAdjustment(ctx, {
         actorStaffProfileId: args.actorStaffProfileId,
         actorUserId: args.actorUserId,
         plan,
         reason: args.reason,
         transaction,
-      }));
+      });
 
     return {
       action: "approval_required" as const,
       approval: buildAdjustmentApprovalRequirement({
-        approvalRequestId,
+        approvalRequestId:
+          pendingApprovalRequest?._id ?? createdApprovalRequest?.approvalRequestId,
         plan,
+        requesterBinding:
+          pendingRequesterBindingResult?.data.requesterBinding ??
+          createdApprovalRequest?.requesterBinding,
         transaction,
       }),
       payloadFingerprint: plan.fingerprint,
@@ -1164,6 +1216,8 @@ export async function adjustTransactionItems(
     actorStaffProfileId: args.actorStaffProfileId,
     approvalProofId: args.approvalProofId,
     plan,
+    requestedByStaffProfileId:
+      approvalRequest ? approvalRequest.requestedByStaffProfileId : args.actorStaffProfileId,
     storeId: transaction.storeId,
   });
   const result = await applyApprovedAdjustment(ctx, {

--- a/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../utils";
 import { toDisplayAmount } from "../../../lib/currency";
 import { buildApprovalRequest } from "../../../operations/approvalRequestHelpers";
+import { createApprovalRequesterChallengeWithCtx } from "../../../operations/approvalRequesterChallenges";
 import {
   APPROVAL_ACTIONS,
   consumeCommandApprovalProofWithCtx,
@@ -999,6 +1000,7 @@ function completedTransactionLabel(transaction: { transactionNumber: string }) {
 function buildVoidApprovalRequirement(args: {
   approvalRequestId?: Id<"approvalRequest">;
   reason?: string;
+  requesterBinding?: ApprovalRequirement["requesterBinding"];
   transaction: {
     _id: Id<"posTransaction">;
     total: number;
@@ -1030,6 +1032,9 @@ function buildVoidApprovalRequirement(args: {
         approvalRequestId: args.approvalRequestId,
       },
     ],
+    ...(args.requesterBinding
+      ? { requesterBinding: args.requesterBinding }
+      : {}),
     metadata: {
       ...(args.reason ? { reason: args.reason } : {}),
       total: args.transaction.total,
@@ -1075,6 +1080,25 @@ async function createVoidApprovalRequest(
   },
 ) {
   const store = await getStoreById(ctx, args.transaction.storeId);
+  const requesterBindingResult = args.actorStaffProfileId
+    ? await createApprovalRequesterChallengeWithCtx(ctx, {
+        actionKey: TRANSACTION_VOID_ACTION.key,
+        organizationId: store?.organizationId,
+        requestedByStaffProfileId: args.actorStaffProfileId,
+        requiredRole: "manager",
+        storeId: args.transaction.storeId,
+        subject: {
+          id: args.transaction._id,
+          label: completedTransactionLabel(args.transaction),
+          type: "pos_transaction",
+        },
+      })
+    : null;
+
+  if (requesterBindingResult?.kind === "user_error") {
+    return requesterBindingResult;
+  }
+
   const approvalRequestId = await ctx.db.insert(
     "approvalRequest",
     buildApprovalRequest({
@@ -1122,7 +1146,10 @@ async function createVoidApprovalRequest(
     subjectType: "pos_transaction",
   });
 
-  return approvalRequestId;
+  return ok({
+    approvalRequestId,
+    requesterBinding: requesterBindingResult?.data.requesterBinding,
+  });
 }
 
 async function requireMatchingPendingVoidApprovalRequest(
@@ -1658,19 +1685,48 @@ export async function voidTransaction(
       storeId: transaction.storeId,
       transactionId: transaction._id,
     });
-    const approvalRequestId =
-      existingApprovalRequest?._id ??
-      (await createVoidApprovalRequest(ctx, {
+    const createdApprovalRequest = existingApprovalRequest
+      ? null
+      : await createVoidApprovalRequest(ctx, {
         actorStaffProfileId,
         actorUserId: args.actorUserId,
         reason,
         transaction,
-      }));
+      });
+
+    if (createdApprovalRequest?.kind === "user_error") {
+      return createdApprovalRequest;
+    }
+
+    const existingRequesterBindingResult =
+      existingApprovalRequest?.requestedByStaffProfileId
+        ? await createApprovalRequesterChallengeWithCtx(ctx, {
+            actionKey: TRANSACTION_VOID_ACTION.key,
+            requestedByStaffProfileId:
+              existingApprovalRequest.requestedByStaffProfileId,
+            requiredRole: "manager",
+            storeId: transaction.storeId,
+            subject: {
+              id: transaction._id,
+              label: completedTransactionLabel(transaction),
+              type: "pos_transaction",
+            },
+          })
+        : null;
+
+    if (existingRequesterBindingResult?.kind === "user_error") {
+      return existingRequesterBindingResult;
+    }
 
     return approvalRequired(
       buildVoidApprovalRequirement({
-        approvalRequestId,
+        approvalRequestId:
+          existingApprovalRequest?._id ??
+          createdApprovalRequest?.data.approvalRequestId,
         reason,
+        requesterBinding:
+          existingRequesterBindingResult?.data.requesterBinding ??
+          createdApprovalRequest?.data.requesterBinding,
         transaction,
       }),
     );
@@ -1689,7 +1745,10 @@ export async function voidTransaction(
   const approvalProof = await consumeCommandApprovalProofWithCtx(ctx, {
     action: TRANSACTION_VOID_ACTION,
     approvalProofId: args.approvalProofId,
-    requestedByStaffProfileId: actorStaffProfileId,
+    requestedByStaffProfileId:
+      matchingApprovalRequest?.kind === "ok"
+        ? matchingApprovalRequest.data.requestedByStaffProfileId
+        : actorStaffProfileId,
     requiredRole: "manager",
     storeId: transaction.storeId,
     subject: {

--- a/packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts
@@ -3,6 +3,7 @@ import type { MutationCtx } from "../../../_generated/server";
 import { isPosUsableRegisterSessionStatus } from "../../../../shared/registerSessionStatus";
 import type { ApprovalRequirement } from "../../../../shared/approvalPolicy";
 import { buildApprovalRequest } from "../../../operations/approvalRequestHelpers";
+import { createApprovalRequesterChallengeWithCtx } from "../../../operations/approvalRequesterChallenges";
 import {
   APPROVAL_ACTIONS,
   consumeCommandApprovalProofWithCtx,
@@ -39,6 +40,7 @@ function buildPaymentMethodCorrectionApprovalRequirement(args: {
   amount: number;
   paymentMethod: string;
   previousPaymentMethod: string;
+  requesterBinding?: ApprovalRequirement["requesterBinding"];
   transaction: {
     _id: Id<"posTransaction">;
     transactionNumber: string;
@@ -75,6 +77,9 @@ function buildPaymentMethodCorrectionApprovalRequirement(args: {
         approvalRequestId: args.approvalRequestId,
       },
     ],
+    ...(args.requesterBinding
+      ? { requesterBinding: args.requesterBinding }
+      : {}),
     metadata: {
       amount: args.amount,
       paymentMethod: args.paymentMethod,
@@ -101,6 +106,25 @@ async function createPaymentMethodCorrectionApprovalRequest(
   },
 ) {
   const store = await ctx.db.get("store", args.transaction.storeId);
+  const requesterBindingResult = args.actorStaffProfileId
+    ? await createApprovalRequesterChallengeWithCtx(ctx, {
+        actionKey: PAYMENT_METHOD_CORRECTION_ACTION_KEY,
+        organizationId: store?.organizationId,
+        requestedByStaffProfileId: args.actorStaffProfileId,
+        requiredRole: "manager",
+        storeId: args.transaction.storeId,
+        subject: {
+          id: args.transaction._id,
+          label: transactionLabel(args.transaction),
+          type: "pos_transaction",
+        },
+      })
+    : null;
+
+  if (requesterBindingResult?.kind === "user_error") {
+    throw new Error(requesterBindingResult.error.message);
+  }
+
   const approvalRequestId = await ctx.db.insert(
     "approvalRequest",
     buildApprovalRequest({
@@ -150,7 +174,10 @@ async function createPaymentMethodCorrectionApprovalRequest(
     posTransactionId: args.transaction._id,
   });
 
-  return approvalRequestId;
+  return {
+    approvalRequestId,
+    requesterBinding: requesterBindingResult?.data.requesterBinding,
+  };
 }
 
 async function requireCompletedTransaction(
@@ -486,7 +513,7 @@ export async function correctTransactionPaymentMethod(
   });
 
   if (!args.approvalProofId) {
-    const approvalRequestId =
+    const approvalRequirement =
       await createPaymentMethodCorrectionApprovalRequest(ctx, {
         actorStaffProfileId: args.actorStaffProfileId,
         actorUserId: args.actorUserId,
@@ -500,10 +527,11 @@ export async function correctTransactionPaymentMethod(
     return {
       action: "approval_required" as const,
       approval: buildPaymentMethodCorrectionApprovalRequirement({
-        approvalRequestId,
+        approvalRequestId: approvalRequirement.approvalRequestId,
         amount: payment.amount,
         paymentMethod: args.paymentMethod,
         previousPaymentMethod: payment.method,
+        requesterBinding: approvalRequirement.requesterBinding,
         transaction,
       }),
       paymentMethod: args.paymentMethod,

--- a/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
+++ b/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
@@ -43,6 +43,7 @@ import {
 } from "../infrastructure/integrations/paymentAllocationService";
 import { updateCustomerStats } from "../infrastructure/repositories/customerRepository";
 import { consumeCommandApprovalProofWithCtx } from "../../operations/approvalActions";
+import { createApprovalRequesterChallengeWithCtx } from "../../operations/approvalRequesterChallenges";
 import { recordOperationalEventWithCtx } from "../../operations/operationalEvents";
 
 vi.mock("../../workflowTraces/core", () => ({
@@ -105,6 +106,21 @@ vi.mock("../../operations/approvalActions", () => ({
   },
   consumeCommandApprovalProofWithCtx: vi.fn(),
 }));
+
+vi.mock(
+  "../../operations/approvalRequesterChallenges",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../operations/approvalRequesterChallenges")
+      >();
+
+    return {
+      ...actual,
+      createApprovalRequesterChallengeWithCtx: vi.fn(),
+    };
+  },
+);
 
 vi.mock("../../operations/operationalEvents", () => ({
   recordOperationalEventWithCtx: vi.fn(),
@@ -335,6 +351,16 @@ describe("voidTransaction", () => {
         approvedByStaffProfileId: "manager-1",
       },
     } as never);
+    vi.mocked(createApprovalRequesterChallengeWithCtx).mockResolvedValue({
+      kind: "ok",
+      data: {
+        requesterBinding: {
+          kind: "operational_staff_challenge",
+          challengeId: "requester-challenge-1",
+          requestedByStaffProfileId: "staff-1",
+        },
+      },
+    } as never);
   });
 
   it("returns approval_required without mutating ledger state on the first attempt", async () => {
@@ -367,6 +393,11 @@ describe("voidTransaction", () => {
           id: "txn-1",
           type: "pos_transaction",
         },
+        requesterBinding: {
+          kind: "operational_staff_challenge",
+          challengeId: "requester-challenge-1",
+          requestedByStaffProfileId: "staff-1",
+        },
       },
     });
 
@@ -376,6 +407,21 @@ describe("voidTransaction", () => {
         requestType: "pos_transaction_void",
         subjectId: "txn-1",
         subjectType: "pos_transaction",
+      }),
+    );
+    expect(createApprovalRequesterChallengeWithCtx).toHaveBeenCalledWith(
+      ctx as never,
+      expect.objectContaining({
+        actionKey: "pos.transaction.void",
+        organizationId: "org-1",
+        requestedByStaffProfileId: "staff-1",
+        requiredRole: "manager",
+        storeId: "store-1",
+        subject: {
+          id: "txn-1",
+          label: "Transaction #POS-0001",
+          type: "pos_transaction",
+        },
       }),
     );
     expectNoVoidBusinessSideEffects();
@@ -411,6 +457,7 @@ describe("voidTransaction", () => {
         {
           _id: "approval-existing-1",
           requestType: "pos_transaction_void",
+          requestedByStaffProfileId: "staff-existing-1",
           status: "pending",
           storeId: "store-1",
           subjectId: "txn-1",
@@ -418,10 +465,20 @@ describe("voidTransaction", () => {
         },
       ],
     });
+    vi.mocked(createApprovalRequesterChallengeWithCtx).mockResolvedValueOnce({
+      kind: "ok",
+      data: {
+        requesterBinding: {
+          kind: "operational_staff_challenge",
+          challengeId: "requester-challenge-existing",
+          requestedByStaffProfileId: "staff-existing-1",
+        },
+      },
+    } as never);
 
     await expect(
       voidTransaction(ctx as never, {
-        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        actorStaffProfileId: "staff-2" as Id<"staffProfile">,
         reason: "Duplicate sale",
         transactionId: "txn-1" as Id<"posTransaction">,
       }),
@@ -434,11 +491,68 @@ describe("voidTransaction", () => {
             kind: "async_request",
           }),
         ]),
+        requesterBinding: {
+          kind: "operational_staff_challenge",
+          challengeId: "requester-challenge-existing",
+          requestedByStaffProfileId: "staff-existing-1",
+        },
       },
     });
 
+    expect(createApprovalRequesterChallengeWithCtx).toHaveBeenCalledWith(
+      ctx as never,
+      expect.objectContaining({
+        actionKey: "pos.transaction.void",
+        requestedByStaffProfileId: "staff-existing-1",
+        requiredRole: "manager",
+        storeId: "store-1",
+      }),
+    );
     expect(ctx.db.insert).not.toHaveBeenCalled();
     expectNoVoidBusinessSideEffects();
+  });
+
+  it("consumes void proof against the stored requester when retrying a pending approval", async () => {
+    const ctx = createVoidCtx({
+      approvalRequests: [
+        {
+          _id: "approval-existing-1",
+          requestType: "pos_transaction_void",
+          requestedByStaffProfileId: "staff-existing-1",
+          status: "pending",
+          storeId: "store-1",
+          subjectId: "txn-1",
+          subjectType: "pos_transaction",
+        },
+      ],
+    });
+
+    await expect(
+      voidTransaction(ctx as never, {
+        actorStaffProfileId: "staff-2" as Id<"staffProfile">,
+        approvalProofId: "approval-proof-1" as Id<"approvalProof">,
+        approvalRequestId: "approval-existing-1" as Id<"approvalRequest">,
+        reason: "Duplicate sale",
+        transactionId: "txn-1" as Id<"posTransaction">,
+      }),
+    ).resolves.toMatchObject({
+      kind: "ok",
+      data: {
+        approvalProofId: "approval-proof-1",
+        approvalRequestId: "approval-existing-1",
+      },
+    });
+
+    expect(consumeCommandApprovalProofWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: expect.objectContaining({ key: "pos.transaction.void" }),
+        approvalProofId: "approval-proof-1",
+        requestedByStaffProfileId: "staff-existing-1",
+        requiredRole: "manager",
+        storeId: "store-1",
+      }),
+    );
   });
 
   it("blocks mixed service sales before creating a void approval request", async () => {

--- a/packages/athena-webapp/convex/pos/application/correctTransactionPaymentMethod.test.ts
+++ b/packages/athena-webapp/convex/pos/application/correctTransactionPaymentMethod.test.ts
@@ -6,6 +6,7 @@ import {
   resolvePaymentMethodCorrectionApprovalDecisionWithCtx,
 } from "./commands/correctTransaction";
 import { consumeCommandApprovalProofWithCtx } from "../../operations/approvalActions";
+import { createApprovalRequesterChallengeWithCtx } from "../../operations/approvalRequesterChallenges";
 import { recordOperationalEventWithCtx } from "../../operations/operationalEvents";
 import { correctSameAmountSinglePaymentAllocationWithCtx } from "../../operations/paymentAllocations";
 import {
@@ -27,6 +28,21 @@ vi.mock("../../operations/approvalActions", () => ({
   consumeCommandApprovalProofWithCtx: vi.fn(),
 }));
 
+vi.mock(
+  "../../operations/approvalRequesterChallenges",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../operations/approvalRequesterChallenges")
+      >();
+
+    return {
+      ...actual,
+      createApprovalRequesterChallengeWithCtx: vi.fn(),
+    };
+  },
+);
+
 vi.mock("../../operations/paymentAllocations", () => ({
   correctSameAmountSinglePaymentAllocationWithCtx: vi.fn(),
 }));
@@ -38,6 +54,16 @@ vi.mock("../infrastructure/repositories/transactionRepository", () => ({
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(createApprovalRequesterChallengeWithCtx).mockResolvedValue({
+    kind: "ok",
+    data: {
+      requesterBinding: {
+        kind: "operational_staff_challenge",
+        challengeId: "requester-challenge-1",
+        requestedByStaffProfileId: "cashier-1",
+      },
+    },
+  } as never);
 });
 
 describe("correctTransactionPaymentMethod", () => {
@@ -94,6 +120,11 @@ describe("correctTransactionPaymentMethod", () => {
           id: "txn-1",
           type: "pos_transaction",
         },
+        requesterBinding: {
+          kind: "operational_staff_challenge",
+          challengeId: "requester-challenge-1",
+          requestedByStaffProfileId: "cashier-1",
+        },
         resolutionModes: [
           {
             kind: "inline_manager_proof",
@@ -123,6 +154,21 @@ describe("correctTransactionPaymentMethod", () => {
           paymentMethod: "card",
           previousPaymentMethod: "cash",
         }),
+      }),
+    );
+    expect(createApprovalRequesterChallengeWithCtx).toHaveBeenCalledWith(
+      ctx as never,
+      expect.objectContaining({
+        actionKey: "pos.transaction.correct_payment_method",
+        organizationId: "org-1",
+        requestedByStaffProfileId: "cashier-1",
+        requiredRole: "manager",
+        storeId: "store-1",
+        subject: {
+          id: "txn-1",
+          label: "Transaction #POS-111111",
+          type: "pos_transaction",
+        },
       }),
     );
     expect(correctSameAmountSinglePaymentAllocationWithCtx).not.toHaveBeenCalled();

--- a/packages/athena-webapp/convex/pos/public/transactions.test.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.test.ts
@@ -23,6 +23,7 @@ import * as correctionCommands from "../application/commands/correctTransaction"
 import * as itemAdjustmentCommands from "../application/commands/adjustTransactionItems";
 import * as completeTransactionCommands from "../application/commands/completeTransaction";
 import * as transactionQueries from "../application/queries/getTransactions";
+import { hashPosLocalStaffProofToken } from "../application/sync/staffProof";
 
 vi.mock("../../lib/athenaUserAuth", () => ({
   requireAuthenticatedAthenaUserWithCtx: vi.fn(),
@@ -345,9 +346,22 @@ describe("POS public transaction read and correction authorization", () => {
   });
 
   function createTransactionAuthCtx(options?: {
+    credentialStatus?: string;
+    credentialStoreId?: string;
+    credentialStaffProfileId?: string;
+    credentialVersion?: number;
     customerStoreId?: string;
+    omitProof?: boolean;
+    proofCredentialId?: string;
+    proofExpiresAt?: number;
+    proofStaffProfileId?: string;
+    proofStatus?: string;
+    proofStoreId?: string;
+    proofTerminalId?: string;
     staffStoreId?: string;
   }) {
+    const tokenHashPromise = hashPosLocalStaffProofToken("proof-token-1");
+
     return {
       db: {
         get: vi.fn(async (tableName: string, id: string) => {
@@ -361,6 +375,18 @@ describe("POS public transaction read and correction authorization", () => {
               storeId: options?.staffStoreId ?? "store-1",
             };
           }
+          if (tableName === "staffCredential" && id === "credential-1") {
+            return {
+              _id: "credential-1",
+              localVerifierVersion: options?.credentialVersion ?? 2,
+              staffProfileId:
+                options?.credentialStaffProfileId ??
+                options?.proofStaffProfileId ??
+                "staff-1",
+              status: options?.credentialStatus ?? "active",
+              storeId: options?.credentialStoreId ?? "store-1",
+            };
+          }
           if (tableName === "customerProfile" && id === "customer-1") {
             return {
               _id: "customer-1",
@@ -370,6 +396,54 @@ describe("POS public transaction read and correction authorization", () => {
           }
           return null;
         }),
+        patch: vi.fn(),
+        query: vi.fn((tableName: string) => ({
+          withIndex: vi.fn(
+            (
+              _indexName: string,
+              applyIndex?: (queryBuilder: {
+                eq: (field: string, value: unknown) => unknown;
+              }) => unknown,
+            ) => {
+              const filters: Array<[string, unknown]> = [];
+              const queryBuilder = {
+                eq(field: string, value: unknown) {
+                  filters.push([field, value]);
+                  return queryBuilder;
+                },
+              };
+              applyIndex?.(queryBuilder);
+
+              return {
+                unique: vi.fn(async () => {
+                  if (tableName !== "posLocalStaffProof") {
+                    return null;
+                  }
+
+                  if (options?.omitProof) {
+                    return null;
+                  }
+
+                  const proof: Record<string, unknown> = {
+                    _id: "proof-1",
+                    credentialId: options?.proofCredentialId ?? "credential-1",
+                    credentialVersion: 2,
+                    expiresAt: options?.proofExpiresAt ?? Date.now() + 60_000,
+                    staffProfileId: options?.proofStaffProfileId ?? "staff-1",
+                    status: options?.proofStatus ?? "active",
+                    storeId: options?.proofStoreId ?? "store-1",
+                    terminalId: options?.proofTerminalId,
+                    tokenHash: await tokenHashPromise,
+                  };
+
+                  return filters.every(([field, value]) => proof[field] === value)
+                    ? proof
+                    : null;
+                }),
+              };
+            },
+          ),
+        })),
       },
     };
   }
@@ -623,6 +697,7 @@ describe("POS public transaction read and correction authorization", () => {
         actorUserId: "forged-user" as Id<"athenaUser">,
         paymentMethod: "card",
         reason: "Wrong payment method",
+        staffProofToken: "proof-token-1",
         transactionId: "txn-1" as Id<"posTransaction">,
       }),
     ).resolves.toMatchObject({ kind: "ok" });
@@ -631,10 +706,146 @@ describe("POS public transaction read and correction authorization", () => {
       ctx,
       expect.objectContaining({
         actorUserId: "user-1",
+        actorStaffProfileId: "staff-1",
         paymentMethod: "card",
+        reason: "Wrong payment method",
         transactionId: "txn-1",
       }),
     );
+    const commandArgs = vi.mocked(
+      correctionCommands.correctTransactionPaymentMethod,
+    ).mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(commandArgs).not.toHaveProperty("staffProofToken");
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "posLocalStaffProof",
+      "proof-1",
+      expect.objectContaining({ lastUsedAt: expect.any(Number) }),
+    );
+  });
+
+  it("rejects spoofed payment correction requester staff without matching staff proof", async () => {
+    vi.mocked(transactionQueries.getTransaction).mockResolvedValue({
+      _id: "txn-1",
+      storeId: "store-1",
+    } as never);
+    const ctx = createTransactionAuthCtx({
+      proofStaffProfileId: "other-staff",
+    });
+
+    await expect(
+      getHandler(correctTransactionPaymentMethod)(ctx as never, {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        paymentMethod: "card",
+        reason: "Wrong payment method",
+        staffProofToken: "proof-token-1",
+        transactionId: "txn-1" as Id<"posTransaction">,
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "authentication_failed",
+        message: "Payment correction staff proof is invalid or expired.",
+      },
+    });
+
+    expect(correctionCommands.correctTransactionPaymentMethod).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "missing staff actor",
+      args: { actorStaffProfileId: undefined },
+      message: "Staff sign-in is required before correcting payment method.",
+    },
+    {
+      name: "missing staff proof token",
+      args: { staffProofToken: undefined },
+      message:
+        "Payment correction staff proof is required for requester attribution.",
+    },
+    {
+      name: "missing proof",
+      options: { omitProof: true },
+      message: "Payment correction staff proof is invalid or expired.",
+    },
+    {
+      name: "wrong proof token",
+      args: { staffProofToken: "wrong-proof-token" },
+      message: "Payment correction staff proof is invalid or expired.",
+    },
+    {
+      name: "inactive proof",
+      options: { proofStatus: "revoked" },
+      message: "Payment correction staff proof is invalid or expired.",
+    },
+    {
+      name: "expired proof",
+      options: { proofExpiresAt: Date.now() - 1 },
+      message: "Payment correction staff proof is invalid or expired.",
+    },
+    {
+      name: "cross-store proof",
+      options: { proofStoreId: "store-2" },
+      message: "Payment correction staff proof is invalid or expired.",
+    },
+    {
+      name: "terminal mismatch",
+      options: { proofTerminalId: "terminal-1" },
+      transaction: { terminalId: "terminal-2" },
+      message: "Payment correction staff proof is invalid for this terminal.",
+    },
+    {
+      name: "missing credential",
+      options: { proofCredentialId: "missing-credential" },
+      message: "Payment correction staff proof is invalid or expired.",
+    },
+    {
+      name: "inactive credential",
+      options: { credentialStatus: "inactive" },
+      message: "Payment correction staff proof is invalid or expired.",
+    },
+    {
+      name: "credential staff mismatch",
+      options: { credentialStaffProfileId: "other-staff" },
+      message: "Payment correction staff proof is invalid or expired.",
+    },
+    {
+      name: "credential store mismatch",
+      options: { credentialStoreId: "store-2" },
+      message: "Payment correction staff proof is invalid or expired.",
+    },
+    {
+      name: "credential version mismatch",
+      options: { credentialVersion: 3 },
+      message: "Payment correction staff proof is invalid or expired.",
+    },
+  ])("rejects payment correction with $name", async (scenario) => {
+    vi.mocked(transactionQueries.getTransaction).mockResolvedValue({
+      _id: "txn-1",
+      storeId: "store-1",
+      ...scenario.transaction,
+    } as never);
+    const ctx = createTransactionAuthCtx(scenario.options);
+
+    await expect(
+      getHandler(correctTransactionPaymentMethod)(ctx as never, {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        paymentMethod: "card",
+        reason: "Wrong payment method",
+        staffProofToken: "proof-token-1",
+        transactionId: "txn-1" as Id<"posTransaction">,
+        ...scenario.args,
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "authentication_failed",
+        message: scenario.message,
+      },
+    });
+
+    expect(correctionCommands.correctTransactionPaymentMethod).not.toHaveBeenCalled();
+    expect(ctx.db.patch).not.toHaveBeenCalled();
   });
 
   it("rejects cross-store customer correction before invoking the command", async () => {

--- a/packages/athena-webapp/convex/pos/public/transactions.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.ts
@@ -990,6 +990,7 @@ export const correctTransactionPaymentMethod = mutation({
     reason: v.string(),
     actorUserId: v.optional(v.id("athenaUser")),
     actorStaffProfileId: v.optional(v.id("staffProfile")),
+    staffProofToken: v.optional(v.string()),
   },
   returns: correctTransactionPaymentMethodResultValidator,
   handler: async (ctx, args) => {
@@ -1009,26 +1010,93 @@ export const correctTransactionPaymentMethod = mutation({
         return access;
       }
 
-      if (args.actorStaffProfileId) {
-        const staffProfile = await ctx.db.get(
-          "staffProfile",
-          args.actorStaffProfileId,
-        );
-        if (
-          !staffProfile ||
-          staffProfile.status !== "active" ||
-          staffProfile.storeId !== access.transaction.storeId
-        ) {
-          return userError({
-            code: "authentication_failed",
-            message:
-              "Payment correction staff profile is not active for this store.",
-          });
-        }
+      if (!args.actorStaffProfileId) {
+        return userError({
+          code: "authentication_failed",
+          message: "Staff sign-in is required before correcting payment method.",
+        });
       }
 
+      if (!args.staffProofToken) {
+        return userError({
+          code: "authentication_failed",
+          message:
+            "Payment correction staff proof is required for requester attribution.",
+        });
+      }
+
+      const staffProfile = await ctx.db.get(
+        "staffProfile",
+        args.actorStaffProfileId,
+      );
+      if (
+        !staffProfile ||
+        staffProfile.status !== "active" ||
+        staffProfile.storeId !== access.transaction.storeId
+      ) {
+        return userError({
+          code: "authentication_failed",
+          message:
+            "Payment correction staff profile is not active for this store.",
+        });
+      }
+
+      const staffProofTokenHash = await hashPosLocalStaffProofToken(
+        args.staffProofToken,
+      );
+      const proof = await ctx.db
+        .query("posLocalStaffProof")
+        .withIndex("by_tokenHash", (q) =>
+          q.eq("tokenHash", staffProofTokenHash),
+        )
+        .unique();
+      if (
+        !proof ||
+        proof.status !== "active" ||
+        proof.staffProfileId !== args.actorStaffProfileId ||
+        proof.storeId !== access.transaction.storeId ||
+        proof.expiresAt <= Date.now()
+      ) {
+        return userError({
+          code: "authentication_failed",
+          message: "Payment correction staff proof is invalid or expired.",
+        });
+      }
+
+      if (
+        access.transaction.terminalId &&
+        proof.terminalId !== access.transaction.terminalId
+      ) {
+        return userError({
+          code: "authentication_failed",
+          message: "Payment correction staff proof is invalid for this terminal.",
+        });
+      }
+
+      const credential = await ctx.db.get(
+        "staffCredential",
+        proof.credentialId,
+      );
+      if (
+        !credential ||
+        credential.status !== "active" ||
+        credential.staffProfileId !== args.actorStaffProfileId ||
+        credential.storeId !== access.transaction.storeId ||
+        credential.localVerifierVersion !== proof.credentialVersion
+      ) {
+        return userError({
+          code: "authentication_failed",
+          message: "Payment correction staff proof is invalid or expired.",
+        });
+      }
+
+      await ctx.db.patch("posLocalStaffProof", proof._id, {
+        lastUsedAt: Date.now(),
+      });
+
+      const { staffProofToken: _staffProofToken, ...commandArgs } = args;
       const result = await correctTransactionPaymentMethodCommand(ctx, {
-        ...args,
+        ...commandArgs,
         actorUserId: access.athenaUser._id,
       });
 

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -230,6 +230,34 @@ const schema = defineSchema({
       "subjectId",
     ])
     .index("by_expiresAt", ["expiresAt"]),
+  approvalRequesterChallenge: defineTable(
+    v.object({
+      storeId: v.id("store"),
+      organizationId: v.optional(v.id("organization")),
+      actionKey: v.string(),
+      subjectType: v.string(),
+      subjectId: v.string(),
+      subjectLabel: v.optional(v.string()),
+      requiredRole: v.union(
+        v.literal("manager"),
+        v.literal("front_desk"),
+        v.literal("stylist"),
+        v.literal("technician"),
+        v.literal("cashier"),
+      ),
+      requestedByStaffProfileId: v.id("staffProfile"),
+      createdAt: v.number(),
+      expiresAt: v.number(),
+      consumedAt: v.optional(v.number()),
+    }),
+  )
+    .index("by_storeId_action_subject", [
+      "storeId",
+      "actionKey",
+      "subjectType",
+      "subjectId",
+    ])
+    .index("by_expiresAt", ["expiresAt"]),
   athenaUser: defineTable(athenaUserSchema),
   contextEvent: defineTable(contextEventSchema)
     .index("by_storeId_surface_idempotencyKey", [

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,9 +7,9 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 93 file(s); key children: -authed-layout.tsx, -index-route-view.tsx, __root.tsx, _authed, _authed.test.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 638 file(s); key children: GenericComboBox.tsx, Navbar.test.tsx, Navbar.tsx, OrganizationView.test.tsx, OrganizationView.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 639 file(s); key children: GenericComboBox.tsx, Navbar.test.tsx, Navbar.tsx, OrganizationView.test.tsx, OrganizationView.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
-- [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 29 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
+- [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 30 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 47 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.test.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 8 file(s); key children: AppShellFullscreenContext.tsx, ManagerElevationContext.test.tsx, ManagerElevationContext.tsx, OnlineOrderContext.tsx, PermissionsContext.tsx.
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 16 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, cycleCountDrafts.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 8 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCaseTracing.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 19 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 617 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 618 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 9 file(s); key children: README.md, SUMMARY.md, pos, prod.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/shared/approvalPolicy.ts
+++ b/packages/athena-webapp/shared/approvalPolicy.ts
@@ -26,6 +26,12 @@ export type ApprovalOperatorCopy = {
   secondaryActionLabel?: string;
 };
 
+export type ApprovalRequesterBinding = {
+  kind: "operational_staff_challenge";
+  challengeId: string;
+  requestedByStaffProfileId: string;
+};
+
 export type InlineManagerProofResolutionMode = {
   kind: "inline_manager_proof";
   proofTtlMs?: number;
@@ -48,6 +54,7 @@ export type ApprovalRequirement = {
   reason: string;
   copy: ApprovalOperatorCopy;
   resolutionModes: ApprovalResolutionMode[];
+  requesterBinding?: ApprovalRequesterBinding;
   selfApproval?: "allowed" | "disallowed";
   metadata?: Record<string, unknown>;
 };

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -2730,7 +2730,6 @@ describe("RegisterSessionViewContent", () => {
         actorStaffProfileId: "staff-1",
         approvalProofId: undefined,
         registerSessionId: "session-1",
-        requestedByStaffProfileId: "staff-1",
         staffPinHash: "hashed-pin",
         staffUsername: "ato",
       }),
@@ -2975,7 +2974,6 @@ describe("RegisterSessionViewContent", () => {
         countedCash: 17600,
         notes: undefined,
         registerSessionId: "session-1",
-        requestedByStaffProfileId: "staff-1",
       }),
     );
   });
@@ -3113,7 +3111,6 @@ describe("RegisterSessionViewContent", () => {
       pinHash: "hashed-pin",
       reason: "Manager counted the overage.",
       requiredRole: "manager",
-      requestedByStaffProfileId: "staff-1",
       storeId: "store-1",
       subject: {
         id: "session-1",

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -27,6 +27,7 @@ import {
   CommandApprovalApprovedResult,
   CommandApprovalProofResult,
 } from "@/components/operations/CommandApprovalDialog";
+import { toApprovalRequesterBindingArg } from "@/components/operations/approvalRequesterBinding";
 import { useApprovedCommand } from "@/components/operations/useApprovedCommand";
 import {
   isApprovalRequiredResult,
@@ -54,7 +55,10 @@ import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
 import { toDisplayAmount } from "~/convex/lib/currency";
 import { userError, type CommandResult } from "~/shared/commandResult";
-import type { ApprovalRequirement } from "~/shared/approvalPolicy";
+import type {
+  ApprovalRequesterBinding,
+  ApprovalRequirement,
+} from "~/shared/approvalPolicy";
 import { currencyDisplaySymbol } from "~/shared/currencyFormatter";
 import { formatStaffDisplayName } from "~/shared/staffDisplayName";
 import View from "../View";
@@ -348,6 +352,7 @@ type RegisterSessionViewContentProps = {
     pinHash: string;
     reason?: string;
     registerSessionId: string;
+    requesterBinding?: ApprovalRequesterBinding;
     requestedByStaffProfileId?: Id<"staffProfile">;
     username: string;
   }) => Promise<CloseoutApprovalAuthenticationCommandResult>;
@@ -2959,8 +2964,7 @@ export function RegisterSessionViewContent({
           approvalProofId: result.approvalProofId,
           decision: intent.decision,
           registerSessionId: intent.registerSessionId,
-          requestedByStaffProfileId:
-            result.requestedByStaffProfileId ?? actorStaffProfileId,
+          requestedByStaffProfileId: result.requestedByStaffProfileId,
           reviewConflictIds: intent.reviewConflictIds,
         });
 
@@ -3001,14 +3005,10 @@ export function RegisterSessionViewContent({
       const commandResult =
         intent.kind === "submit"
           ? await closeoutApprovalRunner.run({
-              requestedByStaffProfileId:
-                result.staffProfileId as Id<"staffProfile">,
               sameSubmissionApproval: credentials
                 ? {
                     canAttemptInlineManagerProof: isManagerStaff(result),
                     pinHash: credentials.pinHash,
-                    requestedByStaffProfileId:
-                      result.staffProfileId as Id<"staffProfile">,
                     username: credentials.username,
                   }
                 : undefined,
@@ -3028,14 +3028,10 @@ export function RegisterSessionViewContent({
           : intent.kind === "finalize"
             ? onFinalizeCloseout
               ? await closeoutApprovalRunner.run({
-                  requestedByStaffProfileId:
-                    result.staffProfileId as Id<"staffProfile">,
                   sameSubmissionApproval: credentials
                     ? {
                         canAttemptInlineManagerProof: isManagerStaff(result),
                         pinHash: credentials.pinHash,
-                        requestedByStaffProfileId:
-                          result.staffProfileId as Id<"staffProfile">,
                         username: credentials.username,
                       }
                     : undefined,
@@ -3045,7 +3041,6 @@ export function RegisterSessionViewContent({
                       approvalProofId:
                         approvalArgs.approvalProofId ?? result.approvalProofId,
                       registerSessionId: intent.registerSessionId,
-                      requestedByStaffProfileId: result.staffProfileId,
                       staffPinHash: credentials?.pinHash,
                       staffUsername: credentials?.username,
                     }),
@@ -3167,7 +3162,6 @@ export function RegisterSessionViewContent({
         actorStaffProfileId: result.approvedByStaffProfileId,
         approvalProofId: result.approvalProofId,
         registerSessionId: registerSession._id,
-        requestedByStaffProfileId: actorStaffProfileId,
       });
 
       applyCloseoutCommandResult(commandResult);
@@ -3213,7 +3207,6 @@ export function RegisterSessionViewContent({
         countedCash: intent.countedCash,
         notes: intent.notes,
         registerSessionId: intent.registerSessionId,
-        requestedByStaffProfileId: actorStaffProfileId,
       });
 
       if (!applyCloseoutCommandResult(commandResult)) {
@@ -3884,9 +3877,6 @@ export function RegisterSessionViewContent({
           setOpeningFloatCorrectionIntent(null);
         }}
         open={Boolean(pendingOpeningFloatApproval)}
-        requestedByStaffProfileId={
-          actorStaffProfileId as Id<"staffProfile"> | undefined
-        }
         storeId={(storeId ?? "missing-store") as Id<"store">}
       />
       <CommandApprovalDialog
@@ -3907,9 +3897,6 @@ export function RegisterSessionViewContent({
         }}
         onDismiss={() => setIsReopenApprovalOpen(false)}
         open={isReopenApprovalOpen}
-        requestedByStaffProfileId={
-          actorStaffProfileId as Id<"staffProfile"> | undefined
-        }
         storeId={(storeId ?? "missing-store") as Id<"store">}
       />
       <CommandApprovalDialog
@@ -3933,9 +3920,6 @@ export function RegisterSessionViewContent({
           setReopenedCloseoutSubmitIntent(null);
         }}
         open={isReopenedCloseoutSubmitApprovalOpen}
-        requestedByStaffProfileId={
-          actorStaffProfileId as Id<"staffProfile"> | undefined
-        }
         storeId={(storeId ?? "missing-store") as Id<"store">}
       />
       <FadeIn>
@@ -5486,6 +5470,7 @@ export function RegisterSessionView() {
     pinHash: string;
     reason?: string;
     registerSessionId: string;
+    requesterBinding?: ApprovalRequesterBinding;
     requestedByStaffProfileId?: Id<"staffProfile">;
     username: string;
   }): Promise<CloseoutApprovalAuthenticationCommandResult> {
@@ -5504,6 +5489,9 @@ export function RegisterSessionView() {
           pinHash: args.pinHash,
           reason: args.reason,
           requiredRole: "manager",
+          requesterBinding: toApprovalRequesterBindingArg(
+            args.requesterBinding,
+          ),
           requestedByStaffProfileId: args.requestedByStaffProfileId,
           storeId: activeStore._id,
           subject: {
@@ -5548,6 +5536,9 @@ export function RegisterSessionView() {
           pinHash: args.pinHash,
           reason: args.reason,
           requiredRole: args.requiredRole,
+          requesterBinding: toApprovalRequesterBindingArg(
+            args.requesterBinding,
+          ),
           requestedByStaffProfileId: args.requestedByStaffProfileId,
           storeId: activeStore._id,
           subject: args.subject,

--- a/packages/athena-webapp/src/components/operations/CommandApprovalDialog.test.tsx
+++ b/packages/athena-webapp/src/components/operations/CommandApprovalDialog.test.tsx
@@ -90,6 +90,11 @@ vi.mock("@/components/ui/dialog", () => {
 const storeId = "store-1" as Id<"store">;
 const staffProfileId = "staff-1" as Id<"staffProfile">;
 const approvalProofId = "proof-1" as Id<"approvalProof">;
+const requesterBinding = {
+  kind: "operational_staff_challenge",
+  challengeId: "requester-challenge-1",
+  requestedByStaffProfileId: "staff-server-requester",
+} as const;
 
 const inlineApproval = {
   action: {
@@ -240,6 +245,7 @@ describe("CommandApprovalDialog", () => {
         pinHash: "hashed:1234",
         reason: "Payment method changes need manager approval.",
         requiredRole: "manager",
+        requesterBinding: undefined,
         requestedByStaffProfileId: undefined,
         storeId,
         subject: inlineApproval.subject,
@@ -252,6 +258,55 @@ describe("CommandApprovalDialog", () => {
       approvedByStaffProfileId: staffProfileId,
       expiresAt: 1234,
     });
+  });
+
+  it("passes server requester binding unchanged for proof creation", async () => {
+    const approvalWithRequesterBinding = {
+      ...inlineApproval,
+      requesterBinding,
+    } satisfies CommandApprovalDialogProps["approval"];
+    const { user, onAuthenticateForApproval } = renderDialog({
+      approval: approvalWithRequesterBinding,
+      requestedByStaffProfileId: "staff-react-requester" as Id<"staffProfile">,
+    });
+
+    await submitCredentials(user);
+
+    await waitFor(() =>
+      expect(onAuthenticateForApproval).toHaveBeenCalledWith({
+        actionKey: "transaction.payment_method_correction",
+        pinHash: "hashed:1234",
+        reason: "Payment method changes need manager approval.",
+        requiredRole: "manager",
+        requesterBinding,
+        requestedByStaffProfileId: undefined,
+        storeId,
+        subject: inlineApproval.subject,
+        username: "manager",
+      }),
+    );
+  });
+
+  it("does not fall back to a React requester when approval has no binding", async () => {
+    const { user, onAuthenticateForApproval } = renderDialog({
+      requestedByStaffProfileId: "staff-react-requester" as Id<"staffProfile">,
+    });
+
+    await submitCredentials(user);
+
+    await waitFor(() =>
+      expect(onAuthenticateForApproval).toHaveBeenCalledWith({
+        actionKey: "transaction.payment_method_correction",
+        pinHash: "hashed:1234",
+        reason: "Payment method changes need manager approval.",
+        requiredRole: "manager",
+        requesterBinding: undefined,
+        requestedByStaffProfileId: undefined,
+        storeId,
+        subject: inlineApproval.subject,
+        username: "manager",
+      }),
+    );
   });
 
   it("dismisses without reporting an approval proof", async () => {

--- a/packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx
+++ b/packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx
@@ -2,7 +2,6 @@ import { useRef } from "react";
 
 import {
   StaffAuthenticationDialog,
-  type StaffAuthMode,
   type StaffAuthenticationResult,
 } from "@/components/staff-auth/StaffAuthenticationDialog";
 import { Button } from "@/components/ui/button";
@@ -17,6 +16,7 @@ import { type NormalizedCommandResult } from "@/lib/errors/runCommand";
 import { presentCommandToast } from "@/lib/errors/presentCommandToast";
 import type { Id } from "~/convex/_generated/dataModel";
 import type {
+  ApprovalRequesterBinding,
   ApprovalRequirement,
   ApprovalResolutionMode,
 } from "~/shared/approvalPolicy";
@@ -53,6 +53,7 @@ export type CommandApprovalDialogProps = {
     pinHash: string;
     reason?: string;
     requiredRole: ApprovalRequirement["requiredRole"];
+    requesterBinding?: ApprovalRequesterBinding;
     requestedByStaffProfileId?: Id<"staffProfile">;
     storeId: Id<"store">;
     subject: ApprovalRequirement["subject"];
@@ -97,7 +98,6 @@ export function CommandApprovalDialog({
   onAuthenticateForApproval,
   onDismiss,
   open,
-  requestedByStaffProfileId,
   storeId,
 }: CommandApprovalDialogProps) {
   const approvedProofRef = useRef<CommandApprovalProofResult | null>(null);
@@ -173,7 +173,8 @@ export function CommandApprovalDialog({
                 pinHash: args.pinHash,
                 reason: approval.reason,
                 requiredRole: approval.requiredRole,
-                requestedByStaffProfileId,
+                requesterBinding: approval.requesterBinding,
+                requestedByStaffProfileId: undefined,
                 storeId,
                 subject: approval.subject,
                 username: args.username,
@@ -189,10 +190,7 @@ export function CommandApprovalDialog({
                 data: toStaffAuthenticationResult(proofResult.data),
               };
             }}
-            onAuthenticated={(
-              _result: StaffAuthenticationResult,
-              _mode: StaffAuthMode,
-            ) => {
+            onAuthenticated={() => {
               const proof = approvedProofRef.current;
               approvedProofRef.current = null;
 

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -39,7 +39,10 @@ import type {
   ApprovalCommandResult,
   CommandResult,
 } from "~/shared/commandResult";
-import type { ApprovalRequirement } from "~/shared/approvalPolicy";
+import type {
+  ApprovalRequesterBinding,
+  ApprovalRequirement,
+} from "~/shared/approvalPolicy";
 import { currencyFormatter } from "~/shared/currencyFormatter";
 import View from "../View";
 import { FadeIn } from "../common/FadeIn";
@@ -70,6 +73,7 @@ import {
   useApprovedCommand,
   type ApprovalRetryArgs,
 } from "./useApprovedCommand";
+import { toApprovalRequesterBindingArg } from "./approvalRequesterBinding";
 import { OperationReviewWorkspace } from "./OperationReviewWorkspace";
 import { OperationReviewItemCard } from "./OperationReviewItemCard";
 import { OperationsSummaryMetric } from "./OperationsSummaryMetric";
@@ -298,6 +302,7 @@ type DailyCloseViewContentProps = {
     pinHash: string;
     reason?: string;
     requiredRole: ApprovalRequirement["requiredRole"];
+    requesterBinding?: ApprovalRequesterBinding;
     requestedByStaffProfileId?: Id<"staffProfile">;
     storeId: Id<"store">;
     subject: ApprovalRequirement["subject"];
@@ -3932,6 +3937,9 @@ function DailyCloseConnectedView({
               pinHash: args.pinHash,
               reason: args.reason,
               requiredRole: args.requiredRole,
+              requesterBinding: toApprovalRequesterBindingArg(
+                args.requesterBinding,
+              ),
               requestedByStaffProfileId: args.requestedByStaffProfileId,
               storeId: args.storeId,
               subject: args.subject,

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
@@ -28,7 +28,10 @@ import {
 import { getOrigin } from "@/lib/navigationUtils";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
-import type { ApprovalRequirement } from "~/shared/approvalPolicy";
+import type {
+  ApprovalRequesterBinding,
+  ApprovalRequirement,
+} from "~/shared/approvalPolicy";
 import type { CommandResult } from "~/shared/commandResult";
 import View from "../View";
 import { FadeIn } from "../common/FadeIn";
@@ -40,6 +43,7 @@ import {
 } from "../common/PageLevelHeader";
 import { EmptyState } from "../states/empty/empty-state";
 import type { CommandApprovalDialogProps } from "./CommandApprovalDialog";
+import { toApprovalRequesterBindingArg } from "./approvalRequesterBinding";
 import { NoPermissionView } from "../states/no-permission/NoPermissionView";
 import { ProtectedAdminSignInView } from "../states/signed-out/ProtectedAdminSignInView";
 import { Badge } from "../ui/badge";
@@ -2010,6 +2014,7 @@ function DailyOpeningConnectedView({
     pinHash: string;
     reason?: string;
     requiredRole: ApprovalRequirement["requiredRole"];
+    requesterBinding?: ApprovalRequesterBinding;
     requestedByStaffProfileId?: Id<"staffProfile">;
     storeId: Id<"store">;
     subject: ApprovalRequirement["subject"];
@@ -2036,6 +2041,7 @@ function DailyOpeningConnectedView({
         pinHash: args.pinHash,
         reason: args.reason,
         requiredRole: args.requiredRole,
+        requesterBinding: toApprovalRequesterBindingArg(args.requesterBinding),
         requestedByStaffProfileId: args.requestedByStaffProfileId,
         storeId: args.storeId,
         subject: args.subject,

--- a/packages/athena-webapp/src/components/operations/approvalRequesterBinding.ts
+++ b/packages/athena-webapp/src/components/operations/approvalRequesterBinding.ts
@@ -1,0 +1,23 @@
+import type { Id } from "~/convex/_generated/dataModel";
+import type { ApprovalRequesterBinding } from "~/shared/approvalPolicy";
+
+export function toApprovalRequesterBindingArg(
+  binding?: ApprovalRequesterBinding,
+):
+  | {
+      challengeId: Id<"approvalRequesterChallenge">;
+      kind: "operational_staff_challenge";
+      requestedByStaffProfileId: Id<"staffProfile">;
+    }
+  | undefined {
+  if (!binding) {
+    return undefined;
+  }
+
+  return {
+    challengeId: binding.challengeId as Id<"approvalRequesterChallenge">,
+    kind: binding.kind,
+    requestedByStaffProfileId:
+      binding.requestedByStaffProfileId as Id<"staffProfile">,
+  };
+}

--- a/packages/athena-webapp/src/components/operations/useApprovedCommand.test.tsx
+++ b/packages/athena-webapp/src/components/operations/useApprovedCommand.test.tsx
@@ -8,6 +8,11 @@ import { useApprovedCommand } from "./useApprovedCommand";
 
 const storeId = "store-1" as Id<"store">;
 const requesterId = "staff-requester" as Id<"staffProfile">;
+const serverRequesterBinding = {
+  kind: "operational_staff_challenge",
+  challengeId: "requester-challenge-1",
+  requestedByStaffProfileId: "staff-server-requester",
+} as const;
 const approval = {
   action: {
     key: "cash_controls.register_session.review_variance",
@@ -26,6 +31,10 @@ const approval = {
     label: "Register 1",
     type: "register_session",
   },
+} satisfies ApprovalRequirement;
+const approvalWithRequesterBinding = {
+  ...approval,
+  requesterBinding: serverRequesterBinding,
 } satisfies ApprovalRequirement;
 
 vi.mock("./CommandApprovalDialog", () => ({
@@ -76,9 +85,11 @@ describe("useApprovedCommand", () => {
 
     expect(result.current.approvalDialog).toMatchObject({
       approval,
-      requestedByStaffProfileId: requesterId,
       storeId,
     });
+    expect(result.current.approvalDialog).not.toHaveProperty(
+      "requestedByStaffProfileId",
+    );
 
     await act(async () => {
       await result.current.approvalDialog?.onApproved({
@@ -135,7 +146,8 @@ describe("useApprovedCommand", () => {
       pinHash: "pin-hash",
       reason: approval.reason,
       requiredRole: approval.requiredRole,
-      requestedByStaffProfileId: requesterId,
+      requesterBinding: undefined,
+      requestedByStaffProfileId: undefined,
       storeId,
       subject: approval.subject,
       username: "manager",
@@ -146,6 +158,62 @@ describe("useApprovedCommand", () => {
     expect(onResult).toHaveBeenCalledWith(ok({ action: "closed" }));
     expect(result.current.pendingApproval).toBeNull();
     expect(result.current.approvalDialog).toBeNull();
+  });
+
+  it("passes the server-returned requester binding instead of React requester fallbacks", async () => {
+    const onResult = vi.fn();
+    const onAuthenticateForApproval = vi.fn().mockResolvedValue(
+      ok({
+        approvalProofId: "proof-1" as Id<"approvalProof">,
+        approvedByStaffProfileId: "manager-1" as Id<"staffProfile">,
+        expiresAt: 123,
+      }),
+    );
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({
+        kind: "approval_required",
+        approval: approvalWithRequesterBinding,
+      })
+      .mockResolvedValueOnce(ok({ action: "closed" }));
+    const { result } = renderHook(() =>
+      useApprovedCommand({
+        storeId,
+        onAuthenticateForApproval,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.run({
+        execute,
+        onResult,
+        requestedByStaffProfileId: requesterId,
+        sameSubmissionApproval: {
+          canAttemptInlineManagerProof: true,
+          pinHash: "pin-hash",
+          requestedByStaffProfileId:
+            "staff-react-requester" as Id<"staffProfile">,
+          username: "manager",
+        },
+      });
+    });
+
+    expect(onAuthenticateForApproval).toHaveBeenCalledWith({
+      actionKey: approval.action.key,
+      pinHash: "pin-hash",
+      reason: approval.reason,
+      requiredRole: approval.requiredRole,
+      requesterBinding: serverRequesterBinding,
+      requestedByStaffProfileId: undefined,
+      storeId,
+      subject: approval.subject,
+      username: "manager",
+    });
+    expect(execute).toHaveBeenLastCalledWith({
+      approvalProofId: "proof-1",
+    });
+    expect(onResult).toHaveBeenCalledWith(ok({ action: "closed" }));
+    expect(result.current.pendingApproval).toBeNull();
   });
 
   it("retries same-submission approvals with the queued approval request id", async () => {
@@ -234,9 +302,11 @@ describe("useApprovedCommand", () => {
     expect(onAuthenticateForApproval).not.toHaveBeenCalled();
     expect(result.current.approvalDialog).toMatchObject({
       approval,
-      requestedByStaffProfileId: requesterId,
       storeId,
     });
+    expect(result.current.approvalDialog).not.toHaveProperty(
+      "requestedByStaffProfileId",
+    );
   });
 
   it("surfaces same-submission proof failures without retrying", async () => {

--- a/packages/athena-webapp/src/components/operations/useApprovedCommand.tsx
+++ b/packages/athena-webapp/src/components/operations/useApprovedCommand.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useMemo, useState } from "react";
 
 import type { Id } from "~/convex/_generated/dataModel";
-import type { ApprovalRequirement } from "~/shared/approvalPolicy";
+import type {
+  ApprovalRequesterBinding,
+  ApprovalRequirement,
+} from "~/shared/approvalPolicy";
 import {
   isApprovalRequiredResult,
   type NormalizedApprovalCommandResult,
@@ -51,6 +54,7 @@ type UseApprovedCommandArgs = {
     pinHash: string;
     reason?: string;
     requiredRole: ApprovalRequirement["requiredRole"];
+    requesterBinding?: ApprovalRequesterBinding;
     requestedByStaffProfileId?: Id<"staffProfile">;
     storeId: Id<"store">;
     subject: ApprovalRequirement["subject"];
@@ -145,9 +149,8 @@ export function useApprovedCommand({ onAuthenticateForApproval, storeId }: UseAp
           pinHash: args.sameSubmissionApproval.pinHash,
           reason: result.approval.reason,
           requiredRole: result.approval.requiredRole,
-          requestedByStaffProfileId:
-            args.sameSubmissionApproval.requestedByStaffProfileId ??
-            args.requestedByStaffProfileId,
+          requesterBinding: result.approval.requesterBinding,
+          requestedByStaffProfileId: undefined,
           storeId,
           subject: result.approval.subject,
           username: args.sameSubmissionApproval.username,
@@ -195,7 +198,6 @@ export function useApprovedCommand({ onAuthenticateForApproval, storeId }: UseAp
       },
       onDismiss: () => setPendingApproval(null),
       open: Boolean(pendingApproval),
-      requestedByStaffProfileId: pendingApproval.requestedByStaffProfileId,
       storeId,
     };
   }, [handleResult, onAuthenticateForApproval, pendingApproval, storeId]);

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
@@ -228,6 +228,11 @@ vi.mock("../../operations/CommandApprovalDialog", () => ({
       copy: { message: string; primaryActionLabel?: string; title: string };
       reason: string;
       requiredRole: "manager";
+      requesterBinding?: {
+        kind: "operational_staff_challenge";
+        challengeId: string;
+        requestedByStaffProfileId: string;
+      };
       resolutionModes: Array<{
         kind: string;
         approvalRequestId?: string;
@@ -240,6 +245,11 @@ vi.mock("../../operations/CommandApprovalDialog", () => ({
       pinHash: string;
       reason?: string;
       requiredRole: "manager";
+      requesterBinding?: {
+        kind: "operational_staff_challenge";
+        challengeId: string;
+        requestedByStaffProfileId: string;
+      };
       requestedByStaffProfileId?: string;
       storeId: string;
       subject: { id: string; label?: string; type: string };
@@ -275,6 +285,7 @@ vi.mock("../../operations/CommandApprovalDialog", () => ({
                 pinHash: "hashed:1234",
                 reason: approval.reason,
                 requiredRole: approval.requiredRole,
+                requesterBinding: approval.requesterBinding,
                 requestedByStaffProfileId,
                 storeId: "store_1",
                 subject: approval.subject,
@@ -453,6 +464,11 @@ describe("TransactionView", () => {
       reason:
         "Manager approval is required to correct a completed transaction payment method.",
       requiredRole: "manager" as const,
+      requesterBinding: {
+        kind: "operational_staff_challenge",
+        challengeId: "requester-challenge-1",
+        requestedByStaffProfileId: "staff_1",
+      },
       resolutionModes: [
         { kind: "inline_manager_proof" },
         {
@@ -1709,6 +1725,7 @@ describe("TransactionView", () => {
       kind: "ok",
       data: {
         activeRoles: ["cashier"],
+        posLocalStaffProof: { expiresAt: 2, token: "proof-token-1" },
         staffProfile: { firstName: "Kwamina", lastName: "Mensah" },
         staffProfileId: "staff_1",
       },
@@ -1795,6 +1812,7 @@ describe("TransactionView", () => {
       approvalProofId: undefined,
       paymentMethod: "card",
       reason: "Wrong tender selected.",
+      staffProofToken: "proof-token-1",
       transactionId: "txn_13",
     });
   });
@@ -1805,6 +1823,7 @@ describe("TransactionView", () => {
       kind: "ok",
       data: {
         activeRoles: ["manager"],
+        posLocalStaffProof: { expiresAt: 2, token: "proof-token-1" },
         staffProfile: { firstName: "Kwamina", lastName: "Mensah" },
         staffProfileId: "staff_1",
       },
@@ -1858,7 +1877,12 @@ describe("TransactionView", () => {
         reason:
           "Manager approval is required to correct a completed transaction payment method.",
         requiredRole: "manager",
-        requestedByStaffProfileId: "staff_1",
+        requesterBinding: {
+          kind: "operational_staff_challenge",
+          challengeId: "requester-challenge-1",
+          requestedByStaffProfileId: "staff_1",
+        },
+        requestedByStaffProfileId: undefined,
         storeId: "store_1",
         subject: {
           id: "txn_19",
@@ -1873,6 +1897,7 @@ describe("TransactionView", () => {
         approvalProofId: "proof-1",
         paymentMethod: "card",
         reason: "Wrong tender selected.",
+        staffProofToken: "proof-token-1",
         transactionId: "txn_19",
       });
     });
@@ -2439,6 +2464,11 @@ describe("TransactionView", () => {
           reason:
             "Manager approval is required to adjust completed transaction items.",
           requiredRole: "manager",
+          requesterBinding: {
+            kind: "operational_staff_challenge",
+            challengeId: "requester-challenge-2",
+            requestedByStaffProfileId: "staff_1",
+          },
           resolutionModes: [
             { kind: "inline_manager_proof" },
             {
@@ -2515,7 +2545,12 @@ describe("TransactionView", () => {
         reason:
           "Manager approval is required to adjust completed transaction items.",
         requiredRole: "manager",
-        requestedByStaffProfileId: "staff_1",
+        requesterBinding: {
+          kind: "operational_staff_challenge",
+          challengeId: "requester-challenge-2",
+          requestedByStaffProfileId: "staff_1",
+        },
+        requestedByStaffProfileId: undefined,
         storeId: "store_1",
         subject: {
           id: "txn_items",

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
@@ -56,6 +56,7 @@ import {
   type StaffAuthenticationResult,
 } from "../../staff-auth/StaffAuthenticationDialog";
 import { useProtectedAdminPageState } from "~/src/hooks/useProtectedAdminPageState";
+import { toApprovalRequesterBindingArg } from "../../operations/approvalRequesterBinding";
 import { useApprovedCommand } from "../../operations/useApprovedCommand";
 import type { ApprovalRequirement } from "~/shared/approvalPolicy";
 import { formatStoredAmount } from "~/src/lib/pos/displayAmounts";
@@ -422,6 +423,9 @@ export function TransactionView() {
             pinHash: args.pinHash,
             reason: args.reason,
             requiredRole: args.requiredRole,
+            requesterBinding: toApprovalRequesterBindingArg(
+              args.requesterBinding,
+            ),
             requestedByStaffProfileId: args.requestedByStaffProfileId,
             storeId: activeStore._id,
             subject: args.subject,
@@ -457,6 +461,9 @@ export function TransactionView() {
             pinHash: args.pinHash,
             reason: args.reason,
             requiredRole: args.requiredRole,
+            requesterBinding: toApprovalRequesterBindingArg(
+              args.requesterBinding,
+            ),
             requestedByStaffProfileId: args.requestedByStaffProfileId,
             storeId: activeStore._id,
             subject: args.subject,
@@ -492,6 +499,9 @@ export function TransactionView() {
             pinHash: args.pinHash,
             reason: args.reason,
             requiredRole: args.requiredRole,
+            requesterBinding: toApprovalRequesterBindingArg(
+              args.requesterBinding,
+            ),
             requestedByStaffProfileId: args.requestedByStaffProfileId,
             storeId: activeStore._id,
             subject: args.subject,
@@ -1032,6 +1042,7 @@ export function TransactionView() {
                 approvalArgs.approvalProofId ?? args?.approvalProofId,
               paymentMethod,
               reason,
+              staffProofToken: args?.staff?.posLocalStaffProof?.token,
               transactionId: transactionId as Id<"posTransaction">,
             }) as Promise<
               ApprovalCommandResult<PaymentMethodCorrectionResultData>

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -31,6 +31,7 @@ import { parseDisplayAmountInput } from "@/lib/pos/displayAmounts";
 import { toOperatorMessage } from "@/lib/errors/operatorMessages";
 import { isApprovalRequiredResult, runCommand } from "@/lib/errors/runCommand";
 import type { CommandApprovalProofResult } from "@/components/operations/CommandApprovalDialog";
+import { toApprovalRequesterBindingArg } from "@/components/operations/approvalRequesterBinding";
 import type { StaffAuthenticationResult } from "@/components/staff-auth/StaffAuthenticationDialog";
 import { useApprovedCommand } from "@/components/operations/useApprovedCommand";
 import { logger } from "@/lib/logger";
@@ -52,7 +53,10 @@ import {
 import { useConvexRegisterState } from "@/lib/pos/infrastructure/convex/registerGateway";
 import { isRegisterSessionSaleUsable } from "~/shared/registerSessionLifecyclePolicy";
 import { userError, type CommandResult } from "~/shared/commandResult";
-import type { ApprovalRequirement } from "~/shared/approvalPolicy";
+import type {
+  ApprovalRequesterBinding,
+  ApprovalRequirement,
+} from "~/shared/approvalPolicy";
 import {
   normalizePosTerminalTransactionCapability,
   posTerminalCanTransactProducts,
@@ -963,6 +967,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       pinHash: string;
       reason?: string;
       requiredRole: ApprovalRequirement["requiredRole"];
+      requesterBinding?: ApprovalRequesterBinding;
       requestedByStaffProfileId?: Id<"staffProfile">;
       storeId: Id<"store">;
       subject: ApprovalRequirement["subject"];
@@ -984,6 +989,9 @@ export function useRegisterViewModel(): RegisterViewModel {
             pinHash: args.pinHash,
             reason: args.reason,
             requiredRole: args.requiredRole,
+            requesterBinding: toApprovalRequesterBindingArg(
+              args.requesterBinding,
+            ),
             requestedByStaffProfileId: args.requestedByStaffProfileId,
             storeId: activeStoreId!,
             subject: args.subject,


### PR DESCRIPTION
## Summary
- Introduces server-issued approval requester challenges so manager approval can bind to the initiating staff profile without requiring that staff profile to match the signed-in Athena user.
- Threads requester binding through POS, cash controls, daily close/opening, transaction review, and the shared approval dialog/hook.
- Hardens public POS payment-correction approval by requiring actor staff evidence plus a local staff proof token before invoking the command.
- Preserves audit state for closeout variance retries by approving the matched pending approval request instead of cancelling it.
- Adds the delivery plan and a durable solution note for this approval-requester binding bug pattern.

## Linear
- V26-922
- V26-923
- V26-924
- V26-925
- V26-926
- V26-927

## Review
- Security: APPROVE
- Data integrity: APPROVE
- Testing: APPROVE
- Correctness: APPROVE

## Validation
- `cd packages/athena-webapp && bun run test -- convex/cashControls/closeouts.test.ts` — 47 passed
- Focused affected suite — 12 files, 411 tests passed
- `cd packages/athena-webapp && bunx tsc --noEmit -p tsconfig.json`
- `cd packages/athena-webapp && bun run lint:convex:changed`
- `cd packages/athena-webapp && bun run lint:frontend:changed` — existing Fast Refresh warnings only
- `cd packages/athena-webapp && bun run audit:convex`
- `git diff --check`
- `bun run pr:athena` — passed, proof recorded