### PR TITLE
fix(pos): correct hub pulse and limit prewarm load

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8411 nodes · 10077 edges · 2083 communities detected
+- 8412 nodes · 10080 edges · 2083 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2341,12 +2341,12 @@ Cohesion: 0.18
 Nodes (23): buildEventMessage(), buildNextEvidence(), buildNextSaleEvidence(), buildReviewPriority(), buildWorkItemPriority(), createOrReusePendingCheckoutItem(), createProvisionalCatalogAnchors(), findMatchingPendingCheckoutItem() (+15 more)
 
 ### Community 55 - "Community 55"
-Cohesion: 0.12
-Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
+Cohesion: 0.14
+Nodes (18): findCurrentStoreDayOpening(), findLatestStoreDayOpening(), getTodaySummary(), getTransactionById(), isActivePosSummaryOpeningAt(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames() (+10 more)
 
 ### Community 56 - "Community 56"
-Cohesion: 0.15
-Nodes (17): findCurrentStoreDayOpening(), getTodaySummary(), getTransactionById(), isActivePosSummaryOpeningAt(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents() (+9 more)
+Cohesion: 0.12
+Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
 
 ### Community 57 - "Community 57"
 Cohesion: 0.17
@@ -3377,8 +3377,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 314 - "Community 314"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 315 - "Community 315"
 Cohesion: 0.33
@@ -3393,76 +3393,76 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 318 - "Community 318"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 319 - "Community 319"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 320 - "Community 320"
+### Community 319 - "Community 319"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
+
+### Community 320 - "Community 320"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 321 - "Community 321"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 322 - "Community 322"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 323 - "Community 323"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 324 - "Community 324"
+### Community 323 - "Community 323"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 325 - "Community 325"
+### Community 324 - "Community 324"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 326 - "Community 326"
+### Community 325 - "Community 325"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 326 - "Community 326"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 327 - "Community 327"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 328 - "Community 328"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 329 - "Community 329"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 330 - "Community 330"
+### Community 329 - "Community 329"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 331 - "Community 331"
+### Community 330 - "Community 330"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 331 - "Community 331"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 332 - "Community 332"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 333 - "Community 333"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 334 - "Community 334"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 335 - "Community 335"
+### Community 334 - "Community 334"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 335 - "Community 335"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 336 - "Community 336"
 Cohesion: 0.53

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2156
-- Graph nodes: 8411
-- Graph edges: 10077
+- Graph nodes: 8412
+- Graph edges: 10080
 - Communities: 2083
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/pos/application/getTransactions.test.ts
+++ b/packages/athena-webapp/convex/pos/application/getTransactions.test.ts
@@ -540,8 +540,8 @@ describe("getTodaySummary", () => {
       1,
       expect.anything(),
       {
-        completedFrom: Date.parse("2026-06-30T00:00:00.000Z"),
-        completedTo: Date.parse("2026-06-30T23:59:59.999Z"),
+        completedFrom: Date.parse("2026-06-30T04:00:00.000Z"),
+        completedTo: Date.parse("2026-07-01T03:59:59.999Z"),
         storeId: "store-1",
       },
     );
@@ -563,8 +563,8 @@ describe("getTodaySummary", () => {
     });
   });
 
-  it("falls back to the server calendar day when the latest opening is already closed", async () => {
-    vi.setSystemTime(new Date("2026-06-20T00:49:30.000Z"));
+  it("does not include the closed previous store day in the fallback POS summary window", async () => {
+    vi.setSystemTime(new Date("2026-07-02T04:03:59.000Z"));
     vi.mocked(listCompletedTransactionsForDay).mockResolvedValue([] as never);
     const query = vi.fn((tableName: string) => ({
       withIndex: vi.fn(() => ({
@@ -572,9 +572,9 @@ describe("getTodaySummary", () => {
           tableName === "dailyClose"
             ? [
                 {
-                  _id: "close-2026-06-19",
+                  _id: "close-2026-07-01",
                   lifecycleStatus: "active",
-                  operatingDate: "2026-06-19",
+                  operatingDate: "2026-07-01",
                   status: "completed",
                   storeId: "store-1",
                 },
@@ -585,9 +585,9 @@ describe("getTodaySummary", () => {
           tableName === "dailyClose"
             ? [
                 {
-                  _id: "close-2026-06-19",
+                  _id: "close-2026-07-01",
                   lifecycleStatus: "active",
-                  operatingDate: "2026-06-19",
+                  operatingDate: "2026-07-01",
                   status: "completed",
                   storeId: "store-1",
                 },
@@ -599,8 +599,10 @@ describe("getTodaySummary", () => {
             tableName === "dailyOpening"
               ? [
                   {
-                    _id: "opening-2026-06-19",
-                    operatingDate: "2026-06-19",
+                    _id: "opening-2026-07-01",
+                    endAt: Date.parse("2026-07-02T04:00:00.000Z"),
+                    operatingDate: "2026-07-01",
+                    startAt: Date.parse("2026-07-01T04:00:00.000Z"),
                     status: "started",
                     storeId: "store-1",
                   },
@@ -623,14 +625,14 @@ describe("getTodaySummary", () => {
     expect(listCompletedTransactionsForDay).toHaveBeenCalledWith(
       expect.anything(),
       {
-        endOfDay: Date.parse("2026-06-20T23:59:59.999Z"),
-        startOfDay: Date.parse("2026-06-20T00:00:00.000Z"),
+        endOfDay: Date.parse("2026-07-03T03:59:59.999Z"),
+        startOfDay: Date.parse("2026-07-02T04:00:00.000Z"),
         storeId: "store-1",
       },
     );
     expect(result).toEqual({
       averageTransaction: 0,
-      date: "2026-06-20",
+      date: "2026-07-02",
       operatorSnapshot: expect.objectContaining({
         historyDays: 14,
         paymentMix: [],

--- a/packages/athena-webapp/convex/pos/application/queries/getTransactions.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/getTransactions.ts
@@ -794,10 +794,20 @@ async function resolveCurrentPosSummaryWindow(
     };
   }
 
+  const latestStoreDay = currentStoreDay
+    ? null
+    : await findLatestStoreDayOpening(ctx, { storeId: args.storeId });
+  const fallbackRangeStart =
+    latestStoreDay &&
+    latestStoreDay.endAt > fallbackStartOfDay &&
+    latestStoreDay.endAt <= fallbackStartOfDay + DAY_MS
+      ? latestStoreDay.endAt
+      : fallbackStartOfDay;
+
   return {
-    endOfDay: storeDayRange?.endOfDay ?? fallbackStartOfDay + DAY_MS - 1,
+    endOfDay: storeDayRange?.endOfDay ?? fallbackRangeStart + DAY_MS - 1,
     operatingDate,
-    startOfDay: storeDayRange?.startOfDay ?? fallbackStartOfDay,
+    startOfDay: storeDayRange?.startOfDay ?? fallbackRangeStart,
   };
 }
 
@@ -853,6 +863,38 @@ async function findCurrentStoreDayOpening(
 
     if (!hasCompletedActiveClose) {
       return opening;
+    }
+  }
+
+  return null;
+}
+
+async function findLatestStoreDayOpening(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    storeId: Id<"store">;
+  },
+): Promise<CurrentStoreDayOpening | null> {
+  const startedOpenings = await ctx.db
+    .query("dailyOpening")
+    .withIndex("by_storeId_status_operatingDate", (q) =>
+      q.eq("storeId", args.storeId).eq("status", "started"),
+    )
+    .order("desc")
+    .take(10);
+
+  for (const opening of startedOpenings) {
+    const { endAt, startAt } = opening;
+    if (
+      typeof startAt === "number" &&
+      typeof endAt === "number" &&
+      isValidPosSummaryWindowRange(startAt, endAt)
+    ) {
+      return {
+        endAt,
+        operatingDate: opening.operatingDate,
+        startAt,
+      };
     }
   }
 

--- a/packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx
@@ -227,15 +227,16 @@ describe("PointOfSaleView", () => {
     ).toBeInTheDocument();
   });
 
-  it("prewarms POS register offline snapshots from the POS landing page", () => {
+  it("prewarms register metadata without refreshing full availability from the POS landing page", () => {
     render(<PointOfSaleView />);
 
     expect(usePrewarmRegisterCatalogOfflineSnapshotsMock).toHaveBeenCalledWith({
+      refreshAvailabilitySnapshot: false,
       storeId: "store-1",
     });
   });
 
-  it("prewarms POS register offline snapshots from local entry context when live store context is unavailable", () => {
+  it("prewarms register metadata from local entry context when live store context is unavailable", () => {
     useGetActiveStoreMock.mockReturnValue({
       activeStore: null,
     });
@@ -251,6 +252,7 @@ describe("PointOfSaleView", () => {
     render(<PointOfSaleView />);
 
     expect(usePrewarmRegisterCatalogOfflineSnapshotsMock).toHaveBeenCalledWith({
+      refreshAvailabilitySnapshot: false,
       storeId: "local-store-1",
     });
   });

--- a/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
+++ b/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
@@ -75,7 +75,10 @@ export default function PointOfSaleView() {
     (localEntryContext.status === "ready"
       ? (localEntryContext.storeId as Id<"store">)
       : undefined);
-  usePrewarmRegisterCatalogOfflineSnapshots({ storeId: snapshotStoreId });
+  usePrewarmRegisterCatalogOfflineSnapshots({
+    refreshAvailabilitySnapshot: false,
+    storeId: snapshotStoreId,
+  });
   const { canAccessPOS, hasFullAdminAccess } = usePermissions();
   const visibleStorePulseWindow = hasFullAdminAccess
     ? storePulseWindow

--- a/packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.test.tsx
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.test.tsx
@@ -7,6 +7,7 @@ import type {
   PosServiceCatalogRowDto,
 } from "@/lib/pos/application/dto";
 import type { Id } from "~/convex/_generated/dataModel";
+import { api } from "~/convex/_generated/api";
 import {
   useConvexRegisterCatalog,
   useConvexRegisterCatalogState,
@@ -288,6 +289,32 @@ describe("catalogGateway", () => {
         storeId: "store-1",
       }),
     );
+  });
+
+  it("can prewarm POS metadata without refreshing the full availability snapshot", async () => {
+    const refreshedRows = [buildRegisterCatalogRow({ sku: "DW-LIGHT" })];
+    convexMocks.query.mockResolvedValue(refreshedRows);
+
+    renderHook(() =>
+      usePrewarmRegisterCatalogOfflineSnapshots({
+        refreshAvailabilitySnapshot: false,
+        storeId: "store-1" as Id<"store">,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(catalogStoreMocks.writeRegisterCatalogSnapshot).toHaveBeenCalledWith({
+        rows: refreshedRows,
+        storeId: "store-1",
+      }),
+    );
+    expect(convexMocks.useQuery).toHaveBeenCalledWith(
+      api.pos.public.catalog.listRegisterCatalogAvailabilitySnapshot,
+      "skip",
+    );
+    expect(
+      catalogStoreMocks.writeRegisterAvailabilitySnapshot,
+    ).not.toHaveBeenCalled();
   });
 
   it("returns the local service catalog snapshot before live service rows refresh it", async () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts
@@ -438,6 +438,7 @@ export function useConvexRegisterCatalogAvailability(
 }
 
 export function usePrewarmRegisterCatalogOfflineSnapshots(input: {
+  refreshAvailabilitySnapshot?: boolean;
   storeId?: Id<"store">;
 }) {
   useConvexRegisterCatalog({
@@ -446,7 +447,7 @@ export function usePrewarmRegisterCatalogOfflineSnapshots(input: {
   });
   useConvexRegisterServiceCatalog({ storeId: input.storeId });
   useConvexRegisterCatalogAvailabilityState({
-    refreshFullAvailabilitySnapshot: true,
+    refreshFullAvailabilitySnapshot: input.refreshAvailabilitySnapshot ?? true,
     storeId: input.storeId,
     productSkuIds: [],
   });


### PR DESCRIPTION
## Summary
- correct POS hub pulse fallback window so closed prior store-day sales do not bucket into today
- keep POS hub prewarm for metadata/service catalog while skipping the heavy availability snapshot refresh
- add focused backend and frontend coverage for the pulse window and prewarm behavior

## Validation
- bun run test -- src/components/pos/PointOfSaleView.test.tsx src/lib/pos/infrastructure/convex/catalogGateway.test.tsx convex/pos/application/getTransactions.test.ts
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- pre-push validation suite passed, including full @athena/webapp test suite, build, POS e2e slices, and harness behavior scenarios

Browser validation left to local reviewer as requested.