### PR TITLE
V26-928 V26-929 V26-930 V26-931 V26-932 V26-933 V26-934 Resolve Open Work workflows

### DIFF
--- a/docs/plans/2026-07-02-001-fix-open-work-resolution-plan.html
+++ b/docs/plans/2026-07-02-001-fix-open-work-resolution-plan.html
@@ -1,0 +1,238 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>fix: Close Open Work resolution gaps</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f6f7f9;
+      --panel: #ffffff;
+      --ink: #17202b;
+      --muted: #617180;
+      --line: #d8e0e8;
+      --accent: #1f6f8b;
+      --accent-soft: #e7f5f8;
+      --risk: #8a4b12;
+      --risk-soft: #fff3e5;
+      --ok: #23623a;
+      --ok-soft: #e8f5ed;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 32px 24px 56px;
+    }
+    header, section {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 22px 24px;
+      margin-bottom: 18px;
+    }
+    h1, h2, h3 {
+      line-height: 1.2;
+      margin: 0 0 12px;
+      text-wrap: balance;
+    }
+    h1 { font-size: 29px; }
+    h2 { font-size: 20px; }
+    h3 { font-size: 16px; color: var(--muted); }
+    p { margin: 0 0 12px; text-wrap: pretty; }
+    a { color: var(--accent); }
+    .meta {
+      color: var(--muted);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px 18px;
+      margin-top: 12px;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      gap: 12px;
+    }
+    .callout {
+      border-left: 4px solid var(--accent);
+      background: var(--accent-soft);
+      padding: 12px 14px;
+      border-radius: 6px;
+    }
+    .risk {
+      border-left-color: var(--risk);
+      background: var(--risk-soft);
+    }
+    .ok {
+      border-left-color: var(--ok);
+      background: var(--ok-soft);
+    }
+    ul, ol { margin: 8px 0 0 20px; padding: 0; }
+    li { margin: 5px 0; text-wrap: pretty; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 10px;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 8px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: #f1f4f7; }
+    code {
+      background: #eef2f5;
+      border-radius: 4px;
+      padding: 1px 4px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.92em;
+    }
+    .unit {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px 16px;
+      margin-top: 12px;
+    }
+    .unit strong { color: var(--accent); }
+    .num { font-variant-numeric: tabular-nums; }
+    .small { color: var(--muted); font-size: 13px; }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>fix: Close Open Work resolution gaps</h1>
+      <p>Open Work stays the dense operations workspace. This plan adds source-owned resolution, type-specific row actions, and focused validation for the work types that can currently strand operators or leave stale rows behind.</p>
+      <div class="meta">
+        <span>Type: fix</span>
+        <span>Status: active</span>
+        <span>Date: <span class="num">2026-07-02</span></span>
+        <span>Worktree: <code>.worktrees/codex/open-work-resolution-gaps</code></span>
+        <span>Source: <a href="2026-07-02-001-fix-open-work-resolution-plan.md">Markdown plan</a></span>
+      </div>
+    </header>
+
+    <section>
+      <h2>Direction</h2>
+      <div class="grid">
+        <div class="callout ok">
+          <h3>Keep</h3>
+          <p>Existing route, operations shell, queue density, filters, pagination, row shell, and restrained operator copy.</p>
+        </div>
+        <div class="callout">
+          <h3>Improve</h3>
+          <p>Per-type owner/action labels, destination links, metadata, focus states, and stable numeric facts inside existing rows.</p>
+        </div>
+        <div class="callout risk">
+          <h3>Avoid</h3>
+          <p>No generic resolve-all button, no card-heavy redesign, no client-side approval authority, and no raw backend labels or metadata in visible copy.</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Resolution Contract</h2>
+      <table>
+        <thead>
+          <tr><th>Work type/state</th><th>Source identity</th><th>Primary owner</th><th>Primary action</th><th>Terminal rule</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>service_case</code></td><td><code>serviceCaseId</code></td><td>Service case workflow</td><td>Open service case</td><td>Completed/cancelled case status</td></tr>
+          <tr><td><code>service_appointment</code> while open</td><td><code>appointmentId</code></td><td>Appointment workflow</td><td>Open appointment</td><td>Cancel closes work; conversion closes appointment work and transfers context to service case if needed</td></tr>
+          <tr><td><code>purchase_order</code></td><td><code>purchaseOrderId</code></td><td>Procurement/receiving</td><td>Open purchase order</td><td>Received/completed completes; cancelled cancels</td></tr>
+          <tr><td><code>stock_adjustment_review</code> pending approval</td><td>Approval + adjustment ids</td><td>Approval requests</td><td>Review adjustment approval</td><td>Approval applies or rejects adjustment</td></tr>
+          <tr><td><code>pos_pending_checkout_item_review</code></td><td>Canonical: <code>posPendingCheckoutItem._id</code>; local-sync fallback uses store, terminal, local register session, <code>localIdKind: "pendingCheckoutItem"</code>, and local pending item id</td><td>Unresolved catalog review</td><td>Review catalog item</td><td>Link/approve/reject completes; flag stays open</td></tr>
+          <tr><td><code>synced_sale_inventory_review</code></td><td>Mapping key: store, terminal, <code>localRegisterSessionId</code>, <code>localIdKind: "inventoryReviewWorkItem"</code>, <code>localId: "${localTransactionId}:inventory-review"</code></td><td>Operations inventory review</td><td>Resolve sale inventory review</td><td>Operations resolver completes, cancels, or supersedes with audit evidence</td></tr>
+          <tr><td><code>daily_close_carry_forward</code></td><td>Store, business date, carry-forward source</td><td>Daily Close</td><td>Resolve carry-forward follow-up</td><td>Daily Close completes or cancels with handoff evidence</td></tr>
+          <tr><td><code>service_deposit_review</code></td><td>Deposit subject</td><td>Not surfaced this release</td><td>Not surfaced</td><td>Suppress until full proof-bound approval semantics exist</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Queue Ordering</h2>
+      <ul>
+        <li>Sort by priority bucket, status urgency, oldest actionable timestamp, stable source identity, then work item id.</li>
+        <li>Keep <code>MAX_QUEUE_ITEMS = 100</code> per server lane: <code>open</code>, <code>in_progress</code>, and pending approvals.</li>
+        <li>Probe each lane with <code>MAX_QUEUE_ITEMS + 1</code> and return <code>overflow.workItems.open</code>, <code>overflow.workItems.inProgress</code>, and <code>overflow.approvalRequests</code>.</li>
+        <li>Tests seed more than <code>100</code> rows per lane and prove the first page contains the highest-priority actionable rows.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Implementation Units</h2>
+      <div class="unit">
+        <p><strong>U1. Characterize Open Work projection</strong></p>
+        <p>Lock down queue inclusion/exclusion, approval separation, source identity, duplicate policy, ordering, caps, mixed work fixtures, and existing terminal behavior in Convex and UI tests.</p>
+      </div>
+      <div class="unit">
+        <p><strong>U2. Add type-specific row contracts</strong></p>
+        <p>Improve titles, owner labels, action destinations, and sanitized row DTO metadata inside the current <code>OperationsQueueView</code> direction. Preserve density and visual language.</p>
+      </div>
+      <div class="unit">
+        <p><strong>U3. Implement synced-sale inventory review ownership</strong></p>
+        <p>Add the Operations-owned <code>openWorkInventoryReviews.resolveSyncedSaleInventoryReview</code> boundary so current inventory review work can complete, cancel, or become superseded with authz checks and audit evidence.</p>
+      </div>
+      <div class="unit">
+        <p><strong>U4. Add daily carry-forward terminal path</strong></p>
+        <p>Keep Opening acknowledgment as handoff evidence and add a Daily Close-owned typed completion/cancellation path requiring consumed manager proof bound to the carry-forward source.</p>
+      </div>
+      <div class="unit">
+        <p><strong>U5. Harden source workflow terminal transitions</strong></p>
+        <p>Cover service appointments, service cases, purchase orders, receiving, and pending checkout item review with source-owned terminal tests and fixes.</p>
+      </div>
+      <div class="unit">
+        <p><strong>U6. Resolve approval ownership ambiguity</strong></p>
+        <p>Keep stock/register approvals approval-owned and fail closed for <code>service_deposit_review</code> by suppressing it from surfaced queue data unless full proof-bound semantics are implemented.</p>
+      </div>
+      <div class="unit">
+        <p><strong>U7. Validate integration, UI direction, and graph</strong></p>
+        <p>Run focused tests, audit current visible rows, verify queue ordering/caps and sanitized DTOs, browser-review the Open Work route against the current workspace direction, and rebuild graph after code changes.</p>
+      </div>
+    </section>
+
+    <section>
+      <h2>Highest-Risk Gaps</h2>
+      <div class="grid">
+        <div class="callout risk">
+          <h3>Synced sale inventory review</h3>
+          <p>No clear terminal path was found. Resolution needs source validation, not SKU-only matching.</p>
+        </div>
+        <div class="callout risk">
+          <h3>Daily close carry-forward</h3>
+          <p>Opening acknowledgment currently leaves work open, so a separate terminal action is needed.</p>
+        </div>
+        <div class="callout risk">
+          <h3>Service deposit review</h3>
+          <p>It is fail-closed for this release: suppress it from surfaced queue data unless full proof-bound behavior is implemented.</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Validation</h2>
+      <ul>
+        <li>Queue projection and row rendering tests cover every intentionally surfaced type.</li>
+        <li>POS sync and terminal currentness tests prove resolved inventory review work stops counting as current.</li>
+        <li>Daily Close and Opening tests separate acknowledgment evidence from terminal work status.</li>
+        <li>Service, procurement, receiving, pending checkout, stock adjustment, and approval tests prove source-owned terminal transitions.</li>
+        <li>Source identity and duplicate-policy tests prevent retries, reprojection, or reopen flows from creating duplicate current rows.</li>
+        <li>Queue ordering and cap/overflow tests prove actionable work remains visible or explicitly paginated.</li>
+        <li>Sanitized row DTO tests prevent raw metadata, proof ids, hidden financial evidence, and internal sync payloads from reaching the UI.</li>
+        <li>Pre-ship visible-row audit migrates, terminally updates, or suppresses any row without a resolvable source target.</li>
+        <li>Browser verification confirms Open Work still looks and behaves like the existing workspace, with clearer rows rather than a new design.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-07-02-001-fix-open-work-resolution-plan.md
+++ b/docs/plans/2026-07-02-001-fix-open-work-resolution-plan.md
@@ -1,0 +1,541 @@
+---
+title: "fix: Close Open Work resolution gaps"
+type: fix
+status: active
+date: 2026-07-02
+deepened: 2026-07-02
+---
+
+# fix: Close Open Work resolution gaps
+
+## Summary
+
+Open Work should remain the store operations workspace for current operational work, not a generic admin console. The fix is to make every surfaced work type answer three questions clearly: who owns resolution, where the operator goes next, and what source transition removes the row from Open Work. The UI direction should stay the same: a dense, calm operations queue with type-specific row context and primary actions inside the existing `OperationsQueueView` patterns.
+
+The plan closes the highest-risk gaps first: `synced_sale_inventory_review`, `daily_close_carry_forward`, `service_appointment`, `service_deposit_review`, `purchase_order` cancellation semantics, and ambiguous rows that currently route operators to non-resolving workspaces.
+
+---
+
+## Problem Frame
+
+Open Work currently projects `operationalWorkItem` rows with `open` or `in_progress` status, plus adjacent approval work in the same component family. Some source workflows already update their linked work item on terminal source transitions. Others only create work, or route the operator to a workspace that does not actually resolve the work item.
+
+That leaves two operator-visible problems:
+
+| Problem | Effect |
+| --- | --- |
+| Missing terminal transition | Work can remain open after the real-world issue is handled. |
+| Missing or wrong owner action | Operators can click into a workspace that cannot resolve the row. |
+| Generic row context | The queue is technically populated but not operationally scannable. |
+| Approval/open-work ambiguity | Some items appear in both mental models without a clear handoff. |
+
+The fix should not redesign the Open Work workspace. It should preserve the current operations list/table direction, row density, filters, route, and component system while improving row-level meaning and source-owned resolution.
+
+---
+
+## Requirements
+
+- R1. Every work type intentionally surfaced on `/operations/open-work` must have one primary owning workflow and one primary next action in the row.
+- R2. Open Work must not provide a broad generic "resolve anything" control. Terminal state changes must remain source-owned unless a type-specific Operations-owned resolver is explicitly part of the domain.
+- R3. `synced_sale_inventory_review` must get a source-validated resolver so corrected, dismissed, or superseded inventory review work leaves Open Work and terminal currentness.
+- R4. `daily_close_carry_forward` must get an explicit terminal path. Daily Opening acknowledgment can preserve handoff evidence, but it cannot be the only lifecycle state if the work remains open.
+- R5. `service_appointment` work items must close or cancel when the appointment source workflow converts, completes, or cancels.
+- R6. `purchase_order` cancellation must preserve cancellation semantics instead of hiding as a completed work item.
+- R7. `pos_pending_checkout_item_review` rows must route to the unresolved catalog review owner before stock correction paths.
+- R8. `stock_adjustment_review` must clearly hand off to the approval owner when approval is the active resolution step, without duplicating an independent Open Work action.
+- R9. `service_deposit_review` approval work surfaced in the operations queue family must either receive full approve/reject behavior or be suppressed until supported. It must not strand unhandled approval rows.
+- R10. Row metadata, labels, and actions must follow the existing Open Work UI direction: same visual language, restrained copy, stable row dimensions, tabular numeric values, explicit owner/action labels, and no new card-heavy or marketing-style layout.
+- R11. Queue projection, terminal currentness, approval separation, and row rendering must have focused tests for source transitions, stale rows, ambiguous targets, and operator copy.
+- R12. Queue rows must expose sanitized per-type DTOs, not raw `operationalWorkItem.metadata` or source metadata. Sensitive proof ids, internal payloads, hidden financial evidence, and cross-store/source identifiers must not reach unauthorized queue viewers.
+- R13. Every surfaced work type must define a stable source identity and duplicate policy so retries, reprojection, reopen flows, and sync replays cannot create multiple current rows for the same source.
+- R14. Queue ordering, pagination, and cap/overflow behavior must be deterministic for mixed open work and approvals. The queue snapshot must sort by priority bucket, then status urgency, then oldest actionable timestamp, then stable id; keep `MAX_QUEUE_ITEMS = 100` as the server lane cap unless implementation intentionally changes it; and return explicit overflow metadata when a lane exceeds that cap.
+- R15. Every new terminal path must record auditable evidence: actor, authorization/proof basis where applicable, reason/outcome, source reference, prior state, next state, and domain trace metadata.
+
+---
+
+## Scope Boundaries
+
+- This plan does not redesign the Open Work route or replace `OperationsQueueView`.
+- This plan does not turn Daily Operations into the owner of work resolution. Daily Operations remains an aggregate/read model.
+- This plan does not add a generic administrative close button for arbitrary operational work items.
+- This plan does not move approval authority into React. Protected decisions remain server-owned with the existing manager-proof and approval boundaries.
+- This plan does not change POS sale continuity policy except where stale inventory-review evidence currently affects terminal currentness.
+- This plan does not introduce a new frontend design system, new color direction, or new layout shell.
+- This plan does not do broad historical cleanup. It does require a pre-ship audit of visible `open` / `in_progress` rows by type, and any visible row without a resolvable source target must be migrated, terminally updated, or suppressed before release.
+
+### Deferred to Follow-Up Work
+
+- A broader Operations information architecture redesign, if operators later need cross-workflow dashboards beyond this queue.
+- Bulk operations for Open Work rows.
+- Historical cleanup beyond rows still visible in Open Work after the pre-ship audit.
+- Capped terminal evidence-quality improvements unless implementation proves they are required for stale Open Work row removal.
+- New analytics around resolution time or queue load.
+
+---
+
+## Context & Research
+
+### Relevant Code
+
+- `packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/open-work.tsx` renders the Open Work route and delegates to `OperationsQueueView`.
+- `packages/athena-webapp/src/components/operations/OperationsQueueView.tsx` renders queue rows, approval rows, type labels, metadata, filters, pagination, and primary links.
+- `packages/athena-webapp/convex/operations/operationalWorkItems.ts` builds the queue snapshot from open/in-progress operational work, pending approvals, and synthetic register sync reviews.
+- `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts` creates `synced_sale_inventory_review`.
+- `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts` suppresses Cash Controls sync-review rows when Operations owns matching inventory review work.
+- `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts` projects current terminal review evidence toward Open Work.
+- `packages/athena-webapp/convex/operations/dailyClose.ts` creates or preserves carry-forward work.
+- `packages/athena-webapp/convex/operations/dailyOpening.ts` reads and acknowledges Opening handoff evidence.
+- `packages/athena-webapp/convex/serviceOps/serviceCases.ts` maps service case status to work item status.
+- `packages/athena-webapp/convex/serviceOps/appointments.ts` owns appointment conversion and cancellation source actions.
+- `packages/athena-webapp/convex/stockOps/purchaseOrders.ts` and `packages/athena-webapp/convex/stockOps/receiving.ts` own purchase order lifecycle transitions.
+- `packages/athena-webapp/convex/stockOps/adjustments.ts` owns stock adjustment approval application and rejection.
+- `packages/athena-webapp/convex/pos/public/catalog.ts` owns pending checkout item review resolution.
+- `packages/athena-webapp/convex/operations/approvalRequests.ts` dispatches approval decisions.
+
+### Institutional Learnings
+
+- `docs/solutions/design-patterns/athena-open-work-row-context-metadata-2026-06-29.md`: shared row shells are acceptable, but each work type owns title, icon, metadata, action, and expanded evidence.
+- `docs/solutions/logic-errors/athena-pos-sync-review-workspace-boundaries-2026-06-19.md`: synced-sale inventory review belongs to Operations once opened; Cash Controls should suppress matching open work.
+- `docs/solutions/logic-errors/athena-terminal-sync-review-currentness-2026-06-28.md`: terminal currentness must count only current actionable work, not stale raw conflicts.
+- `docs/solutions/logic-errors/athena-daily-operations-aggregate-read-model-2026-05-08.md`: Daily Operations routes back to source owners and must not invent lifecycle rules.
+- `docs/solutions/architecture/athena-manager-approval-authority-standard-2026-07-01.md`: approval authority must remain server-owned and proof-scoped.
+- `docs/product-copy-tone.md`: operator copy should be calm, clear, restrained, state-first, and action-oriented.
+
+### Frontend Direction
+
+The user explicitly wants repo-local frontend skills to inform the plan while maintaining the existing UI direction. Apply the frontend guidance conservatively:
+
+- Treat this as an existing app feature, so `OperationsQueueView` keeps the current visual system, spacing, type scale, controls, and list density.
+- Improve row scanability through type-specific title/action/metadata, not by adding cards inside cards or decorative surfaces.
+- Keep row actions familiar: icon plus concise text where the existing workspace already uses it, stable hit areas, visible focus states, and no layout shift from dynamic values.
+- Use tabular numerals for counts, prices, quantities, variances, and receipt-like numeric facts rendered in rows.
+- Use `text-wrap: balance` only for short headings and `text-wrap: pretty` for short row descriptions if the existing styling supports it.
+- Avoid page-load animation or ornamental motion. For high-frequency queue interactions, prefer instant or very short state feedback.
+
+---
+
+## Key Technical Decisions
+
+- **Source-owned resolution remains the invariant.** The queue shows work; source workflows close or cancel work. This matches service cases, purchase orders, stock approvals, and the Daily Operations aggregate pattern.
+- **Every surfaced type gets a primary owner/action contract.** A row without a resolving destination is treated as a bug, not a generic queue fallback.
+- **Operations owns the `synced_sale_inventory_review` resolver contract.** This work is intentionally suppressed from Cash Controls when open, so it needs a named Operations-owned, source-validated terminal path rather than implicit matching against arbitrary stock adjustments.
+- **Daily Close owns carry-forward terminal actions.** Daily Opening remains read/ack-only for handoff evidence; Daily Close provides the narrow typed completion/cancellation helper or mutation.
+- **Approval work remains approval-owned.** If the active next step is approval, the row should say that and link to the approval owner rather than presenting a second Open Work action.
+- **Existing UI direction governs the frontend work.** The implementation should add row mapping, copy, links, focus states, and stable numeric treatment inside current components. It should not create a new dashboard, split-page layout, or card-first redesign.
+- **Unsupported approval types must fail closed.** `service_deposit_review` should be suppressed or creation should stop in this release; full approve/reject semantics are a follow-up unless implemented end to end with existing server proof rules.
+- **Tests are the contract for old rows.** Existing terminal source behaviors should get characterization coverage before behavior changes, so implementation can distinguish intentional source-owned lifecycle from real gaps.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should Open Work have a generic resolver?** No. The repo patterns and prior learnings favor source-owned resolution.
+- **Should the Open Work UI be redesigned?** No. The direction is incremental row/action clarity within the existing workspace.
+- **Should Opening acknowledgment resolve carry-forward work?** No as the default. Existing tests expect acknowledgment to keep work open, so a separate explicit terminal path is needed unless implementation discovers a stronger source rule.
+- **Should `synced_sale_inventory_review` close through Cash Controls register sync review?** No as the default. Once Operations owns the open inventory review, Cash Controls should not double-own it.
+- **Should pending checkout review route first to stock adjustment?** No. The catalog/unresolved-products owner should handle the unresolved item first; stock correction can follow after catalog resolution.
+- **Who owns `daily_close_carry_forward` terminal actions?** Daily Close owns completion/cancellation through a narrow typed helper or mutation; Daily Opening remains read/ack-only.
+- **What is the `service_deposit_review` decision for this slice?** Fail closed: suppress it from surfaced queue data or stop creating it until full approval semantics are implemented.
+
+### Deferred to Implementation
+
+- Whether `service_deposit_review` full approval semantics should be implemented in a follow-up depends on the service deposit domain workflow and manager-proof product decision.
+- Whether a small data cleanup is needed for old orphaned `synced_sale_inventory_review` or `daily_close_carry_forward` rows should be decided after the pre-ship visible-row audit.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  OW["Open Work route / OperationsQueueView"] --> QS["Queue snapshot"]
+  QS --> WI["open or in_progress operationalWorkItem"]
+  QS --> AR["pending approvalRequest"]
+  QS --> SR["synthetic register sync review approvals"]
+
+  WI --> RC["Row contract: owner, action, metadata, terminal rule"]
+  RC --> SW["Source workflow"]
+  SW --> TR["completed or cancelled work item"]
+  TR --> QS
+
+  AR --> AO["Approval owner"]
+  SR --> CO["Cash Controls owner"]
+```
+
+The row contract should be explicit enough that an implementer can reason about each surfaced type:
+
+| Work type/state | Stable source identity | Primary owner | Primary row action | Terminal rule | Duplicate policy |
+| --- | --- | --- | --- | --- | --- |
+| `service_case` | `serviceCaseId` | Service case workflow | Open service case | Service case completed/cancelled status sync | One current work item per service case |
+| `service_appointment` while appointment is open | `appointmentId` | Service appointment workflow | Open appointment | Appointment cancellation cancels work; conversion closes appointment work and transfers operator context to the service case if needed | One current appointment work item per appointment |
+| `purchase_order` | `purchaseOrderId` | Procurement/receiving | Open purchase order | Received/completed completes work; cancelled cancels work | One current work item per purchase order |
+| `stock_adjustment_review` with pending approval | `approvalRequestId` and `stockAdjustmentBatchId` | Approval requests | Review adjustment approval | Approval applies or rejects adjustment and terminally updates linked work | One current approval row per adjustment approval request |
+| `pos_pending_checkout_item_review` | canonical key: `posPendingCheckoutItem._id`; local-sync fallback before cloud id: store id, terminal id, `localRegisterSessionId`, `localIdKind: "pendingCheckoutItem"`, and local `pendingCheckoutItemId` | Unresolved catalog review | Review catalog item | Link/approve/reject completes; flag keeps the same work open | One current work item per pending checkout item key; SKU-only matching is forbidden |
+| `synced_sale_inventory_review` | canonical idempotency key: mapping `{ storeId, terminalId, localRegisterSessionId, localIdKind: "inventoryReviewWorkItem", localId: "${localTransactionId}:inventory-review" }` | Operations inventory review | Resolve sale inventory review | Operations resolver completes, cancels, or supersedes current work with audit evidence | Reprojection reuses the existing mapped work item for that key; `registerSessionId`, `sourceId`, and `receiptNumber` validate context but do not define idempotency |
+| `daily_close_carry_forward` | store, business date, daily close/carry-forward source id | Daily Close | Resolve carry-forward follow-up | Daily Close helper completes or cancels work with handoff/audit evidence | One current carry-forward item per source id and business date |
+| `service_deposit_review` | service intake/case deposit subject | Not surfaced in this release | Not surfaced | Creation/surfacing is suppressed until full server-owned approval semantics exist | No unsupported current approval row may appear |
+
+### Queue Snapshot Ordering and Overflow Contract
+
+The queue snapshot must keep first-page visibility deterministic when current work exceeds the server cap:
+
+- Priority bucket order: approval-blocked work that is represented in Open Work, source-owned resolver work, source workflow continuation work, informational/handoff work.
+- Status urgency: `in_progress` before `open` within the same bucket when both are actionable; approvals keep their existing pending decision order in the approvals lane.
+- Tie-breakers: oldest actionable timestamp first, then stable source identity, then work item id for deterministic output.
+- Server cap: keep `MAX_QUEUE_ITEMS = 100` for each server lane in this slice: `open`, `in_progress`, and pending approvals. If implementation changes this value, update the plan/tests with the new explicit value before coding.
+- Required overflow response shape: probe each lane with `MAX_QUEUE_ITEMS + 1`, return the first `MAX_QUEUE_ITEMS`, and include `overflow: { workItems: { open: boolean, inProgress: boolean }, approvalRequests: boolean }` on the queue snapshot. The UI must surface the relevant overflow state rather than silently truncating.
+- Evidence: tests should seed more than `100` rows per lane across buckets/types and prove the first page contains the highest-priority actionable rows, ordering is stable across retries, and the overflow metadata is visible to the UI.
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 lifecycle characterization"] --> U2["U2 row contract and UI mapping"]
+  U1 --> U3["U3 synced-sale inventory resolver"]
+  U1 --> U4["U4 carry-forward resolver"]
+  U1 --> U5["U5 source workflow terminal fixes"]
+  U2 --> U6["U6 approval ownership and service deposit"]
+  U3 --> U7["U7 terminal currentness and validation"]
+  U4 --> U7
+  U5 --> U7
+  U6 --> U7
+```
+
+- U1. **Characterize Open Work projection and existing terminal behavior**
+
+**Goal:** Lock down how Open Work currently includes and excludes work, which source workflows already close rows, and where rows are orphaned.
+
+**Requirements:** R1, R2, R11, R13, R14, R15
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/operationalWorkItems.test.ts`
+- Modify: `packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx`
+- Inspect as needed: `packages/athena-webapp/convex/operations/operationalWorkItems.ts`
+
+**Approach:**
+- Add tests that prove `open` and `in_progress` rows appear while `completed` and `cancelled` rows do not.
+- Add fixture coverage for every intentionally surfaced work type in the table above.
+- Add source-identity fixtures for each surfaced work type so retries, reprojection, and reopened source flows prove they reuse or intentionally create rows according to the duplicate policy.
+- Add queue ordering and cap/overflow characterization with mixed open work and approvals so implementation does not hide high-priority actionable rows. Use the ordering contract from High-Level Technical Design: priority bucket, status urgency, oldest actionable timestamp, stable source identity, then work item id; probe `MAX_QUEUE_ITEMS + 1` for overflow metadata.
+- Capture current row labels/actions before implementation changes so UI updates are deliberate.
+- Keep this unit focused on behavior characterization; do not add new lifecycle logic here unless a test helper must expose existing behavior.
+
+**Test scenarios:**
+- Queue snapshot includes an open `synced_sale_inventory_review` and excludes it after terminal status is patched by a source helper.
+- Queue snapshot separates open work rows from approval rows.
+- Queue snapshot orders mixed work deterministically and exposes the required `overflow` booleans when `open`, `in_progress`, or approval lanes exceed `MAX_QUEUE_ITEMS = 100`.
+- Duplicate source events for the same source identity do not create multiple current rows.
+- `OperationsQueueView` renders existing row structure and preserves filters, sort, and pagination for mixed work types.
+
+**Verification:**
+- Focused Convex queue snapshot tests pass.
+- Focused `OperationsQueueView` tests pass with current layout expectations.
+
+- U2. **Add type-specific row contracts without changing the workspace direction**
+
+**Goal:** Make each row operationally scannable and actionable while preserving the existing Open Work UI.
+
+**Requirements:** R1, R7, R8, R10, R11, R12
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/operations/OperationsQueueView.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx`
+
+**Approach:**
+- Centralize row presentation mapping near the existing type-label/action helpers rather than spreading conditional copy across JSX.
+- Add primary owner/action mapping for service case, service appointment, purchase order, stock adjustment review, pending checkout review, synced sale inventory review, and daily close carry-forward.
+- Do not map `service_deposit_review` as a normal row in U2; U6 decides fail-closed suppression for this release.
+- Route `pos_pending_checkout_item_review` to the unresolved catalog review owner before stock adjustment correction.
+- For `stock_adjustment_review`, make approval review the sole primary action when approval is active.
+- Project sanitized per-type row DTOs rather than passing raw metadata through to React.
+- Keep the current list/table density, icons, row shell, action placement, empty states, and surrounding controls.
+- Use operator-safe copy: state first, then next action. Avoid raw backend type strings in visible text.
+- Keep row dimensions stable. Numeric metadata such as quantities, prices, counts, and receipt numbers should not cause layout shift.
+- Keep actions accessible with visible focus and at least the current hit-area standard.
+
+**Allowed row metadata fields:**
+- Service rows: public case/appointment label, customer display name if already visible in the service workflow, due/scheduled time, owner/status label, safe source id for navigation.
+- Purchase rows: PO display number, vendor display name, receiving status, item count, safe source id for navigation.
+- Stock adjustment approval rows: adjustment display label, item count, reason label, approval request id for the approval action, no manager proof payload.
+- Pending checkout rows: product/SKU display text, quantity, price when already visible to catalog reviewers, safe pending item id.
+- Synced sale inventory rows: receipt/register display label, product/SKU display text, quantity delta/status label, safe source id for the resolver action.
+- Carry-forward rows: business date, source workflow label, short follow-up reason, safe source id for the Daily Close resolver action.
+
+Raw source metadata, proof ids, hidden financial evidence, internal sync payloads, and cross-store identifiers should stay server-side.
+
+**Test scenarios:**
+- Each supported work type renders a calm title, owner/action label, and destination link.
+- Pending checkout rows route to unresolved catalog review, not directly to stock adjustment.
+- Stock adjustment rows identify approval as the next owner when approval is pending.
+- Raw `operationalWorkItem.metadata`, manager proof ids, internal sync payloads, and hidden financial evidence do not appear in rendered row props or visible copy.
+- Long product names, receipt identifiers, and customer names do not push actions out of the row.
+- Dynamic numeric values render in stable numeric spans where the component controls them.
+
+**Verification:**
+- Focused UI tests cover all row mappings.
+- Browser review of `/wigclub/store/wigclub/operations/open-work` confirms the page still looks like the existing Open Work workspace.
+
+- U3. **Implement `synced_sale_inventory_review` terminal ownership**
+
+**Goal:** Give Operations-owned synced sale inventory work a real close path and keep terminal currentness tied to current work.
+
+**Requirements:** R2, R3, R11, R13, R15
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Create or modify: `packages/athena-webapp/convex/operations/openWorkInventoryReviews.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts`
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts`
+- Modify: `packages/athena-webapp/src/components/operations/OperationsQueueView.tsx`
+- Modify or create focused tests near: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+- Create or modify focused tests near: `packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/terminals.test.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.test.ts` if Cash Controls suppression behavior needs regression coverage
+
+**Approach:**
+- Add an Operations-owned resolver boundary, `openWorkInventoryReviews.resolveSyncedSaleInventoryReview`, that `OperationsQueueView` can invoke from the synced-sale inventory row action.
+- The resolver must authenticate the caller, validate organization/store membership, validate the work item type/status, validate terminal/session/sale/source metadata, require current open work state, and reject cross-store, wrong-terminal, wrong-session, wrong-sale, and already-terminal attempts.
+- Completing after a linked corrective inventory action should use the existing stock/inventory authorization boundary. Dismissal/cancellation that accepts no correction requires manager proof or the narrowest existing operational role that can make inventory-review decisions.
+- Treat inventory correction, explicit dismissal, cancellation, and superseded stale evidence as separate audited outcomes if the current data model can support them without schema churn.
+- Keep Cash Controls suppression keyed to open matching Operations work; once the Operations work is terminal, terminal currentness and sync-review evidence should drop it.
+- Avoid implicit SKU-only matching against arbitrary stock adjustments. The resolver needs enough source context to avoid closing the wrong sale's work.
+- Enforce the canonical mapping key `{ storeId, terminalId, localRegisterSessionId, localIdKind: "inventoryReviewWorkItem", localId: "${localTransactionId}:inventory-review" }` so retry/reprojection reuses the current row and terminal rows do not reopen without a new canonical key. `registerSessionId`, `sourceId`, `receiptNumber`, and trusted line metadata validate context but do not define idempotency.
+- Record actor, proof/authority basis, outcome, reason, source reference, prior state, next state, and domain trace metadata on completion, cancellation, or supersession.
+
+**Test scenarios:**
+- Creating a synced sale inventory review opens one Operations-owned work item and suppresses duplicate Cash Controls register sync review for the same current issue.
+- Resolving the review completes or cancels the work item and removes it from terminal currentness.
+- Stale closed-session or superseded review evidence no longer counts as actionable current work.
+- Duplicate local sync retries reuse the existing current row for the same inventory-review mapping key; SKU-only, receipt-only, and cloud-id-only matching are rejected for idempotency.
+- Resolver rejects cross-store, wrong-terminal, wrong-session, wrong-sale, and already-terminal attempts.
+- Dismissal, cancellation, completion, and supersession record audit evidence.
+
+**Verification:**
+- POS sync, terminal currentness, and Cash Controls suppression tests pass.
+
+- U4. **Add a terminal path for daily close carry-forward work**
+
+**Goal:** Make Daily Close the source owner for carry-forward terminal actions: Opening can acknowledge it, but Daily Close completes or cancels it after follow-up.
+
+**Requirements:** R2, R4, R10, R11, R13, R15
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/dailyClose.ts`
+- Modify: `packages/athena-webapp/convex/operations/dailyOpening.ts`
+- Modify: `packages/athena-webapp/convex/operations/dailyClose.test.ts`
+- Modify: `packages/athena-webapp/convex/operations/dailyOpening.test.ts`
+- Modify: `packages/athena-webapp/src/components/operations/OperationsQueueView.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx`
+
+**Approach:**
+- Preserve current behavior where Opening acknowledgment can record handoff context without automatically closing the work.
+- Add a narrow typed Daily Close completion/cancellation helper or mutation in `dailyClose.ts`.
+- Keep Daily Opening read/ack-only for this lifecycle. It may link the operator to the carry-forward row, but it must not own the terminal transition.
+- Completion/cancellation requires consumed manager proof bound to the `daily_close_carry_forward` subject/source. Queue-viewer access or organization/store membership alone is not sufficient.
+- The Daily Close resolver/helper must authenticate the caller, validate organization/store membership, consume and bind manager proof, validate business date, validate linked daily close/carry-forward source metadata, validate work item type/status, and reject already-terminal or mismatched source attempts.
+- Completing/cancelling carry-forward work must record actor, proof/authority basis, outcome, reason, source reference, prior state, next state, and handoff/audit metadata.
+- Add calm operator copy for the typed resolution action.
+- Ensure Daily Operations continues to aggregate and route, not own the terminal transition.
+
+**Test scenarios:**
+- Daily Close creates or preserves carry-forward work with enough metadata for the Open Work row.
+- Opening acknowledgment records handoff evidence and leaves the item open.
+- Completing the carry-forward removes it from Open Work without deleting historical handoff evidence.
+- Cancelling/marking not applicable records a terminal state with a reason.
+- Duplicate carry-forward source projection for the same business date/source id reuses the current row.
+- Cross-store, wrong-business-date, wrong-source, and already-terminal attempts are rejected.
+- Unauthorized queue viewers cannot complete or cancel carry-forward work.
+- Consumed manager proof must be bound to the carry-forward subject/source and persisted in audit evidence.
+- Missing or stale referenced source data produces safe copy and does not crash the row.
+
+**Verification:**
+- Daily Close, Daily Opening, and Open Work UI tests pass.
+
+- U5. **Harden remaining source workflow terminal transitions**
+
+**Goal:** Close known gaps in source-owned workflows that already have domain lifecycle actions.
+
+**Requirements:** R2, R5, R6, R7, R11, R13, R15
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/serviceOps/appointments.ts`
+- Modify: `packages/athena-webapp/convex/serviceOps/catalogAppointments.test.ts`
+- Modify: `packages/athena-webapp/convex/serviceOps/serviceCases.test.ts`
+- Modify: `packages/athena-webapp/convex/stockOps/purchaseOrders.ts`
+- Modify: `packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts`
+- Modify: `packages/athena-webapp/convex/stockOps/receiving.ts`
+- Modify: `packages/athena-webapp/convex/stockOps/receiving.test.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/catalog.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/catalog.test.ts`
+
+**Approach:**
+- Make `service_appointment` lifecycle changes update linked work items when appointments convert, complete through a case, or cancel.
+- Appointment conversion should close the appointment work item; if follow-up work continues, it should be represented by the service case source row rather than an appointment row that points to a converted case.
+- Preserve existing `service_case` status mapping and strengthen tests around terminal status.
+- Change purchase order cancellation mapping to `cancelled` if current tests confirm it is only using `completed` to hide rows.
+- Preserve receiving completion behavior.
+- Strengthen pending checkout tests so link/approve/reject complete the item and flagged review stays open.
+- Record audit evidence for appointment conversion/cancel, purchase order cancellation, and any new terminal status patch added in this unit.
+- Enforce one current work item per source identity for appointment, service case, purchase order, and pending checkout item rows.
+
+**Test scenarios:**
+- Appointment cancellation cancels the linked work item.
+- Appointment conversion to a service case closes the appointment work item and does not leave a stale appointment row.
+- Completed/cancelled service cases leave Open Work.
+- Received purchase orders complete linked work; cancelled purchase orders cancel linked work.
+- Pending checkout link/approve/reject complete; flagged review stays open and routes to catalog review.
+- Retry/reopen cases do not create duplicate current rows for the same source identity.
+- Appointment conversion/cancel and purchase order cancellation persist auditable actor/source/outcome evidence.
+
+**Verification:**
+- Service, procurement, receiving, and pending checkout focused tests pass.
+
+- U6. **Resolve approval ownership ambiguity**
+
+**Goal:** Keep approvals separate and fail closed for unsupported `service_deposit_review` rows in this release.
+
+**Requirements:** R8, R9, R11, R12, R15
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/approvalRequests.ts`
+- Modify: `packages/athena-webapp/convex/operations/approvalRequests.test.ts`
+- Modify: `packages/athena-webapp/convex/operations/serviceIntake.ts` if `service_deposit_review` creation must be suppressed or retargeted
+- Modify: `packages/athena-webapp/src/components/operations/OperationsQueueView.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx`
+
+**Approach:**
+- Scope this unit to `stock_adjustment_review` handoff copy/regression and `service_deposit_review` surfaced-row handling. Do not expand into a general approval-system audit.
+- Fail closed for `service_deposit_review` in this release: suppress creation or suppress surfacing from queue data until full approve/reject semantics exist.
+- Normalize any stale `service_deposit` fixture/type naming so tests use the real unsupported approval type intentionally.
+- If implementation discovers full `service_deposit_review` support is already safer than suppression, approve/reject must run only through the existing server-owned approval path with consumed manager proof and subject binding.
+- Any full implementation must validate approval request store/org, service deposit/case/intake subject, linked work item, requester/reviewer/proof lanes, and domain effect before applying or rejecting the deposit decision.
+- Make approval rows say the approval owner and protected action, not generic work copy.
+- Keep manager authority and proof handling in server mutations.
+
+**Test scenarios:**
+- `inventory_adjustment_review` continues to approve/reject stock adjustment work and terminally update linked work items.
+- `register_sync_review` remains Cash Controls-owned and resolves through Cash Controls.
+- `service_deposit_review` is intentionally absent from surfaced queue data or not created in this release.
+- If any implementation path makes `service_deposit_review` actionable instead, tests prove proof consumption, subject binding, store/org validation, and domain effect matching.
+- Unsupported approval decisions fail with safe server-side errors, not silent UI no-ops.
+
+**Verification:**
+- Approval request tests and Open Work approval UI tests pass.
+
+- U7. **Run integration, visual, and graph validation**
+
+**Goal:** Prove the queue is stable end to end and document the invariant for future work types.
+
+**Requirements:** R10, R11, R12, R13, R14, R15
+
+**Dependencies:** U2, U3, U4, U5, U6
+
+**Files:**
+- Modify or add: `docs/solutions/` note for the final Open Work source-owned resolution invariant
+- Generated after code changes: `graphify-out/`
+
+**Approach:**
+- Run the focused Vitest set for queue projection, Open Work UI, POS sync currentness, Daily Close/Opening, service appointment/case transitions, purchase orders/receiving, pending checkout, stock adjustment approvals, and approval requests.
+- Run a pre-ship audit of current visible `open` / `in_progress` rows by type. Any row still visible without a resolvable source target must be migrated, terminally updated, or suppressed before release.
+- Prove deterministic queue ordering and the required overflow response shape with more than `MAX_QUEUE_ITEMS = 100` current rows in each lane.
+- Run Convex validation, changed-file linting, typecheck/build gates appropriate for the modified files.
+- Run `bun run graphify:rebuild` after code changes.
+- Browser-review `/wigclub/store/wigclub/operations/open-work` and compare against the existing workspace direction: same shell and density, clearer row copy/actions, no new visual language.
+
+**Test scenarios:**
+- Mixed queue data renders with every supported row type and no layout breakage.
+- Terminal source transitions remove rows from Open Work.
+- Approval rows remain separate from open work rows.
+- Terminal currentness no longer counts resolved synced sale inventory review work.
+- Daily carry-forward completion removes the work while preserving handoff evidence.
+- Queue overflow is explicit through `overflow.workItems.open`, `overflow.workItems.inProgress`, and `overflow.approvalRequests` when mixed current work exceeds `MAX_QUEUE_ITEMS = 100`.
+- Sanitized row DTOs do not expose raw metadata or proof/internal payloads.
+- New terminal paths record audit evidence.
+
+**Verification:**
+- Focused tests pass.
+- Convex/typecheck/build validation passes for touched areas.
+- Graphify rebuild completes after code changes.
+- Browser verification confirms Open Work UI direction is preserved.
+
+---
+
+## System-Wide Impact
+
+- **Operations queue:** `operationalWorkItems.ts` remains the read model for current work, but it should expose sanitized row DTOs with enough metadata for row owner/action routing and no raw metadata passthrough.
+- **POS local sync:** `synced_sale_inventory_review` becomes resolvable current work instead of a potentially stale projection.
+- **Terminal health/currentness:** currentness should drop resolved Operations-owned inventory review work.
+- **Cash Controls:** register sync review suppression must continue to respect open Operations-owned inventory work but stop suppressing once that work is terminal.
+- **Daily Close/Opening:** carry-forward handoff evidence and terminal state become separate concepts.
+- **Service operations:** appointment and case source transitions must not leave orphan work items.
+- **Procurement/receiving:** cancellation semantics become visible in audit state.
+- **Approvals:** unsupported approval types are either implemented or not surfaced.
+- **Frontend:** `OperationsQueueView` gains type-specific row mapping while preserving current route, density, component styling, accessibility expectations, and operator tone.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Closing the wrong synced sale inventory review | Inventory review evidence disappears incorrectly. | Resolver must validate store, source metadata, sale/session/terminal context, and current open work state. |
+| Carry-forward completion loses Opening evidence | Operators lose audit trail for handoff work. | Keep acknowledgment/handoff evidence separate from terminal work status. |
+| UI changes drift into a redesign | Review scope grows and operators lose familiar workspace affordances. | Limit changes to row mapping/copy/actions in `OperationsQueueView`; browser-review against existing route. |
+| Approval authority moves client-side | Protected decisions could bypass server proof rules. | Keep approval decisions in Convex mutations and tests. |
+| Purchase order cancellation semantics affect reports | Existing consumers may treat hidden completed rows as neutral. | Characterize consumers first and test cancelled status projection. |
+| Old orphan rows persist after fix | Operators may still see historical stale rows. | Run the visible-row audit before release and migrate, terminally update, or suppress any row without a resolvable source target. |
+| Queue DTO leaks raw source metadata | Unauthorized operators could see proof ids, hidden financial evidence, or internal sync payloads. | Project sanitized per-type DTOs and add negative exposure tests. |
+| Status-only terminal patches erase audit trail | Rows disappear but support cannot explain who resolved what and why. | Require audit evidence for every new completion, cancellation, dismissal, and supersession path. |
+| Queue caps hide important current work | Operators miss actionable rows even though work exists. | Define deterministic ordering and explicit overflow tests above `MAX_QUEUE_ITEMS = 100` for each lane. |
+
+---
+
+## Validation Plan
+
+- `packages/athena-webapp/convex/operations/operationalWorkItems.test.ts`
+- `packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts`
+- `packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx`
+- `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+- `packages/athena-webapp/convex/pos/application/terminals.test.ts`
+- `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+- `packages/athena-webapp/convex/operations/dailyClose.test.ts`
+- `packages/athena-webapp/convex/operations/dailyOpening.test.ts`
+- `packages/athena-webapp/convex/serviceOps/catalogAppointments.test.ts`
+- `packages/athena-webapp/convex/serviceOps/serviceCases.test.ts`
+- `packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts`
+- `packages/athena-webapp/convex/stockOps/receiving.test.ts`
+- `packages/athena-webapp/convex/pos/public/catalog.test.ts`
+- `packages/athena-webapp/convex/stockOps/adjustments.test.ts`
+- `packages/athena-webapp/convex/operations/approvalRequests.test.ts`
+- Pre-ship visible-row audit for current `open` / `in_progress` rows by type
+- Queue ordering and cap/overflow coverage above `MAX_QUEUE_ITEMS = 100` for each lane
+- Negative row DTO exposure tests for raw metadata, proof ids, hidden financial evidence, and internal sync payloads
+- Browser verification of `/wigclub/store/wigclub/operations/open-work`
+- Post-code-change graph rebuild with `bun run graphify:rebuild`
+
+---
+
+## Plan Handoff Notes
+
+- Start implementation with U1 tests so later units can distinguish current behavior from regression.
+- Keep U2 frontend work constrained to the current workspace direction; UI reviewers should reject layout redesigns in this slice.
+- Treat U3 and U4 as the highest-risk backend lifecycle gaps because they can leave stale current work.
+- Treat U6 as a hard release gate: `service_deposit_review` must be unsupported-and-unsurfaced or fully implemented with proof-bound approve/reject behavior.
+- Treat visible legacy rows as a release gate, not a deferred cleanup, when the pre-ship audit finds rows without resolvable source targets.
+- If any unit discovers a missing source index or schema need, add the smallest schema change and include migration/data-integrity review before implementation proceeds.

--- a/docs/solutions/architecture-patterns/athena-open-work-resolution-ownership-2026-07-02.md
+++ b/docs/solutions/architecture-patterns/athena-open-work-resolution-ownership-2026-07-02.md
@@ -1,0 +1,107 @@
+---
+title: Athena Open Work Resolution Ownership
+date: 2026-07-02
+category: architecture-patterns
+module: athena-webapp
+problem_type: architecture_pattern
+component: service_object
+resolution_type: workflow_improvement
+severity: medium
+applies_when:
+  - "Adding or changing Open Work item types"
+  - "Linking Operations rows to source workflows"
+  - "Resolving review work created from POS sync, Daily Close, service, stock, or catalog workflows"
+tags:
+  - athena-webapp
+  - operations
+  - open-work
+  - work-items
+  - resolution
+  - convex
+---
+
+# Athena Open Work Resolution Ownership
+
+## Problem
+
+Open Work is an aggregate workspace, but each row still belongs to a source
+workflow with its own authority, evidence, and terminal states. Treating the
+queue row as the owner of every resolution path creates stale rows, duplicate
+reviews, or UI actions that send operators to the wrong workspace.
+
+## Solution
+
+Keep Open Work responsible for discovery, prioritization, sanitized row shape,
+and cross-workflow navigation. Resolution belongs to the source workflow unless
+there is a narrow Operations-owned decision with a stable source identity.
+
+The baseline contract is:
+
+- The queue returns sanitized row DTOs, deterministic ordering, stable
+  `sourceIdentity`, and per-lane overflow metadata. UI rows should not infer
+  action targets from raw metadata.
+- Source workflows terminally patch their current work rows when their own
+  action completes, cancels, or converts the underlying subject. Service
+  appointments, service cases, purchase orders, receiving, and unresolved
+  catalog decisions stay source-owned.
+- POS synced sale inventory reviews are the exception that Operations owns:
+  resolution must validate the current store, terminal, register session, sale,
+  work item type/status, and canonical local mapping key
+  `inventoryReviewWorkItem:${localTransactionId}:inventory-review`.
+- Daily Close owns carry-forward completion and cancellation. It must consume
+  manager proof bound to `daily_close_carry_forward` and the
+  `dailyCloseId:sourceId` subject before mutating the row.
+- Unsupported approval rows should fail closed or be suppressed. Do not surface
+  `service_deposit_review` until there is a complete proof-bound source
+  workflow for it.
+
+## Why This Matters
+
+Operators need one place to see unresolved work, but that does not mean one
+mutation can safely resolve every workflow. Keeping ownership explicit preserves
+audit evidence, prevents stale rows after source actions, and avoids using
+receipt numbers, product names, or internal ids as accidental idempotency keys.
+
+## Prevention
+
+- Add source-workflow tests whenever a source action should complete, cancel,
+  or continue an Open Work row.
+- Add negative tests for wrong terminal, wrong store, wrong source metadata,
+  stale work status, and receipt-only or SKU-only matching.
+- Treat manager proof as consumed evidence at the command boundary that owns
+  the decision.
+- Keep unsupported work types out of the visible queue, or render them without
+  a primary action while backend mutations fail closed.
+- Preserve the existing Open Work UI direction: calm rows, type-specific copy,
+  explicit next actions, and no raw proof or internal metadata in collapsed
+  row content.
+
+## Examples
+
+When a pending checkout item is linked to a real catalog product, the POS
+catalog mutation completes the matching current
+`pos_pending_checkout_item_review` row. Open Work links the operator to the
+unresolved catalog workflow, but it does not invent a separate review decision.
+
+When a synced sale creates an inventory review, Operations may resolve it only
+through the canonical local mapping:
+
+```text
+storeId
+terminalId
+localRegisterSessionId
+localIdKind = inventoryReviewWorkItem
+localId = ${localTransactionId}:inventory-review
+```
+
+That mapping is the durable source identity. Receipt numbers, cloud transaction
+ids, and product SKU ids are useful context, not resolution keys.
+
+## Related
+
+- `docs/solutions/design-patterns/athena-open-work-row-context-metadata-2026-06-29.md`
+- `docs/solutions/logic-errors/athena-pos-sync-review-workspace-boundaries-2026-06-19.md`
+- `docs/solutions/architecture/athena-manager-approval-authority-standard-2026-07-01.md`
+- `packages/athena-webapp/convex/operations/operationalWorkItems.ts`
+- `packages/athena-webapp/convex/operations/openWorkInventoryReviews.ts`
+- `packages/athena-webapp/src/components/operations/OperationsQueueView.tsx`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2156 files · ~0 words
+- 2158 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8413 nodes · 10081 edges · 2083 communities detected
+- 8474 nodes · 10200 edges · 2085 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2093,6 +2093,8 @@
 - [[_COMMUNITY_Community 2080|Community 2080]]
 - [[_COMMUNITY_Community 2081|Community 2081]]
 - [[_COMMUNITY_Community 2082|Community 2082]]
+- [[_COMMUNITY_Community 2083|Community 2083]]
+- [[_COMMUNITY_Community 2084|Community 2084]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2121,8 +2123,8 @@
 ## Communities
 
 ### Community 0 - "Community 0"
-Cohesion: 0.05
-Nodes (77): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildApprovalRequestsById(), buildDailyCloseApprovalSubject() (+69 more)
+Cohesion: 0.04
+Nodes (90): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), asCarryForwardItem(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildApprovalRequestsById() (+82 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.06
@@ -2137,12 +2139,12 @@ Cohesion: 0.06
 Nodes (66): attentionSeverity(), automationRunClassification(), automationStatusBucketForRun(), buildApprovalsLane(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents() (+58 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.09
-Nodes (61): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), capNonCashPaymentsToExpectedTotal(), collectExistingSaleMappings() (+53 more)
-
-### Community 5 - "Community 5"
 Cohesion: 0.04
 Nodes (32): buildDailyCloseExpenseSearch(), buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), getBucketCountClassName(), getDailyCloseSalesMetricLabels(), getDailyCloseStatus(), getDisplayMetadataLabel() (+24 more)
+
+### Community 5 - "Community 5"
+Cohesion: 0.09
+Nodes (61): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), capNonCashPaymentsToExpectedTotal(), collectExistingSaleMappings() (+53 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.05
@@ -2185,32 +2187,32 @@ Cohesion: 0.07
 Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
 ### Community 16 - "Community 16"
+Cohesion: 0.07
+Nodes (19): Boolean(), buildMissingDraftResult(), formatQueueWorkItemValue(), formatWorkItemTitle(), getQueueWorkItemInventoryReviewLineCount(), getQueueWorkItemNumberDetail(), getQueueWorkItemStockAdjustmentSkuId(), getQueueWorkItemStringDetail() (+11 more)
+
+### Community 17 - "Community 17"
 Cohesion: 0.08
 Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
 
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
 Cohesion: 0.14
 Nodes (35): asRecord(), calculateLocalSaleExpectedCashDelta(), canUploadedRegisterOpenReplaceBlockedDrawer(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale() (+27 more)
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.11
 Nodes (33): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+25 more)
 
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
 Cohesion: 0.13
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.08
 Nodes (21): buildDisplaySafeConflictSummary(), buildTerminalSyncReviewSummary(), classifyTerminalSyncReviewConflict(), dedupeConflictsById(), emptyTerminalSyncReviewSummary(), getConflictBusinessKey(), getCurrentConflictKey(), getLatestRuntimeStatusForTerminal() (+13 more)
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.1
 Nodes (25): applyTodayRefreshSnapshot(), buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), formatOnlineOrderTimelineFallbackMessage(), formatPendingApprovalsLabel(), formatTimelineMessage() (+17 more)
-
-### Community 22 - "Community 22"
-Cohesion: 0.07
-Nodes (15): buildMissingDraftResult(), formatQueueWorkItemValue(), formatWorkItemTitle(), getQueueWorkItemArrayMetadataCount(), getQueueWorkItemInventoryReviewLineCount(), getQueueWorkItemStockAdjustmentSkuId(), getQueueWorkItemStringMetadata(), getQueueWorkItemTransactionId() (+7 more)
 
 ### Community 23 - "Community 23"
 Cohesion: 0.07
@@ -2385,1008 +2387,1008 @@ Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
 ### Community 66 - "Community 66"
+Cohesion: 0.17
+Nodes (15): actionableWorkItemTimestamp(), buildOperationalWorkItem(), compareOperationalWorkItems(), compareStrings(), createOperationalWorkItemWithCtx(), joinSourceIdentity(), metadataArrayCount(), metadataNumber() (+7 more)
+
+### Community 67 - "Community 67"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.21
 Nodes (18): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), formatRecoveryCode(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode() (+10 more)
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.13
 Nodes (9): asCloudOperableSession(), countPendingSyncableLocalEventsForStaff(), hasSyncedSaleLocalEventsForStaff(), hasUploadedLocalEventsForStaff(), isCloudOperableSession(), isEmptyLocalSaleShell(), selectPassiveCloseoutBlockedRegisterSession(), trimOptional() (+1 more)
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.21
 Nodes (19): getRegisterCatalogPrice(), getRegisterCatalogProjectionPrice(), isActiveProvisionalImportSkuForStore(), isDraftAllowedInTrustedRegisterCatalog(), isTrustedRegisterCatalogProjection(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailability() (+11 more)
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.11
 Nodes (3): formatMinuteOfDayLabel(), formatStoreHoursTimeLabel(), parseStoreHoursTimeLabel()
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.27
 Nodes (18): assertConformsToExportedReturns(), collectReturnValidatorIssues(), decodeSerializedFloat64(), decodeSerializedInt64(), decodeSerializedLiteralValue(), describeValue(), formatReturnValidatorIssues(), isConvexValue() (+10 more)
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.22
 Nodes (15): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), classifyRegisterSessionSyncReview(), findProjectedRegisterSessionIdForRepairableMissingMapping(), findTransactionIdForSyncEvent(), hasInventoryReviewWorkItemForProjectedSale(), isNonSaleMissingRegisterSessionMappingConflict() (+7 more)
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.22
 Nodes (18): assertPrAthenaProofReady(), classifySnapshotError(), collectFilesUnder(), collectProofSnapshot(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof() (+10 more)
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.13
 Nodes (5): buildRegisterCloseoutSubmittedTimelineMessage(), buildRegisterCloseoutVarianceTimelineMessage(), cancelPendingApprovalIfNeeded(), formatCloseoutVarianceAmount(), omitUndefined()
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.17
 Nodes (13): buildProviderRegistry(), createIntelligenceRun(), defaultFakeOutput(), failedGenerationResult(), getStoreInsightsSnapshotFallback(), isActivityTrend(), isDeviceDistribution(), isInsightGenerationInProgressError() (+5 more)
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.16
 Nodes (10): buildProductSkuSearchProjection(), buildSearchText(), hydrateCanonicalProjection(), normalizeAttributes(), normalizeLookup(), projectionsEqual(), requireProductSkuSearchAccess(), requireProductSkuSearchAdmin() (+2 more)
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.22
 Nodes (15): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+7 more)
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.25
 Nodes (16): buildStorefrontContextEvent(), buildStorefrontIdempotencyKey(), compactScalarPayload(), createStorefrontContextTrackingEnvelope(), createStorefrontRouteViewedContextEvent(), getCartChange(), getCartContextEventInput(), getCheckoutBlocker() (+8 more)
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.22
 Nodes (14): assertActorMatchesStore(), buildCompiledContextBundle(), buildStoreInsightsContextBundleFromContextEvents(), buildUserInsightsContextBundleFromContextEvents(), compileContextEvent(), compileContextEventsWithReport(), getDataWindow(), getStoreFrontActorById() (+6 more)
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.19
 Nodes (10): canListRegisterSessionSyncConflicts(), filterPendingCompletedSaleVoidApprovals(), filterPendingTransactionItemAdjustmentApprovals(), getNumberMetadata(), getPendingItemAdjustmentCashDelta(), getStringMetadata(), listPendingCompletedSaleVoidApprovals(), listPendingRegisterSessionApprovalRequests() (+2 more)
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.13
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.15
 Nodes (7): getBlockedPosTerminalShellCopy(), getBrowserPathWithSearch(), getLoginHref(), getPosHubRouteParams(), getRouteParamsForPattern(), getStoreWorkspaceRouteParams(), PosTerminalBlockedShell()
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.23
 Nodes (13): buildAbusePartitionKey(), buildServerContextTrackingEnvelope(), deriveBrowserFamily(), deriveContextEnvironment(), deriveOsFamily(), derivePrimarySubject(), isAcceptedSyntheticContext(), isRecord() (+5 more)
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.19
 Nodes (10): buildLatestRunDebugPayload(), getBoundedDebugRunsByCapability(), getLatestDebugRunByCapability(), getLatestDebugRunBySubject(), isActiveRunStale(), isActiveRunStatus(), selectLatestDebugRunFromCandidates(), shouldRecoverActiveRun() (+2 more)
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.3
 Nodes (15): buildPosOperatorSnapshot(), buildRecentDayBuckets(), buildSummaryTrendBucket(), buildTransactionDateBuckets(), calculateDeltaPercent(), formatHourLabel(), formatPaymentMethodLabel(), formatShortDate() (+7 more)
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.13
 Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.17
 Nodes (8): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterCatalogState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.24
 Nodes (15): buildGeneratedControlId(), captureRemoteAssistCoBrowseFrame(), collectSanitizedSurface(), collectSensitiveRegions(), collectVisibleText(), getControlId(), getControlPriority(), getElementLabel() (+7 more)
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.22
 Nodes (11): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), getInvalidationNodes(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline() (+3 more)
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.23
 Nodes (13): collectConvexReturnValidatorContractFindings(), escapeRegExp(), extractConvexPublicFunctionsWithReturns(), fileExists(), findMatchingDefinitionEnd(), hasConvexReturnContractProofForExport(), isConvexReturnContractSourcePath(), isRelevantConvexContractProofPath() (+5 more)
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.22
 Nodes (9): buildHistoricalContextEventAppendArgs(), buildHistoricalImportIdempotencyKey(), buildPrimarySubject(), buildStoppedReport(), countOmittedFields(), createEmptyReport(), increment(), planHistoricalStorefrontContextImport() (+1 more)
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.28
 Nodes (14): buildActorRefs(), buildReturnExchangeTraceEvent(), buildReturnExchangeTraceRecord(), buildTraceEvent(), buildTraceRecord(), compactDetails(), recordOnlineOrderReturnExchangeTraceBestEffort(), recordOnlineOrderTraceBestEffort() (+6 more)
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.2
 Nodes (9): canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), drawerAuthorityMatchesActiveRegisterSession(), getSaleBlockingDrawerAuthority(), isDrawerAuthoritySaleBlocking(), isRegisterSessionConflictBlocking(), isRegisterSessionReplacementBlocking(), isRegisterSessionSaleUsable() (+1 more)
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.17
 Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.22
 Nodes (10): extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), normalizeIdentifier(), parseCatalogSearchInput(), searchByText(), searchRegisterCatalog() (+2 more)
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.26
 Nodes (12): applyTheme(), emitThemeChange(), getStorage(), getStoredThemeMode(), getSystemTheme(), getThemeSnapshot(), initializeAthenaTheme(), isThemeMode() (+4 more)
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
+Cohesion: 0.3
+Nodes (13): assertApprovalDecisionCanApply(), buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError() (+5 more)
+
+### Community 112 - "Community 112"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 111 - "Community 111"
+### Community 113 - "Community 113"
 Cohesion: 0.22
 Nodes (10): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), canProjectRegisterOpenForTerminalCloudRepair(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), getRepairOpenRegisterCloseoutReviewState(), getRepairRegisterSessionCloseoutBoundaryAt(), isDuplicateRegisterOpenConflict() (+2 more)
 
-### Community 112 - "Community 112"
+### Community 114 - "Community 114"
 Cohesion: 0.31
-Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
+Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getStatusesToOrdered() (+5 more)
 
-### Community 113 - "Community 113"
+### Community 115 - "Community 115"
 Cohesion: 0.14
 Nodes (0):
 
-### Community 114 - "Community 114"
+### Community 116 - "Community 116"
 Cohesion: 0.16
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
-### Community 115 - "Community 115"
+### Community 117 - "Community 117"
 Cohesion: 0.26
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 116 - "Community 116"
+### Community 118 - "Community 118"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 117 - "Community 117"
+### Community 119 - "Community 119"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 118 - "Community 118"
+### Community 120 - "Community 120"
 Cohesion: 0.22
 Nodes (6): buildParticipantIdentity(), getDataPublishRouting(), getParticipantRole(), isAllowedSender(), LiveKitRemoteAssistClient, parseParticipantRole()
 
-### Community 119 - "Community 119"
+### Community 121 - "Community 121"
 Cohesion: 0.26
 Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
-### Community 120 - "Community 120"
+### Community 122 - "Community 122"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 121 - "Community 121"
+### Community 123 - "Community 123"
 Cohesion: 0.31
 Nodes (12): backfillStoreSchedulesFromLegacyPolicyWithCtx(), buildBackfillRow(), buildCandidateWeeklyWindows(), compatibilityMetadata(), compatibilityOnlyRow(), findExistingScheduleToSkip(), firstPolicy(), isValidMinute() (+4 more)
 
-### Community 122 - "Community 122"
+### Community 124 - "Community 124"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 123 - "Community 123"
+### Community 125 - "Community 125"
 Cohesion: 0.18
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 124 - "Community 124"
+### Community 126 - "Community 126"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 125 - "Community 125"
+### Community 127 - "Community 127"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 126 - "Community 126"
+### Community 128 - "Community 128"
 Cohesion: 0.22
 Nodes (6): buildTrustedInventoryFinalizationPayload(), buildTrustedInventoryMoneyPayload(), getTrustedInventoryReviewValidationMessage(), isNonNegativeInteger(), parseVariantDisplayMoney(), resolveTrustedInventoryReviewState()
 
-### Community 127 - "Community 127"
+### Community 129 - "Community 129"
 Cohesion: 0.18
 Nodes (4): formatProductLineMeta(), formatServiceLabel(), formatServiceLineMeta(), formatStoredAmount()
 
-### Community 128 - "Community 128"
+### Community 130 - "Community 130"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 129 - "Community 129"
+### Community 131 - "Community 131"
 Cohesion: 0.17
 Nodes (2): getNextTransactionPageSearch(), getNextTransactionTimeFilterSearch()
 
-### Community 130 - "Community 130"
+### Community 132 - "Community 132"
 Cohesion: 0.22
 Nodes (6): blocked(), evaluateLocalPosReadiness(), hasSettledLocalCloseout(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 131 - "Community 131"
+### Community 133 - "Community 133"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 132 - "Community 132"
+### Community 134 - "Community 134"
 Cohesion: 0.22
 Nodes (9): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCashVoidApprovals(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus() (+1 more)
 
-### Community 133 - "Community 133"
+### Community 135 - "Community 135"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 134 - "Community 134"
+### Community 136 - "Community 136"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 135 - "Community 135"
+### Community 137 - "Community 137"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 136 - "Community 136"
+### Community 138 - "Community 138"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 137 - "Community 137"
+### Community 139 - "Community 139"
 Cohesion: 0.17
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 138 - "Community 138"
+### Community 140 - "Community 140"
+Cohesion: 0.18
+Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
+
+### Community 141 - "Community 141"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 139 - "Community 139"
+### Community 142 - "Community 142"
 Cohesion: 0.21
 Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
-### Community 140 - "Community 140"
+### Community 143 - "Community 143"
 Cohesion: 0.18
 Nodes (2): expenseItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 141 - "Community 141"
+### Community 144 - "Community 144"
 Cohesion: 0.29
 Nodes (8): isFiniteNumber(), isPointInsideViewport(), isPositiveFiniteNumber(), isRecord(), isValidViewport(), validateKeyEvent(), validatePointerEvent(), validateRemoteAssistControlEvent()
 
-### Community 142 - "Community 142"
+### Community 145 - "Community 145"
 Cohesion: 0.29
 Nodes (8): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), resolveStoreOperatingRangeForDateWithCtx(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
 
-### Community 143 - "Community 143"
+### Community 146 - "Community 146"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
-### Community 144 - "Community 144"
-Cohesion: 0.36
-Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
+### Community 147 - "Community 147"
+Cohesion: 0.35
+Nodes (10): buildCtx(), buildMapping(), buildRegisterSession(), buildStaffProfile(), buildStore(), buildTerminal(), buildTransaction(), buildWorkItem() (+2 more)
 
-### Community 145 - "Community 145"
-Cohesion: 0.2
-Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
-
-### Community 146 - "Community 146"
+### Community 148 - "Community 148"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 147 - "Community 147"
+### Community 149 - "Community 149"
 Cohesion: 0.2
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 148 - "Community 148"
+### Community 150 - "Community 150"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 149 - "Community 149"
+### Community 151 - "Community 151"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 150 - "Community 150"
+### Community 152 - "Community 152"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 151 - "Community 151"
+### Community 153 - "Community 153"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 152 - "Community 152"
+### Community 154 - "Community 154"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 153 - "Community 153"
+### Community 155 - "Community 155"
 Cohesion: 0.25
 Nodes (5): getRuntimeStatusPublishMaterialSignature(), getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusPublishMaterial(), normalizeRuntimeStatusSignature()
 
-### Community 154 - "Community 154"
+### Community 156 - "Community 156"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
-
-### Community 155 - "Community 155"
-Cohesion: 0.18
-Nodes (0):
-
-### Community 156 - "Community 156"
-Cohesion: 0.24
-Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
 
 ### Community 157 - "Community 157"
 Cohesion: 0.18
 Nodes (0):
 
 ### Community 158 - "Community 158"
+Cohesion: 0.24
+Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
+
+### Community 159 - "Community 159"
+Cohesion: 0.18
+Nodes (0):
+
+### Community 160 - "Community 160"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 159 - "Community 159"
+### Community 161 - "Community 161"
 Cohesion: 0.25
 Nodes (6): buildGitProcessEnv(), clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), runProcess(), writePrAthenaProviderEvidence()
 
-### Community 160 - "Community 160"
+### Community 162 - "Community 162"
 Cohesion: 0.33
 Nodes (7): createAthenaProviderError(), createProviderFailureResult(), getProviderFailureDiagnostic(), invokeStructuredTextProvider(), isJsonObject(), isJsonValue(), sanitizeDiagnostic()
 
-### Community 161 - "Community 161"
+### Community 163 - "Community 163"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 162 - "Community 162"
+### Community 164 - "Community 164"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 163 - "Community 163"
+### Community 165 - "Community 165"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 164 - "Community 164"
+### Community 166 - "Community 166"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 165 - "Community 165"
+### Community 167 - "Community 167"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 166 - "Community 166"
+### Community 168 - "Community 168"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 167 - "Community 167"
+### Community 169 - "Community 169"
 Cohesion: 0.27
 Nodes (5): getLocalOperatingDate(), getLocalOperatingDateRange(), getReadinessDiagnosticRows(), getReadinessLoadingBlockers(), POSReadinessLoadingState()
 
-### Community 168 - "Community 168"
+### Community 170 - "Community 170"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 169 - "Community 169"
+### Community 171 - "Community 171"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
 
-### Community 170 - "Community 170"
+### Community 172 - "Community 172"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 171 - "Community 171"
+### Community 173 - "Community 173"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 172 - "Community 172"
+### Community 174 - "Community 174"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 173 - "Community 173"
+### Community 175 - "Community 175"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 174 - "Community 174"
+### Community 176 - "Community 176"
 Cohesion: 0.31
 Nodes (7): architectureSolutionNote(), createFixtureRepo(), gitEnv(), nonFoundationalArchitectureSolutionNote(), runGit(), solutionNote(), write()
 
-### Community 175 - "Community 175"
+### Community 177 - "Community 177"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 176 - "Community 176"
+### Community 178 - "Community 178"
 Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
 
-### Community 177 - "Community 177"
+### Community 179 - "Community 179"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 178 - "Community 178"
+### Community 180 - "Community 180"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
-
-### Community 179 - "Community 179"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 180 - "Community 180"
-Cohesion: 0.31
-Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
 ### Community 181 - "Community 181"
 Cohesion: 0.22
 Nodes (0):
 
 ### Community 182 - "Community 182"
+Cohesion: 0.31
+Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
+
+### Community 183 - "Community 183"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 184 - "Community 184"
 Cohesion: 0.39
 Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 183 - "Community 183"
+### Community 185 - "Community 185"
 Cohesion: 0.39
 Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
 
-### Community 184 - "Community 184"
+### Community 186 - "Community 186"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 185 - "Community 185"
+### Community 187 - "Community 187"
 Cohesion: 0.33
 Nodes (6): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), saveProduct(), updateVariantSku()
 
-### Community 186 - "Community 186"
+### Community 188 - "Community 188"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 187 - "Community 187"
+### Community 189 - "Community 189"
 Cohesion: 0.25
 Nodes (2): getNextExpenseReportFilterSearch(), getNextExpenseReportPageSearch()
 
-### Community 188 - "Community 188"
+### Community 190 - "Community 190"
 Cohesion: 0.28
 Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
 
-### Community 189 - "Community 189"
+### Community 191 - "Community 191"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 190 - "Community 190"
+### Community 192 - "Community 192"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 191 - "Community 191"
+### Community 193 - "Community 193"
 Cohesion: 0.28
 Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
 
-### Community 192 - "Community 192"
+### Community 194 - "Community 194"
 Cohesion: 0.25
 Nodes (2): isValidMessageBlocker(), isValidPriority()
 
-### Community 193 - "Community 193"
+### Community 195 - "Community 195"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 194 - "Community 194"
+### Community 196 - "Community 196"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 195 - "Community 195"
+### Community 197 - "Community 197"
 Cohesion: 0.28
 Nodes (4): comparePendingEvents(), getPendingEventUploadSequence(), selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 196 - "Community 196"
+### Community 198 - "Community 198"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
-### Community 197 - "Community 197"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
-### Community 198 - "Community 198"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
 ### Community 199 - "Community 199"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 200 - "Community 200"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 201 - "Community 201"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
+### Community 200 - "Community 200"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
+
+### Community 201 - "Community 201"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
 ### Community 202 - "Community 202"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 203 - "Community 203"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 205 - "Community 205"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 204 - "Community 204"
+### Community 206 - "Community 206"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 205 - "Community 205"
+### Community 207 - "Community 207"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 206 - "Community 206"
+### Community 208 - "Community 208"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 207 - "Community 207"
+### Community 209 - "Community 209"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 208 - "Community 208"
+### Community 210 - "Community 210"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 209 - "Community 209"
+### Community 211 - "Community 211"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 210 - "Community 210"
+### Community 212 - "Community 212"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 211 - "Community 211"
+### Community 213 - "Community 213"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 212 - "Community 212"
+### Community 214 - "Community 214"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 213 - "Community 213"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 214 - "Community 214"
-Cohesion: 0.5
-Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
 ### Community 215 - "Community 215"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 216 - "Community 216"
+Cohesion: 0.5
+Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
+
+### Community 217 - "Community 217"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 219 - "Community 219"
 Cohesion: 0.36
 Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
 
-### Community 218 - "Community 218"
+### Community 220 - "Community 220"
 Cohesion: 0.36
 Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
 
-### Community 219 - "Community 219"
+### Community 221 - "Community 221"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 220 - "Community 220"
+### Community 222 - "Community 222"
 Cohesion: 0.29
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 221 - "Community 221"
+### Community 223 - "Community 223"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 222 - "Community 222"
+### Community 224 - "Community 224"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 223 - "Community 223"
+### Community 225 - "Community 225"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
-
-### Community 224 - "Community 224"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 225 - "Community 225"
-Cohesion: 0.29
-Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 226 - "Community 226"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 227 - "Community 227"
+Cohesion: 0.29
+Nodes (2): handleKeyDown(), isDebugShortcut()
+
+### Community 228 - "Community 228"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 229 - "Community 229"
 Cohesion: 0.39
 Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
-### Community 228 - "Community 228"
+### Community 230 - "Community 230"
 Cohesion: 0.39
 Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
 
-### Community 229 - "Community 229"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 230 - "Community 230"
-Cohesion: 0.25
-Nodes (0):
-
 ### Community 231 - "Community 231"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 232 - "Community 232"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 233 - "Community 233"
 Cohesion: 0.29
 Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
 
-### Community 232 - "Community 232"
+### Community 234 - "Community 234"
 Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
-### Community 233 - "Community 233"
+### Community 235 - "Community 235"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 234 - "Community 234"
+### Community 236 - "Community 236"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 235 - "Community 235"
+### Community 237 - "Community 237"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 236 - "Community 236"
+### Community 238 - "Community 238"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 237 - "Community 237"
+### Community 239 - "Community 239"
 Cohesion: 0.38
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 238 - "Community 238"
+### Community 240 - "Community 240"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 239 - "Community 239"
+### Community 241 - "Community 241"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 240 - "Community 240"
+### Community 242 - "Community 242"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 241 - "Community 241"
+### Community 243 - "Community 243"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 242 - "Community 242"
-Cohesion: 0.33
-Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
+### Community 244 - "Community 244"
+Cohesion: 0.52
+Nodes (6): conflictError(), inventoryReviewLocalId(), resolveSyncedSaleInventoryReviewWithCtx(), stringMetadataValue(), terminalStatusForOutcome(), validationError()
 
-### Community 243 - "Community 243"
+### Community 245 - "Community 245"
 Cohesion: 0.43
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
-### Community 244 - "Community 244"
+### Community 246 - "Community 246"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 245 - "Community 245"
+### Community 247 - "Community 247"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 246 - "Community 246"
+### Community 248 - "Community 248"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 247 - "Community 247"
+### Community 249 - "Community 249"
 Cohesion: 0.52
 Nodes (5): getBlockingRegisterSessionIdFromConflict(), isRegisterSessionConflict(), resolveScopedRegisterSession(), resolveTerminalRegisterConflict(), resolveTerminalRegisterSessionConflict()
 
-### Community 248 - "Community 248"
+### Community 250 - "Community 250"
 Cohesion: 0.33
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 249 - "Community 249"
+### Community 251 - "Community 251"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 250 - "Community 250"
+### Community 252 - "Community 252"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 251 - "Community 251"
+### Community 253 - "Community 253"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 252 - "Community 252"
+### Community 254 - "Community 254"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 253 - "Community 253"
+### Community 255 - "Community 255"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 254 - "Community 254"
+### Community 256 - "Community 256"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 255 - "Community 255"
+### Community 257 - "Community 257"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 256 - "Community 256"
+### Community 258 - "Community 258"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 257 - "Community 257"
+### Community 259 - "Community 259"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 258 - "Community 258"
+### Community 260 - "Community 260"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 259 - "Community 259"
+### Community 261 - "Community 261"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 260 - "Community 260"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 261 - "Community 261"
-Cohesion: 0.29
-Nodes (0):
-
 ### Community 262 - "Community 262"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 263 - "Community 263"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 264 - "Community 264"
 Cohesion: 0.33
 Nodes (2): handlePinChange(), normalizeOtpCode()
 
-### Community 263 - "Community 263"
+### Community 265 - "Community 265"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 264 - "Community 264"
-Cohesion: 0.29
-Nodes (1): ResizeObserverStub
-
-### Community 265 - "Community 265"
-Cohesion: 0.29
-Nodes (1): ResizeObserverStub
-
 ### Community 266 - "Community 266"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 267 - "Community 267"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 268 - "Community 268"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 267 - "Community 267"
+### Community 269 - "Community 269"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 268 - "Community 268"
+### Community 270 - "Community 270"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 269 - "Community 269"
+### Community 271 - "Community 271"
 Cohesion: 0.52
 Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
-### Community 270 - "Community 270"
+### Community 272 - "Community 272"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 271 - "Community 271"
+### Community 273 - "Community 273"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 272 - "Community 272"
+### Community 274 - "Community 274"
 Cohesion: 0.52
 Nodes (6): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isDuplicatePosSessionSaleReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
-### Community 273 - "Community 273"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 274 - "Community 274"
-Cohesion: 0.29
-Nodes (0):
-
 ### Community 275 - "Community 275"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 276 - "Community 276"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 277 - "Community 277"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 276 - "Community 276"
+### Community 278 - "Community 278"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 277 - "Community 277"
+### Community 279 - "Community 279"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 278 - "Community 278"
+### Community 280 - "Community 280"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 279 - "Community 279"
+### Community 281 - "Community 281"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 280 - "Community 280"
+### Community 282 - "Community 282"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 281 - "Community 281"
+### Community 283 - "Community 283"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 282 - "Community 282"
+### Community 284 - "Community 284"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 283 - "Community 283"
+### Community 285 - "Community 285"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
 
-### Community 284 - "Community 284"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 285 - "Community 285"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 286 - "Community 286"
-Cohesion: 0.73
-Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 287 - "Community 287"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 288 - "Community 288"
-Cohesion: 0.6
-Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 289 - "Community 289"
-Cohesion: 0.53
-Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
+Cohesion: 0.73
+Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 290 - "Community 290"
-Cohesion: 0.6
-Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 291 - "Community 291"
 Cohesion: 0.6
-Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
+Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
 ### Community 292 - "Community 292"
+Cohesion: 0.53
+Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
+
+### Community 293 - "Community 293"
+Cohesion: 0.6
+Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+
+### Community 294 - "Community 294"
+Cohesion: 0.6
+Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
+
+### Community 295 - "Community 295"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 293 - "Community 293"
+### Community 296 - "Community 296"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 294 - "Community 294"
+### Community 297 - "Community 297"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 295 - "Community 295"
+### Community 298 - "Community 298"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 296 - "Community 296"
+### Community 299 - "Community 299"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 297 - "Community 297"
+### Community 300 - "Community 300"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 298 - "Community 298"
+### Community 301 - "Community 301"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 299 - "Community 299"
+### Community 302 - "Community 302"
 Cohesion: 0.4
 Nodes (2): moveBestSeller(), saveOrder()
 
-### Community 300 - "Community 300"
+### Community 303 - "Community 303"
 Cohesion: 0.4
 Nodes (2): moveFeaturedItem(), saveOrder()
 
-### Community 301 - "Community 301"
+### Community 304 - "Community 304"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 302 - "Community 302"
+### Community 305 - "Community 305"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 303 - "Community 303"
-Cohesion: 0.4
-Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
-
-### Community 304 - "Community 304"
-Cohesion: 0.33
-Nodes (1): ResizeObserverStub
-
-### Community 305 - "Community 305"
-Cohesion: 0.4
-Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 306 - "Community 306"
 Cohesion: 0.4
-Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
+Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
 ### Community 307 - "Community 307"
-Cohesion: 0.47
-Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
+Cohesion: 0.33
+Nodes (1): ResizeObserverStub
 
 ### Community 308 - "Community 308"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 309 - "Community 309"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
 ### Community 310 - "Community 310"
 Cohesion: 0.47
-Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
+Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
 ### Community 311 - "Community 311"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 312 - "Community 312"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 313 - "Community 313"
+Cohesion: 0.47
+Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
+
+### Community 314 - "Community 314"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 315 - "Community 315"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 313 - "Community 313"
+### Community 316 - "Community 316"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
-
-### Community 314 - "Community 314"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 315 - "Community 315"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 316 - "Community 316"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 317 - "Community 317"
 Cohesion: 0.33
@@ -3397,132 +3399,132 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 319 - "Community 319"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 320 - "Community 320"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 321 - "Community 321"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 320 - "Community 320"
+### Community 322 - "Community 322"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
-### Community 321 - "Community 321"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 322 - "Community 322"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 323 - "Community 323"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 324 - "Community 324"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 325 - "Community 325"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 324 - "Community 324"
+### Community 326 - "Community 326"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 325 - "Community 325"
+### Community 327 - "Community 327"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 326 - "Community 326"
+### Community 328 - "Community 328"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 327 - "Community 327"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 328 - "Community 328"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 329 - "Community 329"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 330 - "Community 330"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 331 - "Community 331"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 330 - "Community 330"
+### Community 332 - "Community 332"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 331 - "Community 331"
+### Community 333 - "Community 333"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 332 - "Community 332"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 333 - "Community 333"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 334 - "Community 334"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 335 - "Community 335"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 336 - "Community 336"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
+### Community 337 - "Community 337"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 338 - "Community 338"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+
+### Community 339 - "Community 339"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 337 - "Community 337"
+### Community 340 - "Community 340"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 338 - "Community 338"
+### Community 341 - "Community 341"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 339 - "Community 339"
+### Community 342 - "Community 342"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 340 - "Community 340"
+### Community 343 - "Community 343"
 Cohesion: 0.53
 Nodes (5): commitFixtureRepo(), createFixtureRepo(), gitFixtureEnv(), runFixtureCommand(), write()
 
-### Community 341 - "Community 341"
+### Community 344 - "Community 344"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 342 - "Community 342"
+### Community 345 - "Community 345"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 343 - "Community 343"
+### Community 346 - "Community 346"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 344 - "Community 344"
+### Community 347 - "Community 347"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 345 - "Community 345"
+### Community 348 - "Community 348"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
-### Community 346 - "Community 346"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 347 - "Community 347"
-Cohesion: 0.6
-Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
-
-### Community 348 - "Community 348"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 349 - "Community 349"
-Cohesion: 0.5
-Nodes (2): createMutationCtx(), seedTrustedConversionData()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 350 - "Community 350"
-Cohesion: 0.5
-Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
+Cohesion: 0.6
+Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
 ### Community 351 - "Community 351"
 Cohesion: 0.4
@@ -3530,107 +3532,107 @@ Nodes (0):
 
 ### Community 352 - "Community 352"
 Cohesion: 0.5
-Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
+Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 353 - "Community 353"
+Cohesion: 0.5
+Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
+
+### Community 354 - "Community 354"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 354 - "Community 354"
+### Community 355 - "Community 355"
+Cohesion: 0.5
+Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
+
+### Community 356 - "Community 356"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 357 - "Community 357"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 355 - "Community 355"
+### Community 358 - "Community 358"
 Cohesion: 0.6
 Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
 
-### Community 356 - "Community 356"
+### Community 359 - "Community 359"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 357 - "Community 357"
+### Community 360 - "Community 360"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 358 - "Community 358"
-Cohesion: 0.6
-Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
-
-### Community 359 - "Community 359"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 360 - "Community 360"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 361 - "Community 361"
-Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 362 - "Community 362"
-Cohesion: 0.5
-Nodes (2): baseInput(), buildRuntimeStatus()
+Cohesion: 0.6
+Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
 ### Community 363 - "Community 363"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 364 - "Community 364"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 365 - "Community 365"
 Cohesion: 0.5
-Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
+Nodes (2): baseInput(), buildRuntimeStatus()
 
 ### Community 366 - "Community 366"
-Cohesion: 0.6
-Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 367 - "Community 367"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 368 - "Community 368"
-Cohesion: 0.7
-Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
+Cohesion: 0.5
+Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
 ### Community 369 - "Community 369"
 Cohesion: 0.6
-Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
+Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
 ### Community 370 - "Community 370"
-Cohesion: 0.5
-Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 371 - "Community 371"
 Cohesion: 0.7
-Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
+Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
 ### Community 372 - "Community 372"
-Cohesion: 0.5
-Nodes (2): createAdminTraceReadCtx(), createTestCtx()
+Cohesion: 0.6
+Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
 ### Community 373 - "Community 373"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
 ### Community 374 - "Community 374"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
 ### Community 375 - "Community 375"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): createAdminTraceReadCtx(), createTestCtx()
 
 ### Community 376 - "Community 376"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 377 - "Community 377"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 378 - "Community 378"
 Cohesion: 0.4
@@ -3641,32 +3643,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 380 - "Community 380"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 381 - "Community 381"
-Cohesion: 0.5
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 382 - "Community 382"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 383 - "Community 383"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
-
-### Community 384 - "Community 384"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 384 - "Community 384"
+Cohesion: 0.5
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 385 - "Community 385"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 386 - "Community 386"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 387 - "Community 387"
 Cohesion: 0.4
@@ -3677,184 +3679,184 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 389 - "Community 389"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 390 - "Community 390"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 391 - "Community 391"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 392 - "Community 392"
+Cohesion: 0.7
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+
+### Community 393 - "Community 393"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 394 - "Community 394"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 392 - "Community 392"
+### Community 395 - "Community 395"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 393 - "Community 393"
+### Community 396 - "Community 396"
 Cohesion: 0.5
 Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
-### Community 394 - "Community 394"
+### Community 397 - "Community 397"
 Cohesion: 0.5
 Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
-### Community 395 - "Community 395"
+### Community 398 - "Community 398"
 Cohesion: 0.5
 Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
 
-### Community 396 - "Community 396"
+### Community 399 - "Community 399"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 397 - "Community 397"
+### Community 400 - "Community 400"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 398 - "Community 398"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 399 - "Community 399"
-Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
-
-### Community 400 - "Community 400"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 401 - "Community 401"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 402 - "Community 402"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 403 - "Community 403"
-Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
-
-### Community 404 - "Community 404"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 404 - "Community 404"
+Cohesion: 0.6
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+
 ### Community 405 - "Community 405"
-Cohesion: 0.7
-Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
+Cohesion: 0.6
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 406 - "Community 406"
-Cohesion: 0.5
-Nodes (2): buildAdminSkuSearchOption(), compactJoin()
+Cohesion: 0.6
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
 ### Community 407 - "Community 407"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 408 - "Community 408"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 409 - "Community 409"
+Cohesion: 0.5
+Nodes (2): buildAdminSkuSearchOption(), compactJoin()
+
+### Community 410 - "Community 410"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 410 - "Community 410"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
-
 ### Community 411 - "Community 411"
-Cohesion: 0.5
-Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 412 - "Community 412"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 413 - "Community 413"
+Cohesion: 0.5
+Nodes (2): completePendingAuthSync(), sleep()
+
+### Community 414 - "Community 414"
+Cohesion: 0.5
+Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+
+### Community 415 - "Community 415"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 416 - "Community 416"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 414 - "Community 414"
+### Community 417 - "Community 417"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 415 - "Community 415"
+### Community 418 - "Community 418"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
-### Community 416 - "Community 416"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 417 - "Community 417"
-Cohesion: 0.6
-Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
-
-### Community 418 - "Community 418"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 419 - "Community 419"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 420 - "Community 420"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
 ### Community 421 - "Community 421"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 422 - "Community 422"
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+
+### Community 423 - "Community 423"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 423 - "Community 423"
+### Community 424 - "Community 424"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 425 - "Community 425"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 426 - "Community 426"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 424 - "Community 424"
+### Community 427 - "Community 427"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 425 - "Community 425"
+### Community 428 - "Community 428"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 426 - "Community 426"
+### Community 429 - "Community 429"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 427 - "Community 427"
+### Community 430 - "Community 430"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 428 - "Community 428"
+### Community 431 - "Community 431"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 429 - "Community 429"
+### Community 432 - "Community 432"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 430 - "Community 430"
+### Community 433 - "Community 433"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 431 - "Community 431"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 432 - "Community 432"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 433 - "Community 433"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 434 - "Community 434"
 Cohesion: 0.5
@@ -3866,27 +3868,27 @@ Nodes (0):
 
 ### Community 436 - "Community 436"
 Cohesion: 0.67
-Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 437 - "Community 437"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 438 - "Community 438"
-Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
-
-### Community 439 - "Community 439"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 439 - "Community 439"
+Cohesion: 0.67
+Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
 ### Community 440 - "Community 440"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 441 - "Community 441"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 442 - "Community 442"
 Cohesion: 0.5
@@ -3897,44 +3899,44 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 444 - "Community 444"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
-
-### Community 445 - "Community 445"
-Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
-
-### Community 446 - "Community 446"
-Cohesion: 0.67
-Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
-
-### Community 447 - "Community 447"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 448 - "Community 448"
+### Community 445 - "Community 445"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 446 - "Community 446"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 447 - "Community 447"
 Cohesion: 0.83
-Nodes (3): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), formatOnlineOrderLabel()
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+
+### Community 448 - "Community 448"
+Cohesion: 0.67
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
 ### Community 449 - "Community 449"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
 ### Community 450 - "Community 450"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 451 - "Community 451"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), formatOnlineOrderLabel()
 
 ### Community 452 - "Community 452"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 453 - "Community 453"
-Cohesion: 0.67
-Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 454 - "Community 454"
 Cohesion: 0.5
@@ -3942,19 +3944,19 @@ Nodes (0):
 
 ### Community 455 - "Community 455"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 456 - "Community 456"
+Cohesion: 0.67
+Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
+
+### Community 457 - "Community 457"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 457 - "Community 457"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
-
 ### Community 458 - "Community 458"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 459 - "Community 459"
 Cohesion: 0.5
@@ -3962,35 +3964,35 @@ Nodes (0):
 
 ### Community 460 - "Community 460"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 461 - "Community 461"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 462 - "Community 462"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 463 - "Community 463"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 464 - "Community 464"
-Cohesion: 0.67
-Nodes (2): buildCtx(), buildQueryCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 465 - "Community 465"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 466 - "Community 466"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 467 - "Community 467"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildCtx(), buildQueryCtx()
 
 ### Community 468 - "Community 468"
 Cohesion: 0.5
@@ -4001,20 +4003,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 470 - "Community 470"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 471 - "Community 471"
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+
+### Community 472 - "Community 472"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 472 - "Community 472"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
-
 ### Community 473 - "Community 473"
-Cohesion: 0.83
-Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 474 - "Community 474"
 Cohesion: 0.5
@@ -4025,16 +4027,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 476 - "Community 476"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 477 - "Community 477"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 478 - "Community 478"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
 ### Community 479 - "Community 479"
 Cohesion: 0.5
@@ -4045,52 +4047,52 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 481 - "Community 481"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 482 - "Community 482"
 Cohesion: 0.83
-Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 483 - "Community 483"
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+
+### Community 484 - "Community 484"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 484 - "Community 484"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
 ### Community 485 - "Community 485"
-Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 486 - "Community 486"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 487 - "Community 487"
-Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Cohesion: 0.83
+Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
 ### Community 488 - "Community 488"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 489 - "Community 489"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 490 - "Community 490"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 491 - "Community 491"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 492 - "Community 492"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 493 - "Community 493"
 Cohesion: 0.5
@@ -4105,8 +4107,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 496 - "Community 496"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 497 - "Community 497"
 Cohesion: 0.5
@@ -4121,12 +4123,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 500 - "Community 500"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 501 - "Community 501"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 501 - "Community 501"
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 502 - "Community 502"
 Cohesion: 0.5
@@ -4137,136 +4139,136 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 504 - "Community 504"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 505 - "Community 505"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 505 - "Community 505"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 506 - "Community 506"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 507 - "Community 507"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 508 - "Community 508"
-Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 509 - "Community 509"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 510 - "Community 510"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 511 - "Community 511"
-Cohesion: 0.67
-Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
-
-### Community 512 - "Community 512"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 512 - "Community 512"
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 513 - "Community 513"
 Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 514 - "Community 514"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 515 - "Community 515"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 515 - "Community 515"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
-
 ### Community 516 - "Community 516"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
 ### Community 517 - "Community 517"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 518 - "Community 518"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 519 - "Community 519"
-Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
-
-### Community 520 - "Community 520"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 520 - "Community 520"
+Cohesion: 0.67
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
+
 ### Community 521 - "Community 521"
-Cohesion: 0.83
-Nodes (3): completedEvent(), event(), item()
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 522 - "Community 522"
-Cohesion: 0.67
-Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 523 - "Community 523"
-Cohesion: 0.83
-Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 524 - "Community 524"
-Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+Cohesion: 0.67
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
 ### Community 525 - "Community 525"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 526 - "Community 526"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): completedEvent(), event(), item()
 
 ### Community 527 - "Community 527"
-Cohesion: 0.83
-Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
+Cohesion: 0.67
+Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
 ### Community 528 - "Community 528"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
 ### Community 529 - "Community 529"
 Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
 ### Community 530 - "Community 530"
-Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
-
-### Community 531 - "Community 531"
-Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 532 - "Community 532"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 531 - "Community 531"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 532 - "Community 532"
+Cohesion: 0.83
+Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
 ### Community 533 - "Community 533"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 534 - "Community 534"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 535 - "Community 535"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 536 - "Community 536"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 537 - "Community 537"
 Cohesion: 0.5
@@ -4281,79 +4283,79 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 540 - "Community 540"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 541 - "Community 541"
-Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 542 - "Community 542"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 543 - "Community 543"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 544 - "Community 544"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
-
-### Community 545 - "Community 545"
-Cohesion: 0.67
-Nodes (2): write(), writePublicQueryWithReturns()
-
-### Community 546 - "Community 546"
-Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
-
-### Community 547 - "Community 547"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 548 - "Community 548"
+### Community 545 - "Community 545"
 Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
+
+### Community 546 - "Community 546"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 547 - "Community 547"
+Cohesion: 0.83
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+
+### Community 548 - "Community 548"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 549 - "Community 549"
-Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Cohesion: 0.83
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 550 - "Community 550"
-Cohesion: 0.83
-Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
+Cohesion: 0.67
+Nodes (2): write(), writePublicQueryWithReturns()
 
 ### Community 551 - "Community 551"
-Cohesion: 0.67
-Nodes (2): collectHarnessTestTargets(), runHarnessTest()
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 552 - "Community 552"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 553 - "Community 553"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 554 - "Community 554"
 Cohesion: 0.67
-Nodes (0):
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
 ### Community 555 - "Community 555"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
 ### Community 556 - "Community 556"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+Cohesion: 0.67
+Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
 ### Community 557 - "Community 557"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 558 - "Community 558"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 559 - "Community 559"
@@ -4365,8 +4367,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 561 - "Community 561"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 562 - "Community 562"
 Cohesion: 0.67
@@ -4409,48 +4411,48 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 572 - "Community 572"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 573 - "Community 573"
-Cohesion: 1.0
-Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 574 - "Community 574"
-Cohesion: 1.0
-Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 575 - "Community 575"
-Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 576 - "Community 576"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 577 - "Community 577"
-Cohesion: 0.67
-Nodes (1): PosServerError
+Cohesion: 1.0
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 578 - "Community 578"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
 ### Community 579 - "Community 579"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 580 - "Community 580"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 581 - "Community 581"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 582 - "Community 582"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Cohesion: 0.67
+Nodes (1): PosServerError
 
 ### Community 583 - "Community 583"
 Cohesion: 0.67
@@ -4469,16 +4471,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 587 - "Community 587"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 588 - "Community 588"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 589 - "Community 589"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 590 - "Community 590"
 Cohesion: 0.67
@@ -4493,16 +4495,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 593 - "Community 593"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 594 - "Community 594"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 594 - "Community 594"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
-
 ### Community 595 - "Community 595"
-Cohesion: 1.0
-Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 596 - "Community 596"
 Cohesion: 0.67
@@ -4513,20 +4515,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 598 - "Community 598"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 599 - "Community 599"
 Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
 
 ### Community 600 - "Community 600"
-Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 601 - "Community 601"
-Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 602 - "Community 602"
 Cohesion: 0.67
@@ -4534,23 +4536,23 @@ Nodes (0):
 
 ### Community 603 - "Community 603"
 Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 604 - "Community 604"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 605 - "Community 605"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 606 - "Community 606"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 607 - "Community 607"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 608 - "Community 608"
 Cohesion: 0.67
@@ -4562,11 +4564,11 @@ Nodes (0):
 
 ### Community 610 - "Community 610"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 611 - "Community 611"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 612 - "Community 612"
 Cohesion: 0.67
@@ -4581,20 +4583,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 615 - "Community 615"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 616 - "Community 616"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 617 - "Community 617"
-Cohesion: 1.0
-Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 618 - "Community 618"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 619 - "Community 619"
 Cohesion: 0.67
@@ -4606,11 +4608,11 @@ Nodes (0):
 
 ### Community 621 - "Community 621"
 Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
+Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
 ### Community 622 - "Community 622"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 623 - "Community 623"
 Cohesion: 0.67
@@ -4618,11 +4620,11 @@ Nodes (0):
 
 ### Community 624 - "Community 624"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 625 - "Community 625"
 Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 626 - "Community 626"
 Cohesion: 0.67
@@ -4634,15 +4636,15 @@ Nodes (0):
 
 ### Community 628 - "Community 628"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 629 - "Community 629"
 Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 630 - "Community 630"
-Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 631 - "Community 631"
 Cohesion: 0.67
@@ -4653,12 +4655,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 633 - "Community 633"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 634 - "Community 634"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 635 - "Community 635"
 Cohesion: 0.67
@@ -4681,8 +4683,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 640 - "Community 640"
-Cohesion: 1.0
-Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 641 - "Community 641"
 Cohesion: 0.67
@@ -4697,8 +4699,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 644 - "Community 644"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
 
 ### Community 645 - "Community 645"
 Cohesion: 0.67
@@ -4706,91 +4708,91 @@ Nodes (0):
 
 ### Community 646 - "Community 646"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 647 - "Community 647"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 648 - "Community 648"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (0):
 
 ### Community 649 - "Community 649"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (0):
 
 ### Community 650 - "Community 650"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 651 - "Community 651"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 652 - "Community 652"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): AppSkeleton()
 
 ### Community 653 - "Community 653"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): DashboardSkeleton()
 
 ### Community 654 - "Community 654"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): TableSkeleton()
 
 ### Community 655 - "Community 655"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 656 - "Community 656"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): NotFound()
 
 ### Community 657 - "Community 657"
-Cohesion: 0.67
-Nodes (1): LoadingButton()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 658 - "Community 658"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): AppContextMenu()
 
 ### Community 659 - "Community 659"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): Badge()
 
 ### Community 660 - "Community 660"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (0):
 
 ### Community 661 - "Community 661"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): LoadingButton()
 
 ### Community 662 - "Community 662"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): onChange()
 
 ### Community 663 - "Community 663"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): AlertModal()
 
 ### Community 664 - "Community 664"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): OverlayModal()
 
 ### Community 665 - "Community 665"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Skeleton()
 
 ### Community 666 - "Community 666"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 667 - "Community 667"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 668 - "Community 668"
 Cohesion: 0.67
@@ -4810,7 +4812,7 @@ Nodes (0):
 
 ### Community 672 - "Community 672"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 673 - "Community 673"
 Cohesion: 0.67
@@ -4826,7 +4828,7 @@ Nodes (0):
 
 ### Community 676 - "Community 676"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 677 - "Community 677"
 Cohesion: 0.67
@@ -4845,12 +4847,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 681 - "Community 681"
-Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 682 - "Community 682"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 683 - "Community 683"
 Cohesion: 0.67
@@ -4862,23 +4864,23 @@ Nodes (0):
 
 ### Community 685 - "Community 685"
 Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
+Nodes (2): getApprovalGuidance(), presentCommandToast()
 
 ### Community 686 - "Community 686"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 687 - "Community 687"
-Cohesion: 1.0
-Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
-
-### Community 688 - "Community 688"
-Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
-
-### Community 689 - "Community 689"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 688 - "Community 688"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 689 - "Community 689"
+Cohesion: 1.0
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 690 - "Community 690"
 Cohesion: 0.67
@@ -4886,11 +4888,11 @@ Nodes (0):
 
 ### Community 691 - "Community 691"
 Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
+Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
 ### Community 692 - "Community 692"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 693 - "Community 693"
 Cohesion: 0.67
@@ -4901,8 +4903,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 695 - "Community 695"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 696 - "Community 696"
 Cohesion: 0.67
@@ -4917,12 +4919,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 699 - "Community 699"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 700 - "Community 700"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 701 - "Community 701"
 Cohesion: 0.67
@@ -4934,75 +4936,75 @@ Nodes (0):
 
 ### Community 703 - "Community 703"
 Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 704 - "Community 704"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 705 - "Community 705"
 Cohesion: 0.67
-Nodes (1): hashPassword()
+Nodes (0):
 
 ### Community 706 - "Community 706"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 707 - "Community 707"
-Cohesion: 0.67
-Nodes (1): manualChunks()
+Cohesion: 1.0
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 708 - "Community 708"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 709 - "Community 709"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 710 - "Community 710"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 711 - "Community 711"
-Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Cohesion: 0.67
+Nodes (1): manualChunks()
 
 ### Community 712 - "Community 712"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 713 - "Community 713"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 714 - "Community 714"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 715 - "Community 715"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 716 - "Community 716"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 717 - "Community 717"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 718 - "Community 718"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 719 - "Community 719"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 720 - "Community 720"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 721 - "Community 721"
 Cohesion: 0.67
@@ -5018,7 +5020,7 @@ Nodes (0):
 
 ### Community 724 - "Community 724"
 Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 725 - "Community 725"
 Cohesion: 0.67
@@ -5033,8 +5035,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 728 - "Community 728"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 729 - "Community 729"
 Cohesion: 0.67
@@ -5089,60 +5091,60 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 742 - "Community 742"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 743 - "Community 743"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 744 - "Community 744"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 745 - "Community 745"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 746 - "Community 746"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
 ### Community 747 - "Community 747"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 748 - "Community 748"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 748 - "Community 748"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 749 - "Community 749"
 Cohesion: 1.0
-Nodes (2): gitFixtureEnv(), runGit()
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 750 - "Community 750"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 751 - "Community 751"
 Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 752 - "Community 752"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 753 - "Community 753"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): gitFixtureEnv(), runGit()
 
 ### Community 754 - "Community 754"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 755 - "Community 755"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 756 - "Community 756"
 Cohesion: 1.0
@@ -6246,7 +6248,7 @@ Nodes (0):
 
 ### Community 1031 - "Community 1031"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1032 - "Community 1032"
 Cohesion: 1.0
@@ -6258,7 +6260,7 @@ Nodes (0):
 
 ### Community 1034 - "Community 1034"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1035 - "Community 1035"
 Cohesion: 1.0
@@ -10452,366 +10454,372 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2083 - "Community 2083"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2084 - "Community 2084"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 752`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 756`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 757`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 758`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 759`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 760`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 761`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 762`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 763`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 764`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 765`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 766`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 767`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 768`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 769`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 770`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 771`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 772`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 773`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 774`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 775`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 776`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 777`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 778`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 779`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 780`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 781`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 782`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 783`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 784`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 785`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 786`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 787`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 788`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 789`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 790`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 791`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 792`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 793`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 794`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 795`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 796`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 797`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 798`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 799`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 800`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 801`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 802`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 803`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 804`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 805`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 806`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 807`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 808`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 809`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 810`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 811`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
+- **Thin community `Community 812`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 813`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 814`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 815`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 816`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 817`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 818`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 819`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 820`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 821`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 822`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 823`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 824`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 825`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 826`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 827`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 828`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 829`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 830`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 831`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 832`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 833`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 834`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 835`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 836`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 837`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 838`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 839`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 840`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 841`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 842`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 843`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 844`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 845`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 846`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 847`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 848`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 849`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 850`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 851`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 852`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 853`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 854`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 855`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 856`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 857`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 858`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 859`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 860`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 861`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 862`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 863`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 864`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 865`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 866`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 867`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 868`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 869`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 870`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 871`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 872`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 873`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 874`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 875`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 876`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 877`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 878`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 879`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 880`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 881`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 882`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 883`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 884`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 885`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 886`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 887`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 888`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 889`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 890`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 891`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 892`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 893`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 894`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 895`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 896`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 897`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 898`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 899`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 900`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 901`** (2 nodes): `getTodayRefreshCalls()`, `DailyOperationsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `getTodayRefreshCalls()`, `DailyOperationsView.test.tsx`
+- **Thin community `Community 902`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 903`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
+- **Thin community `Community 904`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 905`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 906`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 907`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 908`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 909`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 910`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 911`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 912`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 913`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 914`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 915`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 916`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 917`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 918`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
+- **Thin community `Community 919`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 920`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 921`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 922`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 923`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 924`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 925`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 926`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 927`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 928`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 929`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 930`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 931`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 932`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 933`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -10847,2309 +10855,2307 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 934`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 935`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 936`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 937`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 938`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 939`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 940`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 941`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 942`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 943`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
+- **Thin community `Community 944`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 945`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 946`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 947`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 948`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 949`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 950`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 951`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 952`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 953`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 954`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 955`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 956`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 957`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 958`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 959`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 960`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 961`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 962`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 963`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 964`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 965`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 966`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 967`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 968`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 969`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 970`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 971`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 972`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 973`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 974`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 975`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 976`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 977`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 978`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 979`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 980`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 981`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 982`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 983`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 984`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 985`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 986`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 987`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 988`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 989`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 990`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 991`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 992`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 993`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 994`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 995`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 996`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 997`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 998`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 999`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 1000`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 1001`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 1002`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 1003`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 1004`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 1005`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 1006`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 1007`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1008`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1009`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1010`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1011`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1012`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1013`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1014`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1015`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1016`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1017`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1018`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1019`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1020`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1021`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1022`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1023`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1024`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1025`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1026`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1027`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1028`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1029`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1030`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1031`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1032`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1033`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1034`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1035`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1036`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1037`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1038`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1039`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1040`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1041`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1042`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1043`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1044`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1045`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1046`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1047`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1048`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1049`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1050`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1051`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1052`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1053`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1054`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1055`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1056`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
+- **Thin community `Community 1057`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1058`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1059`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1060`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1061`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1062`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1063`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1064`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1065`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1066`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1067`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1068`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1069`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `Index()`, `-index-route-view.tsx`
+- **Thin community `Community 1070`** (2 nodes): `Index()`, `-index-route-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1071`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1072`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1073`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1074`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1075`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1076`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1077`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1078`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1079`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
+- **Thin community `Community 1080`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1081`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1082`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1083`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1084`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1085`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1086`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1087`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1088`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1089`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1090`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1091`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1092`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1093`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1094`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1095`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1096`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1097`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1098`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1099`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1100`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1101`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1102`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1103`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1104`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1105`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1106`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1107`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1108`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1109`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1110`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1111`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1112`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1113`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1114`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1115`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1116`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1117`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1118`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1119`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1120`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1121`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1122`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1123`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1124`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1125`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1126`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1127`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1128`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1129`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1130`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1131`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1132`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1133`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1134`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1135`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1136`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1137`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1138`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1139`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1140`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1141`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1142`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1143`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1144`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1145`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1146`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1147`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1148`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1149`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1150`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1151`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1152`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1153`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1154`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1155`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1156`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1157`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1158`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1159`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1160`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1161`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1162`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1163`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1164`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1165`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1166`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1167`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1168`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1169`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1170`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1171`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1172`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1173`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1174`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1175`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1176`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1177`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1178`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1179`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1180`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1181`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1182`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1183`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1184`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1185`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1186`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1187`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1188`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1189`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1190`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1191`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1192`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1193`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1194`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1195`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1196`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1197`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1198`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1199`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1200`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1201`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1202`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1203`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1204`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1205`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1206`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1207`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1208`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1209`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1210`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1211`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1212`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1213`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1214`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1215`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1216`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1217`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1218`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1219`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1220`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1221`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1222`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1223`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1224`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1225`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `api.js`
+- **Thin community `Community 1226`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1227`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1228`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `server.js`
+- **Thin community `Community 1229`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `app.ts`
+- **Thin community `Community 1230`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1231`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1232`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1233`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1234`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `auth.ts`
+- **Thin community `Community 1235`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1236`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1237`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1238`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `countries.ts`
+- **Thin community `Community 1239`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `email.ts`
+- **Thin community `Community 1240`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1241`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `payment.ts`
+- **Thin community `Community 1242`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `contextEvents.test.ts`
+- **Thin community `Community 1243`** (1 nodes): `contextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1244`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `types.ts`
+- **Thin community `Community 1245`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1246`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `crons.ts`
+- **Thin community `Community 1247`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1248`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `internal.ts`
+- **Thin community `Community 1249`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1250`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1251`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1252`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1253`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1254`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1255`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1256`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1257`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1258`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1259`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1260`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `env.ts`
+- **Thin community `Community 1261`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1262`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `auth.ts`
+- **Thin community `Community 1263`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1264`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `colors.ts`
+- **Thin community `Community 1265`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `index.ts`
+- **Thin community `Community 1266`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1267`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `products.ts`
+- **Thin community `Community 1268`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1269`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `stores.ts`
+- **Thin community `Community 1270`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1271`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `bag.ts`
+- **Thin community `Community 1272`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `guest.ts`
+- **Thin community `Community 1273`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1274`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `index.ts`
+- **Thin community `Community 1275`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `me.ts`
+- **Thin community `Community 1276`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `offers.ts`
+- **Thin community `Community 1277`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1278`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1279`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1280`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1281`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1282`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1283`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1284`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1285`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1286`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `user.ts`
+- **Thin community `Community 1287`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1288`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `index.ts`
+- **Thin community `Community 1289`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1290`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `http.ts`
+- **Thin community `Community 1291`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `access.ts`
+- **Thin community `Community 1292`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1293`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1294`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1295`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `index.ts`
+- **Thin community `Community 1296`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1297`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `types.ts`
+- **Thin community `Community 1298`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1299`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `categories.ts`
+- **Thin community `Community 1300`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `colors.ts`
+- **Thin community `Community 1301`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1302`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1303`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1304`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1305`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `pos.ts`
+- **Thin community `Community 1306`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1307`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1308`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1309`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1310`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1311`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1312`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1313`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1314`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1315`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1316`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1317`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1318`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1319`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1320`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1321`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1322`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1323`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `types.ts`
+- **Thin community `Community 1324`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1325`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `eventBuilders.test.ts`
+- **Thin community `Community 1326`** (1 nodes): `eventBuilders.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1327`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `registerSessionCloseoutGate.test.ts`
+- **Thin community `Community 1328`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1329`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1330`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1331`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1332`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `dto.ts`
+- **Thin community `Community 1333`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1334`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1335`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1336`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `types.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `facts.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `types.ts`
+- **Thin community `Community 1337`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1338`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1339`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1340`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1341`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `customers.ts`
+- **Thin community `Community 1342`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `register.test.ts`
+- **Thin community `Community 1343`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `register.ts`
+- **Thin community `Community 1344`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `sync.ts`
+- **Thin community `Community 1345`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1346`** (1 nodes): `register.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1347`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1348`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `schema.ts`
+- **Thin community `Community 1349`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `automation.ts`
+- **Thin community `Community 1350`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1351`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1352`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `index.ts`
+- **Thin community `Community 1353`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1354`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1355`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1356`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1357`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1358`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1359`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1360`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `category.ts`
+- **Thin community `Community 1361`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `color.ts`
+- **Thin community `Community 1362`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1363`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1364`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `index.ts`
+- **Thin community `Community 1365`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1366`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1367`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1368`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1369`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `organization.ts`
+- **Thin community `Community 1370`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1371`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `product.ts`
+- **Thin community `Community 1372`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1373`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1374`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1375`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `store.ts`
+- **Thin community `Community 1376`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1377`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1378`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `index.ts`
+- **Thin community `Community 1379`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1380`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1381`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1382`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1383`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1384`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1385`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1386`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `index.ts`
+- **Thin community `Community 1387`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1388`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1389`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1390`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1391`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1392`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1393`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1394`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1395`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1396`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1397`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1398`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `customer.ts`
+- **Thin community `Community 1399`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1400`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1401`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1402`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1403`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `index.ts`
+- **Thin community `Community 1404`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1405`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1406`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1407`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1408`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1409`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1410`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1411`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1412`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1413`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1414`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1415`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1416`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1417`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1418`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1419`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1420`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1421`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1422`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1423`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `index.ts`
+- **Thin community `Community 1424`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1425`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1426`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1427`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1428`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1429`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1430`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1431`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1432`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1433`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `index.ts`
+- **Thin community `Community 1434`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1435`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1436`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1437`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1438`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1439`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1440`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `bag.ts`
+- **Thin community `Community 1441`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1442`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1443`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1444`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `guest.ts`
+- **Thin community `Community 1445`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `index.ts`
+- **Thin community `Community 1446`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `offer.ts`
+- **Thin community `Community 1447`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1448`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1449`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `review.ts`
+- **Thin community `Community 1450`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1451`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1452`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1453`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1454`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1455`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1456`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1457`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1458`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1459`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `bag.ts`
+- **Thin community `Community 1460`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1461`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `customer.ts`
+- **Thin community `Community 1462`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `guest.ts`
+- **Thin community `Community 1463`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1464`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1465`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1466`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1467`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1468`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1469`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1470`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `users.ts`
+- **Thin community `Community 1471`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `payment.ts`
+- **Thin community `Community 1472`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1473`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1474`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1475`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1476`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1477`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1478`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1479`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `index.ts`
+- **Thin community `Community 1480`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1481`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1482`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1483`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1484`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `auth.ts`
+- **Thin community `Community 1485`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1486`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1487`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1488`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1489`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1490`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1491`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1492`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `index.ts`
+- **Thin community `Community 1493`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1494`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1495`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1496`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1497`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1498`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1499`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1500`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1501`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1502`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `Navbar.test.tsx`
+- **Thin community `Community 1503`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1504`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1505`** (1 nodes): `Navbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1506`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1507`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1508`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1509`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1510`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1511`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1512`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1513`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1514`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1515`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `constants.ts`
+- **Thin community `Community 1516`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1517`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1518`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1519`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `types.ts`
+- **Thin community `Community 1520`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1521`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1522`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1523`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1524`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1525`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1526`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1527`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1528`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1529`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1530`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1531`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1532`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1533`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1534`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1535`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1536`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1537`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1538`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1539`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1540`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `constants.ts`
+- **Thin community `Community 1541`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1542`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1543`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1544`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `data.ts`
+- **Thin community `Community 1545`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1546`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1547`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1548`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1549`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1550`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1551`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1552`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1553`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `app-sidebar.test.tsx`
+- **Thin community `Community 1554`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1555`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `constants.ts`
+- **Thin community `Community 1556`** (1 nodes): `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1557`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1558`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1559`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `data.ts`
+- **Thin community `Community 1560`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1561`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1562`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1563`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1564`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1565`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1566`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1567`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1568`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1569`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1570`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1571`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1572`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `constants.ts`
+- **Thin community `Community 1573`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1574`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1575`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 1576`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1577`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1578`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1579`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1580`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1581`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1582`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1583`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1584`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1585`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1586`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1587`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1588`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1589`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1590`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1591`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1592`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1593`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1594`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1595`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1596`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1597`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `OperationReviewItemCard.tsx`
+- **Thin community `Community 1598`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1599`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1600`** (1 nodes): `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1601`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1602`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1603`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1604`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1605`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1606`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1607`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1608`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1609`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `constants.ts`
+- **Thin community `Community 1610`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1611`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1612`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1613`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `data.ts`
+- **Thin community `Community 1614`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1615`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1616`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `constants.ts`
+- **Thin community `Community 1617`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1618`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1619`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1620`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1621`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `data.ts`
+- **Thin community `Community 1622`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1623`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `constants.ts`
+- **Thin community `Community 1624`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1625`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1626`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1627`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1628`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `data.ts`
+- **Thin community `Community 1629`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1630`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1631`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1632`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1633`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1634`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1635`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1636`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1637`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1638`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1639`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1640`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1641`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1642`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1643`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1644`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1645`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1646`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1647`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1648`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1649`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1650`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1651`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1652`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1653`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1654`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1655`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1656`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1657`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `types.ts`
+- **Thin community `Community 1658`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1659`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1660`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1661`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1662`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1663`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1664`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1665`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1666`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 1667`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1668`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1669`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1670`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1671`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1672`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1673`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1674`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1675`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1676`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `data.ts`
+- **Thin community `Community 1677`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1678`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1679`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1680`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1681`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1682`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1683`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1684`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1685`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1686`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1687`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1688`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1689`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `constants.ts`
+- **Thin community `Community 1690`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1691`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1692`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1693`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `data.ts`
+- **Thin community `Community 1694`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `types.ts`
+- **Thin community `Community 1695`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1696`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1697`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1698`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1699`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1700`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `index.ts`
+- **Thin community `Community 1701`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1702`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1703`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1704`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1705`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `index.tsx`
+- **Thin community `Community 1706`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1707`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1708`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1709`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1710`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1711`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1712`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1713`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `StoreHoursView.test.tsx`
+- **Thin community `Community 1714`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1715`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 1716`** (1 nodes): `StoreHoursView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `index.tsx`
+- **Thin community `Community 1717`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1718`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1719`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1720`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `button.tsx`
+- **Thin community `Community 1721`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1722`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `card.tsx`
+- **Thin community `Community 1723`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1724`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1725`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `command.tsx`
+- **Thin community `Community 1726`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1727`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1728`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1729`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `form.tsx`
+- **Thin community `Community 1730`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1731`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1732`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `input.tsx`
+- **Thin community `Community 1733`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1734`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1735`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1736`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1737`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1738`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1739`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `select.tsx`
+- **Thin community `Community 1740`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1741`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1742`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1743`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1744`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `table.tsx`
+- **Thin community `Community 1745`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1746`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1747`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1748`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1749`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1750`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1751`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1752`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1753`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `constants.ts`
+- **Thin community `Community 1754`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1755`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1756`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1757`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `data.ts`
+- **Thin community `Community 1758`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1759`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1760`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1761`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1762`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1763`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1764`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1765`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1766`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1767`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1768`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `index.ts`
+- **Thin community `Community 1769`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1770`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1771`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1772`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 1773`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1774`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1775`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1776`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1777`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1778`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1779`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 1780`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1781`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1782`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 1783`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 1784`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `index.ts`
+- **Thin community `Community 1785`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 1786`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1787`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 1788`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 1789`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `aws.ts`
+- **Thin community `Community 1790`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `constants.ts`
+- **Thin community `Community 1791`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `countries.ts`
+- **Thin community `Community 1792`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1793`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1794`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1795`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1796`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1797`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1798`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1799`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 1800`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `dto.ts`
+- **Thin community `Community 1801`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `ports.ts`
+- **Thin community `Community 1802`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `constants.ts`
+- **Thin community `Community 1803`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1804`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1805`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `index.ts`
+- **Thin community `Community 1806`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1807`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `types.ts`
+- **Thin community `Community 1808`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1809`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1810`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1811`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1812`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1813`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1814`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1815`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1816`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1817`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 1818`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 1819`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 1820`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 1821`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 1822`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1823`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1824`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1825`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1826`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `index.ts`
+- **Thin community `Community 1827`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1828`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `category.ts`
+- **Thin community `Community 1829`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `product.ts`
+- **Thin community `Community 1830`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `store.ts`
+- **Thin community `Community 1831`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1832`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `user.ts`
+- **Thin community `Community 1833`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1834`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1835`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1836`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1837`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1838`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `main.tsx`
+- **Thin community `Community 1839`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 1840`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1841`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1842`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1843`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1844`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1845`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `index.tsx`
+- **Thin community `Community 1846`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `index.tsx`
+- **Thin community `Community 1847`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1848`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1849`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1850`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1851`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1852`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1853`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `index.tsx`
+- **Thin community `Community 1854`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1855`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1856`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1857`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `home.tsx`
+- **Thin community `Community 1858`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1859`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1860`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1861`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `index.tsx`
+- **Thin community `Community 1862`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `review.tsx`
+- **Thin community `Community 1863`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1864`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1865`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `index.tsx`
+- **Thin community `Community 1866`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1867`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1868`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1869`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `index.tsx`
+- **Thin community `Community 1870`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1871`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1872`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1873`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1874`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1875`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1876`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 1877`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `index.tsx`
+- **Thin community `Community 1878`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1879`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1880`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1881`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1882`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1883`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1884`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1885`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1886`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1887`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `index.tsx`
+- **Thin community `Community 1888`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1889`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1890`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `new.tsx`
+- **Thin community `Community 1891`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1892`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1893`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1894`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1895`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `index.tsx`
+- **Thin community `Community 1896`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `new.tsx`
+- **Thin community `Community 1897`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1898`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1899`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1900`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1901`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1902`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `index.tsx`
+- **Thin community `Community 1903`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1904`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1905`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1906`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `index.tsx`
+- **Thin community `Community 1907`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1908`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `_authed.tsx`
+- **Thin community `Community 1909`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1910`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `index.tsx`
+- **Thin community `Community 1911`** (1 nodes): `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1912`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1913`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1914`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 1915`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1916`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 1917`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1918`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 1919`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1920`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1921`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1922`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1923`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1924`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1925`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1926`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1927`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1928`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1929`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1930`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1931`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1932`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1933`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1934`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1935`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `setup.ts`
+- **Thin community `Community 1936`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1937`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `types.ts`
+- **Thin community `Community 1938`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1939`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1940`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1941`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1942`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1943`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1944`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1945`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `types.ts`
+- **Thin community `Community 1946`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1947`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1948`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1949`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1950`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1951`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1952`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1953`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1954`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `schema.ts`
+- **Thin community `Community 1955`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1956`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1957`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1958`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1959`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1960`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1961`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1962`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1963`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1964`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `types.ts`
+- **Thin community `Community 1965`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1966`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1967`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1968`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1969`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1970`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1971`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1972`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `constants.ts`
+- **Thin community `Community 1973`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1974`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `About.tsx`
+- **Thin community `Community 1975`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1976`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1977`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1978`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1979`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1980`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1981`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1982`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1983`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1984`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1985`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `types.ts`
+- **Thin community `Community 1986`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1987`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1988`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1989`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1990`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1991`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1992`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1993`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1994`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1995`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1996`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1997`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `button.tsx`
+- **Thin community `Community 1998`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `card.tsx`
+- **Thin community `Community 1999`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2000`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `command.tsx`
+- **Thin community `Community 2001`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2002`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2003`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2004`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `form.tsx`
+- **Thin community `Community 2005`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2006`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2007`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2008`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2009`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `input.tsx`
+- **Thin community `Community 2010`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `label.tsx`
+- **Thin community `Community 2011`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2012`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2013`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2014`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `index.ts`
+- **Thin community `Community 2015`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `types.ts`
+- **Thin community `Community 2016`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2017`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2018`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2019`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2020`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `select.tsx`
+- **Thin community `Community 2021`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2022`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2023`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `table.tsx`
+- **Thin community `Community 2024`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2025`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2026`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2027`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2028`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2029`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `config.ts`
+- **Thin community `Community 2030`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2031`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2032`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2033`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2034`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2035`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `constants.ts`
+- **Thin community `Community 2036`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `countries.ts`
+- **Thin community `Community 2037`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2038`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2039`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2040`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2041`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `index.ts`
+- **Thin community `Community 2042`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2043`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `store.ts`
+- **Thin community `Community 2044`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `bag.ts`
+- **Thin community `Community 2045`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2046`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `category.ts`
+- **Thin community `Community 2047`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `organization.ts`
+- **Thin community `Community 2048`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `product.ts`
+- **Thin community `Community 2049`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `store.ts`
+- **Thin community `Community 2050`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2051`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `user.ts`
+- **Thin community `Community 2052`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `states.ts`
+- **Thin community `Community 2053`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2054`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2055`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2056`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2056`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2057`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2057`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2058`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2058`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2059`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2059`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2060`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2060`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2061`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2061`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2062`** (1 nodes): `index.tsx`
+- **Thin community `Community 2062`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2063`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2063`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2064`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2065`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2065`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2066`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2066`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2067`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2067`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2068`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2068`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2069`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2069`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2070`** (1 nodes): `index.tsx`
+- **Thin community `Community 2070`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2071`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2071`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2072`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2072`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2073`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2073`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2074`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2074`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2075`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2075`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2076`** (1 nodes): `index.js`
+- **Thin community `Community 2076`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2077`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2077`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2078`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2078`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2079`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2079`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2080`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2080`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2081`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2081`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2082`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2082`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2083`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2084`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -13158,7 +13164,7 @@ _Questions this graph is uniquely positioned to answer:_
 - **What connects `FakeMessageChannel`, `HelpRequested` to the rest of the system?**
   _2 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.05 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.04 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**
@@ -13166,6 +13172,6 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 3` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**
-  _Cohesion score 0.09 - nodes in this community are weakly interconnected._
-- **Should `Community 5` be split into smaller, more focused modules?**
   _Cohesion score 0.04 - nodes in this community are weakly interconnected._
+- **Should `Community 5` be split into smaller, more focused modules?**
+  _Cohesion score 0.09 - nodes in this community are weakly interconnected._

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,18 +7,18 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2156
-- Graph nodes: 8413
-- Graph edges: 10081
-- Communities: 2083
+- Code files discovered: 2158
+- Graph nodes: 8474
+- Graph edges: 10200
+- Communities: 2085
 
 ## Graph Hotspots
-- `dailyClose.ts` (90 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (102 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-inferential-review.ts` (86 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `terminalHealthPresentation.ts` (76 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (71 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `DailyCloseView.tsx` (65 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `projectLocalEvents.ts` (65 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `DailyCloseView.tsx` (66 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `projectLocalEvents.ts` (65 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `posLocalStore.ts` (56 edges, Community 6) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 - `ingestLocalEvents.ts` (54 edges, Community 7) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,11 +17,11 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `dailyClose.ts` (90 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (102 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `terminalHealthPresentation.ts` (76 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (71 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `DailyCloseView.tsx` (65 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `projectLocalEvents.ts` (65 edges, Community 4) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `DailyCloseView.tsx` (66 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `projectLocalEvents.ts` (65 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,8 +20,8 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 12) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 12) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 65) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `storefrontContextEvents.ts` (17 edges, Community 82) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
-- `checkoutSession.ts` (14 edges, Community 98) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `storefrontContextEvents.ts` (17 edges, Community 83) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
+- `checkoutSession.ts` (14 edges, Community 99) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (15 edges, Community 99) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 203) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 99) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossCluster()` (4 edges, Community 99) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossClusterWithPipeline()` (4 edges, Community 99) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (15 edges, Community 100) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.test.js` (6 edges, Community 205) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `createRedisClient()` (4 edges, Community 100) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossCluster()` (4 edges, Community 100) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossClusterWithPipeline()` (4 edges, Community 100) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/_generated/api.d.ts
+++ b/packages/athena-webapp/convex/_generated/api.d.ts
@@ -169,6 +169,7 @@ import type * as operations_helpers_eventBuilders from "../operations/helpers/ev
 import type * as operations_helpers_linking from "../operations/helpers/linking.js";
 import type * as operations_inventoryMovements from "../operations/inventoryMovements.js";
 import type * as operations_managerElevations from "../operations/managerElevations.js";
+import type * as operations_openWorkInventoryReviews from "../operations/openWorkInventoryReviews.js";
 import type * as operations_operationalEvents from "../operations/operationalEvents.js";
 import type * as operations_operationalWorkItems from "../operations/operationalWorkItems.js";
 import type * as operations_paymentAllocations from "../operations/paymentAllocations.js";
@@ -595,6 +596,7 @@ declare const fullApi: ApiFromModules<{
   "operations/helpers/linking": typeof operations_helpers_linking;
   "operations/inventoryMovements": typeof operations_inventoryMovements;
   "operations/managerElevations": typeof operations_managerElevations;
+  "operations/openWorkInventoryReviews": typeof operations_openWorkInventoryReviews;
   "operations/operationalEvents": typeof operations_operationalEvents;
   "operations/operationalWorkItems": typeof operations_operationalWorkItems;
   "operations/paymentAllocations": typeof operations_paymentAllocations;

--- a/packages/athena-webapp/convex/cashControls/deposits.test.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.test.ts
@@ -260,6 +260,16 @@ function createProjectedInventoryReviewQueryCtx(input: {
         cloudTable: "registerSession",
         cloudId: "session_open",
       },
+      {
+        _id: "sync_mapping_inventory_work",
+        storeId: "store_1",
+        terminalId: "terminal_1",
+        localRegisterSessionId: "local-register-1",
+        localIdKind: "inventoryReviewWorkItem",
+        localId: "local-transaction-1:inventory-review",
+        cloudTable: "operationalWorkItem",
+        cloudId: "work_item_inventory",
+      },
     ],
     registerSession: [
       {
@@ -1697,6 +1707,78 @@ describe("cash control deposits", () => {
         }),
       ]),
     );
+  });
+
+  it("rejects synced register reviews with an inline manager approval proof", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      ...createMissingMappingRepairSeed(),
+      approvalProof: [
+        {
+          _id: "approval_proof_1",
+          actionKey: "cash_controls.register_session.resolve_sync_review",
+          approvedByCredentialId: "credential_manager_1",
+          approvedByStaffProfileId: "manager_1",
+          createdAt: 1,
+          expiresAt: Date.now() + 60_000,
+          requestedByStaffProfileId: "staff_1",
+          requiredRole: "manager",
+          storeId: "store_1",
+          subjectId: "session_open",
+          subjectLabel: "1",
+          subjectType: "register_session",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "manager_1",
+          linkedUserId: "athena_user_2",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "staff_1",
+          linkedUserId: "athena_user_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+    });
+
+    const result = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        approvalProofId: "approval_proof_1" as Id<"approvalProof">,
+        decision: "rejected",
+        registerSessionId: "session_open" as Id<"registerSession">,
+        requestedByStaffProfileId: "staff_1" as Id<"staffProfile">,
+        reviewConflictIds: ["sync_conflict_missing_mapping"],
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual(
+      ok({
+        action: "rejected",
+        projectedCount: 0,
+        registerSession: expect.objectContaining({ _id: "session_open" }),
+        resolvedCount: 1,
+      }),
+    );
+    expect(ctx.tables.get("approvalProof")).toEqual([
+      expect.objectContaining({
+        _id: "approval_proof_1",
+        consumedAt: expect.any(Number),
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncConflict")).toEqual([
+      expect.objectContaining({
+        _id: "sync_conflict_missing_mapping",
+        resolvedByStaffProfileId: "manager_1",
+        status: "resolved",
+      }),
+    ]);
   });
 
   it("repairs missing register-session mappings for completed synced sales", async () => {
@@ -3844,7 +3926,23 @@ describe("cash control deposits", () => {
     ).resolves.toEqual(new Map());
   });
 
-  it("keeps projected inventory sales in cash-controls review when inventory work is closed", async () => {
+  it("does not keep projected inventory sales in cash-controls review after terminal Operations resolution", async () => {
+    for (const workItemStatus of ["completed", "cancelled"] as const) {
+      const ctx = createProjectedInventoryReviewQueryCtx({
+        workItemStatus,
+      });
+
+      await expect(
+        listOpenLocalSyncConflictsByRegisterSession(
+          ctx as never,
+          "store_1" as Id<"store">,
+          { includeRejectedEvidence: true },
+        ),
+      ).resolves.toEqual(new Map());
+    }
+  });
+
+  it("keeps projected inventory sales in cash-controls review when inventory work has an unknown status", async () => {
     const ctx = createProjectedInventoryReviewQueryCtx({
       workItemStatus: "resolved",
     });

--- a/packages/athena-webapp/convex/cashControls/deposits.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.ts
@@ -1505,7 +1505,8 @@ export const resolveRegisterSessionSyncReview = mutation({
     }
 
     const decision = args.decision ?? "approved";
-    const isAutomaticResolution = !args.actorStaffProfileId;
+    const isAutomaticResolution =
+      !args.actorStaffProfileId && !args.approvalProofId;
     let reviewActorStaffProfileId: Id<"staffProfile"> | undefined;
     if (decision === "rejected" && isAutomaticResolution) {
       return userError({

--- a/packages/athena-webapp/convex/operations/approvalRequests.test.ts
+++ b/packages/athena-webapp/convex/operations/approvalRequests.test.ts
@@ -562,6 +562,51 @@ describe("approval request helpers", () => {
     });
   });
 
+  it("rejects unsupported service deposit reviews before consuming manager proof", async () => {
+    const { ctx, tables } = createApprovalRequestMutationCtx({
+      authUserId: "auth-user-1",
+      role: "full_admin",
+    });
+    tables.approvalRequest.set("approval-service-deposit", {
+      _id: "approval-service-deposit",
+      organizationId: "org-1",
+      requestType: "service_deposit_review",
+      status: "pending",
+      storeId: "store-1",
+      subjectId: "service-case-1",
+      subjectType: "service_case",
+    });
+    tables.approvalProof.set("proof-service-deposit", {
+      _id: "proof-service-deposit",
+      actionKey: "operations.approval_request.decide",
+      approvedByCredentialId: "credential-1",
+      approvedByStaffProfileId: "staff-manager-1",
+      createdAt: 1,
+      expiresAt: Date.now() + 60_000,
+      requiredRole: "manager",
+      storeId: "store-1",
+      subjectId: "approval-service-deposit",
+      subjectLabel: "service_deposit_review",
+      subjectType: "approval_request",
+    });
+
+    await expect(
+      decideApprovalRequestAsAuthenticatedUserWithCtx(ctx, {
+        approvalProofId: "proof-service-deposit" as Id<"approvalProof">,
+        approvalRequestId:
+          "approval-service-deposit" as Id<"approvalRequest">,
+        decision: "approved",
+      }),
+    ).rejects.toThrow("Service deposit approval reviews can only be retired.");
+
+    expect(tables.approvalProof.get("proof-service-deposit")).not.toHaveProperty(
+      "consumedAt",
+    );
+    expect(tables.approvalRequest.get("approval-service-deposit")).toMatchObject({
+      status: "pending",
+    });
+  });
+
   it("rejects ambiguous duplicate Athena user matches for the authenticated reviewer", async () => {
     const { ctx } = createApprovalRequestMutationCtx({
       athenaUsers: [
@@ -707,6 +752,267 @@ describe("approval request helpers", () => {
           "This transaction already has an item adjustment waiting for approval.",
       },
     });
+  });
+
+  it("rejects unsupported service deposit approval while allowing retirement", async () => {
+    const { ctx, tables } = createApprovalRequestMutationCtx({
+      authUserId: "auth-user-1",
+      role: "full_admin",
+    });
+    tables.approvalRequest.set("approval-service-deposit-1", {
+      _id: "approval-service-deposit-1",
+      organizationId: "org-1",
+      requestType: "service_deposit_review",
+      status: "pending",
+      storeId: "store-1",
+      subjectId: "service-case-1",
+      subjectType: "service_case",
+      workItemId: "work-item-service-1",
+    });
+    tables.operationalWorkItem.set("work-item-service-1", {
+      _id: "work-item-service-1",
+      approvalRequestId: "approval-service-deposit-1",
+      approvalState: "pending",
+      organizationId: "org-1",
+      status: "open",
+      storeId: "store-1",
+      type: "service_deposit_review",
+    });
+    tables.approvalProof.set("proof-1", {
+      ...tables.approvalProof.get("proof-1"),
+      subjectId: "approval-service-deposit-1",
+      subjectLabel: "service_deposit_review",
+    });
+
+    await expect(
+      decideApprovalRequestAsCommandWithCtx(ctx, {
+        approvalProofId: "proof-1" as Id<"approvalProof">,
+        approvalRequestId:
+          "approval-service-deposit-1" as Id<"approvalRequest">,
+        decision: "approved",
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Service deposit approval reviews can only be retired.",
+      },
+    });
+    expect(
+      tables.approvalRequest.get("approval-service-deposit-1"),
+    ).toMatchObject({
+      status: "pending",
+    });
+    expect(tables.approvalProof.get("proof-1")).not.toHaveProperty(
+      "consumedAt",
+    );
+
+    await expect(
+      decideApprovalRequestAsCommandWithCtx(ctx, {
+        approvalProofId: "proof-1" as Id<"approvalProof">,
+        approvalRequestId:
+          "approval-service-deposit-1" as Id<"approvalRequest">,
+        decision: "rejected",
+      }),
+    ).resolves.toMatchObject({
+      kind: "ok",
+      data: {
+        status: "rejected",
+      },
+    });
+    expect(
+      tables.operationalWorkItem.get("work-item-service-1"),
+    ).toMatchObject({
+      approvalState: "rejected",
+      status: "cancelled",
+    });
+  });
+
+  it("does not retire unrelated work items from stale legacy approval links", async () => {
+    const { ctx, tables } = createApprovalRequestMutationCtx({
+      authUserId: "auth-user-1",
+      role: "full_admin",
+    });
+    tables.approvalRequest.set("approval-service-deposit-stale", {
+      _id: "approval-service-deposit-stale",
+      organizationId: "org-1",
+      requestType: "service_deposit_review",
+      status: "pending",
+      storeId: "store-1",
+      subjectId: "service-case-1",
+      subjectType: "service_case",
+      workItemId: "work-item-unrelated",
+    });
+    tables.operationalWorkItem.set("work-item-unrelated", {
+      _id: "work-item-unrelated",
+      approvalRequestId: "approval-other",
+      approvalState: "pending",
+      organizationId: "org-1",
+      status: "open",
+      storeId: "store-1",
+      type: "service_deposit_review",
+    });
+    tables.approvalProof.set("proof-stale", {
+      ...tables.approvalProof.get("proof-1"),
+      _id: "proof-stale",
+      subjectId: "approval-service-deposit-stale",
+      subjectLabel: "service_deposit_review",
+    });
+
+    await expect(
+      decideApprovalRequestAsCommandWithCtx(ctx, {
+        approvalProofId: "proof-stale" as Id<"approvalProof">,
+        approvalRequestId:
+          "approval-service-deposit-stale" as Id<"approvalRequest">,
+        decision: "rejected",
+      }),
+    ).resolves.toMatchObject({
+      kind: "ok",
+      data: {
+        status: "rejected",
+      },
+    });
+    expect(tables.operationalWorkItem.get("work-item-unrelated")).toMatchObject({
+      approvalRequestId: "approval-other",
+      approvalState: "pending",
+      status: "open",
+    });
+  });
+
+  it.each([
+    {
+      field: "storeId",
+      value: "store-2",
+    },
+    {
+      field: "organizationId",
+      value: "org-2",
+    },
+  ])(
+    "does not retire unsupported approval work items when $field does not match",
+    async ({ field, value }) => {
+      const { ctx, tables } = createApprovalRequestMutationCtx({
+        authUserId: "auth-user-1",
+        role: "full_admin",
+      });
+      tables.approvalRequest.set("approval-service-deposit-mismatch", {
+        _id: "approval-service-deposit-mismatch",
+        organizationId: "org-1",
+        requestType: "service_deposit_review",
+        status: "pending",
+        storeId: "store-1",
+        subjectId: "service-case-1",
+        subjectType: "service_case",
+        workItemId: "work-item-mismatch",
+      });
+      tables.operationalWorkItem.set("work-item-mismatch", {
+        _id: "work-item-mismatch",
+        approvalRequestId: "approval-service-deposit-mismatch",
+        approvalState: "pending",
+        organizationId: "org-1",
+        status: "open",
+        storeId: "store-1",
+        type: "service_deposit_review",
+        [field]: value,
+      });
+      tables.approvalProof.set("proof-mismatch", {
+        ...tables.approvalProof.get("proof-1"),
+        _id: "proof-mismatch",
+        subjectId: "approval-service-deposit-mismatch",
+        subjectLabel: "service_deposit_review",
+      });
+
+      await expect(
+        decideApprovalRequestAsCommandWithCtx(ctx, {
+          approvalProofId: "proof-mismatch" as Id<"approvalProof">,
+          approvalRequestId:
+            "approval-service-deposit-mismatch" as Id<"approvalRequest">,
+          decision: "rejected",
+        }),
+      ).resolves.toMatchObject({
+        kind: "ok",
+        data: {
+          status: "rejected",
+        },
+      });
+      expect(tables.operationalWorkItem.get("work-item-mismatch")).toMatchObject(
+        {
+          approvalState: "pending",
+          status: "open",
+          [field]: value,
+        },
+      );
+    },
+  );
+
+  it("rejects unsupported approval-only request types before consuming proof", async () => {
+    const { ctx, tables } = createApprovalRequestMutationCtx({
+      authUserId: "auth-user-1",
+      role: "full_admin",
+    });
+    tables.approvalRequest.set("approval-online-return-1", {
+      _id: "approval-online-return-1",
+      organizationId: "org-1",
+      requestType: "online_order_return_review",
+      status: "pending",
+      storeId: "store-1",
+      subjectId: "online-order-1",
+      subjectType: "online_order",
+    });
+    tables.approvalRequest.set("approval-legacy-item-1", {
+      _id: "approval-legacy-item-1",
+      organizationId: "org-1",
+      requestType: "pos_item_adjustment_review",
+      status: "pending",
+      storeId: "store-1",
+      subjectId: "adjustment-1",
+      subjectType: "pos_item_adjustment",
+    });
+    tables.approvalProof.set("proof-online-return", {
+      ...tables.approvalProof.get("proof-1"),
+      _id: "proof-online-return",
+      subjectId: "approval-online-return-1",
+      subjectLabel: "online_order_return_review",
+    });
+    tables.approvalProof.set("proof-legacy-item", {
+      ...tables.approvalProof.get("proof-1"),
+      _id: "proof-legacy-item",
+      subjectId: "approval-legacy-item-1",
+      subjectLabel: "pos_item_adjustment_review",
+    });
+
+    await expect(
+      decideApprovalRequestAsCommandWithCtx(ctx, {
+        approvalProofId: "proof-online-return" as Id<"approvalProof">,
+        approvalRequestId: "approval-online-return-1" as Id<"approvalRequest">,
+        decision: "approved",
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Online return approval reviews are not supported yet.",
+      },
+    });
+    await expect(
+      decideApprovalRequestAsCommandWithCtx(ctx, {
+        approvalProofId: "proof-legacy-item" as Id<"approvalProof">,
+        approvalRequestId: "approval-legacy-item-1" as Id<"approvalRequest">,
+        decision: "approved",
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Legacy item adjustment approval reviews can only be retired.",
+      },
+    });
+    expect(tables.approvalProof.get("proof-online-return")).not.toHaveProperty(
+      "consumedAt",
+    );
+    expect(tables.approvalProof.get("proof-legacy-item")).not.toHaveProperty(
+      "consumedAt",
+    );
   });
 
   it("maps queued void resolver precondition failures to command user errors", async () => {

--- a/packages/athena-webapp/convex/operations/approvalRequests.ts
+++ b/packages/athena-webapp/convex/operations/approvalRequests.ts
@@ -27,6 +27,13 @@ import { consumeApprovalProofWithCtx } from "./approvalProofs";
 const APPROVAL_DECISION_ACTION_KEY = "operations.approval_request.decide";
 const ITEM_ADJUSTMENT_REQUEST_TYPE = "pos_item_adjustment";
 const ITEM_ADJUSTMENT_SUBJECT_TYPE = "pos_transaction_item_adjustment";
+const SERVICE_DEPOSIT_REVIEW_REQUEST_TYPE = "service_deposit_review";
+const APPROVAL_APPLY_UNSUPPORTED_REQUEST_TYPES = new Set([
+  SERVICE_DEPOSIT_REVIEW_REQUEST_TYPE,
+  "online_order_return_review",
+  "pos_item_adjustment_review",
+]);
+const TERMINAL_WORK_ITEM_STATUSES = new Set(["completed", "cancelled"]);
 const ITEM_ADJUSTMENT_RETIRED_PRECONDITION_MESSAGES = new Set([
   "Register session expected cash cannot be negative.",
 ]);
@@ -124,6 +131,83 @@ function shouldRetireItemAdjustmentApprovalAfterApplyFailure(error: unknown) {
   return ITEM_ADJUSTMENT_RETIRED_PRECONDITION_MESSAGES.has(message);
 }
 
+function unsupportedApprovalDecisionMessage(requestType: string) {
+  if (requestType === SERVICE_DEPOSIT_REVIEW_REQUEST_TYPE) {
+    return "Service deposit approval reviews can only be retired.";
+  }
+
+  if (requestType === "online_order_return_review") {
+    return "Online return approval reviews are not supported yet.";
+  }
+
+  if (requestType === "pos_item_adjustment_review") {
+    return "Legacy item adjustment approval reviews can only be retired.";
+  }
+
+  return null;
+}
+
+function assertApprovalDecisionCanApply(args: {
+  decision: DecideApprovalRequestArgs["decision"];
+  requestType: string;
+}) {
+  if (
+    args.decision === "approved" &&
+    APPROVAL_APPLY_UNSUPPORTED_REQUEST_TYPES.has(args.requestType)
+  ) {
+    throw new Error(
+      unsupportedApprovalDecisionMessage(args.requestType) ??
+        "Approval reviews of this type are not supported yet.",
+    );
+  }
+}
+
+async function retireLinkedUnsupportedApprovalWorkItemWithCtx(
+  ctx: MutationCtx,
+  args: {
+    approvalRequest: {
+      _id: Id<"approvalRequest">;
+      organizationId?: Id<"organization">;
+      requestType: string;
+      storeId: Id<"store">;
+      workItemId?: Id<"operationalWorkItem">;
+    };
+    decision: Exclude<DecideApprovalRequestArgs["decision"], "approved">;
+  },
+) {
+  if (!APPROVAL_APPLY_UNSUPPORTED_REQUEST_TYPES.has(args.approvalRequest.requestType)) {
+    return;
+  }
+
+  if (!args.approvalRequest.workItemId) {
+    return;
+  }
+
+  const workItem = await ctx.db.get(
+    "operationalWorkItem",
+    args.approvalRequest.workItemId,
+  );
+  if (!workItem) {
+    return;
+  }
+
+  if (
+    workItem.storeId !== args.approvalRequest.storeId ||
+    workItem.organizationId !== args.approvalRequest.organizationId ||
+    workItem.approvalRequestId !== args.approvalRequest._id ||
+    TERMINAL_WORK_ITEM_STATUSES.has(workItem.status)
+  ) {
+    return;
+  }
+
+  await ctx.db.patch("operationalWorkItem", workItem._id, {
+    approvalState: args.decision,
+    ...(workItem.type === SERVICE_DEPOSIT_REVIEW_REQUEST_TYPE
+      ? { status: "cancelled" }
+      : {}),
+  });
+}
+
 async function retireItemAdjustmentApprovalAfterApplyFailure(
   ctx: MutationCtx,
   args: {
@@ -208,6 +292,11 @@ export async function decideApprovalRequestWithCtx(
     throw new Error("Only full admins can resolve approval requests.");
   }
 
+  assertApprovalDecisionCanApply({
+    decision: args.decision,
+    requestType: approvalRequest.requestType,
+  });
+
   if (
     approvalRequest.requestType === "inventory_adjustment_review" &&
     approvalRequest.subjectType === "stock_adjustment_batch"
@@ -261,6 +350,13 @@ export async function decideApprovalRequestWithCtx(
       ? approvalRequest.notes ?? approvalRequest.reason
       : undefined);
 
+  if (args.decision !== "approved") {
+    await retireLinkedUnsupportedApprovalWorkItemWithCtx(ctx, {
+      approvalRequest,
+      decision: args.decision,
+    });
+  }
+
   await ctx.db.patch("approvalRequest", args.approvalRequestId, {
     status: args.decision,
     decisionApprovedByStaffProfileId: args.decisionApprovedByStaffProfileId,
@@ -306,6 +402,11 @@ export async function decideApprovalRequestAsAuthenticatedUserWithCtx(
     failureMessage: "Only full admins can resolve approval requests.",
     organizationId: approvalRequest.organizationId,
     userId: reviewer._id,
+  });
+
+  assertApprovalDecisionCanApply({
+    decision: args.decision,
+    requestType: approvalRequest.requestType,
   });
 
   if (!args.approvalProofId) {
@@ -375,6 +476,9 @@ function mapDecideApprovalRequestError(
 
   if (
     message === "Approval request has already been decided." ||
+    message === "Service deposit approval reviews can only be retired." ||
+    message === "Online return approval reviews are not supported yet." ||
+    message === "Legacy item adjustment approval reviews can only be retired." ||
     message === "Approval proof was not found." ||
     message === "Approval proof does not match this command." ||
     message === "Approval proof has already been used." ||

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -12,6 +12,8 @@ import {
   getDailyCloseOpeningContext,
   getDailyCloseOpeningContextWithCtx,
   listCompletedDailyCloseHistoryWithCtx,
+  resolveDailyCloseCarryForward,
+  resolveDailyCloseCarryForwardWithCtx,
   reopenDailyClose,
   reopenDailyCloseWithCtx,
 } from "./dailyClose";
@@ -27,6 +29,7 @@ type TableName =
   | "approvalRequest"
   | "automationRun"
   | "dailyClose"
+  | "dailyOpening"
   | "expenseSession"
   | "expenseTransaction"
   | "expenseTransactionItem"
@@ -306,6 +309,26 @@ function dailyCloseReopenApprovalProof(overrides: Partial<Row> = {}): Row {
     subjectId: "daily-close-1",
     subjectLabel: "EOD Review 2026-05-07",
     subjectType: "daily_close",
+    ...overrides,
+  };
+}
+
+function dailyCloseCarryForwardApprovalProof(
+  overrides: Partial<Row> = {},
+): Row {
+  return {
+    _id: "approval-proof-carry-forward-1",
+    actionKey: "operations.daily_close.resolve_carry_forward",
+    approvedByCredentialId: "credential-manager-1",
+    approvedByStaffProfileId: "staff-manager-1",
+    createdAt: Date.UTC(2026, 4, 8, 10),
+    expiresAt: Date.UTC(2026, 4, 8, 12),
+    requiredRole: "manager",
+    requestedByStaffProfileId: "staff-1",
+    storeId: "store-1",
+    subjectId: "daily-close-1:customer-follow-up:completed",
+    subjectLabel: "Carry-forward follow-up for EOD Review 2026-05-07",
+    subjectType: "daily_close_carry_forward",
     ...overrides,
   };
 }
@@ -3065,6 +3088,719 @@ describe("end-of-day review backend foundation", () => {
     ).not.toThrow();
   });
 
+  it("requires source-bound manager proof before completing carry-forward work", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 8, 10));
+    const { db, inserts, patches, tables } = createDb({
+      approvalProof: [dailyCloseCarryForwardApprovalProof()],
+      dailyClose: [
+        completedDailyCloseRow({
+          carryForwardWorkItemIds: ["work-1"],
+        }),
+      ],
+      dailyOpening: [
+        {
+          _id: "daily-opening-1",
+          acknowledgedItemKeys: ["operational_work_item:work-1:carry_forward"],
+          actorStaffProfileId: "staff-1",
+          actorUserId: "user-1",
+          carryForwardWorkItemIds: ["work-1"],
+          createdAt: Date.UTC(2026, 4, 8, 8),
+          operatingDate: "2026-05-08",
+          organizationId: "org-1",
+          priorDailyCloseId: "daily-close-1",
+          readiness: {
+            blockerCount: 0,
+            carryForwardCount: 1,
+            readyCount: 1,
+            reviewCount: 0,
+            status: "needs_attention",
+          },
+          sourceSubjects: [
+            { id: "work-1", label: "Call customer", type: "operational_work_item" },
+          ],
+          startedAt: Date.UTC(2026, 4, 8, 8),
+          status: "started",
+          storeId: "store-1",
+          updatedAt: Date.UTC(2026, 4, 8, 8),
+        },
+      ],
+      operationalWorkItem: [
+        {
+          _id: "work-1",
+          approvalState: "not_required",
+          createdAt: Date.UTC(2026, 4, 7, 20),
+          metadata: {
+            businessDate: "2026-05-07",
+            carryForwardSourceId: "customer-follow-up",
+            dailyCloseId: "daily-close-1",
+            source: "daily_close",
+          },
+          organizationId: "org-1",
+          priority: "normal",
+          status: "open",
+          storeId: "store-1",
+          title: "Call customer",
+          type: "daily_close_carry_forward",
+        },
+      ],
+      store: [store],
+    });
+
+    const proofRequired = await resolveDailyCloseCarryForwardWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        actorUserId: "user-1" as Id<"athenaUser">,
+        businessDate: "2026-05-07",
+        dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+        outcome: "completed",
+        reason: "Customer follow-up completed.",
+        sourceId: "customer-follow-up",
+        storeId: "store-1" as Id<"store">,
+        workItemId: "work-1" as Id<"operationalWorkItem">,
+      },
+    );
+
+    expect(proofRequired).toMatchObject({
+      kind: "approval_required",
+      approval: {
+        action: {
+          key: "operations.daily_close.resolve_carry_forward",
+        },
+        subject: {
+          id: "daily-close-1:customer-follow-up:completed",
+          type: "daily_close_carry_forward",
+        },
+      },
+    });
+    expect(patches).toEqual([]);
+
+    const result = await resolveDailyCloseCarryForwardWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        actorUserId: "user-1" as Id<"athenaUser">,
+        approvalProofId:
+          "approval-proof-carry-forward-1" as Id<"approvalProof">,
+        businessDate: "2026-05-07",
+        dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+        outcome: "completed",
+        reason: "Customer follow-up completed.",
+        sourceId: "customer-follow-up",
+        storeId: "store-1" as Id<"store">,
+        workItemId: "work-1" as Id<"operationalWorkItem">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "completed",
+        workItem: {
+          _id: "work-1",
+          status: "completed",
+        },
+      },
+    });
+    expect(() =>
+      assertConformsToExportedReturns(resolveDailyCloseCarryForward, result),
+    ).not.toThrow();
+    expect(tables.get("approvalProof")?.get("approval-proof-carry-forward-1"))
+      .toMatchObject({
+        consumedAt: Date.UTC(2026, 4, 8, 10),
+      });
+    expect(tables.get("operationalWorkItem")?.get("work-1")).toMatchObject({
+      status: "completed",
+      completedAt: Date.UTC(2026, 4, 8, 10),
+      metadata: {
+        carryForwardResolution: {
+          actorStaffProfileId: "staff-1",
+          actorUserId: "user-1",
+          approvalProofId: "approval-proof-carry-forward-1",
+          approvedByStaffProfileId: "staff-manager-1",
+          businessDate: "2026-05-07",
+          dailyCloseId: "daily-close-1",
+          handoff: {
+            dailyOpeningIds: ["daily-opening-1"],
+          },
+          nextStatus: "completed",
+          outcome: "completed",
+          priorStatus: "open",
+          reason: "Customer follow-up completed.",
+          resolvedAt: Date.UTC(2026, 4, 8, 10),
+          sourceId: "customer-follow-up",
+        },
+      },
+    });
+    expect(inserts.at(-1)).toMatchObject({
+      table: "operationalEvent",
+      value: {
+        actorStaffProfileId: "staff-1",
+        actorUserId: "user-1",
+        eventType: "daily_close_carry_forward_completed",
+        reason: "Customer follow-up completed.",
+        subjectId: "work-1",
+        subjectType: "daily_close_carry_forward",
+        metadata: {
+          approvalProofId: "approval-proof-carry-forward-1",
+          approvedByStaffProfileId: "staff-manager-1",
+          businessDate: "2026-05-07",
+          dailyCloseId: "daily-close-1",
+          handoff: {
+            dailyOpeningIds: ["daily-opening-1"],
+          },
+          nextState: {
+            status: "completed",
+          },
+          outcome: "completed",
+          priorState: {
+            status: "open",
+          },
+          sourceReference: {
+            sourceId: "customer-follow-up",
+            workItemId: "work-1",
+          },
+        },
+      },
+    });
+  });
+
+  it("resolves carry-forward work through the public mutation boundary", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 8, 10));
+    vi.mocked(
+      athenaUserAuth.requireAuthenticatedAthenaUserWithCtx,
+    ).mockResolvedValue({
+      _creationTime: 0,
+      _id: "user-1" as Id<"athenaUser">,
+      email: "manager@wigclub.store",
+    });
+    vi.mocked(
+      athenaUserAuth.requireOrganizationMemberRoleWithCtx,
+    ).mockResolvedValue({
+      _creationTime: 0,
+      _id: "member-1" as Id<"organizationMember">,
+      organizationId: "org-1" as Id<"organization">,
+      role: "full_admin",
+      userId: "user-1" as Id<"athenaUser">,
+    });
+    const { db, tables } = createDb({
+      approvalProof: [
+        dailyCloseCarryForwardApprovalProof({
+          requestedByStaffProfileId: undefined,
+        }),
+      ],
+      dailyClose: [
+        completedDailyCloseRow({
+          carryForwardWorkItemIds: ["work-1"],
+        }),
+      ],
+      operationalWorkItem: [
+        {
+          _id: "work-1",
+          approvalState: "not_required",
+          createdAt: Date.UTC(2026, 4, 7, 20),
+          metadata: {
+            businessDate: "2026-05-07",
+            carryForwardSourceId: "customer-follow-up",
+            dailyCloseId: "daily-close-1",
+            source: "daily_close",
+          },
+          organizationId: "org-1",
+          priority: "normal",
+          status: "open",
+          storeId: "store-1",
+          title: "Call customer",
+          type: "daily_close_carry_forward",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "staff-1",
+          linkedUserId: "user-1",
+          storeId: "store-1",
+        },
+      ],
+      store: [store],
+    });
+
+    const result = await getHandler(resolveDailyCloseCarryForward)(
+      { db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-spoof" as Id<"staffProfile">,
+        approvalProofId:
+          "approval-proof-carry-forward-1" as Id<"approvalProof">,
+        businessDate: "2026-05-07",
+        dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+        outcome: "completed",
+        reason: "Customer follow-up completed.",
+        sourceId: "customer-follow-up",
+        storeId: "store-1" as Id<"store">,
+        workItemId: "work-1" as Id<"operationalWorkItem">,
+      } as never,
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "completed",
+        workItem: {
+          _id: "work-1",
+          status: "completed",
+        },
+      },
+    });
+    expect(
+      athenaUserAuth.requireOrganizationMemberRoleWithCtx,
+    ).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        allowedRoles: ["full_admin", "pos_only"],
+        organizationId: "org-1",
+        userId: "user-1",
+      }),
+    );
+    expect(tables.get("operationalWorkItem")?.get("work-1")).toMatchObject({
+      completedAt: Date.UTC(2026, 4, 8, 10),
+      metadata: expect.objectContaining({
+        carryForwardResolution: expect.objectContaining({
+          actorStaffProfileId: "staff-1",
+        }),
+      }),
+      status: "completed",
+    });
+  });
+
+  it("rejects carry-forward resolution when manager proof is bound to another source", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 8, 10));
+    const { db, tables } = createDb({
+      approvalProof: [
+        dailyCloseCarryForwardApprovalProof({
+          subjectId: "daily-close-1:other-source",
+        }),
+      ],
+      dailyClose: [
+        completedDailyCloseRow({
+          carryForwardWorkItemIds: ["work-1"],
+        }),
+      ],
+      operationalWorkItem: [
+        {
+          _id: "work-1",
+          approvalState: "not_required",
+          createdAt: Date.UTC(2026, 4, 7, 20),
+          metadata: {
+            businessDate: "2026-05-07",
+            carryForwardSourceId: "customer-follow-up",
+            dailyCloseId: "daily-close-1",
+            source: "daily_close",
+          },
+          organizationId: "org-1",
+          priority: "normal",
+          status: "open",
+          storeId: "store-1",
+          title: "Call customer",
+          type: "daily_close_carry_forward",
+        },
+      ],
+      store: [store],
+    });
+
+    const result = await resolveDailyCloseCarryForwardWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        actorUserId: "user-1" as Id<"athenaUser">,
+        approvalProofId:
+          "approval-proof-carry-forward-1" as Id<"approvalProof">,
+        businessDate: "2026-05-07",
+        dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+        outcome: "completed",
+        reason: "Customer follow-up completed.",
+        sourceId: "customer-follow-up",
+        storeId: "store-1" as Id<"store">,
+        workItemId: "work-1" as Id<"operationalWorkItem">,
+      },
+    );
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Approval proof does not match this command.",
+      },
+    });
+    expect(
+      tables.get("approvalProof")?.get("approval-proof-carry-forward-1"),
+    ).not.toHaveProperty("consumedAt");
+    expect(tables.get("operationalWorkItem")?.get("work-1")).toMatchObject({
+      status: "open",
+    });
+  });
+
+  it("rejects carry-forward resolution when manager proof is bound to another outcome", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 8, 10));
+    const seed = {
+      dailyClose: [
+        completedDailyCloseRow({
+          carryForwardWorkItemIds: ["work-1"],
+        }),
+      ],
+      operationalWorkItem: [
+        {
+          _id: "work-1",
+          approvalState: "not_required",
+          createdAt: Date.UTC(2026, 4, 7, 20),
+          metadata: {
+            businessDate: "2026-05-07",
+            carryForwardSourceId: "customer-follow-up",
+            dailyCloseId: "daily-close-1",
+            source: "daily_close",
+          },
+          organizationId: "org-1",
+          priority: "normal",
+          status: "open",
+          storeId: "store-1",
+          title: "Call customer",
+          type: "daily_close_carry_forward",
+        },
+      ],
+      store: [store],
+    };
+
+    const completeProofDb = createDb({
+      ...seed,
+      approvalProof: [dailyCloseCarryForwardApprovalProof()],
+    });
+    const completeProofCancelResult = await resolveDailyCloseCarryForwardWithCtx(
+      { db: completeProofDb.db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        actorUserId: "user-1" as Id<"athenaUser">,
+        approvalProofId:
+          "approval-proof-carry-forward-1" as Id<"approvalProof">,
+        businessDate: "2026-05-07",
+        dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+        outcome: "cancelled",
+        reason: "Customer follow-up cancelled.",
+        sourceId: "customer-follow-up",
+        storeId: "store-1" as Id<"store">,
+        workItemId: "work-1" as Id<"operationalWorkItem">,
+      },
+    );
+
+    expect(completeProofCancelResult).toEqual({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Approval proof does not match this command.",
+      },
+    });
+    expect(
+      completeProofDb.tables
+        .get("approvalProof")
+        ?.get("approval-proof-carry-forward-1"),
+    ).not.toHaveProperty("consumedAt");
+    expect(
+      completeProofDb.tables.get("operationalWorkItem")?.get("work-1"),
+    ).toMatchObject({
+      status: "open",
+    });
+
+    const cancelProofDb = createDb({
+      ...seed,
+      approvalProof: [
+        dailyCloseCarryForwardApprovalProof({
+          _id: "approval-proof-cancel-1",
+          subjectId: "daily-close-1:customer-follow-up:cancelled",
+        }),
+      ],
+    });
+    const cancelProofCompleteResult =
+      await resolveDailyCloseCarryForwardWithCtx(
+        { db: cancelProofDb.db } as unknown as MutationCtx,
+        {
+          actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+          actorUserId: "user-1" as Id<"athenaUser">,
+          approvalProofId: "approval-proof-cancel-1" as Id<"approvalProof">,
+          businessDate: "2026-05-07",
+          dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+          outcome: "completed",
+          reason: "Customer follow-up completed.",
+          sourceId: "customer-follow-up",
+          storeId: "store-1" as Id<"store">,
+          workItemId: "work-1" as Id<"operationalWorkItem">,
+        },
+      );
+
+    expect(cancelProofCompleteResult).toEqual({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Approval proof does not match this command.",
+      },
+    });
+    expect(
+      cancelProofDb.tables.get("approvalProof")?.get("approval-proof-cancel-1"),
+    ).not.toHaveProperty("consumedAt");
+    expect(
+      cancelProofDb.tables.get("operationalWorkItem")?.get("work-1"),
+    ).toMatchObject({
+      status: "open",
+    });
+  });
+
+  it("cancels carry-forward work with a terminal reason and rejects replay", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 8, 11));
+    const { db, tables } = createDb({
+      approvalProof: [
+        dailyCloseCarryForwardApprovalProof({
+          _id: "approval-proof-cancel-1",
+          subjectId: "daily-close-1:customer-follow-up:cancelled",
+        }),
+      ],
+      dailyClose: [
+        completedDailyCloseRow({
+          carryForwardWorkItemIds: ["work-1"],
+        }),
+      ],
+      operationalWorkItem: [
+        {
+          _id: "work-1",
+          approvalState: "not_required",
+          createdAt: Date.UTC(2026, 4, 7, 20),
+          metadata: {
+            businessDate: "2026-05-07",
+            carryForwardSourceId: "customer-follow-up",
+            dailyCloseId: "daily-close-1",
+            source: "daily_close",
+          },
+          organizationId: "org-1",
+          priority: "normal",
+          status: "open",
+          storeId: "store-1",
+          title: "Call customer",
+          type: "daily_close_carry_forward",
+        },
+      ],
+      store: [store],
+    });
+
+    const result = await resolveDailyCloseCarryForwardWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        actorUserId: "user-1" as Id<"athenaUser">,
+        approvalProofId: "approval-proof-cancel-1" as Id<"approvalProof">,
+        businessDate: "2026-05-07",
+        dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+        outcome: "cancelled",
+        reason: "Follow-up is no longer applicable.",
+        sourceId: "customer-follow-up",
+        storeId: "store-1" as Id<"store">,
+        workItemId: "work-1" as Id<"operationalWorkItem">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "cancelled",
+        workItem: {
+          status: "cancelled",
+        },
+      },
+    });
+    expect(tables.get("operationalWorkItem")?.get("work-1")).toMatchObject({
+      status: "cancelled",
+      metadata: {
+        carryForwardResolution: {
+          nextStatus: "cancelled",
+          outcome: "cancelled",
+          reason: "Follow-up is no longer applicable.",
+        },
+      },
+    });
+
+    const replay = await resolveDailyCloseCarryForwardWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        actorUserId: "user-1" as Id<"athenaUser">,
+        approvalProofId: "approval-proof-cancel-1" as Id<"approvalProof">,
+        businessDate: "2026-05-07",
+        dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+        outcome: "cancelled",
+        reason: "Follow-up is no longer applicable.",
+        sourceId: "customer-follow-up",
+        storeId: "store-1" as Id<"store">,
+        workItemId: "work-1" as Id<"operationalWorkItem">,
+      },
+    );
+
+    expect(replay).toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Carry-forward work is already completed or cancelled.",
+      },
+    });
+  });
+
+  it("reuses the current carry-forward row for the same business date and source", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 7, 22));
+    const { db, inserts } = createDb({
+      approvalProof: [dailyCloseApprovalProof()],
+      operationalWorkItem: [
+        {
+          _id: "work-existing",
+          approvalState: "not_required",
+          createdAt: Date.UTC(2026, 4, 7, 19),
+          metadata: {
+            businessDate: "2026-05-07",
+            carryForwardSourceId: "customer-follow-up",
+            source: "daily_close",
+          },
+          organizationId: "org-1",
+          priority: "normal",
+          status: "open",
+          storeId: "store-1",
+          title: "Call customer",
+          type: "daily_close_carry_forward",
+        },
+      ],
+      store: [store],
+    });
+
+    const result = await completeDailyCloseWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        actorUserId: "user-1" as Id<"athenaUser">,
+        approvalProofId: "approval-proof-1" as Id<"approvalProof">,
+        createCarryForwardWorkItems: [
+          {
+            title: "Call customer",
+            metadata: {
+              carryForwardSourceId: "customer-follow-up",
+            },
+          },
+        ],
+        operatingDate: "2026-05-07",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        carryForwardWorkItems: [
+          {
+            _id: "work-existing",
+          },
+        ],
+        dailyClose: {
+          carryForwardWorkItemIds: ["work-existing"],
+          readiness: {
+            carryForwardCount: 1,
+          },
+        },
+      },
+    });
+    expect(
+      inserts.filter((insert) => insert.table === "operationalWorkItem"),
+    ).toHaveLength(0);
+    expect(
+      inserts.filter(
+        (insert) =>
+          insert.table === "operationalEvent" &&
+          insert.value.eventType === "daily_close_carry_forward_created",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("reuses matching carry-forward work beyond the standard daily close query window", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 7, 22));
+    const nonMatchingCarryForwardItems = Array.from({ length: 200 }, (_, index) => ({
+      _id: `work-existing-${index}`,
+      approvalState: "not_required",
+      createdAt: Date.UTC(2026, 4, 7, 18, index % 60),
+      metadata: {
+        businessDate: "2026-05-07",
+        carryForwardSourceId: `other-follow-up-${index}`,
+        source: "daily_close",
+      },
+      organizationId: "org-1",
+      priority: "normal",
+      status: "open",
+      storeId: "store-1",
+      title: `Other follow-up ${index}`,
+      type: "daily_close_carry_forward",
+    }));
+    const { db, inserts } = createDb({
+      approvalProof: [dailyCloseApprovalProof()],
+      operationalWorkItem: [
+        ...nonMatchingCarryForwardItems,
+        {
+          _id: "work-existing-target",
+          approvalState: "not_required",
+          createdAt: Date.UTC(2026, 4, 7, 19),
+          metadata: {
+            businessDate: "2026-05-07",
+            carryForwardSourceId: "customer-follow-up",
+            source: "daily_close",
+          },
+          organizationId: "org-1",
+          priority: "normal",
+          status: "open",
+          storeId: "store-1",
+          title: "Call customer",
+          type: "daily_close_carry_forward",
+        },
+      ],
+      store: [store],
+    });
+
+    const result = await completeDailyCloseWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        actorUserId: "user-1" as Id<"athenaUser">,
+        approvalProofId: "approval-proof-1" as Id<"approvalProof">,
+        createCarryForwardWorkItems: [
+          {
+            title: "Call customer",
+            metadata: {
+              carryForwardSourceId: "customer-follow-up",
+            },
+          },
+        ],
+        operatingDate: "2026-05-07",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        carryForwardWorkItems: [
+          {
+            _id: "work-existing-target",
+          },
+        ],
+      },
+    });
+    expect(
+      inserts.filter((insert) => insert.table === "operationalWorkItem"),
+    ).toHaveLength(0);
+    expect(
+      inserts.filter(
+        (insert) =>
+          insert.table === "operationalEvent" &&
+          insert.value.eventType === "daily_close_carry_forward_created",
+      ),
+    ).toHaveLength(0);
+  });
+
   it("completes a ready day through automation with durable attribution and no approval proof metadata", async () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 7, 22));
     const { db, inserts } = createDb({
@@ -3970,6 +4706,9 @@ describe("end-of-day review backend foundation", () => {
         carryForwardWorkItemIds: ["work-1"],
       },
     });
+    expect(
+      dailyClose?.reportSnapshot?.carryForwardItems[0],
+    ).not.toHaveProperty("carryForwardResolution");
     expect(inserts.map((insert) => insert.table)).toEqual([
       "dailyClose",
       "operationalEvent",
@@ -3986,6 +4725,74 @@ describe("end-of-day review backend foundation", () => {
         readiness: {
           carryForwardCount: 1,
         },
+      },
+    });
+  });
+
+  it("stamps automation carry-forward work metadata when snapshot exposes resolution", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 7, 22));
+    const { db, tables } = createDb({
+      operationalWorkItem: [
+        {
+          _id: "work-1",
+          approvalState: "not_required",
+          createdAt: 4,
+          organizationId: "org-1",
+          priority: "normal",
+          status: "open",
+          storeId: "store-1",
+          title: "Call customer tomorrow",
+          type: "daily_close_carry_forward",
+        },
+      ],
+      store: [store],
+    });
+
+    const result = await completeDailyCloseForAutomationWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        automationDecisionReason: "EOD Review passed policy checks.",
+        automationPolicyVersion: "daily-close-auto-complete.v1",
+        automationRunId: "automation-run-carry-forward" as Id<"automationRun">,
+        eodAutoCompletePolicy: {
+          cleanDayAutoCompleteEnabled: true,
+          maxAbsoluteCashVariance: 500,
+          maxVoidedSaleCount: 2,
+          maxVoidedSaleTotal: 1000,
+        },
+        operatingDate: "2026-05-07",
+        policyReviewedItemKeys: [],
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        dailyClose: {
+          _id: "dailyClose-1",
+          carryForwardWorkItemIds: ["work-1"],
+        },
+      },
+    });
+    expect(
+      result.kind === "ok"
+        ? result.data.dailyClose.reportSnapshot?.carryForwardItems[0]
+        : null,
+    ).toMatchObject({
+      carryForwardResolution: {
+        businessDate: "2026-05-07",
+        dailyCloseId: "dailyClose-1",
+        sourceId: "work-1",
+        workItemId: "work-1",
+      },
+    });
+    expect(tables.get("operationalWorkItem")?.get("work-1")).toMatchObject({
+      metadata: {
+        businessDate: "2026-05-07",
+        carryForwardSourceId: "work-1",
+        dailyCloseId: "dailyClose-1",
+        source: "daily_close",
       },
     });
   });

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -34,6 +34,7 @@ import { buildPaymentTotals, transactionCashDelta } from "./paymentTotals";
 import type { AutomationDecisionEvidence } from "../automation/runLedger";
 
 const DAILY_CLOSE_QUERY_LIMIT = 200;
+const DAILY_CLOSE_CARRY_FORWARD_SOURCE_PROBE_LIMIT = 1_000;
 const REGISTER_SESSION_DAILY_CLOSE_SOURCE_LIMIT = 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_OPERATING_DATE_RANGE_MS = 36 * 60 * 60 * 1000;
@@ -50,6 +51,10 @@ const REVIEW_ONLY_REGISTER_CLOSEOUT_STATUSES = ["closeout_rejected"] as const;
 const OPEN_POS_SESSION_STATUSES = ["active", "held"] as const;
 const DAILY_CLOSE_COMPLETION_ACTION = APPROVAL_ACTIONS.dailyCloseCompletion;
 const DAILY_CLOSE_REOPEN_ACTION = APPROVAL_ACTIONS.dailyCloseReopen;
+const DAILY_CLOSE_CARRY_FORWARD_RESOLUTION_ACTION = {
+  key: "operations.daily_close.resolve_carry_forward",
+  label: "Resolve carry-forward work",
+} as const;
 const DAILY_CLOSE_BLOCKER_CATEGORY_PRECEDENCE: Record<string, number> = {
   approval: 0,
   register_session: 10,
@@ -75,6 +80,12 @@ type DailyCloseItem = {
     params?: Record<string, string>;
     search?: Record<string, string>;
     to?: string;
+  };
+  carryForwardResolution?: {
+    businessDate: string;
+    dailyCloseId: Id<"dailyClose">;
+    sourceId: string;
+    workItemId: Id<"operationalWorkItem">;
   };
   metadata?: Record<string, unknown>;
 };
@@ -524,6 +535,26 @@ type ReopenDailyCloseResult = ApprovalCommandResult<{
   reopenedDailyClose: Doc<"dailyClose">;
 }>;
 
+type ResolveDailyCloseCarryForwardArgs = {
+  actorUserId?: Id<"athenaUser">;
+  actorStaffProfileId?: Id<"staffProfile">;
+  approvalProofId?: Id<"approvalProof">;
+  businessDate: string;
+  dailyCloseId: Id<"dailyClose">;
+  organizationId?: Id<"organization">;
+  outcome: "completed" | "cancelled";
+  reason: string;
+  sourceId: string;
+  storeId: Id<"store">;
+  workItemId: Id<"operationalWorkItem">;
+};
+
+type ResolveDailyCloseCarryForwardResult = ApprovalCommandResult<{
+  action: "completed" | "cancelled";
+  operationalEventId?: Id<"operationalEvent">;
+  workItem: Doc<"operationalWorkItem">;
+}>;
+
 function buildDailyCloseApprovalSubject(args: {
   operatingDate: string;
   storeId: Id<"store">;
@@ -593,6 +624,57 @@ function buildDailyCloseReopenApprovalRequirement(args: {
     metadata: {
       dailyCloseId: args.dailyCloseId,
       operatingDate: args.operatingDate,
+    },
+  };
+}
+
+function buildDailyCloseCarryForwardApprovalSubject(args: {
+  businessDate: string;
+  dailyCloseId: Id<"dailyClose">;
+  outcome: "completed" | "cancelled";
+  sourceId: string;
+}) {
+  return {
+    id: `${args.dailyCloseId}:${args.sourceId}:${args.outcome}`,
+    label: `Carry-forward follow-up for EOD Review ${args.businessDate}`,
+    type: DAILY_CLOSE_CARRY_FORWARD_TYPE,
+  };
+}
+
+function buildDailyCloseCarryForwardApprovalRequirement(args: {
+  businessDate: string;
+  dailyCloseId: Id<"dailyClose">;
+  outcome: "completed" | "cancelled";
+  sourceId: string;
+}): ApprovalRequirement {
+  return {
+    action: DAILY_CLOSE_CARRY_FORWARD_RESOLUTION_ACTION,
+    reason: "Manager approval is required to resolve carry-forward work.",
+    requiredRole: "manager",
+    selfApproval: "allowed",
+    subject: buildDailyCloseCarryForwardApprovalSubject(args),
+    copy: {
+      title: "Manager approval required",
+      message:
+        args.outcome === "completed"
+          ? "A manager needs to approve completing this carry-forward follow-up."
+          : "A manager needs to approve cancelling this carry-forward follow-up.",
+      primaryActionLabel:
+        args.outcome === "completed"
+          ? "Approve and complete"
+          : "Approve and cancel",
+      secondaryActionLabel: "Cancel",
+    },
+    resolutionModes: [
+      {
+        kind: "inline_manager_proof",
+      },
+    ],
+    metadata: {
+      businessDate: args.businessDate,
+      dailyCloseId: args.dailyCloseId,
+      outcome: args.outcome,
+      sourceId: args.sourceId,
     },
   };
 }
@@ -879,7 +961,31 @@ async function buildExpenseSessionsById(
 
 function asCarryForwardItem(
   workItem: Doc<"operationalWorkItem">,
+  fallback?: {
+    businessDate?: string;
+    dailyCloseId?: Id<"dailyClose">;
+    sourceId?: string;
+  },
 ): DailyCloseItem {
+  const businessDate =
+    carryForwardBusinessDate(workItem) ?? fallback?.businessDate;
+  const dailyCloseId =
+    stringFromMetadata(workItem.metadata, "dailyCloseId") ??
+    fallback?.dailyCloseId;
+  const sourceId = fallback?.sourceId ?? carryForwardSourceId(workItem);
+  const carryForwardResolution =
+    workItem.type === DAILY_CLOSE_CARRY_FORWARD_TYPE &&
+    businessDate &&
+    dailyCloseId &&
+    sourceId
+      ? {
+          businessDate,
+          dailyCloseId: dailyCloseId as Id<"dailyClose">,
+          sourceId,
+          workItemId: workItem._id,
+        }
+      : undefined;
+
   return {
     key: `operational_work_item:${workItem._id}:carry_forward`,
     severity: "carry_forward",
@@ -897,7 +1003,34 @@ function asCarryForwardItem(
       status: workItem.status,
       type: workItem.type,
     },
+    ...(carryForwardResolution ? { carryForwardResolution } : {}),
   };
+}
+
+async function patchDailyCloseCarryForwardWorkItemMetadata(
+  ctx: MutationCtx,
+  args: {
+    dailyCloseId: Id<"dailyClose">;
+    operatingDate: string;
+    workItems: Array<Doc<"operationalWorkItem">>;
+  },
+) {
+  for (const workItem of args.workItems) {
+    if (workItem.type !== DAILY_CLOSE_CARRY_FORWARD_TYPE) {
+      continue;
+    }
+
+    await ctx.db.patch("operationalWorkItem", workItem._id, {
+      metadata: {
+        ...(workItem.metadata ?? {}),
+        businessDate:
+          carryForwardBusinessDate(workItem) ?? args.operatingDate,
+        carryForwardSourceId: carryForwardSourceId(workItem),
+        dailyCloseId: args.dailyCloseId,
+        source: DAILY_CLOSE_SUBJECT_TYPE,
+      },
+    });
+  }
 }
 
 async function getStore(
@@ -1875,6 +2008,7 @@ function buildDailyCloseReportSnapshot(args: {
   completionRequestedByStaffProfileId?: Id<"staffProfile">;
   completionRequestedByUserId?: Id<"athenaUser">;
   currentnessMode?: "mark_current" | "historical_record";
+  dailyCloseId?: Id<"dailyClose">;
   notes?: string;
   policyReviewedItemKeys?: string[];
   readiness: DailyCloseReadiness;
@@ -1913,7 +2047,13 @@ function buildDailyCloseReportSnapshot(args: {
     reviewedItems: snapshotReviewedItems(args.snapshot, args.reviewedItemKeys),
     carryForwardItems: uniqueDailyCloseItems([
       ...args.snapshot.carryForwardItems,
-      ...args.carryForwardWorkItems.map(asCarryForwardItem),
+      ...args.carryForwardWorkItems.map((workItem) =>
+        asCarryForwardItem(workItem, {
+          businessDate: args.snapshot.operatingDate,
+          dailyCloseId: args.dailyCloseId,
+          sourceId: carryForwardSourceId(workItem),
+        }),
+      ),
     ]),
     readyItems: args.snapshot.readyItems,
     sourceCompleteness: args.snapshot.sourceCompleteness,
@@ -2675,7 +2815,9 @@ export async function buildDailyCloseSnapshotWithCtx(
   const blockers: DailyCloseItem[] = [];
   const reviewItems: DailyCloseItem[] = [];
   const readyItems: DailyCloseItem[] = [];
-  const carryForwardItems = openWorkItems.map(asCarryForwardItem);
+  const carryForwardItems = openWorkItems.map((workItem) =>
+    asCarryForwardItem(workItem),
+  );
 
   activeRegisterSessions.forEach((session) => {
     const terminalLabel = session.terminalId
@@ -3438,6 +3580,89 @@ function uniqueOperationalWorkItemIds(
   return Array.from(new Set(workItemIds));
 }
 
+function stringFromMetadata(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+) {
+  const value = metadata?.[key];
+
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function carryForwardBusinessDate(
+  workItem: Pick<Doc<"operationalWorkItem">, "metadata">,
+) {
+  return (
+    stringFromMetadata(workItem.metadata, "businessDate") ??
+    stringFromMetadata(workItem.metadata, "operatingDate")
+  );
+}
+
+function carryForwardSourceId(
+  workItem: Pick<Doc<"operationalWorkItem">, "_id" | "metadata">,
+) {
+  return (
+    stringFromMetadata(workItem.metadata, "carryForwardSourceId") ??
+    stringFromMetadata(workItem.metadata, "sourceId") ??
+    workItem._id
+  );
+}
+
+function sourceIdFromCarryForwardInput(
+  item: NonNullable<CompleteDailyCloseArgs["createCarryForwardWorkItems"]>[number],
+) {
+  return (
+    stringFromMetadata(item.metadata, "carryForwardSourceId") ??
+    stringFromMetadata(item.metadata, "sourceId")
+  );
+}
+
+function carryForwardMetadataMatches(args: {
+  businessDate: string;
+  sourceId: string;
+  workItem: Pick<Doc<"operationalWorkItem">, "_id" | "metadata">;
+}) {
+  return (
+    carryForwardBusinessDate(args.workItem) === args.businessDate &&
+    carryForwardSourceId(args.workItem) === args.sourceId
+  );
+}
+
+async function findCurrentCarryForwardWorkItemBySource(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    businessDate: string;
+    sourceId: string;
+    storeId: Id<"store">;
+  },
+) {
+  const pages = await Promise.all(
+    OPEN_OPERATIONAL_WORK_ITEM_STATUSES.map((status) =>
+      ctx.db
+        .query("operationalWorkItem")
+        .withIndex("by_storeId_type_status", (q) =>
+          q
+            .eq("storeId", args.storeId)
+            .eq("type", DAILY_CLOSE_CARRY_FORWARD_TYPE)
+            .eq("status", status),
+        )
+        .take(DAILY_CLOSE_CARRY_FORWARD_SOURCE_PROBE_LIMIT),
+    ),
+  );
+
+  return (
+    pages
+      .flat()
+      .find((workItem) =>
+        carryForwardMetadataMatches({
+          businessDate: args.businessDate,
+          sourceId: args.sourceId,
+          workItem,
+        }),
+      ) ?? null
+  );
+}
+
 function carryForwardWorkItemIdFromItem(
   item: DailyCloseItem,
 ): Id<"operationalWorkItem"> | null {
@@ -3533,6 +3758,7 @@ async function createCarryForwardWorkItems(
   },
 ) {
   const workItems: Array<Doc<"operationalWorkItem">> = [];
+  const createdWorkItems: Array<Doc<"operationalWorkItem">> = [];
 
   for (const item of args.items) {
     const title = trimOptional(item.title);
@@ -3542,6 +3768,24 @@ async function createCarryForwardWorkItems(
         ok: false as const,
         message: "Carry-forward work items require a title.",
       };
+    }
+
+    const sourceId = sourceIdFromCarryForwardInput(item);
+
+    if (sourceId) {
+      const existingWorkItem = await findCurrentCarryForwardWorkItemBySource(
+        ctx,
+        {
+          businessDate: args.operatingDate,
+          sourceId,
+          storeId: args.storeId,
+        },
+      );
+
+      if (existingWorkItem) {
+        workItems.push(existingWorkItem);
+        continue;
+      }
     }
 
     const workItem = await createOperationalWorkItemWithCtx(ctx, {
@@ -3558,6 +3802,8 @@ async function createCarryForwardWorkItems(
       assignedToStaffProfileId: item.assignedToStaffProfileId,
       metadata: {
         ...(item.metadata ?? {}),
+        businessDate: args.operatingDate,
+        ...(sourceId ? { carryForwardSourceId: sourceId } : {}),
         operatingDate: args.operatingDate,
         source: DAILY_CLOSE_SUBJECT_TYPE,
       },
@@ -3565,11 +3811,13 @@ async function createCarryForwardWorkItems(
 
     if (workItem) {
       workItems.push(workItem);
+      createdWorkItems.push(workItem);
     }
   }
 
   return {
     ok: true as const,
+    createdWorkItems,
     workItems,
   };
 }
@@ -3829,6 +4077,23 @@ export async function completeDailyCloseWithCtx(
     ...snapshot.summary,
     carryForwardWorkItemCount: carryForwardWorkItemIds.length,
   };
+  const reportSnapshotArgs = {
+    carryForwardWorkItemIds,
+    carryForwardWorkItems,
+    completedAt: now,
+    completedByStaffProfileId,
+    completedByUserId: args.actorUserId,
+    completionApprovalProofId,
+    completionApprovedByStaffProfileId,
+    completionRequestedByStaffProfileId,
+    completionRequestedByUserId,
+    actorType: "human" as const,
+    notes,
+    readiness,
+    reviewedItemKeys,
+    snapshot,
+    summary,
+  };
   const closeFields = {
     storeId: args.storeId,
     organizationId: store.organizationId,
@@ -3840,23 +4105,7 @@ export async function completeDailyCloseWithCtx(
     summary,
     sourceCompleteness: snapshot.sourceCompleteness,
     sourceSubjects: snapshot.sourceSubjects,
-    reportSnapshot: buildDailyCloseReportSnapshot({
-      carryForwardWorkItemIds,
-      carryForwardWorkItems,
-      completedAt: now,
-      completedByStaffProfileId,
-      completedByUserId: args.actorUserId,
-      completionApprovalProofId,
-      completionApprovedByStaffProfileId,
-      completionRequestedByStaffProfileId,
-      completionRequestedByUserId,
-      actorType: "human",
-      notes,
-      readiness,
-      reviewedItemKeys,
-      snapshot,
-      summary,
-    }),
+    reportSnapshot: buildDailyCloseReportSnapshot(reportSnapshotArgs),
     carryForwardWorkItemIds,
     reviewedItemKeys,
     notes,
@@ -3882,6 +4131,13 @@ export async function completeDailyCloseWithCtx(
     });
   }
 
+  await ctx.db.patch("dailyClose", dailyCloseId, {
+    reportSnapshot: buildDailyCloseReportSnapshot({
+      ...reportSnapshotArgs,
+      dailyCloseId,
+    }),
+  });
+
   await markOtherDailyClosesNotCurrent(ctx, {
     currentCloseId: dailyCloseId,
     storeId: args.storeId,
@@ -3906,6 +4162,12 @@ export async function completeDailyCloseWithCtx(
     });
   }
 
+  await patchDailyCloseCarryForwardWorkItemMetadata(ctx, {
+    dailyCloseId: dailyClose._id,
+    operatingDate: args.operatingDate,
+    workItems: carryForwardWorkItems,
+  });
+
   const operationalEvent = await recordDailyCloseCompletedEvent(ctx, {
     storeId: args.storeId,
     organizationId: store.organizationId,
@@ -3920,7 +4182,7 @@ export async function completeDailyCloseWithCtx(
     operatingDate: args.operatingDate,
   });
 
-  for (const workItem of createdWorkItemResult.workItems) {
+  for (const workItem of createdWorkItemResult.createdWorkItems) {
     await recordOperationalEventWithCtx(ctx, {
       storeId: args.storeId,
       organizationId: store.organizationId,
@@ -4135,6 +4397,21 @@ export async function completeDailyCloseForAutomationWithCtx(
     policy: args.eodAutoCompletePolicy,
     snapshot,
   });
+  const reportSnapshotArgs = {
+    actorType: "automation" as const,
+    automationDecisionReason: args.automationDecisionReason,
+    automationPolicyVersion: args.automationPolicyVersion,
+    automationRunId: args.automationRunId,
+    carryForwardWorkItemIds,
+    carryForwardWorkItems,
+    completedAt: now,
+    currentnessMode,
+    policyReviewedItemKeys: args.policyReviewedItemKeys,
+    readiness,
+    reviewedItemKeys: args.policyReviewedItemKeys,
+    snapshot,
+    summary,
+  };
   const closeFields = {
     storeId: args.storeId,
     organizationId: store.organizationId,
@@ -4146,21 +4423,7 @@ export async function completeDailyCloseForAutomationWithCtx(
     summary,
     sourceCompleteness: snapshot.sourceCompleteness,
     sourceSubjects: snapshot.sourceSubjects,
-    reportSnapshot: buildDailyCloseReportSnapshot({
-      actorType: "automation",
-      automationDecisionReason: args.automationDecisionReason,
-      automationPolicyVersion: args.automationPolicyVersion,
-      automationRunId: args.automationRunId,
-      carryForwardWorkItemIds,
-      carryForwardWorkItems,
-      completedAt: now,
-      currentnessMode,
-      policyReviewedItemKeys: args.policyReviewedItemKeys,
-      readiness,
-      reviewedItemKeys: args.policyReviewedItemKeys,
-      snapshot,
-      summary,
-    }),
+    reportSnapshot: buildDailyCloseReportSnapshot(reportSnapshotArgs),
     carryForwardWorkItemIds,
     reviewedItemKeys: args.policyReviewedItemKeys,
     actorType: "automation" as const,
@@ -4182,6 +4445,13 @@ export async function completeDailyCloseForAutomationWithCtx(
       createdAt: now,
     });
   }
+
+  await ctx.db.patch("dailyClose", dailyCloseId, {
+    reportSnapshot: buildDailyCloseReportSnapshot({
+      ...reportSnapshotArgs,
+      dailyCloseId,
+    }),
+  });
 
   if (markAsCurrent) {
     await markOtherDailyClosesNotCurrent(ctx, {
@@ -4209,6 +4479,12 @@ export async function completeDailyCloseForAutomationWithCtx(
     });
   }
 
+  await patchDailyCloseCarryForwardWorkItemMetadata(ctx, {
+    dailyCloseId: dailyClose._id,
+    operatingDate: args.operatingDate,
+    workItems: carryForwardWorkItems,
+  });
+
   const operationalEvent = await recordDailyCloseCompletedEvent(ctx, {
     storeId: args.storeId,
     organizationId: store.organizationId,
@@ -4227,6 +4503,303 @@ export async function completeDailyCloseForAutomationWithCtx(
     dailyClose,
     carryForwardWorkItems,
     operationalEventId: operationalEvent?._id,
+  });
+}
+
+async function listDailyOpeningHandoffsForCarryForward(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    dailyCloseId: Id<"dailyClose">;
+    storeId: Id<"store">;
+    workItemId: Id<"operationalWorkItem">;
+  },
+) {
+  const openings = await ctx.db
+    .query("dailyOpening")
+    .withIndex("by_storeId_status", (q) =>
+      q.eq("storeId", args.storeId).eq("status", "started"),
+    )
+    .take(DAILY_CLOSE_QUERY_LIMIT);
+
+  return openings
+    .filter(
+      (opening) =>
+        opening.priorDailyCloseId === args.dailyCloseId &&
+        opening.carryForwardWorkItemIds.includes(args.workItemId),
+    )
+    .map((opening) => ({
+      dailyOpeningId: opening._id,
+      operatingDate: opening.operatingDate,
+      acknowledgedItemKeys: opening.acknowledgedItemKeys,
+      startedAt: opening.startedAt,
+    }));
+}
+
+function carryForwardResolutionValidationError(message: string) {
+  return userError({
+    code: "precondition_failed",
+    message,
+  });
+}
+
+export async function resolveDailyCloseCarryForwardWithCtx(
+  ctx: MutationCtx,
+  args: ResolveDailyCloseCarryForwardArgs,
+): Promise<ResolveDailyCloseCarryForwardResult> {
+  const reason = trimOptional(args.reason);
+
+  if (!reason) {
+    return userError({
+      code: "validation_failed",
+      message: "A carry-forward resolution reason is required.",
+    });
+  }
+
+  const store = await getStore(ctx, args.storeId);
+
+  if (!store) {
+    return userError({
+      code: "not_found",
+      message: "Store not found.",
+    });
+  }
+
+  if (args.organizationId && args.organizationId !== store.organizationId) {
+    return userError({
+      code: "authorization_failed",
+      message: "Carry-forward work does not belong to this organization.",
+    });
+  }
+
+  const dailyClose = await ctx.db.get("dailyClose", args.dailyCloseId);
+
+  if (!dailyClose || dailyClose.storeId !== args.storeId) {
+    return userError({
+      code: "not_found",
+      message: "EOD Review was not found for this store.",
+    });
+  }
+
+  if (dailyClose.operatingDate !== args.businessDate) {
+    return carryForwardResolutionValidationError(
+      "Carry-forward work does not match this business date.",
+    );
+  }
+
+  const workItem = await ctx.db.get("operationalWorkItem", args.workItemId);
+
+  if (!workItem || workItem.storeId !== args.storeId) {
+    return userError({
+      code: "not_found",
+      message: "Carry-forward work was not found for this store.",
+    });
+  }
+
+  if (workItem.organizationId !== store.organizationId) {
+    return userError({
+      code: "authorization_failed",
+      message: "Carry-forward work does not belong to this organization.",
+    });
+  }
+
+  if (!dailyClose.carryForwardWorkItemIds.includes(workItem._id)) {
+    return carryForwardResolutionValidationError(
+      "Carry-forward work is not linked to this EOD Review.",
+    );
+  }
+
+  if (workItem.type !== DAILY_CLOSE_CARRY_FORWARD_TYPE) {
+    return carryForwardResolutionValidationError(
+      "Only Daily Close carry-forward work can be resolved here.",
+    );
+  }
+
+  if (TERMINAL_WORK_ITEM_STATUSES.has(workItem.status)) {
+    return carryForwardResolutionValidationError(
+      "Carry-forward work is already completed or cancelled.",
+    );
+  }
+
+  if (
+    !OPEN_OPERATIONAL_WORK_ITEM_STATUSES.includes(
+      workItem.status as (typeof OPEN_OPERATIONAL_WORK_ITEM_STATUSES)[number],
+    )
+  ) {
+    return carryForwardResolutionValidationError(
+      "Carry-forward work must be open before it can be resolved.",
+    );
+  }
+
+  const metadataBusinessDate = carryForwardBusinessDate(workItem);
+
+  if (metadataBusinessDate !== args.businessDate) {
+    return carryForwardResolutionValidationError(
+      "Carry-forward source metadata does not match this business date.",
+    );
+  }
+
+  if (stringFromMetadata(workItem.metadata, "source") !== DAILY_CLOSE_SUBJECT_TYPE) {
+    return carryForwardResolutionValidationError(
+      "Carry-forward source metadata is incomplete.",
+    );
+  }
+
+  const metadataDailyCloseId = stringFromMetadata(
+    workItem.metadata,
+    "dailyCloseId",
+  );
+
+  if (metadataDailyCloseId !== args.dailyCloseId) {
+    return carryForwardResolutionValidationError(
+      "Carry-forward source metadata does not match this EOD Review.",
+    );
+  }
+
+  const metadataSourceId = carryForwardSourceId(workItem);
+
+  if (metadataSourceId !== args.sourceId) {
+    return carryForwardResolutionValidationError(
+      "Carry-forward source metadata does not match this source.",
+    );
+  }
+
+  if (!args.approvalProofId) {
+    return approvalRequired(
+      buildDailyCloseCarryForwardApprovalRequirement({
+        businessDate: args.businessDate,
+        dailyCloseId: args.dailyCloseId,
+        outcome: args.outcome,
+        sourceId: args.sourceId,
+      }),
+    );
+  }
+
+  const approvalProofRecord = await ctx.db.get("approvalProof", args.approvalProofId);
+  const approvalProof = await consumeCommandApprovalProofWithCtx(ctx, {
+    action: DAILY_CLOSE_CARRY_FORWARD_RESOLUTION_ACTION,
+    approvalProofId: args.approvalProofId,
+    requiredRole: "manager",
+    requestedByStaffProfileId: approvalProofRecord?.requestedByStaffProfileId
+      ? args.actorStaffProfileId
+      : undefined,
+    storeId: args.storeId,
+    subject: buildDailyCloseCarryForwardApprovalSubject({
+      businessDate: args.businessDate,
+      dailyCloseId: args.dailyCloseId,
+      outcome: args.outcome,
+      sourceId: args.sourceId,
+    }),
+  });
+
+  if (approvalProof.kind !== "ok") {
+    return approvalProof;
+  }
+
+  const now = Date.now();
+  const nextStatus = args.outcome === "completed" ? "completed" : "cancelled";
+  const handoffs = await listDailyOpeningHandoffsForCarryForward(ctx, {
+    dailyCloseId: args.dailyCloseId,
+    storeId: args.storeId,
+    workItemId: args.workItemId,
+  });
+  const handoff = {
+    dailyOpeningIds: handoffs.map((opening) => opening.dailyOpeningId),
+    openings: handoffs,
+  };
+  const priorState = {
+    approvalState: workItem.approvalState,
+    status: workItem.status,
+  };
+  const nextState = {
+    approvalState: workItem.approvalState,
+    status: nextStatus,
+  };
+  const resolutionEvidence = {
+    actorStaffProfileId: args.actorStaffProfileId,
+    actorUserId: args.actorUserId,
+    approvalBasis: {
+      actionKey: DAILY_CLOSE_CARRY_FORWARD_RESOLUTION_ACTION.key,
+      approvalProofId: approvalProof.data.approvalProofId,
+      approvedByStaffProfileId: approvalProof.data.approvedByStaffProfileId,
+      requiredRole: "manager",
+      subject: buildDailyCloseCarryForwardApprovalSubject({
+        businessDate: args.businessDate,
+        dailyCloseId: args.dailyCloseId,
+        outcome: args.outcome,
+        sourceId: args.sourceId,
+      }),
+    },
+    approvalProofId: approvalProof.data.approvalProofId,
+    approvedByStaffProfileId: approvalProof.data.approvedByStaffProfileId,
+    businessDate: args.businessDate,
+    dailyCloseId: args.dailyCloseId,
+    handoff,
+    nextStatus,
+    outcome: args.outcome,
+    priorStatus: workItem.status,
+    reason,
+    resolvedAt: now,
+    sourceId: args.sourceId,
+  };
+
+  await ctx.db.patch("operationalWorkItem", workItem._id, {
+    status: nextStatus,
+    ...(nextStatus === "completed" ? { completedAt: now } : {}),
+    metadata: {
+      ...(workItem.metadata ?? {}),
+      carryForwardResolution: resolutionEvidence,
+    },
+  });
+
+  const updatedWorkItem = await ctx.db.get("operationalWorkItem", workItem._id);
+
+  if (!updatedWorkItem) {
+    return userError({
+      code: "unavailable",
+      message: "Carry-forward work could not be loaded after resolution.",
+      retryable: true,
+    });
+  }
+
+  const event = await recordOperationalEventWithCtx(ctx, {
+    storeId: args.storeId,
+    organizationId: store.organizationId,
+    eventType: `daily_close_carry_forward_${nextStatus}`,
+    subjectType: DAILY_CLOSE_CARRY_FORWARD_TYPE,
+    subjectId: workItem._id,
+    subjectLabel: workItem.title,
+    message:
+      nextStatus === "completed"
+        ? "Daily Close carry-forward work completed."
+        : "Daily Close carry-forward work cancelled.",
+    reason,
+    actorUserId: args.actorUserId,
+    actorStaffProfileId: args.actorStaffProfileId,
+    workItemId: workItem._id,
+    metadata: {
+      approvalBasis: resolutionEvidence.approvalBasis,
+      approvalProofId: approvalProof.data.approvalProofId,
+      approvedByStaffProfileId: approvalProof.data.approvedByStaffProfileId,
+      businessDate: args.businessDate,
+      dailyCloseId: args.dailyCloseId,
+      handoff,
+      nextState,
+      outcome: args.outcome,
+      priorState,
+      reason,
+      resolvedAt: now,
+      sourceReference: {
+        dailyCloseId: args.dailyCloseId,
+        sourceId: args.sourceId,
+        workItemId: workItem._id,
+      },
+    },
+  });
+
+  return ok({
+    action: args.outcome,
+    operationalEventId: event?._id,
+    workItem: updatedWorkItem,
   });
 }
 
@@ -4727,6 +5300,73 @@ export const completeDailyCloseForAutomation = internalMutation({
   },
   returns: commandResultValidator(v.any()),
   handler: (ctx, args) => completeDailyCloseForAutomationWithCtx(ctx, args),
+});
+
+export const resolveDailyCloseCarryForward = mutation({
+  args: {
+    actorStaffProfileId: v.optional(v.id("staffProfile")),
+    approvalProofId: v.optional(v.id("approvalProof")),
+    businessDate: v.string(),
+    dailyCloseId: v.id("dailyClose"),
+    organizationId: v.optional(v.id("organization")),
+    outcome: v.union(v.literal("completed"), v.literal("cancelled")),
+    reason: v.string(),
+    sourceId: v.string(),
+    storeId: v.id("store"),
+    workItemId: v.id("operationalWorkItem"),
+  },
+  returns: commandResultValidator(v.any()),
+  handler: async (ctx, args) => {
+    let athenaUser: Awaited<
+      ReturnType<typeof requireAuthenticatedAthenaUserWithCtx>
+    >;
+    try {
+      athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
+    } catch {
+      return userError({
+        code: "authorization_failed",
+        message: "Sign in again to continue.",
+      });
+    }
+
+    const store = await ctx.db.get("store", args.storeId);
+
+    if (!store) {
+      return userError({
+        code: "not_found",
+        message: "Store not found.",
+      });
+    }
+
+    try {
+      await requireOrganizationMemberRoleWithCtx(ctx, {
+        allowedRoles: ["full_admin", "pos_only"],
+        failureMessage:
+          "You cannot resolve carry-forward work for this store.",
+        organizationId: store.organizationId,
+        userId: athenaUser._id,
+      });
+    } catch {
+      return userError({
+        code: "authorization_failed",
+        message: "You cannot resolve carry-forward work for this store.",
+      });
+    }
+
+    const actorStaffProfile = await ctx.db
+      .query("staffProfile")
+      .withIndex("by_storeId_linkedUserId", (q) =>
+        q.eq("storeId", args.storeId).eq("linkedUserId", athenaUser._id),
+      )
+      .first();
+
+    return resolveDailyCloseCarryForwardWithCtx(ctx, {
+      ...args,
+      actorStaffProfileId: actorStaffProfile?._id,
+      actorUserId: athenaUser._id,
+      organizationId: args.organizationId ?? store.organizationId,
+    });
+  },
 });
 
 export const reopenDailyClose = mutation({

--- a/packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts
+++ b/packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts
@@ -1,0 +1,595 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Doc, Id } from "../_generated/dataModel";
+import * as athenaUserAuth from "../lib/athenaUserAuth";
+import { assertConformsToExportedReturns } from "../lib/returnValidatorContract";
+import {
+  resolveSyncedSaleInventoryReview,
+  resolveSyncedSaleInventoryReviewWithCtx,
+} from "./openWorkInventoryReviews";
+
+vi.mock("../lib/athenaUserAuth", () => ({
+  requireAuthenticatedAthenaUserWithCtx: vi.fn(),
+  requireOrganizationMemberRoleWithCtx: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.spyOn(Date, "now").mockReturnValue(1_772_550_000_000);
+  vi.mocked(athenaUserAuth.requireAuthenticatedAthenaUserWithCtx).mockResolvedValue(
+    {
+      _id: "user-1",
+      email: "manager@example.com",
+    } as never,
+  );
+  vi.mocked(athenaUserAuth.requireOrganizationMemberRoleWithCtx).mockResolvedValue(
+    {
+      _id: "membership-1",
+      organizationId: "org-1",
+      role: "full_admin",
+      userId: "user-1",
+    } as never,
+  );
+});
+
+describe("resolveSyncedSaleInventoryReviewWithCtx", () => {
+  it("resolves current synced sale inventory review work through the canonical local mapping", async () => {
+    const ctx = buildCtx();
+
+    const result = await resolveSyncedSaleInventoryReviewWithCtx(
+      ctx as never,
+      defaultArgs(),
+    );
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: {
+        action: "resolved",
+        outcome: "completed",
+        status: "completed",
+        workItemId: "work-item-1",
+      },
+    });
+    assertConformsToExportedReturns(resolveSyncedSaleInventoryReview, result);
+    expect(
+      athenaUserAuth.requireOrganizationMemberRoleWithCtx,
+    ).toHaveBeenCalledWith(ctx, {
+      allowedRoles: ["full_admin"],
+      failureMessage: "Only store admins can resolve inventory review work.",
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "operationalWorkItem",
+      "work-item-1",
+      {
+        completedAt: 1_772_550_000_000,
+        metadata: expect.objectContaining({
+          resolution: expect.objectContaining({
+            actorStaffProfileId: "staff-manager-1",
+            actorUserId: "user-1",
+            authority: {
+              kind: "organization_member_role",
+              role: "full_admin",
+            },
+            domainTrace: {
+              boundary:
+                "operations.openWorkInventoryReviews.resolveSyncedSaleInventoryReview",
+              mappingId: "mapping-inventory-review",
+            },
+            nextState: { status: "completed" },
+            outcome: "completed",
+            priorState: { status: "open" },
+            reason: "Inventory was corrected from the sale review.",
+            source: expect.objectContaining({
+              localId: "local-txn-1:inventory-review",
+              localIdKind: "inventoryReviewWorkItem",
+              localRegisterSessionId: "local-register-1",
+              localTransactionId: "local-txn-1",
+              receiptNumber: "LR-001",
+              registerSessionId: "register-session-1",
+              sourceId: "transaction-1",
+              terminalId: "terminal-1",
+            }),
+            terminalAudit: {
+              displayName: "Front register",
+              registerNumber: "1",
+              terminalId: "terminal-1",
+            },
+          }),
+        }),
+        status: "completed",
+      },
+    );
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      "operationalEvent",
+      expect.objectContaining({
+        actorStaffProfileId: "staff-manager-1",
+        actorUserId: "user-1",
+        eventType: "synced_sale_inventory_review_completed",
+        reason: "Inventory was corrected from the sale review.",
+        subjectId: "work-item-1",
+        subjectType: "synced_sale_inventory_review",
+        workItemId: "work-item-1",
+        metadata: expect.objectContaining({
+          mappingId: "mapping-inventory-review",
+          nextState: { status: "completed" },
+          outcome: "completed",
+          priorState: { status: "open" },
+        }),
+      }),
+    );
+  });
+
+  it("cancels dismissed or superseded reviews while preserving audited outcome", async () => {
+    const ctx = buildCtx();
+
+    const result = await resolveSyncedSaleInventoryReviewWithCtx(
+      ctx as never,
+      defaultArgs({
+        outcome: "superseded",
+        reason: "A newer inventory review replaced this sale evidence.",
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: {
+        action: "resolved",
+        outcome: "superseded",
+        status: "cancelled",
+        workItemId: "work-item-1",
+      },
+    });
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "operationalWorkItem",
+      "work-item-1",
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          resolution: expect.objectContaining({
+            nextState: { status: "cancelled" },
+            outcome: "superseded",
+          }),
+        }),
+        status: "cancelled",
+      }),
+    );
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      "operationalEvent",
+      expect.objectContaining({
+        eventType: "synced_sale_inventory_review_cancelled",
+        metadata: expect.objectContaining({
+          nextState: { status: "cancelled" },
+          outcome: "superseded",
+        }),
+      }),
+    );
+  });
+
+  it("rejects client-supplied staff attribution that does not match the authenticated user", async () => {
+    const ctx = buildCtx();
+
+    const result = await resolveSyncedSaleInventoryReviewWithCtx(
+      ctx as never,
+      defaultArgs({
+        actorStaffProfileId: "staff-other" as Id<"staffProfile">,
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message: "Staff attribution does not match the authenticated user.",
+      },
+    });
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects already-terminal work item attempts", async () => {
+    const ctx = buildCtx({
+      operationalWorkItem: buildWorkItem({ status: "completed" }),
+    });
+
+    const result = await resolveSyncedSaleInventoryReviewWithCtx(
+      ctx as never,
+      defaultArgs(),
+    );
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "conflict",
+        message: "Inventory review work is already terminal.",
+      },
+    });
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it("rejects wrong terminal, session, sale, and store context", async () => {
+    await expectRejectedContext(
+      { terminalId: "terminal-other" as Id<"posTerminal"> },
+      "Terminal does not match the inventory review store.",
+      {
+        posTerminal: buildTerminal({
+          _id: "terminal-other" as Id<"posTerminal">,
+          storeId: "store-2" as Id<"store">,
+        }),
+      },
+    );
+    await expectRejectedContext(
+      { registerSessionId: "register-session-other" as Id<"registerSession"> },
+      "Register session does not match the inventory review terminal.",
+      {
+        registerSession: buildRegisterSession({
+          _id: "register-session-other" as Id<"registerSession">,
+          terminalId: "terminal-other" as Id<"posTerminal">,
+        }),
+      },
+    );
+    await expectRejectedContext(
+      { sourceId: "transaction-other" as Id<"posTransaction"> },
+      "Sale does not match the inventory review context.",
+      {
+        posTransaction: buildTransaction({
+          _id: "transaction-other" as Id<"posTransaction">,
+          registerSessionId: "register-session-other" as Id<"registerSession">,
+        }),
+      },
+    );
+    await expectRejectedContext(
+      { storeId: "store-other" as Id<"store"> },
+      "Inventory review work item not found for this store.",
+      { store: buildStore({ _id: "store-other" as Id<"store"> }) },
+    );
+  });
+
+  it("rejects cloud-id-only, receipt-only, and SKU-only idempotency attempts", async () => {
+    const cloudIdOnly = await resolveSyncedSaleInventoryReviewWithCtx(
+      buildCtx() as never,
+      {
+        outcome: "completed",
+        reason: "Resolved",
+        storeId: "store-1" as Id<"store">,
+        workItemId: "work-item-1" as Id<"operationalWorkItem">,
+      },
+    );
+    expect(cloudIdOnly).toEqual({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message:
+          "Inventory review resolution requires terminal, local register session, and local transaction context.",
+      },
+    });
+    assertConformsToExportedReturns(
+      resolveSyncedSaleInventoryReview,
+      cloudIdOnly,
+    );
+
+    const receiptOnly = await resolveSyncedSaleInventoryReviewWithCtx(
+      buildCtx() as never,
+      defaultArgs({
+        localTransactionId: undefined,
+        receiptNumber: "LR-001",
+      }),
+    );
+    expect(receiptOnly).toMatchObject({
+      error: {
+        message:
+          "Inventory review resolution requires terminal, local register session, and local transaction context.",
+      },
+      kind: "user_error",
+    });
+
+    const skuOnly = await resolveSyncedSaleInventoryReviewWithCtx(
+      buildCtx() as never,
+      defaultArgs({
+        localTransactionId: "sku-1",
+      }),
+    );
+    expect(skuOnly).toEqual({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message:
+          "Work item metadata does not match the sale context.",
+      },
+    });
+  });
+
+  it("rejects transaction and receipt mappings that do not use the canonical inventory-review key", async () => {
+    const ctx = buildCtx({
+      posLocalSyncMapping: buildMapping({
+        cloudId: "transaction-1",
+        cloudTable: "posTransaction",
+        localId: "local-txn-1",
+        localIdKind: "transaction",
+      }),
+    });
+
+    const result = await resolveSyncedSaleInventoryReviewWithCtx(
+      ctx as never,
+      defaultArgs(),
+    );
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+        message:
+          "Inventory review resolution requires the canonical local work-item mapping.",
+      },
+    });
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+});
+
+async function expectRejectedContext(
+  args: Partial<ReturnType<typeof defaultArgs>>,
+  message: string,
+  seed: BuildCtxSeed,
+) {
+  const ctx = buildCtx(seed);
+  const result = await resolveSyncedSaleInventoryReviewWithCtx(
+    ctx as never,
+    defaultArgs(args),
+  );
+
+  expect(result).toMatchObject({
+    error: { message },
+    kind: "user_error",
+  });
+  expect(ctx.db.patch).not.toHaveBeenCalled();
+}
+
+function defaultArgs(
+  overrides: Partial<{
+    actorStaffProfileId?: Id<"staffProfile">;
+    localRegisterSessionId?: string;
+    localTransactionId?: string;
+    outcome: "completed" | "dismissed" | "cancelled" | "superseded";
+    reason: string;
+    receiptNumber?: string;
+    registerSessionId?: Id<"registerSession">;
+    sourceId?: Id<"posTransaction">;
+    storeId: Id<"store">;
+    terminalId?: Id<"posTerminal">;
+    workItemId: Id<"operationalWorkItem">;
+  }> = {},
+) {
+  return {
+    actorStaffProfileId: "staff-manager-1" as Id<"staffProfile">,
+    localRegisterSessionId: "local-register-1",
+    localTransactionId: "local-txn-1",
+    outcome: "completed" as const,
+    reason: "Inventory was corrected from the sale review.",
+    receiptNumber: "LR-001",
+    registerSessionId: "register-session-1" as Id<"registerSession">,
+    sourceId: "transaction-1" as Id<"posTransaction">,
+    storeId: "store-1" as Id<"store">,
+    terminalId: "terminal-1" as Id<"posTerminal">,
+    workItemId: "work-item-1" as Id<"operationalWorkItem">,
+    ...overrides,
+  };
+}
+
+type BuildCtxSeed = Partial<{
+  operationalWorkItem: Doc<"operationalWorkItem">;
+  posLocalSyncMapping: Doc<"posLocalSyncMapping">;
+  posTerminal: Doc<"posTerminal">;
+  posTransaction: Doc<"posTransaction">;
+  registerSession: Doc<"registerSession">;
+  staffProfile: Doc<"staffProfile">;
+  store: Doc<"store">;
+}>;
+
+function buildCtx(seed: BuildCtxSeed = {}) {
+  const rows = {
+    operationalWorkItem: seed.operationalWorkItem ?? buildWorkItem(),
+    posLocalSyncMapping: seed.posLocalSyncMapping ?? buildMapping(),
+    posTerminal: seed.posTerminal ?? buildTerminal(),
+    posTransaction: seed.posTransaction ?? buildTransaction(),
+    registerSession: seed.registerSession ?? buildRegisterSession(),
+    staffProfile: seed.staffProfile ?? buildStaffProfile(),
+    store: seed.store ?? buildStore(),
+  };
+  const get = vi.fn(async (tableName: string, id: string) => {
+    const row = rows[tableName as keyof typeof rows];
+    return row && row._id === id ? row : null;
+  });
+  const query = vi.fn((tableName: string) => ({
+    withIndex: vi.fn((_indexName: string, builder: (q: QueryBuilder) => QueryBuilder) => {
+      const constraints: Record<string, unknown> = {};
+      const q = {
+        eq(field: string, value: unknown) {
+          constraints[field] = value;
+          return q;
+        },
+      };
+      builder(q);
+      return {
+        collect: vi.fn(async () => {
+          const row = rows[tableName as keyof typeof rows];
+          if (!row) return [];
+          return Object.entries(constraints).every(
+            ([field, value]) => row[field as keyof typeof row] === value,
+          )
+            ? [row]
+            : [];
+        }),
+        first: vi.fn(async () => {
+          const row = rows[tableName as keyof typeof rows];
+          if (!row) return null;
+          return Object.entries(constraints).every(
+            ([field, value]) => row[field as keyof typeof row] === value,
+          )
+            ? row
+            : null;
+        }),
+        unique: vi.fn(async () => {
+          const row = rows[tableName as keyof typeof rows];
+          if (!row) return null;
+          return Object.entries(constraints).every(
+            ([field, value]) => row[field as keyof typeof row] === value,
+          )
+            ? row
+            : null;
+        }),
+      };
+    }),
+  }));
+
+  return {
+    db: {
+      get,
+      insert: vi.fn(async (tableName: string) => `${tableName}-1`),
+      patch: vi.fn(),
+      query,
+    },
+  };
+}
+
+type QueryBuilder = {
+  eq(field: string, value: unknown): QueryBuilder;
+};
+
+function buildStore(
+  overrides: Partial<Doc<"store">> = {},
+): Doc<"store"> {
+  return {
+    _creationTime: 1,
+    _id: "store-1" as Id<"store">,
+    name: "Wig Club",
+    organizationId: "org-1" as Id<"organization">,
+    slug: "wigclub",
+    ...overrides,
+  } as Doc<"store">;
+}
+
+function buildStaffProfile(
+  overrides: Partial<Doc<"staffProfile">> = {},
+): Doc<"staffProfile"> {
+  return {
+    _creationTime: 1,
+    _id: "staff-manager-1" as Id<"staffProfile">,
+    linkedUserId: "user-1" as Id<"athenaUser">,
+    name: "Manager",
+    status: "active",
+    storeId: "store-1" as Id<"store">,
+    ...overrides,
+  } as Doc<"staffProfile">;
+}
+
+function buildWorkItem(
+  overrides: Partial<Doc<"operationalWorkItem">> = {},
+): Doc<"operationalWorkItem"> {
+  return {
+    _creationTime: 1,
+    _id: "work-item-1" as Id<"operationalWorkItem">,
+    approvalState: "not_required",
+    createdAt: 1,
+    metadata: {
+      localEventId: "event-sale-completed-1",
+      localRegisterSessionId: "local-register-1",
+      localTransactionId: "local-txn-1",
+      primaryProductSkuId: "sku-1",
+      receiptNumber: "LR-001",
+      registerSessionId: "register-session-1",
+      sourceId: "transaction-1",
+      sourceType: "posTransaction",
+    },
+    organizationId: "org-1" as Id<"organization">,
+    priority: "high",
+    status: "open",
+    storeId: "store-1" as Id<"store">,
+    title: "Review inventory for Wig Cap",
+    type: "synced_sale_inventory_review",
+    ...overrides,
+  } as Doc<"operationalWorkItem">;
+}
+
+function buildTerminal(
+  overrides: Partial<Doc<"posTerminal">> = {},
+): Doc<"posTerminal"> {
+  return {
+    _creationTime: 1,
+    _id: "terminal-1" as Id<"posTerminal">,
+    browserInfo: {
+      userAgent: "test",
+    },
+    displayName: "Front register",
+    fingerprintHash: "fingerprint",
+    registeredAt: 1,
+    registeredByUserId: "user-1" as Id<"athenaUser">,
+    registerNumber: "1",
+    status: "active",
+    storeId: "store-1" as Id<"store">,
+    ...overrides,
+  } as Doc<"posTerminal">;
+}
+
+function buildRegisterSession(
+  overrides: Partial<Doc<"registerSession">> = {},
+): Doc<"registerSession"> {
+  return {
+    _creationTime: 1,
+    _id: "register-session-1" as Id<"registerSession">,
+    closeoutRecords: [],
+    expectedCash: 0,
+    openedAt: 1,
+    openedByStaffProfileId: "staff-1" as Id<"staffProfile">,
+    openingFloat: 0,
+    organizationId: "org-1" as Id<"organization">,
+    registerNumber: "1",
+    status: "closed",
+    storeId: "store-1" as Id<"store">,
+    terminalId: "terminal-1" as Id<"posTerminal">,
+    ...overrides,
+  } as Doc<"registerSession">;
+}
+
+function buildTransaction(
+  overrides: Partial<Doc<"posTransaction">> = {},
+): Doc<"posTransaction"> {
+  return {
+    _creationTime: 1,
+    _id: "transaction-1" as Id<"posTransaction">,
+    completedAt: 1,
+    payments: [],
+    receiptPrinted: false,
+    registerNumber: "1",
+    registerSessionId: "register-session-1" as Id<"registerSession">,
+    staffProfileId: "staff-1" as Id<"staffProfile">,
+    status: "completed",
+    storeId: "store-1" as Id<"store">,
+    subtotal: 2500,
+    tax: 0,
+    terminalId: "terminal-1" as Id<"posTerminal">,
+    total: 2500,
+    totalPaid: 2500,
+    transactionNumber: "LR-001",
+    ...overrides,
+  } as Doc<"posTransaction">;
+}
+
+function buildMapping(
+  overrides: Partial<Doc<"posLocalSyncMapping">> = {},
+): Doc<"posLocalSyncMapping"> {
+  return {
+    _creationTime: 1,
+    _id: "mapping-inventory-review" as Id<"posLocalSyncMapping">,
+    cloudId: "work-item-1",
+    cloudTable: "operationalWorkItem",
+    createdAt: 1,
+    localEventId: "event-sale-completed-1",
+    localId: "local-txn-1:inventory-review",
+    localIdKind: "inventoryReviewWorkItem",
+    localRegisterSessionId: "local-register-1",
+    sourceEventType: "sale_completed",
+    storeId: "store-1" as Id<"store">,
+    terminalId: "terminal-1" as Id<"posTerminal">,
+    ...overrides,
+  } as Doc<"posLocalSyncMapping">;
+}

--- a/packages/athena-webapp/convex/operations/openWorkInventoryReviews.ts
+++ b/packages/athena-webapp/convex/operations/openWorkInventoryReviews.ts
@@ -1,0 +1,335 @@
+import { v } from "convex/values";
+
+import type { Id } from "../_generated/dataModel";
+import { mutation, type MutationCtx } from "../_generated/server";
+import { commandResultValidator } from "../lib/commandResultValidators";
+import {
+  requireAuthenticatedAthenaUserWithCtx,
+  requireOrganizationMemberRoleWithCtx,
+} from "../lib/athenaUserAuth";
+import { ok, userError, type CommandResult } from "../../shared/commandResult";
+import { recordOperationalEventWithCtx } from "./operationalEvents";
+
+const SYNCED_SALE_INVENTORY_REVIEW_TYPE = "synced_sale_inventory_review";
+const INVENTORY_REVIEW_LOCAL_ID_KIND = "inventoryReviewWorkItem";
+const TERMINAL_STATUSES = new Set(["completed", "cancelled"]);
+
+const syncedSaleInventoryReviewOutcomeValidator = v.union(
+  v.literal("completed"),
+  v.literal("dismissed"),
+  v.literal("cancelled"),
+  v.literal("superseded"),
+);
+
+type SyncedSaleInventoryReviewOutcome =
+  | "completed"
+  | "dismissed"
+  | "cancelled"
+  | "superseded";
+
+type ResolveSyncedSaleInventoryReviewArgs = {
+  actorStaffProfileId?: Id<"staffProfile">;
+  localRegisterSessionId?: string;
+  localTransactionId?: string;
+  outcome: SyncedSaleInventoryReviewOutcome;
+  reason: string;
+  receiptNumber?: string;
+  registerSessionId?: Id<"registerSession">;
+  sourceId?: Id<"posTransaction">;
+  storeId: Id<"store">;
+  terminalId?: Id<"posTerminal">;
+  workItemId: Id<"operationalWorkItem">;
+};
+
+type ResolveSyncedSaleInventoryReviewData = {
+  action: "resolved";
+  outcome: SyncedSaleInventoryReviewOutcome;
+  status: "completed" | "cancelled";
+  workItemId: Id<"operationalWorkItem">;
+};
+
+function inventoryReviewLocalId(localTransactionId: string) {
+  return `${localTransactionId}:inventory-review`;
+}
+
+function stringMetadataValue(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+) {
+  const value = metadata?.[key];
+  return typeof value === "string" ? value : null;
+}
+
+function validationError(message: string) {
+  return userError({
+    code: "validation_failed",
+    message,
+  });
+}
+
+function conflictError(message: string) {
+  return userError({
+    code: "conflict",
+    message,
+  });
+}
+
+function terminalStatusForOutcome(
+  outcome: SyncedSaleInventoryReviewOutcome,
+): "completed" | "cancelled" {
+  return outcome === "completed" ? "completed" : "cancelled";
+}
+
+export async function resolveSyncedSaleInventoryReviewWithCtx(
+  ctx: MutationCtx,
+  args: ResolveSyncedSaleInventoryReviewArgs,
+): Promise<CommandResult<ResolveSyncedSaleInventoryReviewData>> {
+  const requiredLocalContext = [
+    args.terminalId,
+    args.localRegisterSessionId,
+    args.localTransactionId,
+  ];
+  if (requiredLocalContext.some((value) => !value)) {
+    return validationError(
+      "Inventory review resolution requires terminal, local register session, and local transaction context.",
+    );
+  }
+  if (!args.registerSessionId || !args.sourceId) {
+    return validationError(
+      "Inventory review resolution requires the linked register session and sale.",
+    );
+  }
+  if (!args.reason.trim()) {
+    return validationError("Reason is required to resolve inventory review work.");
+  }
+
+  const [athenaUser, workItem, store] = await Promise.all([
+    requireAuthenticatedAthenaUserWithCtx(ctx),
+    ctx.db.get("operationalWorkItem", args.workItemId),
+    ctx.db.get("store", args.storeId),
+  ]);
+  if (!store) {
+    return userError({
+      code: "not_found",
+      message: "Store not found.",
+    });
+  }
+  await requireOrganizationMemberRoleWithCtx(ctx, {
+    allowedRoles: ["full_admin"],
+    failureMessage: "Only store admins can resolve inventory review work.",
+    organizationId: store.organizationId,
+    userId: athenaUser._id,
+  });
+
+  if (!workItem || workItem.storeId !== args.storeId) {
+    return userError({
+      code: "not_found",
+      message: "Inventory review work item not found for this store.",
+    });
+  }
+  if (
+    workItem.organizationId !== store.organizationId ||
+    workItem.type !== SYNCED_SALE_INVENTORY_REVIEW_TYPE
+  ) {
+    return validationError("Work item is not a synced sale inventory review.");
+  }
+  if (TERMINAL_STATUSES.has(workItem.status)) {
+    return conflictError("Inventory review work is already terminal.");
+  }
+  if (workItem.status !== "open" && workItem.status !== "in_progress") {
+    return conflictError("Inventory review work is not currently resolvable.");
+  }
+
+  const actorStaffProfile = await ctx.db
+    .query("staffProfile")
+    .withIndex("by_storeId_linkedUserId", (q) =>
+      q.eq("storeId", args.storeId).eq("linkedUserId", athenaUser._id),
+    )
+    .first();
+
+  if (
+    args.actorStaffProfileId &&
+    (!actorStaffProfile || actorStaffProfile._id !== args.actorStaffProfileId)
+  ) {
+    return validationError(
+      "Staff attribution does not match the authenticated user.",
+    );
+  }
+
+  const actorStaffProfileId = actorStaffProfile?._id;
+
+  const terminal = await ctx.db.get("posTerminal", args.terminalId!);
+  if (!terminal || terminal.storeId !== args.storeId) {
+    return validationError("Terminal does not match the inventory review store.");
+  }
+
+  const registerSession = await ctx.db.get(
+    "registerSession",
+    args.registerSessionId,
+  );
+  if (
+    !registerSession ||
+    registerSession.storeId !== args.storeId ||
+    registerSession.terminalId !== args.terminalId
+  ) {
+    return validationError(
+      "Register session does not match the inventory review terminal.",
+    );
+  }
+
+  const sale = await ctx.db.get("posTransaction", args.sourceId);
+  if (
+    !sale ||
+    sale.storeId !== args.storeId ||
+    sale.registerSessionId !== args.registerSessionId ||
+    sale.terminalId !== args.terminalId
+  ) {
+    return validationError("Sale does not match the inventory review context.");
+  }
+
+  const metadata = workItem.metadata ?? {};
+  if (
+    stringMetadataValue(metadata, "localRegisterSessionId") !==
+      args.localRegisterSessionId ||
+    stringMetadataValue(metadata, "localTransactionId") !==
+      args.localTransactionId ||
+    stringMetadataValue(metadata, "registerSessionId") !==
+      args.registerSessionId ||
+    stringMetadataValue(metadata, "sourceId") !== args.sourceId
+  ) {
+    return validationError("Work item metadata does not match the sale context.");
+  }
+  if (
+    args.receiptNumber &&
+    stringMetadataValue(metadata, "receiptNumber") !== args.receiptNumber
+  ) {
+    return validationError("Receipt number does not match the inventory review.");
+  }
+  if (args.receiptNumber && sale.transactionNumber !== args.receiptNumber) {
+    return validationError("Sale receipt does not match the inventory review.");
+  }
+
+  const canonicalLocalId = inventoryReviewLocalId(args.localTransactionId!);
+  const mapping = await ctx.db
+    .query("posLocalSyncMapping")
+    .withIndex("by_store_terminal_local", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("terminalId", args.terminalId!)
+        .eq("localRegisterSessionId", args.localRegisterSessionId!)
+        .eq("localIdKind", INVENTORY_REVIEW_LOCAL_ID_KIND)
+        .eq("localId", canonicalLocalId),
+    )
+    .unique();
+  if (
+    !mapping ||
+    mapping.cloudTable !== "operationalWorkItem" ||
+    mapping.cloudId !== args.workItemId
+  ) {
+    return validationError(
+      "Inventory review resolution requires the canonical local work-item mapping.",
+    );
+  }
+
+  const resolvedAt = Date.now();
+  const status = terminalStatusForOutcome(args.outcome);
+  const resolution = {
+    actorStaffProfileId,
+    actorUserId: athenaUser._id,
+    authority: {
+      kind: "organization_member_role",
+      role: "full_admin",
+    },
+    domainTrace: {
+      boundary:
+        "operations.openWorkInventoryReviews.resolveSyncedSaleInventoryReview",
+      mappingId: mapping._id,
+    },
+    outcome: args.outcome,
+    priorState: {
+      status: workItem.status,
+    },
+    reason: args.reason.trim(),
+    resolvedAt,
+    source: {
+      localId: canonicalLocalId,
+      localIdKind: INVENTORY_REVIEW_LOCAL_ID_KIND,
+      localRegisterSessionId: args.localRegisterSessionId,
+      localTransactionId: args.localTransactionId,
+      receiptNumber: args.receiptNumber,
+      registerSessionId: args.registerSessionId,
+      sourceId: args.sourceId,
+      terminalId: args.terminalId,
+    },
+    terminalAudit: {
+      displayName: terminal.displayName,
+      registerNumber: terminal.registerNumber ?? registerSession.registerNumber,
+      terminalId: args.terminalId,
+    },
+    nextState: {
+      status,
+    },
+  };
+
+  await ctx.db.patch("operationalWorkItem", args.workItemId, {
+    ...(status === "completed" ? { completedAt: resolvedAt } : {}),
+    metadata: {
+      ...metadata,
+      resolution,
+    },
+    status,
+  });
+
+  await recordOperationalEventWithCtx(ctx, {
+    actorStaffProfileId,
+    actorUserId: athenaUser._id,
+    eventType: `synced_sale_inventory_review_${status}`,
+    message:
+      status === "completed"
+        ? "Synced sale inventory review completed."
+        : "Synced sale inventory review cancelled.",
+    organizationId: store.organizationId,
+    reason: args.reason.trim(),
+    storeId: args.storeId,
+    subjectId: args.workItemId,
+    subjectLabel: workItem.title,
+    subjectType: SYNCED_SALE_INVENTORY_REVIEW_TYPE,
+    workItemId: args.workItemId,
+    metadata: {
+      authority: resolution.authority,
+      domainTrace: resolution.domainTrace,
+      mappingId: mapping._id,
+      nextState: resolution.nextState,
+      outcome: args.outcome,
+      priorState: resolution.priorState,
+      reason: resolution.reason,
+      source: resolution.source,
+      terminalAudit: resolution.terminalAudit,
+    },
+  });
+
+  return ok({
+    action: "resolved",
+    outcome: args.outcome,
+    status,
+    workItemId: args.workItemId,
+  });
+}
+
+export const resolveSyncedSaleInventoryReview = mutation({
+  args: {
+    actorStaffProfileId: v.optional(v.id("staffProfile")),
+    localRegisterSessionId: v.optional(v.string()),
+    localTransactionId: v.optional(v.string()),
+    outcome: syncedSaleInventoryReviewOutcomeValidator,
+    reason: v.string(),
+    receiptNumber: v.optional(v.string()),
+    registerSessionId: v.optional(v.id("registerSession")),
+    sourceId: v.optional(v.id("posTransaction")),
+    storeId: v.id("store"),
+    terminalId: v.optional(v.id("posTerminal")),
+    workItemId: v.id("operationalWorkItem"),
+  },
+  returns: commandResultValidator(v.any()),
+  handler: resolveSyncedSaleInventoryReviewWithCtx,
+});

--- a/packages/athena-webapp/convex/operations/operationalWorkItems.test.ts
+++ b/packages/athena-webapp/convex/operations/operationalWorkItems.test.ts
@@ -4,6 +4,8 @@ import type { Id } from "../_generated/dataModel";
 import { getQueueSnapshot } from "./operationalWorkItems";
 import * as athenaUserAuth from "../lib/athenaUserAuth";
 
+const TEST_MAX_QUEUE_ITEMS = 100;
+
 vi.mock("../lib/athenaUserAuth", () => ({
   requireAuthenticatedAthenaUserWithCtx: vi.fn(),
   requireOrganizationMemberRoleWithCtx: vi.fn(),
@@ -11,6 +13,100 @@ vi.mock("../lib/athenaUserAuth", () => ({
 
 function getHandler(definition: unknown) {
   return (definition as { _handler: Function })._handler;
+}
+
+type QueueTestRow = Record<string, unknown>;
+
+function workItem(overrides: Partial<QueueTestRow> = {}) {
+  return {
+    _id: "work-item-1" as Id<"operationalWorkItem">,
+    approvalState: "not_required",
+    createdAt: 1,
+    organizationId: "org-1" as Id<"organization">,
+    priority: "normal",
+    status: "open",
+    storeId: "store-1" as Id<"store">,
+    title: "Operational work",
+    type: "service_case",
+    ...overrides,
+  } as QueueTestRow;
+}
+
+function approvalRequest(overrides: Partial<QueueTestRow> = {}) {
+  return {
+    _id: "approval-1" as Id<"approvalRequest">,
+    createdAt: 1,
+    requestType: "variance_review",
+    status: "pending",
+    storeId: "store-1" as Id<"store">,
+    subjectId: "subject-1",
+    subjectType: "register_session",
+    ...overrides,
+  } as QueueTestRow;
+}
+
+function createQueueContext(args: {
+  approvalRequests?: QueueTestRow[];
+  stores?: QueueTestRow[];
+  workItems?: QueueTestRow[];
+} = {}) {
+  const stores = args.stores ?? [
+    { _id: "store-1", organizationId: "org-1" },
+  ];
+  const workItems = args.workItems ?? [];
+  const approvalRequests = args.approvalRequests ?? [];
+
+  return {
+    db: {
+      get: vi.fn(async (tableName: string, id: string) => {
+        if (tableName === "store") {
+          return stores.find((store) => store._id === id) ?? null;
+        }
+        if (tableName === "operationalWorkItem") {
+          return workItems.find((item) => item._id === id) ?? null;
+        }
+        return null;
+      }),
+      query: vi.fn((tableName: string) => ({
+        withIndex: vi.fn((_indexName: string, callback: Function) => {
+          const constraints = new Map<string, unknown>();
+          const queryBuilder = {
+            eq(fieldName: string, value: unknown) {
+              constraints.set(fieldName, value);
+              return queryBuilder;
+            },
+          };
+          callback(queryBuilder);
+
+          const collectMatchingRows = async () => {
+            if (tableName === "operationalWorkItem") {
+              return workItems.filter((item) =>
+                Array.from(constraints.entries()).every(
+                  ([fieldName, value]) => item[fieldName] === value,
+                ),
+              );
+            }
+            if (tableName === "approvalRequest") {
+              return approvalRequests.filter((request) =>
+                Array.from(constraints.entries()).every(
+                  ([fieldName, value]) => request[fieldName] === value,
+                ),
+              );
+            }
+            return [];
+          };
+
+          return {
+            collect: vi.fn(collectMatchingRows),
+            take: vi.fn(async (limit: number) =>
+              (await collectMatchingRows()).slice(0, limit),
+            ),
+            unique: vi.fn(async () => null),
+          };
+        }),
+      })),
+    },
+  };
 }
 
 beforeEach(() => {
@@ -21,6 +117,693 @@ beforeEach(() => {
 });
 
 describe("getQueueSnapshot", () => {
+  it("includes current open work items and excludes terminal rows from the queue snapshot", async () => {
+    const ctx = createQueueContext({
+      workItems: [
+        workItem({
+          _id: "work-open" as Id<"operationalWorkItem">,
+          status: "open",
+          type: "synced_sale_inventory_review",
+        }),
+        workItem({
+          _id: "work-in-progress" as Id<"operationalWorkItem">,
+          status: "in_progress",
+          type: "purchase_order",
+        }),
+        workItem({
+          _id: "work-completed" as Id<"operationalWorkItem">,
+          status: "completed",
+          type: "service_case",
+        }),
+        workItem({
+          _id: "work-cancelled" as Id<"operationalWorkItem">,
+          status: "cancelled",
+          type: "service_appointment",
+        }),
+      ],
+    });
+
+    const result = await getHandler(getQueueSnapshot)(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(result.workItems.map((item: QueueTestRow) => item._id)).toEqual([
+      "work-open",
+      "work-in-progress",
+    ]);
+    expect(result.approvalRequests).toEqual([]);
+    expect(result.overflow).toEqual({
+      approvalRequests: false,
+      workItems: { inProgress: false, open: false },
+    });
+  });
+
+  it("keeps work items and approval requests in separate lanes", async () => {
+    const ctx = createQueueContext({
+      approvalRequests: [
+        approvalRequest({
+          _id: "approval-pending" as Id<"approvalRequest">,
+          createdAt: 2,
+        }),
+      ],
+      workItems: [
+        workItem({
+          _id: "work-open" as Id<"operationalWorkItem">,
+          createdAt: 1,
+        }),
+      ],
+    });
+
+    const result = await getHandler(getQueueSnapshot)(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(result.workItems.map((item: QueueTestRow) => item._id)).toEqual([
+      "work-open",
+    ]);
+    expect(
+      result.approvalRequests.map((request: QueueTestRow) => request._id),
+    ).toEqual(["approval-pending"]);
+  });
+
+  it("projects sanitized work-item details without raw metadata", async () => {
+    const ctx = createQueueContext({
+      workItems: [
+        workItem({
+          _id: "work-carry-forward" as Id<"operationalWorkItem">,
+          metadata: {
+            businessDate: "2026-07-01",
+            decisionApprovalProofId: "proof-should-not-leave-server",
+            hiddenFinancialEvidence: "card-token-should-not-leave-server",
+            internalPayload: { raw: true },
+            managerProofId: "manager-proof-should-not-leave-server",
+          },
+          type: "daily_close_carry_forward",
+        }),
+        workItem({
+          _id: "work-inventory-review" as Id<"operationalWorkItem">,
+          metadata: {
+            localRegisterSessionId: "local-session-1",
+            localTransactionId: "local-txn-1",
+            primaryProductSkuId: "sku-1",
+            receiptNumber: "939540",
+            registerSessionId: "register-session-1",
+            skippedMutationItems: [{ productSkuId: "sku-1" }],
+            sourceId: "transaction-1",
+            sourceType: "posTransaction",
+            terminalId: "terminal-1",
+          },
+          type: "synced_sale_inventory_review",
+        }),
+      ],
+    });
+
+    const result = await getHandler(getQueueSnapshot)(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(result.workItems).toEqual([
+      expect.objectContaining({
+        _id: "work-carry-forward",
+        details: { businessDate: "2026-07-01", followUpReason: null },
+      }),
+      expect.objectContaining({
+        _id: "work-inventory-review",
+        details: expect.objectContaining({
+          inventoryReviewLineCount: 1,
+          localRegisterSessionId: "local-session-1",
+          localTransactionId: "local-txn-1",
+          primaryProductSkuId: "sku-1",
+          receiptNumber: "939540",
+          registerSessionId: "register-session-1",
+          sourceId: "transaction-1",
+          terminalId: "terminal-1",
+        }),
+      }),
+    ]);
+    expect(JSON.stringify(result.workItems)).not.toContain("metadata");
+    expect(JSON.stringify(result.workItems)).not.toContain(
+      "proof-should-not-leave-server",
+    );
+    expect(JSON.stringify(result.workItems)).not.toContain(
+      "card-token-should-not-leave-server",
+    );
+  });
+
+  it("surfaces legacy service deposit approvals while suppressing unsupported work items", async () => {
+    const ctx = createQueueContext({
+      approvalRequests: [
+        approvalRequest({
+          _id: "approval-service-deposit" as Id<"approvalRequest">,
+          requestType: "service_deposit_review",
+        }),
+        approvalRequest({
+          _id: "approval-variance" as Id<"approvalRequest">,
+          requestType: "variance_review",
+        }),
+      ],
+      workItems: [
+        workItem({
+          _id: "work-service-deposit" as Id<"operationalWorkItem">,
+          type: "service_deposit_review",
+        }),
+        workItem({
+          _id: "work-service-case" as Id<"operationalWorkItem">,
+          type: "service_case",
+        }),
+      ],
+    });
+
+    const result = await getHandler(getQueueSnapshot)(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(result.workItems.map((item: QueueTestRow) => item._id)).toEqual([
+      "work-service-case",
+    ]);
+    expect(
+      result.approvalRequests.map((request: QueueTestRow) => request._id),
+    ).toEqual(["approval-service-deposit", "approval-variance"]);
+    expect(result.overflow.approvalRequests).toBe(false);
+  });
+
+  it("surfaces supported return and legacy item adjustment approvals", async () => {
+    const ctx = createQueueContext({
+      approvalRequests: [
+        approvalRequest({
+          _id: "approval-online-return" as Id<"approvalRequest">,
+          createdAt: 20,
+          requestType: "online_order_return_review",
+          subjectId: "return-1",
+          subjectType: "online_order_return",
+        }),
+        approvalRequest({
+          _id: "approval-legacy-item-adjustment" as Id<"approvalRequest">,
+          createdAt: 10,
+          metadata: {
+            transactionId: "transaction-1",
+          },
+          requestType: "pos_item_adjustment_review",
+          subjectId: "adjustment-1",
+          subjectType: "pos_item_adjustment",
+        }),
+        approvalRequest({
+          _id: "approval-service-deposit" as Id<"approvalRequest">,
+          createdAt: 30,
+          requestType: "service_deposit_review",
+        }),
+      ],
+    });
+
+    const result = await getHandler(getQueueSnapshot)(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(
+      result.approvalRequests.map((request: QueueTestRow) => request._id),
+    ).toEqual([
+      "approval-service-deposit",
+      "approval-online-return",
+      "approval-legacy-item-adjustment",
+    ]);
+    expect(
+      result.approvalRequests.map(
+        (request: QueueTestRow) => request.requestType,
+      ),
+    ).toEqual([
+      "service_deposit_review",
+      "online_order_return_review",
+      "pos_item_adjustment_review",
+    ]);
+  });
+
+  it("does not let unsupported legacy rows starve supported queue lanes", async () => {
+    const unsupportedWorkItems = Array.from(
+      { length: TEST_MAX_QUEUE_ITEMS * 3 },
+      (_value, index) =>
+        workItem({
+          _id: `work-service-deposit-${index}` as Id<"operationalWorkItem">,
+          createdAt: index,
+          type: "service_deposit_review",
+        }),
+    );
+    const unsupportedApprovalRequests = Array.from(
+      { length: TEST_MAX_QUEUE_ITEMS * 3 },
+      (_value, index) =>
+        approvalRequest({
+          _id: `approval-service-deposit-${index}` as Id<"approvalRequest">,
+          createdAt: index,
+          requestType: "service_deposit_review",
+          subjectId: `service-deposit-${index}`,
+        }),
+    );
+    const ctx = createQueueContext({
+      approvalRequests: [
+        ...unsupportedApprovalRequests,
+        approvalRequest({
+          _id: "approval-variance" as Id<"approvalRequest">,
+          createdAt: 1_000,
+          requestType: "variance_review",
+        }),
+      ],
+      workItems: [
+        ...unsupportedWorkItems,
+        workItem({
+          _id: "work-service-case" as Id<"operationalWorkItem">,
+          createdAt: 1_000,
+          type: "service_case",
+        }),
+      ],
+    });
+
+    const result = await getHandler(getQueueSnapshot)(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(result.workItems.map((item: QueueTestRow) => item._id)).toEqual([
+      "work-service-case",
+    ]);
+    expect(
+      result.approvalRequests.map((request: QueueTestRow) => request._id),
+    ).toContain("approval-variance");
+    expect(result.overflow.approvalRequests).toBe(true);
+    expect(result.overflow.workItems.open).toBe(false);
+  });
+
+  it("orders work items by bucket, status urgency, actionable timestamp, source identity, then id", async () => {
+    const ctx = createQueueContext({
+      workItems: [
+        workItem({
+          _id: "work-purchase-z" as Id<"operationalWorkItem">,
+          createdAt: 5,
+          metadata: { purchaseOrderId: "po-z" },
+          status: "open",
+          type: "purchase_order",
+        }),
+        workItem({
+          _id: "work-purchase-a" as Id<"operationalWorkItem">,
+          createdAt: 5,
+          metadata: { purchaseOrderId: "po-a" },
+          status: "open",
+          type: "purchase_order",
+        }),
+        workItem({
+          _id: "work-synced-open" as Id<"operationalWorkItem">,
+          createdAt: 1,
+          metadata: {
+            localRegisterSessionId: "local-session-1",
+            localTransactionId: "txn-open",
+            terminalId: "terminal-1",
+          },
+          status: "open",
+          type: "synced_sale_inventory_review",
+        }),
+        workItem({
+          _id: "work-synced-in-progress" as Id<"operationalWorkItem">,
+          createdAt: 20,
+          metadata: {
+            localRegisterSessionId: "local-session-2",
+            localTransactionId: "txn-progress",
+            terminalId: "terminal-1",
+          },
+          startedAt: 30,
+          status: "in_progress",
+          type: "synced_sale_inventory_review",
+        }),
+        workItem({
+          _id: "work-adjustment-approval" as Id<"operationalWorkItem">,
+          approvalRequestId: "approval-stock" as Id<"approvalRequest">,
+          approvalState: "pending",
+          createdAt: 50,
+          metadata: { stockAdjustmentBatchId: "batch-1" },
+          status: "open",
+          type: "stock_adjustment_review",
+        }),
+      ],
+    });
+
+    const result = await getHandler(getQueueSnapshot)(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(result.workItems.map((item: QueueTestRow) => item._id)).toEqual([
+      "work-adjustment-approval",
+      "work-synced-in-progress",
+      "work-synced-open",
+      "work-purchase-a",
+      "work-purchase-z",
+    ]);
+  });
+
+  it("returns explicit overflow metadata when open, in-progress, or approval lanes exceed the queue cap", async () => {
+    const openItems = Array.from(
+      { length: TEST_MAX_QUEUE_ITEMS + 1 },
+      (_value, index) =>
+        workItem({
+          _id: `work-open-${String(index).padStart(3, "0")}` as Id<"operationalWorkItem">,
+          createdAt: index,
+          metadata: { sourceId: `open-${index}` },
+          status: "open",
+        }),
+    );
+    const inProgressItems = Array.from(
+      { length: TEST_MAX_QUEUE_ITEMS + 1 },
+      (_value, index) =>
+        workItem({
+          _id: `work-in-progress-${String(index).padStart(3, "0")}` as Id<"operationalWorkItem">,
+          createdAt: index,
+          metadata: { sourceId: `in-progress-${index}` },
+          status: "in_progress",
+        }),
+    );
+    const pendingApprovals = Array.from(
+      { length: TEST_MAX_QUEUE_ITEMS + 1 },
+      (_value, index) =>
+        approvalRequest({
+          _id: `approval-${String(index).padStart(3, "0")}` as Id<"approvalRequest">,
+          createdAt: index,
+          subjectId: `approval-subject-${index}`,
+        }),
+    );
+    const ctx = createQueueContext({
+      approvalRequests: pendingApprovals,
+      workItems: [...openItems, ...inProgressItems],
+    });
+
+    const result = await getHandler(getQueueSnapshot)(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(result.overflow).toEqual({
+      approvalRequests: true,
+      workItems: { inProgress: true, open: true },
+    });
+    expect(result.workItems).toHaveLength(TEST_MAX_QUEUE_ITEMS);
+    expect(result.approvalRequests).toHaveLength(TEST_MAX_QUEUE_ITEMS);
+  });
+
+  it("marks overflow when exact status-cap lanes combine beyond the display cap", async () => {
+    const openItems = Array.from({ length: TEST_MAX_QUEUE_ITEMS }, (_value, index) =>
+      workItem({
+        _id: `work-open-exact-${String(index).padStart(3, "0")}` as Id<"operationalWorkItem">,
+        createdAt: index,
+        metadata: { sourceId: `open-exact-${index}` },
+        status: "open",
+      }),
+    );
+    const inProgressItems = Array.from(
+      { length: TEST_MAX_QUEUE_ITEMS },
+      (_value, index) =>
+        workItem({
+          _id: `work-progress-exact-${String(index).padStart(3, "0")}` as Id<"operationalWorkItem">,
+          createdAt: index,
+          metadata: { sourceId: `progress-exact-${index}` },
+          status: "in_progress",
+        }),
+    );
+    const pendingApprovals = Array.from(
+      { length: TEST_MAX_QUEUE_ITEMS },
+      (_value, index) =>
+        approvalRequest({
+          _id: `approval-exact-${String(index).padStart(3, "0")}` as Id<"approvalRequest">,
+          createdAt: index,
+          subjectId: `approval-exact-subject-${index}`,
+        }),
+    );
+    const ctx = createQueueContext({
+      approvalRequests: pendingApprovals,
+      workItems: [...openItems, ...inProgressItems],
+    });
+
+    const result = await getHandler(getQueueSnapshot)(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(result.overflow).toEqual({
+      approvalRequests: false,
+      workItems: { inProgress: false, open: true },
+    });
+    expect(result.workItems).toHaveLength(TEST_MAX_QUEUE_ITEMS);
+    expect(result.approvalRequests).toHaveLength(TEST_MAX_QUEUE_ITEMS);
+  });
+
+  it("keeps high-priority work on the first page even when inserted beyond the display cap", async () => {
+    const lowPriorityItems = Array.from(
+      { length: TEST_MAX_QUEUE_ITEMS },
+      (_value, index) =>
+        workItem({
+          _id: `work-low-${String(index).padStart(3, "0")}` as Id<"operationalWorkItem">,
+          createdAt: index,
+          metadata: { purchaseOrderId: `po-${String(index).padStart(3, "0")}` },
+          priority: "normal",
+          status: "open",
+          type: "purchase_order",
+        }),
+    );
+    const ctx = createQueueContext({
+      workItems: [
+        ...lowPriorityItems,
+        workItem({
+          _id: "work-high-review" as Id<"operationalWorkItem">,
+          approvalRequestId: "approval-stock" as Id<"approvalRequest">,
+          approvalState: "pending",
+          createdAt: 999,
+          metadata: { stockAdjustmentBatchId: "batch-late" },
+          priority: "high",
+          status: "open",
+          type: "stock_adjustment_review",
+        }),
+      ],
+    });
+
+    const result = await getHandler(getQueueSnapshot)(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+    const returnedIds = result.workItems.map((item: QueueTestRow) => item._id);
+
+    expect(returnedIds).toHaveLength(TEST_MAX_QUEUE_ITEMS);
+    expect(returnedIds[0]).toBe("work-high-review");
+    expect(returnedIds).toContain("work-low-098");
+    expect(returnedIds).not.toContain("work-low-099");
+  });
+
+  it("keeps high-priority work from another supported lane past an overloaded low-priority lane", async () => {
+    const lowPriorityItems = Array.from(
+      { length: TEST_MAX_QUEUE_ITEMS + 1 },
+      (_value, index) =>
+        workItem({
+          _id: `work-low-service-${String(index).padStart(3, "0")}` as Id<"operationalWorkItem">,
+          createdAt: index,
+          priority: "normal",
+          status: "open",
+          type: "service_case",
+        }),
+    );
+    const ctx = createQueueContext({
+      workItems: [
+        ...lowPriorityItems,
+        workItem({
+          _id: "work-high-stock-adjustment" as Id<"operationalWorkItem">,
+          approvalRequestId: "approval-stock" as Id<"approvalRequest">,
+          approvalState: "pending",
+          createdAt: 2_000,
+          metadata: { stockAdjustmentBatchId: "batch-late" },
+          priority: "high",
+          status: "open",
+          type: "stock_adjustment_review",
+        }),
+      ],
+    });
+
+    const result = await getHandler(getQueueSnapshot)(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+    const returnedIds = result.workItems.map((item: QueueTestRow) => item._id);
+
+    expect(returnedIds).toHaveLength(TEST_MAX_QUEUE_ITEMS);
+    expect(returnedIds[0]).toBe("work-high-stock-adjustment");
+    expect(result.overflow.workItems.open).toBe(true);
+  });
+
+  it("exposes stable source identities and collapses duplicate current rows for surfaced work types", async () => {
+    const ctx = createQueueContext({
+      workItems: [
+        workItem({
+          _id: "work-synced-a" as Id<"operationalWorkItem">,
+          createdAt: 1,
+          metadata: {
+            localRegisterSessionId: "local-session-1",
+            localTransactionId: "txn-1",
+            terminalId: "terminal-1",
+          },
+          type: "synced_sale_inventory_review",
+        }),
+        workItem({
+          _id: "work-synced-b" as Id<"operationalWorkItem">,
+          createdAt: 2,
+          metadata: {
+            localRegisterSessionId: "local-session-1",
+            localTransactionId: "txn-1",
+            terminalId: "terminal-1",
+          },
+          type: "synced_sale_inventory_review",
+        }),
+        workItem({
+          _id: "work-pending-checkout-a" as Id<"operationalWorkItem">,
+          createdAt: 3,
+          metadata: { posPendingCheckoutItemId: "pending-checkout-1" },
+          type: "pos_pending_checkout_item_review",
+        }),
+        workItem({
+          _id: "work-pending-checkout-b" as Id<"operationalWorkItem">,
+          createdAt: 4,
+          metadata: { posPendingCheckoutItemId: "pending-checkout-1" },
+          type: "pos_pending_checkout_item_review",
+        }),
+        workItem({
+          _id: "work-service-appointment" as Id<"operationalWorkItem">,
+          createdAt: 5,
+          metadata: { appointmentId: "appointment-1" },
+          type: "service_appointment",
+        }),
+        workItem({
+          _id: "work-purchase-order" as Id<"operationalWorkItem">,
+          createdAt: 6,
+          metadata: { purchaseOrderId: "purchase-order-1" },
+          type: "purchase_order",
+        }),
+        workItem({
+          _id: "work-daily-carry-forward" as Id<"operationalWorkItem">,
+          createdAt: 7,
+          metadata: {
+            businessDate: "2026-07-01",
+            carryForwardSourceId: "carry-forward-1",
+          },
+          type: "daily_close_carry_forward",
+        }),
+      ],
+    });
+
+    const result = await getHandler(getQueueSnapshot)(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(result.workItems).toHaveLength(5);
+    expect(
+      result.workItems.map((item: QueueTestRow) => [
+        item._id,
+        item.sourceIdentity,
+      ]),
+    ).toEqual([
+      [
+        "work-pending-checkout-a",
+        "pos_pending_checkout_item_review:pending-checkout-1",
+      ],
+      [
+        "work-daily-carry-forward",
+        "daily_close_carry_forward:2026-07-01:carry-forward-1",
+      ],
+      [
+        "work-synced-a",
+        "synced_sale_inventory_review:store-1:terminal-1:local-session-1:txn-1",
+      ],
+      ["work-service-appointment", "service_appointment:appointment-1"],
+      ["work-purchase-order", "purchase_order:purchase-order-1"],
+    ]);
+  });
+
+  it("prefers the complete synced sale resolver row when duplicate current rows exist", async () => {
+    const ctx = createQueueContext({
+      workItems: [
+        workItem({
+          _id: "work-synced-incomplete" as Id<"operationalWorkItem">,
+          createdAt: 1,
+          metadata: {
+            localRegisterSessionId: "local-session-1",
+            localTransactionId: "txn-1",
+            terminalId: "terminal-1",
+          },
+          type: "synced_sale_inventory_review",
+        }),
+        workItem({
+          _id: "work-synced-complete" as Id<"operationalWorkItem">,
+          createdAt: 2,
+          metadata: {
+            localRegisterSessionId: "local-session-1",
+            localTransactionId: "txn-1",
+            registerSessionId: "register-session-1",
+            sourceId: "transaction-1",
+            sourceType: "posTransaction",
+            terminalId: "terminal-1",
+          },
+          type: "synced_sale_inventory_review",
+        }),
+      ],
+    });
+
+    const result = await getHandler(getQueueSnapshot)(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(result.workItems).toEqual([
+      expect.objectContaining({
+        _id: "work-synced-complete",
+        details: expect.objectContaining({
+          registerSessionId: "register-session-1",
+          sourceId: "transaction-1",
+        }),
+      }),
+    ]);
+  });
+
+  it("dedupes current lane probes before the queue cap hides complete resolver rows", async () => {
+    const incompleteDuplicates = Array.from({ length: TEST_MAX_QUEUE_ITEMS + 1 }, (_, index) =>
+      workItem({
+        _id: `work-synced-incomplete-${index}` as Id<"operationalWorkItem">,
+        createdAt: index + 1,
+        metadata: {
+          localRegisterSessionId: "local-session-1",
+          localTransactionId: "txn-1",
+          terminalId: "terminal-1",
+        },
+        type: "synced_sale_inventory_review",
+      }),
+    );
+    const ctx = createQueueContext({
+      workItems: [
+        ...incompleteDuplicates,
+        workItem({
+          _id: "work-synced-complete" as Id<"operationalWorkItem">,
+          createdAt: TEST_MAX_QUEUE_ITEMS + 2,
+          metadata: {
+            localRegisterSessionId: "local-session-1",
+            localTransactionId: "txn-1",
+            registerSessionId: "register-session-1",
+            sourceId: "transaction-1",
+            sourceType: "posTransaction",
+            terminalId: "terminal-1",
+          },
+          type: "synced_sale_inventory_review",
+        }),
+      ],
+    });
+
+    const result = await getHandler(getQueueSnapshot)(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(result.workItems).toEqual([
+      expect.objectContaining({
+        _id: "work-synced-complete",
+        details: expect.objectContaining({
+          registerSessionId: "register-session-1",
+          sourceId: "transaction-1",
+        }),
+      }),
+    ]);
+    expect(result.overflow.workItems.open).toBe(true);
+  });
+
   it("normalizes item adjustment approval payloads for the operations queue", async () => {
     const approvalRequest = {
       _id: "approval-1" as Id<"approvalRequest">,
@@ -73,14 +856,33 @@ describe("getQueueSnapshot", () => {
           return null;
         }),
         query: vi.fn((tableName: string) => ({
-          withIndex: vi.fn(() => ({
-            take: vi.fn(async () => {
-              if (tableName === "approvalRequest") {
-                return [approvalRequest];
-              }
-              return [];
+          withIndex: vi.fn((_indexName: string, callback: Function) => {
+            const constraints = new Map<string, unknown>();
+            const queryBuilder = {
+              eq(fieldName: string, value: unknown) {
+                constraints.set(fieldName, value);
+                return queryBuilder;
+              },
+            };
+            callback(queryBuilder);
+            const rows =
+              tableName === "approvalRequest" &&
+              Array.from(constraints.entries()).every(
+                ([fieldName, value]) =>
+                  (approvalRequest as QueueTestRow)[fieldName] === value,
+              )
+                ? [approvalRequest]
+                : [];
+
+            return {
+            collect: vi.fn(async () => {
+              return rows;
             }),
-          })),
+            take: vi.fn(async () => {
+              return rows;
+            }),
+          };
+          }),
         })),
       },
     };
@@ -169,14 +971,33 @@ describe("getQueueSnapshot", () => {
           return null;
         }),
         query: vi.fn((tableName: string) => ({
-          withIndex: vi.fn(() => ({
-            take: vi.fn(async () => {
-              if (tableName === "approvalRequest") {
-                return [approvalRequest];
-              }
-              return [];
+          withIndex: vi.fn((_indexName: string, callback: Function) => {
+            const constraints = new Map<string, unknown>();
+            const queryBuilder = {
+              eq(fieldName: string, value: unknown) {
+                constraints.set(fieldName, value);
+                return queryBuilder;
+              },
+            };
+            callback(queryBuilder);
+            const rows =
+              tableName === "approvalRequest" &&
+              Array.from(constraints.entries()).every(
+                ([fieldName, value]) =>
+                  (approvalRequest as QueueTestRow)[fieldName] === value,
+              )
+                ? [approvalRequest]
+                : [];
+
+            return {
+            collect: vi.fn(async () => {
+              return rows;
             }),
-          })),
+            take: vi.fn(async () => {
+              return rows;
+            }),
+          };
+          }),
         })),
       },
     };
@@ -230,6 +1051,12 @@ describe("getQueueSnapshot", () => {
         }),
         query: vi.fn((tableName: string) => ({
           withIndex: vi.fn(() => ({
+            collect: vi.fn(async () => {
+              if (tableName === "posLocalSyncConflict") {
+                return [];
+              }
+              return [];
+            }),
             take: vi.fn(async () => {
               if (tableName === "posLocalSyncConflict") {
                 return [

--- a/packages/athena-webapp/convex/operations/operationalWorkItems.ts
+++ b/packages/athena-webapp/convex/operations/operationalWorkItems.ts
@@ -13,10 +13,372 @@ import {
 import { listOpenLocalSyncConflictsByRegisterSession } from "../cashControls/deposits";
 
 const MAX_QUEUE_ITEMS = 100;
+const QUEUE_LANE_PROBE_LIMIT = 1_000;
+const APPROVAL_REQUEST_PROBE_LIMIT = MAX_QUEUE_ITEMS + 1;
 const TERMINAL_WORK_ITEM_STATUSES = new Set(["completed", "cancelled"]);
 const OPEN_WORK_ITEM_STATUSES = ["open", "in_progress"] as const;
 const REGISTER_SYNC_REVIEW_REQUEST_TYPE = "register_sync_review";
 const REGISTER_SYNC_REVIEW_SUBJECT_TYPE = "register_session_sync_review";
+const QUEUE_APPROVAL_REQUEST_TYPES = [
+  "inventory_adjustment_review",
+  "online_order_return_review",
+  "payment_method_correction",
+  "pos_item_adjustment",
+  "pos_item_adjustment_review",
+  "pos_transaction_void",
+  "service_deposit_review",
+  "variance_review",
+] as const;
+const QUEUE_WORK_ITEM_TYPES = [
+  "daily_close_carry_forward",
+  "pos_pending_checkout_item_review",
+  "purchase_order",
+  "service_appointment",
+  "service_case",
+  "service_intake",
+  "stock_adjustment_review",
+  "synced_sale_inventory_review",
+] as const;
+const APPROVAL_BLOCKED_WORK_ITEM_TYPES = new Set([
+  "stock_adjustment_review",
+]);
+const SOURCE_RESOLVER_WORK_ITEM_TYPES = new Set([
+  "daily_close_carry_forward",
+  "pos_pending_checkout_item_review",
+  "synced_sale_inventory_review",
+]);
+const SOURCE_CONTINUATION_WORK_ITEM_TYPES = new Set([
+  "purchase_order",
+  "service_appointment",
+  "service_case",
+]);
+
+function metadataString(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+) {
+  const value = metadata?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function joinSourceIdentity(parts: Array<string | null | undefined>) {
+  return parts.filter((part): part is string => Boolean(part)).join(":");
+}
+
+function stableOperationalWorkItemSourceIdentity(
+  item: Doc<"operationalWorkItem">,
+) {
+  const metadata = item.metadata;
+
+  switch (item.type) {
+    case "daily_close_carry_forward": {
+      const businessDate = metadataString(metadata, "businessDate");
+      const sourceId =
+        metadataString(metadata, "carryForwardSourceId") ??
+        metadataString(metadata, "dailyCloseId") ??
+        metadataString(metadata, "sourceId");
+      if (businessDate || sourceId) {
+        return joinSourceIdentity([
+          item.type,
+          businessDate ?? item.storeId,
+          sourceId ?? item._id,
+        ]);
+      }
+      break;
+    }
+    case "pos_pending_checkout_item_review": {
+      const pendingCheckoutItemId =
+        metadataString(metadata, "posPendingCheckoutItemId") ??
+        metadataString(metadata, "pendingCheckoutItemId");
+      if (pendingCheckoutItemId) {
+        return joinSourceIdentity([item.type, pendingCheckoutItemId]);
+      }
+
+      const localIdentity = joinSourceIdentity([
+        item.type,
+        String(item.storeId),
+        metadataString(metadata, "terminalId"),
+        metadataString(metadata, "localRegisterSessionId"),
+        "pendingCheckoutItem",
+        metadataString(metadata, "localPendingCheckoutItemId") ??
+          metadataString(metadata, "localId") ??
+          metadataString(metadata, "localItemId"),
+      ]);
+      if (localIdentity !== item.type) {
+        return localIdentity;
+      }
+      break;
+    }
+    case "purchase_order": {
+      const purchaseOrderId = metadataString(metadata, "purchaseOrderId");
+      if (purchaseOrderId) {
+        return joinSourceIdentity([item.type, purchaseOrderId]);
+      }
+      break;
+    }
+    case "service_appointment": {
+      const appointmentId = item.appointmentId
+        ? String(item.appointmentId)
+        : metadataString(metadata, "appointmentId");
+      if (appointmentId) {
+        return joinSourceIdentity([item.type, appointmentId]);
+      }
+      break;
+    }
+    case "service_case": {
+      const serviceCaseId =
+        metadataString(metadata, "serviceCaseId") ??
+        metadataString(metadata, "sourceId");
+      if (serviceCaseId) {
+        return joinSourceIdentity([item.type, serviceCaseId]);
+      }
+      break;
+    }
+    case "stock_adjustment_review": {
+      const stockAdjustmentBatchId = metadataString(
+        metadata,
+        "stockAdjustmentBatchId",
+      );
+      if (item.approvalRequestId || stockAdjustmentBatchId) {
+        return joinSourceIdentity([
+          item.type,
+          item.approvalRequestId ? String(item.approvalRequestId) : null,
+          stockAdjustmentBatchId,
+        ]);
+      }
+      break;
+    }
+    case "synced_sale_inventory_review": {
+      const localTransactionId = metadataString(metadata, "localTransactionId");
+      const localRegisterSessionId = metadataString(
+        metadata,
+        "localRegisterSessionId",
+      );
+      if (localTransactionId || localRegisterSessionId) {
+        return joinSourceIdentity([
+          item.type,
+          String(item.storeId),
+          metadataString(metadata, "terminalId"),
+          localRegisterSessionId,
+          localTransactionId ??
+            metadataString(metadata, "localEventId") ??
+            metadataString(metadata, "receiptNumber"),
+        ]);
+      }
+      break;
+    }
+  }
+
+  const sourceType = metadataString(metadata, "sourceType");
+  const sourceId = metadataString(metadata, "sourceId");
+  if (sourceType || sourceId) {
+    return joinSourceIdentity([
+      item.type,
+      sourceType,
+      sourceId ?? String(item._id),
+    ]);
+  }
+
+  return joinSourceIdentity([item.type, String(item._id)]);
+}
+
+function workItemPriorityBucket(item: Doc<"operationalWorkItem">) {
+  if (
+    item.approvalRequestId ||
+    item.approvalState === "pending" ||
+    APPROVAL_BLOCKED_WORK_ITEM_TYPES.has(item.type)
+  ) {
+    return 0;
+  }
+
+  if (SOURCE_RESOLVER_WORK_ITEM_TYPES.has(item.type)) {
+    return 1;
+  }
+
+  if (SOURCE_CONTINUATION_WORK_ITEM_TYPES.has(item.type)) {
+    return 2;
+  }
+
+  return 3;
+}
+
+function workItemStatusUrgency(item: Doc<"operationalWorkItem">) {
+  if (item.status === "in_progress") {
+    return 0;
+  }
+
+  if (item.status === "open") {
+    return 1;
+  }
+
+  return 2;
+}
+
+function actionableWorkItemTimestamp(item: Doc<"operationalWorkItem">) {
+  return item.dueAt ?? item.startedAt ?? item.createdAt ?? 0;
+}
+
+function resolverCompletenessBucket(item: Doc<"operationalWorkItem">) {
+  if (item.type !== "synced_sale_inventory_review") {
+    return 0;
+  }
+
+  const metadata = item.metadata;
+  const hasRequiredResolverContext = Boolean(
+    metadataString(metadata, "terminalId") &&
+      metadataString(metadata, "localRegisterSessionId") &&
+      metadataString(metadata, "localTransactionId") &&
+      metadataString(metadata, "registerSessionId") &&
+      metadataString(metadata, "sourceId") &&
+      metadataString(metadata, "sourceType") === "posTransaction",
+  );
+
+  return hasRequiredResolverContext ? 0 : 1;
+}
+
+function compareStrings(left: string, right: string) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compareOperationalWorkItems(
+  left: Doc<"operationalWorkItem">,
+  right: Doc<"operationalWorkItem">,
+) {
+  return (
+    workItemPriorityBucket(left) - workItemPriorityBucket(right) ||
+    workItemStatusUrgency(left) - workItemStatusUrgency(right) ||
+    resolverCompletenessBucket(left) - resolverCompletenessBucket(right) ||
+    actionableWorkItemTimestamp(left) - actionableWorkItemTimestamp(right) ||
+    compareStrings(
+      stableOperationalWorkItemSourceIdentity(left),
+      stableOperationalWorkItemSourceIdentity(right),
+    ) ||
+    compareStrings(String(left._id), String(right._id))
+  );
+}
+
+function sortAndDedupeCurrentWorkItems(items: Array<Doc<"operationalWorkItem">>) {
+  const seenSourceIdentities = new Set<string>();
+
+  return [...items].sort(compareOperationalWorkItems).filter((item) => {
+    const sourceIdentity = stableOperationalWorkItemSourceIdentity(item);
+    if (seenSourceIdentities.has(sourceIdentity)) {
+      return false;
+    }
+    seenSourceIdentities.add(sourceIdentity);
+    return true;
+  });
+}
+
+function metadataNumber(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+) {
+  const value = metadata?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function metadataArrayCount(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+) {
+  const value = metadata?.[key];
+  return Array.isArray(value) ? value.length : null;
+}
+
+function sanitizeOperationalWorkItemDetails(
+  item: Doc<"operationalWorkItem">,
+) {
+  const metadata = item.metadata;
+
+  switch (item.type) {
+    case "daily_close_carry_forward":
+      return {
+        businessDate: metadataString(metadata, "businessDate"),
+        followUpReason: metadataString(metadata, "followUpReason"),
+      };
+    case "pos_pending_checkout_item_review":
+      return {
+        lookupCode: metadataString(metadata, "lookupCode"),
+        price: metadataNumber(metadata, "price"),
+        quantitySold: metadataNumber(metadata, "quantitySold"),
+        totalQuantitySold: metadataNumber(metadata, "totalQuantitySold"),
+      };
+    case "purchase_order":
+      return {
+        displayNumber: metadataString(metadata, "displayNumber"),
+        itemCount: metadataNumber(metadata, "itemCount"),
+        purchaseOrderNumber: metadataString(metadata, "purchaseOrderNumber"),
+        vendorName: metadataString(metadata, "vendorName"),
+      };
+    case "stock_adjustment_review":
+      return {
+        reasonLabel: metadataString(metadata, "reasonLabel"),
+      };
+    case "synced_sale_inventory_review": {
+      const skippedLineCount = metadataArrayCount(
+        metadata,
+        "skippedMutationItems",
+      );
+      const trustedLineCount = metadataArrayCount(
+        metadata,
+        "trustedInventoryLines",
+      );
+
+      return {
+        inventoryReviewLineCount:
+          skippedLineCount && skippedLineCount > 0
+            ? skippedLineCount
+            : trustedLineCount,
+        localRegisterSessionId: metadataString(
+          metadata,
+          "localRegisterSessionId",
+        ),
+        localTransactionId: metadataString(metadata, "localTransactionId"),
+        primaryProductSkuId: metadataString(metadata, "primaryProductSkuId"),
+        receiptNumber: metadataString(metadata, "receiptNumber"),
+        registerSessionId: metadataString(metadata, "registerSessionId"),
+        sourceId:
+          metadataString(metadata, "sourceType") === "posTransaction"
+            ? metadataString(metadata, "sourceId")
+            : null,
+        terminalId: metadataString(metadata, "terminalId"),
+      };
+    }
+    default:
+      return {};
+  }
+}
+
+function projectOperationalWorkItemForQueue(args: {
+  customerMap: Map<Id<"customerProfile">, Doc<"customerProfile">>;
+  item: Doc<"operationalWorkItem">;
+  staffMap: Map<Id<"staffProfile">, Doc<"staffProfile">>;
+}) {
+  const { customerMap, item, staffMap } = args;
+
+  return {
+    _id: item._id,
+    approvalRequestId: item.approvalRequestId,
+    approvalState: item.approvalState,
+    assignedStaffName: item.assignedToStaffProfileId
+      ? staffMap.get(item.assignedToStaffProfileId)?.fullName
+      : null,
+    completedAt: item.completedAt,
+    createdAt: item.createdAt,
+    customerName: item.customerProfileId
+      ? customerMap.get(item.customerProfileId)?.fullName
+      : null,
+    details: sanitizeOperationalWorkItemDetails(item),
+    dueAt: item.dueAt,
+    priority: item.priority,
+    sourceIdentity: stableOperationalWorkItemSourceIdentity(item),
+    startedAt: item.startedAt,
+    status: item.status,
+    title: item.title,
+    type: item.type,
+  };
+}
 
 function approvalRequestTransactionId(request: Doc<"approvalRequest">) {
   if (
@@ -121,6 +483,7 @@ export function buildOperationalWorkItem(args: {
   assignedToStaffProfileId?: Id<"staffProfile">;
   customerProfileId?: Id<"customerProfile">;
   approvalRequestId?: Id<"approvalRequest">;
+  appointmentId?: Id<"serviceAppointment">;
 }) {
   return {
     ...args,
@@ -157,6 +520,7 @@ export const createOperationalWorkItem = internalMutation({
     assignedToStaffProfileId: v.optional(v.id("staffProfile")),
     customerProfileId: v.optional(v.id("customerProfile")),
     approvalRequestId: v.optional(v.id("approvalRequest")),
+    appointmentId: v.optional(v.id("serviceAppointment")),
   },
   handler: (ctx, args) => createOperationalWorkItemWithCtx(ctx, args),
 });
@@ -236,28 +600,70 @@ export const getQueueSnapshot = query({
       userId: athenaUser._id,
     });
 
-    const [workItems, approvalRequests, syncConflictsBySessionId] =
+    const [workItemLanes, approvalRequestLanes, syncConflictsBySessionId] =
       await Promise.all([
-      Promise.all(
-        OPEN_WORK_ITEM_STATUSES.map((status) =>
-          ctx.db
-            .query("operationalWorkItem")
-            .withIndex("by_storeId_status", (q) =>
-              q.eq("storeId", args.storeId).eq("status", status),
-            )
-            .take(MAX_QUEUE_ITEMS),
-        ),
-      ).then((items) => items.flat()),
-      ctx.db
-        .query("approvalRequest")
-        .withIndex("by_storeId_status", (q) =>
-          q.eq("storeId", args.storeId).eq("status", "pending"),
-        )
-        .take(MAX_QUEUE_ITEMS),
-      listOpenLocalSyncConflictsByRegisterSession(ctx, args.storeId),
-    ]);
+        Promise.all(
+          OPEN_WORK_ITEM_STATUSES.flatMap((status) =>
+            QUEUE_WORK_ITEM_TYPES.map(async (type) => {
+              const items = await ctx.db
+                .query("operationalWorkItem")
+                .withIndex("by_storeId_type_status", (q) =>
+                  q
+                    .eq("storeId", args.storeId)
+                    .eq("type", type)
+                    .eq("status", status),
+                )
+                .take(QUEUE_LANE_PROBE_LIMIT);
 
-    const openWorkItems = workItems;
+              return {
+                items,
+                overflow: items.length > MAX_QUEUE_ITEMS,
+                status,
+                type,
+              };
+            }),
+          ),
+        ),
+        Promise.all(
+          QUEUE_APPROVAL_REQUEST_TYPES.map(async (requestType) => {
+            const requests = await ctx.db
+              .query("approvalRequest")
+              .withIndex("by_storeId_status_requestType", (q) =>
+                q
+                  .eq("storeId", args.storeId)
+                  .eq("status", "pending")
+                  .eq("requestType", requestType),
+              )
+              .take(APPROVAL_REQUEST_PROBE_LIMIT);
+
+            return {
+              items: requests.slice(0, MAX_QUEUE_ITEMS),
+              overflow: requests.length > MAX_QUEUE_ITEMS,
+              requestType,
+            };
+          }),
+        ),
+        listOpenLocalSyncConflictsByRegisterSession(ctx, args.storeId),
+      ]);
+
+    const sortedWorkItems = sortAndDedupeCurrentWorkItems(
+      workItemLanes.flatMap((lane) => lane.items),
+    );
+    const openWorkItems = sortedWorkItems.slice(0, MAX_QUEUE_ITEMS);
+    const approvalRequests = approvalRequestLanes
+      .flatMap((lane) => lane.items)
+      .sort((left, right) => (right.createdAt ?? 0) - (left.createdAt ?? 0))
+      .slice(0, MAX_QUEUE_ITEMS);
+    const hiddenWorkItems = sortedWorkItems.slice(MAX_QUEUE_ITEMS);
+    const workItemOverflow = {
+      inProgress:
+        workItemLanes.some(
+          (lane) => lane.status === "in_progress" && lane.overflow,
+        ) || hiddenWorkItems.some((item) => item.status === "in_progress"),
+      open:
+        workItemLanes.some((lane) => lane.status === "open" && lane.overflow) ||
+        hiddenWorkItems.some((item) => item.status === "open"),
+    };
 
     const customerIds = new Set<string>();
     const posTransactionIds = new Set<string>();
@@ -564,19 +970,26 @@ export const getQueueSnapshot = query({
       };
     });
 
+    const combinedApprovalRequests = [
+      ...mappedApprovalRequests,
+      ...mappedSyncReviewRequests,
+    ].sort((left, right) => (right.createdAt ?? 0) - (left.createdAt ?? 0));
+
     return {
-      approvalRequests: [...mappedApprovalRequests, ...mappedSyncReviewRequests]
-        .sort((left, right) => (right.createdAt ?? 0) - (left.createdAt ?? 0))
-        .slice(0, MAX_QUEUE_ITEMS),
-      workItems: openWorkItems.map((item) => ({
-        ...item,
-        assignedStaffName: item.assignedToStaffProfileId
-          ? staffMap.get(item.assignedToStaffProfileId)?.fullName
-          : null,
-        customerName: item.customerProfileId
-          ? customerMap.get(item.customerProfileId)?.fullName
-          : null,
-      })),
+      approvalRequests: combinedApprovalRequests.slice(0, MAX_QUEUE_ITEMS),
+      overflow: {
+        approvalRequests:
+          approvalRequestLanes.some((lane) => lane.overflow) ||
+          combinedApprovalRequests.length > MAX_QUEUE_ITEMS,
+        workItems: workItemOverflow,
+      },
+      workItems: openWorkItems.map((item) =>
+        projectOperationalWorkItemForQueue({
+          customerMap,
+          item,
+          staffMap,
+        }),
+      ),
     };
   },
 });

--- a/packages/athena-webapp/convex/operations/serviceIntake.test.ts
+++ b/packages/athena-webapp/convex/operations/serviceIntake.test.ts
@@ -1,9 +1,31 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
+import * as athenaUserAuth from "../lib/athenaUserAuth";
 import {
   createServiceIntake,
   validateServiceIntakeInput,
 } from "./serviceIntake";
+
+vi.mock("../lib/athenaUserAuth", () => ({
+  requireAuthenticatedAthenaUserWithCtx: vi.fn(),
+  requireOrganizationMemberRoleWithCtx: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(athenaUserAuth.requireAuthenticatedAthenaUserWithCtx).mockResolvedValue({
+    _id: "user-auth",
+    email: "admin@example.com",
+  } as never);
+  vi.mocked(athenaUserAuth.requireOrganizationMemberRoleWithCtx).mockResolvedValue(
+    {
+      _id: "member-1",
+      organizationId: "org-1",
+      role: "full_admin",
+      userId: "user-auth",
+    } as never,
+  );
+});
 
 function getSource(relativePath: string) {
   return readFileSync(new URL(relativePath, import.meta.url), "utf8");
@@ -68,6 +90,106 @@ function createMutationCtx(args?: {
       patch: vi.fn(),
       query: vi.fn(),
     },
+  };
+}
+
+function createServiceIntakeBehaviorCtx() {
+  const rows: Record<string, Map<string, Record<string, unknown>>> = {
+    approvalRequest: new Map(),
+    customerProfile: new Map([
+      [
+        "customer-1",
+        {
+          _id: "customer-1",
+          fullName: "Ama Mensah",
+          phoneNumber: "+233200000000",
+          storeId: "store-1",
+        },
+      ],
+    ]),
+    inventoryMovement: new Map(),
+    operationalEvent: new Map(),
+    operationalWorkItem: new Map(),
+    paymentAllocation: new Map(),
+    serviceCase: new Map(),
+    staffProfile: new Map([
+      [
+        "staff-1",
+        {
+          _id: "staff-1",
+          linkedUserId: "user-auth",
+          status: "active",
+          storeId: "store-1",
+        },
+      ],
+    ]),
+    store: new Map([
+      [
+        "store-1",
+        {
+          _id: "store-1",
+          organizationId: "org-1",
+        },
+      ],
+    ]),
+  };
+  const inserts: Array<{ table: string; value: Record<string, unknown> }> = [];
+  const get = vi.fn(async (tableName: string, id: string) => {
+    return rows[tableName]?.get(id) ?? null;
+  });
+  const insert = vi.fn(async (tableName: string, value: Record<string, unknown>) => {
+    const id = `${tableName}-${(rows[tableName]?.size ?? 0) + 1}`;
+    const row = { _id: id, ...value };
+    inserts.push({ table: tableName, value });
+    rows[tableName] ??= new Map();
+    rows[tableName].set(id, row);
+    return id;
+  });
+  const patch = vi.fn(
+    async (tableName: string, id: string, patchValue: Record<string, unknown>) => {
+      const row = rows[tableName]?.get(id);
+      if (row) {
+        rows[tableName].set(id, { ...row, ...patchValue });
+      }
+    },
+  );
+  const query = vi.fn((tableName: string) => ({
+    withIndex: vi.fn((_indexName: string, applyIndex: Function) => {
+      const constraints: Record<string, unknown> = {};
+      const queryBuilder = {
+        eq(fieldName: string, value: unknown) {
+          constraints[fieldName] = value;
+          return queryBuilder;
+        },
+      };
+      applyIndex(queryBuilder);
+
+      const matchingRows = () =>
+        Array.from(rows[tableName]?.values() ?? []).filter((row) =>
+          Object.entries(constraints).every(([fieldName, value]) => row[fieldName] === value),
+        );
+
+      return {
+        collect: vi.fn(async () => matchingRows()),
+        first: vi.fn(async () => matchingRows()[0] ?? null),
+        order: vi.fn(() => ({
+          first: vi.fn(async () => matchingRows()[0] ?? null),
+        })),
+        take: vi.fn(async (limit: number) => matchingRows().slice(0, limit)),
+        unique: vi.fn(async () => matchingRows()[0] ?? null),
+      };
+    }),
+  }));
+
+  return {
+    db: {
+      get,
+      insert,
+      patch,
+      query,
+    },
+    inserts,
+    rows,
   };
 }
 
@@ -139,6 +261,34 @@ describe("service intake validation", () => {
     });
   });
 
+  it("requires store admin access before service intake writes", async () => {
+    const ctx = createMutationCtx();
+    vi.mocked(athenaUserAuth.requireOrganizationMemberRoleWithCtx).mockRejectedValue(
+      new Error("Only store admins can create service intake work."),
+    );
+
+    await expect(
+      getHandler(createServiceIntake)(
+        ctx as never,
+        buildCreateServiceIntakeArgs() as never,
+      ),
+    ).rejects.toThrow("Only store admins can create service intake work.");
+
+    expect(
+      athenaUserAuth.requireAuthenticatedAthenaUserWithCtx,
+    ).toHaveBeenCalledWith(ctx);
+    expect(
+      athenaUserAuth.requireOrganizationMemberRoleWithCtx,
+    ).toHaveBeenCalledWith(ctx, {
+      allowedRoles: ["full_admin"],
+      failureMessage: "Only store admins can create service intake work.",
+      organizationId: "org-1",
+      userId: "user-auth",
+    });
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
   it("keeps unexpected infrastructure faults thrown", async () => {
     const ctx = createMutationCtx({
       dbGetError: new Error("database offline"),
@@ -152,6 +302,70 @@ describe("service intake validation", () => {
     ).rejects.toThrow("database offline");
   });
 
+  it("records service deposits without creating approval requests", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 6, 2, 12));
+    const ctx = createServiceIntakeBehaviorCtx();
+
+    const result = await getHandler(createServiceIntake)(
+      ctx as never,
+      buildCreateServiceIntakeArgs({
+        createdByUserId: "user-spoof",
+        customerProfileId: "customer-1",
+        depositAmount: 2500,
+        depositMethod: "cash",
+        intakeChannel: "phone_booking",
+      }) as never,
+    );
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        customerProfileId: "customer-1",
+        serviceCaseId: "serviceCase-1",
+        workItemId: "operationalWorkItem-1",
+      },
+    });
+    expect(ctx.rows.approvalRequest.size).toBe(0);
+    expect(ctx.inserts).not.toContainEqual(
+      expect.objectContaining({ table: "approvalRequest" }),
+    );
+    expect(ctx.rows.operationalWorkItem.get("operationalWorkItem-1")).toMatchObject({
+      approvalState: "not_required",
+      createdByStaffProfileId: "staff-1",
+      createdByUserId: "user-auth",
+      type: "service_intake",
+    });
+    expect(ctx.rows.paymentAllocation.get("paymentAllocation-1")).toMatchObject({
+      actorStaffProfileId: "staff-1",
+      actorUserId: "user-auth",
+      allocationType: "service_deposit",
+      amount: 2500,
+      targetId: "serviceCase-1",
+      targetType: "service_case",
+      workItemId: "operationalWorkItem-1",
+    });
+    expect(
+      Array.from(ctx.rows.operationalEvent.values()).map((event) => ({
+        actorStaffProfileId: event.actorStaffProfileId,
+        actorUserId: event.actorUserId,
+        eventType: event.eventType,
+      })),
+    ).toEqual(
+      expect.arrayContaining([
+        {
+          actorStaffProfileId: undefined,
+          actorUserId: "user-auth",
+          eventType: "service_case_created",
+        },
+        {
+          actorStaffProfileId: "staff-1",
+          actorUserId: "user-auth",
+          eventType: "service_intake_created",
+        },
+      ]),
+    );
+  });
+
   it("writes through the shared operations rails", () => {
     const source = getSource("./serviceIntake.ts");
 
@@ -160,7 +374,8 @@ describe("service intake validation", () => {
     expect(source).toContain("recordOperationalEventWithCtx");
     expect(source).toContain("recordInventoryMovementWithCtx");
     expect(source).toContain("recordPaymentAllocationWithCtx");
-    expect(source).toContain("buildApprovalRequest");
+    expect(source).not.toContain("buildApprovalRequest");
+    expect(source).not.toContain("service_deposit_review");
     expect(source).toContain("return ok(");
     expect(source).toContain("return userError(");
   });

--- a/packages/athena-webapp/convex/operations/serviceIntake.ts
+++ b/packages/athena-webapp/convex/operations/serviceIntake.ts
@@ -1,6 +1,5 @@
 import { v } from "convex/values";
 import { mutation, query } from "../_generated/server";
-import { buildApprovalRequest } from "./approvalRequestHelpers";
 import { resolveRegisterSessionForInStoreCollectionWithCtx } from "../cashControls/paymentAllocationAttribution";
 import { normalizeLookupValue, normalizePhoneNumber } from "./helpers/linking";
 import { recordInventoryMovementWithCtx } from "./inventoryMovements";
@@ -9,6 +8,10 @@ import { recordOperationalEventWithCtx } from "./operationalEvents";
 import { recordPaymentAllocationWithCtx } from "./paymentAllocations";
 import { createServiceCaseWithCtx } from "../serviceOps/serviceCases";
 import { recordServiceCaseTraceBestEffort } from "../serviceOps/serviceCaseTracing";
+import {
+  requireAuthenticatedAthenaUserWithCtx,
+  requireOrganizationMemberRoleWithCtx,
+} from "../lib/athenaUserAuth";
 import { ok, userError } from "../../shared/commandResult";
 import { validateServiceIntakeInput } from "../../shared/serviceIntake";
 
@@ -237,6 +240,15 @@ export const createServiceIntake = mutation({
       });
     }
 
+    const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
+    await requireOrganizationMemberRoleWithCtx(ctx, {
+      allowedRoles: ["full_admin"],
+      failureMessage: "Only store admins can create service intake work.",
+      organizationId: store.organizationId,
+      userId: athenaUser._id,
+    });
+    const actorUserId = athenaUser._id;
+
     const assignedStaffProfile = await ctx.db.get(
       "staffProfile",
       args.assignedStaffProfileId
@@ -253,14 +265,12 @@ export const createServiceIntake = mutation({
       });
     }
 
-    const createdByStaffProfile = args.createdByUserId
-      ? await ctx.db
-          .query("staffProfile")
-          .withIndex("by_storeId_linkedUserId", (q) =>
-            q.eq("storeId", args.storeId).eq("linkedUserId", args.createdByUserId!)
-          )
-          .first()
-      : null;
+    const createdByStaffProfile = await ctx.db
+      .query("staffProfile")
+      .withIndex("by_storeId_linkedUserId", (q) =>
+        q.eq("storeId", args.storeId).eq("linkedUserId", actorUserId)
+      )
+      .first();
 
     const customerProfileResult = await resolveServiceIntakeCustomerProfile(ctx, {
       customerEmail: args.customerEmail,
@@ -287,16 +297,16 @@ export const createServiceIntake = mutation({
     const resolvedRegisterSessionId = hasDeposit && collectedInStore
       ? await resolveRegisterSessionForInStoreCollectionWithCtx(ctx, {
           actorStaffProfileId: createdByStaffProfile?._id,
-          actorUserId: args.createdByUserId,
+          actorUserId,
           registerSessionId: args.registerSessionId,
           storeId: args.storeId,
         })
       : undefined;
     const workItem = await createOperationalWorkItemWithCtx(ctx, {
-      approvalState: hasDeposit ? "pending" : "not_required",
+      approvalState: "not_required",
       assignedToStaffProfileId: args.assignedStaffProfileId,
       createdByStaffProfileId: createdByStaffProfile?._id,
-      createdByUserId: args.createdByUserId,
+      createdByUserId: actorUserId,
       customerProfileId: customerProfile._id,
       dueAt: args.scheduledAt,
       metadata: {
@@ -320,7 +330,7 @@ export const createServiceIntake = mutation({
 
     const serviceCase = await createServiceCaseWithCtx(ctx, {
       assignedStaffProfileId: args.assignedStaffProfileId,
-      createdByUserId: args.createdByUserId,
+      createdByUserId: actorUserId,
       customerProfileId: customerProfile._id,
       notes: trimOptional(args.notes),
       operationalWorkItemId: workItem._id,
@@ -334,41 +344,9 @@ export const createServiceIntake = mutation({
 
     const createdServiceCase = serviceCase.data;
 
-    const approvalRequest = hasDeposit
-      ? await (async () => {
-          const approvalRequestId = await ctx.db.insert(
-            "approvalRequest",
-            buildApprovalRequest({
-              metadata: {
-                depositAmount: args.depositAmount,
-                depositMethod: args.depositMethod,
-                intakeChannel: args.intakeChannel,
-              },
-              notes: trimOptional(args.notes),
-              organizationId: store.organizationId,
-              reason: `Approve deposit for ${args.serviceTitle.trim()}`,
-              requestType: "service_deposit_review",
-              registerSessionId: resolvedRegisterSessionId,
-              requestedByStaffProfileId: createdByStaffProfile?._id,
-              requestedByUserId: args.createdByUserId,
-              storeId: args.storeId,
-              subjectId: createdServiceCase._id,
-              subjectType: "service_case",
-              workItemId: workItem._id,
-            })
-          );
-
-          await ctx.db.patch("operationalWorkItem", workItem._id, {
-            approvalRequestId,
-          });
-
-          return ctx.db.get("approvalRequest", approvalRequestId);
-        })()
-      : null;
-
     const inventoryMovement = await recordInventoryMovementWithCtx(ctx, {
       actorStaffProfileId: createdByStaffProfile?._id,
-      actorUserId: args.createdByUserId,
+      actorUserId,
       customerProfileId: customerProfile._id,
       movementType: "service_item_received",
       notes: trimOptional(args.itemDescription) ?? args.serviceTitle.trim(),
@@ -385,7 +363,7 @@ export const createServiceIntake = mutation({
       hasDeposit && args.depositMethod
         ? await recordPaymentAllocationWithCtx(ctx, {
             actorStaffProfileId: createdByStaffProfile?._id,
-            actorUserId: args.createdByUserId,
+            actorUserId,
             allocationType: "service_deposit",
             amount: args.depositAmount!,
             collectedInStore,
@@ -402,8 +380,7 @@ export const createServiceIntake = mutation({
 
     await recordOperationalEventWithCtx(ctx, {
       actorStaffProfileId: createdByStaffProfile?._id,
-      actorUserId: args.createdByUserId,
-      approvalRequestId: approvalRequest?._id,
+      actorUserId,
       customerProfileId: customerProfile._id,
       eventType: "service_intake_created",
       inventoryMovementId: inventoryMovement?._id,
@@ -424,9 +401,8 @@ export const createServiceIntake = mutation({
 
     await recordServiceCaseTraceBestEffort(ctx, {
       actorStaffProfileId: createdByStaffProfile?._id,
-      actorUserId: args.createdByUserId,
+      actorUserId,
       amount: args.depositAmount,
-      approvalRequestId: approvalRequest?._id,
       direction: hasDeposit ? "in" : undefined,
       inventoryMovementId: inventoryMovement?._id,
       method: args.depositMethod,
@@ -437,7 +413,6 @@ export const createServiceIntake = mutation({
     });
 
     return ok({
-      approvalRequestId: approvalRequest?._id,
       customerProfileId: customerProfile._id,
       serviceCaseId: createdServiceCase._id,
       workItemId: workItem._id,

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -2705,6 +2705,7 @@ describe("projectLocalSyncEvent", () => {
             }),
           ],
           sourceType: "posTransaction",
+          terminalId: "terminal-1",
           trustedInventoryLines: [
             expect.objectContaining({
               productSkuId: "sku-1",
@@ -2718,6 +2719,26 @@ describe("projectLocalSyncEvent", () => {
         type: "synced_sale_inventory_review",
       }),
     ]);
+    expect(repository.mappings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          cloudId: "service-work-item-1",
+          cloudTable: "operationalWorkItem",
+          localId: "local-txn-1:inventory-review",
+          localIdKind: "inventoryReviewWorkItem",
+          localRegisterSessionId: "local-register-1",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        }),
+      ]),
+    );
+    expect(
+      repository.mappings.filter(
+        (mapping) =>
+          mapping.localIdKind === "inventoryReviewWorkItem" &&
+          mapping.localId === "local-txn-1:inventory-review",
+      ),
+    ).toHaveLength(1);
   });
 
   it("keeps existing reviewed sale mappings against closed drawers as conflict evidence", async () => {

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -2379,6 +2379,7 @@ async function createSkippedInventoryReviewWorkItem(
       skippedMutationItems: input.inventoryValidation.skippedMutationItems,
       sourceId: input.sale.transactionId,
       sourceType,
+      terminalId: args.terminalId,
       trustedInventoryLines: trustedLines,
     },
     notes:

--- a/packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts
@@ -315,36 +315,51 @@ async function hasInventoryReviewWorkItemForProjectedSale(
   const localTransactionId =
     stringDetail(conflict.details, "localTransactionId") ??
     stringDetail(syncEvent.payload, "localTransactionId");
-  const receiptNumber = stringDetail(syncEvent.payload, "receiptNumber");
-  const inventoryReviewWorkItems = await ctx.db
-    .query("operationalWorkItem")
-    .withIndex("by_storeId_type", (q) =>
+  if (!localTransactionId || !conflict.terminalId) {
+    return false;
+  }
+
+  const canonicalLocalId = `${localTransactionId}:inventory-review`;
+  const mapping = await ctx.db
+    .query("posLocalSyncMapping")
+    .withIndex("by_store_terminal_local", (q) =>
       q
         .eq("storeId", storeId)
-        .eq("type", SYNCED_SALE_INVENTORY_REVIEW_WORK_ITEM_TYPE),
+        .eq("terminalId", conflict.terminalId!)
+        .eq("localRegisterSessionId", conflict.localRegisterSessionId)
+        .eq("localIdKind", "inventoryReviewWorkItem")
+        .eq("localId", canonicalLocalId),
     )
-    .take(SYNC_CONFLICT_LIMIT);
+    .unique();
+  if (
+    !mapping ||
+    mapping.cloudTable !== "operationalWorkItem" ||
+    !ctx.db.normalizeId("operationalWorkItem", mapping.cloudId)
+  ) {
+    return false;
+  }
 
-  return inventoryReviewWorkItems.some((workItem) => {
-    if (workItem.status !== "open") {
-      return false;
-    }
+  const workItem = await ctx.db.get(
+    "operationalWorkItem",
+    mapping.cloudId as Id<"operationalWorkItem">,
+  );
+  if (
+    !workItem ||
+    workItem.storeId !== storeId ||
+    !["open", "in_progress", "completed", "cancelled"].includes(
+      workItem.status,
+    ) ||
+    workItem.type !== SYNCED_SALE_INVENTORY_REVIEW_WORK_ITEM_TYPE
+  ) {
+    return false;
+  }
 
-    const metadata = workItem.metadata ?? {};
-    const metadataLocalRegisterSessionId =
-      typeof metadata.localRegisterSessionId === "string"
-        ? metadata.localRegisterSessionId
-        : null;
-
-    return (
-      metadata.localEventId === conflict.localEventId ||
-      (localTransactionId !== null &&
-        metadata.localTransactionId === localTransactionId) ||
-      (receiptNumber !== null &&
-        metadata.receiptNumber === receiptNumber &&
-        metadataLocalRegisterSessionId === conflict.localRegisterSessionId)
-    );
-  });
+  const metadata = workItem.metadata ?? {};
+  return (
+    metadata.localEventId === conflict.localEventId &&
+    metadata.localRegisterSessionId === conflict.localRegisterSessionId &&
+    metadata.localTransactionId === localTransactionId
+  );
 }
 
 async function isNonSaleMissingRegisterSessionMappingConflict(

--- a/packages/athena-webapp/convex/pos/public/catalog.test.ts
+++ b/packages/athena-webapp/convex/pos/public/catalog.test.ts
@@ -73,6 +73,7 @@ import {
   listRegisterCatalogSnapshot,
   listRegisterCatalogAvailability,
   listRegisterCatalogAvailabilitySnapshot,
+  mapPendingCheckoutReviewStatusToWorkItemPatch,
   quickAddSku,
   resolvePendingCheckoutItemReview,
 } from "./catalog";
@@ -202,6 +203,27 @@ describe("POS public catalog queries", () => {
       resolvePendingCheckoutItemReview,
       pendingReviewItem,
     );
+  });
+
+  it("maps pending checkout review decisions to source-owned work item states", () => {
+    expect(mapPendingCheckoutReviewStatusToWorkItemPatch("approved")).toEqual({
+      approvalState: "approved",
+      status: "completed",
+    });
+    expect(
+      mapPendingCheckoutReviewStatusToWorkItemPatch("linked_to_catalog"),
+    ).toEqual({
+      approvalState: "approved",
+      status: "completed",
+    });
+    expect(mapPendingCheckoutReviewStatusToWorkItemPatch("rejected")).toEqual({
+      approvalState: "rejected",
+      status: "completed",
+    });
+    expect(mapPendingCheckoutReviewStatusToWorkItemPatch("flagged")).toEqual({
+      approvalState: "needs_review",
+      status: "open",
+    });
   });
 
   it("requires same-organization POS access before returning full-store availability", async () => {

--- a/packages/athena-webapp/convex/pos/public/catalog.ts
+++ b/packages/athena-webapp/convex/pos/public/catalog.ts
@@ -144,6 +144,29 @@ const pendingCheckoutReviewItemValidator = v.object({
   createdFrom: v.union(v.literal("online"), v.literal("offline_sync")),
 });
 
+type PendingCheckoutReviewStatus =
+  | "approved"
+  | "linked_to_catalog"
+  | "rejected"
+  | "flagged";
+
+export function mapPendingCheckoutReviewStatusToWorkItemPatch(
+  status: PendingCheckoutReviewStatus,
+) {
+  if (status === "flagged") {
+    return {
+      approvalState: "needs_review" as const,
+      status: "open" as const,
+    };
+  }
+
+  return {
+    approvalState:
+      status === "rejected" ? ("rejected" as const) : ("approved" as const),
+    status: "completed" as const,
+  };
+}
+
 async function requireRegisterCatalogStoreAccess(
   ctx: Pick<QueryCtx, "auth" | "db">,
   args: {
@@ -509,14 +532,12 @@ export const resolvePendingCheckoutItemReview = mutation({
     });
 
     if (item.operationalWorkItemId) {
+      const workItemPatch = mapPendingCheckoutReviewStatusToWorkItemPatch(
+        args.status,
+      );
       await updateOperationalWorkItemStatusWithCtx(ctx, {
-        approvalState:
-          args.status === "rejected"
-            ? "rejected"
-            : args.status === "flagged"
-              ? "needs_review"
-              : "approved",
-        status: args.status === "flagged" ? "open" : "completed",
+        approvalState: workItemPatch.approvalState,
+        status: workItemPatch.status,
         workItemId: item.operationalWorkItemId,
       });
     }

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -154,6 +154,11 @@ const schema = defineSchema({
   approvalRequest: defineTable(approvalRequestSchema)
     .index("by_storeId", ["storeId"])
     .index("by_storeId_status", ["storeId", "status"])
+    .index("by_storeId_status_requestType", [
+      "storeId",
+      "status",
+      "requestType",
+    ])
     .index("by_storeId_subject", ["storeId", "subjectType", "subjectId"])
     .index("by_storeId_status_posTransactionId", [
       "storeId",
@@ -895,6 +900,12 @@ const schema = defineSchema({
     .index("by_storeId_status", ["storeId", "status"])
     .index("by_storeId_type", ["storeId", "type"])
     .index("by_storeId_type_status", ["storeId", "type", "status"])
+    .index("by_storeId_type_status_appointmentId", [
+      "storeId",
+      "type",
+      "status",
+      "appointmentId",
+    ])
     .index("by_storeId_assignedTo", ["storeId", "assignedToStaffProfileId"])
     .index("by_customerProfileId", ["customerProfileId"])
     .index("by_approvalState", ["approvalState"]),

--- a/packages/athena-webapp/convex/schemas/operations/operationalWorkItem.ts
+++ b/packages/athena-webapp/convex/schemas/operations/operationalWorkItem.ts
@@ -19,4 +19,5 @@ export const operationalWorkItemSchema = v.object({
   assignedToStaffProfileId: v.optional(v.id("staffProfile")),
   customerProfileId: v.optional(v.id("customerProfile")),
   approvalRequestId: v.optional(v.id("approvalRequest")),
+  appointmentId: v.optional(v.id("serviceAppointment")),
 });

--- a/packages/athena-webapp/convex/serviceOps/appointments.ts
+++ b/packages/athena-webapp/convex/serviceOps/appointments.ts
@@ -1,9 +1,16 @@
 /* eslint-disable @convex-dev/no-collect-in-query -- V26-276 keeps service appointment screens and staff overlap checks store-scoped until we add pagination and time-windowed query helpers; truncating these indexed reads would hide real conflicts and appointments. */
 
-import { mutation, query } from "../_generated/server";
-import { Id } from "../_generated/dataModel";
+import { mutation, query, type MutationCtx } from "../_generated/server";
+import { Doc, Id } from "../_generated/dataModel";
 import { v } from "convex/values";
-import { createOperationalWorkItemWithCtx } from "../operations/operationalWorkItems";
+import {
+  createOperationalWorkItemWithCtx,
+  updateOperationalWorkItemStatusWithCtx,
+} from "../operations/operationalWorkItems";
+import {
+  requireAuthenticatedAthenaUserWithCtx,
+  requireOrganizationMemberRoleWithCtx,
+} from "../lib/athenaUserAuth";
 import { recordOperationalEventWithCtx } from "../operations/operationalEvents";
 import { createServiceCaseWithCtx } from "./serviceCases";
 import { recordServiceCaseTraceBestEffort } from "./serviceCaseTracing";
@@ -14,6 +21,8 @@ const NON_BLOCKING_APPOINTMENT_STATUSES = new Set([
   "completed",
   "converted_to_walk_in",
 ]);
+const CURRENT_WORK_ITEM_STATUSES = ["open", "in_progress"] as const;
+const LEGACY_APPOINTMENT_WORK_ITEM_PROBE_LIMIT = 1_000;
 
 export function buildServiceAppointment(args: {
   assignedStaffProfileId: Id<"staffProfile">;
@@ -83,6 +92,74 @@ export function findOverlappingAppointment(
       );
     }) ?? null
   );
+}
+
+export async function closeCurrentServiceAppointmentWorkItemsWithCtx(
+  ctx: MutationCtx,
+  args: {
+    appointmentId: Id<"serviceAppointment">;
+    status: "completed" | "cancelled";
+    storeId: Id<"store">;
+  },
+) {
+  const indexedWorkItemGroups = await Promise.all(
+    CURRENT_WORK_ITEM_STATUSES.map((status) =>
+      ctx.db
+        .query("operationalWorkItem")
+        .withIndex("by_storeId_type_status_appointmentId", (q) =>
+          q
+            .eq("storeId", args.storeId)
+            .eq("type", "service_appointment")
+            .eq("status", status)
+            .eq("appointmentId", args.appointmentId),
+        )
+        .collect(),
+    ),
+  );
+  const legacyWorkItemGroups = await Promise.all(
+    CURRENT_WORK_ITEM_STATUSES.map((status) =>
+      ctx.db
+        .query("operationalWorkItem")
+        .withIndex("by_storeId_type_status", (q) =>
+          q
+            .eq("storeId", args.storeId)
+            .eq("type", "service_appointment")
+            .eq("status", status),
+        )
+        .take(LEGACY_APPOINTMENT_WORK_ITEM_PROBE_LIMIT),
+    ),
+  );
+  const workItemsById = new Map<
+    Id<"operationalWorkItem">,
+    Doc<"operationalWorkItem">
+  >();
+
+  for (const workItem of indexedWorkItemGroups.flat()) {
+    workItemsById.set(workItem._id, workItem);
+  }
+
+  for (const workItem of legacyWorkItemGroups.flat()) {
+    if (
+      workItem.appointmentId ||
+      workItem.metadata?.appointmentId !== args.appointmentId
+    ) {
+      continue;
+    }
+
+    workItemsById.set(workItem._id, workItem);
+  }
+
+  const patchedWorkItemIds: Array<Id<"operationalWorkItem">> = [];
+
+  for (const workItem of workItemsById.values()) {
+    await updateOperationalWorkItemStatusWithCtx(ctx, {
+      status: args.status,
+      workItemId: workItem._id,
+    });
+    patchedWorkItemIds.push(workItem._id);
+  }
+
+  return patchedWorkItemIds;
 }
 
 export const listAppointments = query({
@@ -294,16 +371,68 @@ export const cancelAppointment = mutation({
       });
     }
 
+    if (!appointment.organizationId) {
+      return userError({
+        code: "precondition_failed",
+        message: "Appointment is missing organization context.",
+      });
+    }
+
+    const store = await ctx.db.get("store", appointment.storeId);
+
+    if (!store) {
+      return userError({
+        code: "not_found",
+        message: "Store not found.",
+      });
+    }
+
+    if (store.organizationId !== appointment.organizationId) {
+      return userError({
+        code: "precondition_failed",
+        message: "Appointment store does not match its organization.",
+      });
+    }
+
+    const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
+    await requireOrganizationMemberRoleWithCtx(ctx, {
+      allowedRoles: ["full_admin"],
+      failureMessage: "Only store admins can cancel service appointments.",
+      organizationId: store.organizationId,
+      userId: athenaUser._id,
+    });
+
+    const actorUserId = athenaUser._id;
+    const actorStaffProfile = await ctx.db
+      .query("staffProfile")
+      .withIndex("by_storeId_linkedUserId", (q) =>
+        q.eq("storeId", appointment.storeId).eq("linkedUserId", actorUserId),
+      )
+      .first();
+
     await ctx.db.patch("serviceAppointment", appointment._id, {
       cancelledAt: Date.now(),
       notes: args.notes ?? appointment.notes,
       status: "cancelled",
       updatedAt: Date.now(),
     });
+    const closedWorkItemIds =
+      await closeCurrentServiceAppointmentWorkItemsWithCtx(ctx, {
+        appointmentId: appointment._id,
+        status: "cancelled",
+        storeId: appointment.storeId,
+      });
 
     await recordOperationalEventWithCtx(ctx, {
+      actorStaffProfileId: actorStaffProfile?._id,
+      actorUserId,
       customerProfileId: appointment.customerProfileId,
       eventType: "service_appointment_cancelled",
+      metadata: {
+        closedWorkItemIds,
+        nextWorkItemStatus: "cancelled",
+        previousStatus: appointment.status,
+      },
       organizationId: appointment.organizationId,
       storeId: appointment.storeId,
       subjectId: appointment._id,
@@ -336,6 +465,20 @@ export const convertAppointmentToWalkIn = mutation({
       });
     }
 
+    if (NON_BLOCKING_APPOINTMENT_STATUSES.has(appointment.status)) {
+      return userError({
+        code: "precondition_failed",
+        message: "This appointment can no longer be converted.",
+      });
+    }
+
+    if (!appointment.organizationId) {
+      return userError({
+        code: "precondition_failed",
+        message: "Appointment is missing organization context.",
+      });
+    }
+
     const [catalogItem, customerProfile, store] = await Promise.all([
       ctx.db.get("serviceCatalog", appointment.serviceCatalogId),
       ctx.db.get("customerProfile", appointment.customerProfileId),
@@ -363,21 +506,35 @@ export const convertAppointmentToWalkIn = mutation({
       });
     }
 
-    const createdByStaffProfile = args.createdByUserId
-      ? await ctx.db
-          .query("staffProfile")
-          .withIndex("by_storeId_linkedUserId", (q) =>
-            q
-              .eq("storeId", appointment.storeId)
-              .eq("linkedUserId", args.createdByUserId!)
-          )
-          .first()
-      : null;
+    if (store.organizationId !== appointment.organizationId) {
+      return userError({
+        code: "precondition_failed",
+        message: "Appointment store does not match its organization.",
+      });
+    }
+
+    const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
+    await requireOrganizationMemberRoleWithCtx(ctx, {
+      allowedRoles: ["full_admin"],
+      failureMessage:
+        "Only store admins can convert service appointments to cases.",
+      organizationId: store.organizationId,
+      userId: athenaUser._id,
+    });
+
+    const actorUserId = athenaUser._id;
+    const createdByStaffProfile = await ctx.db
+      .query("staffProfile")
+      .withIndex("by_storeId_linkedUserId", (q) =>
+        q.eq("storeId", appointment.storeId).eq("linkedUserId", actorUserId),
+      )
+      .first();
 
     const workItem = await createOperationalWorkItemWithCtx(ctx, {
       assignedToStaffProfileId: appointment.assignedStaffProfileId,
+      appointmentId: appointment._id,
       createdByStaffProfileId: createdByStaffProfile?._id,
-      createdByUserId: args.createdByUserId,
+      createdByUserId: actorUserId,
       customerProfileId: appointment.customerProfileId,
       metadata: {
         appointmentId: appointment._id,
@@ -390,7 +547,7 @@ export const convertAppointmentToWalkIn = mutation({
       status: "open",
       storeId: appointment.storeId,
       title: catalogItem.name,
-      type: "service_appointment",
+      type: "service_case",
     });
 
     if (!workItem) {
@@ -403,7 +560,7 @@ export const convertAppointmentToWalkIn = mutation({
     const serviceCase = await createServiceCaseWithCtx(ctx, {
       appointmentId: appointment._id,
       assignedStaffProfileId: appointment.assignedStaffProfileId,
-      createdByUserId: args.createdByUserId,
+      createdByUserId: actorUserId,
       customerProfileId: appointment.customerProfileId,
       notes: appointment.notes,
       operationalWorkItemId: workItem._id,
@@ -425,12 +582,25 @@ export const convertAppointmentToWalkIn = mutation({
       status: "converted_to_walk_in",
       updatedAt: Date.now(),
     });
+    const closedAppointmentWorkItemIds =
+      await closeCurrentServiceAppointmentWorkItemsWithCtx(ctx, {
+        appointmentId: appointment._id,
+        status: "completed",
+        storeId: appointment.storeId,
+      });
 
     await recordOperationalEventWithCtx(ctx, {
       actorStaffProfileId: createdByStaffProfile?._id,
-      actorUserId: args.createdByUserId,
+      actorUserId,
       customerProfileId: customerProfile._id,
       eventType: "service_appointment_converted_to_walk_in",
+      metadata: {
+        closedAppointmentWorkItemIds,
+        nextAppointmentWorkItemStatus: "completed",
+        previousStatus: appointment.status,
+        serviceCaseId: createdServiceCase._id,
+        serviceCaseWorkItemId: workItem._id,
+      },
       organizationId: store.organizationId,
       storeId: appointment.storeId,
       subjectId: appointment._id,
@@ -441,7 +611,7 @@ export const convertAppointmentToWalkIn = mutation({
 
     await recordServiceCaseTraceBestEffort(ctx, {
       actorStaffProfileId: createdByStaffProfile?._id,
-      actorUserId: args.createdByUserId,
+      actorUserId,
       appointmentId: appointment._id,
       serviceCase: createdServiceCase,
       stage: "appointment_converted",

--- a/packages/athena-webapp/convex/serviceOps/catalogAppointments.test.ts
+++ b/packages/athena-webapp/convex/serviceOps/catalogAppointments.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Id } from "../_generated/dataModel";
+import * as athenaUserAuth from "../lib/athenaUserAuth";
 import {
   buildPosServiceCatalogRow,
   buildServiceCatalogItem,
@@ -8,8 +9,35 @@ import {
 } from "./catalog";
 import {
   buildServiceAppointment,
+  cancelAppointment,
+  closeCurrentServiceAppointmentWorkItemsWithCtx,
+  convertAppointmentToWalkIn,
   findOverlappingAppointment,
 } from "./appointments";
+
+vi.mock("../lib/athenaUserAuth", () => ({
+  requireAuthenticatedAthenaUserWithCtx: vi.fn(),
+  requireOrganizationMemberRoleWithCtx: vi.fn(),
+}));
+
+function getHandler(definition: unknown) {
+  return (definition as { _handler: Function })._handler;
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(athenaUserAuth.requireAuthenticatedAthenaUserWithCtx).mockResolvedValue({
+    _id: "user-admin" as Id<"athenaUser">,
+  } as never);
+  vi.mocked(athenaUserAuth.requireOrganizationMemberRoleWithCtx).mockResolvedValue(
+    {
+      _id: "member-1",
+      organizationId: "org-1",
+      role: "full_admin",
+      userId: "user-admin",
+    } as never,
+  );
+});
 
 describe("service catalog and appointment helpers", () => {
   it("lists POS service catalog snapshot rows without requiring admin auth", async () => {
@@ -304,4 +332,445 @@ describe("service catalog and appointment helpers", () => {
       )
     ).toBeNull();
   });
+
+  it("terminal appointment transitions patch only current work for the appointment source", async () => {
+    const patch = vi.fn();
+    const workItems: Array<Record<string, unknown>> = [
+      {
+        _id: "work-current-open",
+        appointmentId: "appointment-1",
+        metadata: { appointmentId: "appointment-1" },
+        status: "open",
+        storeId: "store-1",
+        type: "service_appointment",
+      },
+      {
+        _id: "work-other-appointment",
+        appointmentId: "appointment-2",
+        metadata: { appointmentId: "appointment-2" },
+        status: "open",
+        storeId: "store-1",
+        type: "service_appointment",
+      },
+      {
+        _id: "work-current-progress",
+        metadata: { appointmentId: "appointment-1" },
+        status: "in_progress",
+        storeId: "store-1",
+        type: "service_appointment",
+      },
+    ];
+    const ctx = {
+      db: {
+        get: vi.fn(async (_table: string, id: string) => ({
+          _id: id,
+        })),
+        patch,
+        query: vi.fn(() => ({
+          withIndex: vi.fn(
+            (
+              _index: string,
+              applyIndex: (queryBuilder: {
+                eq: (field: string, value: unknown) => unknown;
+              }) => unknown,
+            ) => {
+              const constraints = new Map<string, unknown>();
+              const queryBuilder = {
+                eq(field: string, value: unknown) {
+                  constraints.set(field, value);
+                  return queryBuilder;
+                },
+              };
+
+              applyIndex(queryBuilder);
+              const matchingRows = () =>
+                workItems.filter((workItem) =>
+                  Array.from(constraints.entries()).every(
+                    ([field, value]) => workItem[field] === value,
+                  ),
+                );
+
+              return {
+                collect: vi.fn(async () => matchingRows()),
+                take: vi.fn(async (limit: number) =>
+                  matchingRows().slice(0, limit),
+                ),
+              };
+            },
+          ),
+        })),
+      },
+    };
+
+    const patchedIds = await closeCurrentServiceAppointmentWorkItemsWithCtx(
+      ctx as never,
+      {
+        appointmentId: "appointment-1" as Id<"serviceAppointment">,
+        status: "completed",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(patchedIds).toEqual(["work-current-open", "work-current-progress"]);
+    expect(patch).toHaveBeenCalledWith(
+      "operationalWorkItem",
+      "work-current-open",
+      expect.objectContaining({ status: "completed" }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      "operationalWorkItem",
+      "work-current-progress",
+      expect.objectContaining({ status: "completed" }),
+    );
+    expect(patch).not.toHaveBeenCalledWith(
+      "operationalWorkItem",
+      "work-other-appointment",
+      expect.anything(),
+    );
+  });
+
+  it("requires full-admin access before terminal appointment mutations write", async () => {
+    vi.mocked(athenaUserAuth.requireOrganizationMemberRoleWithCtx).mockRejectedValue(
+      new Error("Only store admins can update service appointments."),
+    );
+    const cancelCtx = createAppointmentMutationCtx();
+
+    await expect(
+      getHandler(cancelAppointment)(cancelCtx, {
+        appointmentId: "appointment-1" as Id<"serviceAppointment">,
+      }),
+    ).rejects.toThrow("Only store admins can update service appointments.");
+    expect(cancelCtx.db.patch).not.toHaveBeenCalled();
+    expect(cancelCtx.db.insert).not.toHaveBeenCalled();
+
+    vi.mocked(athenaUserAuth.requireOrganizationMemberRoleWithCtx).mockRejectedValue(
+      new Error("Only store admins can convert service appointments to cases."),
+    );
+    const convertCtx = createAppointmentMutationCtx();
+
+    await expect(
+      getHandler(convertAppointmentToWalkIn)(convertCtx, {
+        appointmentId: "appointment-1" as Id<"serviceAppointment">,
+        createdByUserId: "user-spoof" as Id<"athenaUser">,
+      }),
+    ).rejects.toThrow(
+      "Only store admins can convert service appointments to cases.",
+    );
+    expect(convertCtx.db.patch).not.toHaveBeenCalled();
+    expect(convertCtx.db.insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects appointment cancellation when the appointment store belongs to another organization", async () => {
+    const ctx = createAppointmentMutationCtx();
+    ctx.rows.store.set("store-1", {
+      _id: "store-1",
+      organizationId: "org-other",
+    });
+
+    const result = await getHandler(cancelAppointment)(ctx, {
+      appointmentId: "appointment-1" as Id<"serviceAppointment">,
+    });
+
+    expect(result).toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Appointment store does not match its organization.",
+      },
+    });
+    expect(
+      athenaUserAuth.requireAuthenticatedAthenaUserWithCtx,
+    ).not.toHaveBeenCalled();
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects appointment conversion when the appointment store belongs to another organization", async () => {
+    const ctx = createAppointmentMutationCtx();
+    ctx.rows.store.set("store-1", {
+      _id: "store-1",
+      organizationId: "org-other",
+    });
+
+    const result = await getHandler(convertAppointmentToWalkIn)(ctx, {
+      appointmentId: "appointment-1" as Id<"serviceAppointment">,
+      createdByUserId: "user-spoof" as Id<"athenaUser">,
+    });
+
+    expect(result).toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Appointment store does not match its organization.",
+      },
+    });
+    expect(
+      athenaUserAuth.requireAuthenticatedAthenaUserWithCtx,
+    ).not.toHaveBeenCalled();
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects conversion for cancelled appointments before creating case work", async () => {
+    const ctx = createAppointmentMutationCtx();
+    ctx.rows.serviceAppointment.set("appointment-1", {
+      ...ctx.rows.serviceAppointment.get("appointment-1"),
+      status: "cancelled",
+    });
+
+    const result = await getHandler(convertAppointmentToWalkIn)(ctx, {
+      appointmentId: "appointment-1" as Id<"serviceAppointment">,
+      createdByUserId: "user-spoof" as Id<"athenaUser">,
+    });
+
+    expect(result).toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "This appointment can no longer be converted.",
+      },
+    });
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
+  it("attributes walk-in conversion to the authenticated user instead of the caller supplied user", async () => {
+    const ctx = createAppointmentMutationCtx();
+
+    const result = await getHandler(convertAppointmentToWalkIn)(ctx, {
+      appointmentId: "appointment-1" as Id<"serviceAppointment">,
+      createdByUserId: "user-spoof" as Id<"athenaUser">,
+    });
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        serviceCaseId: "serviceCase-1",
+        workItemId: "operationalWorkItem-1",
+      },
+    });
+    expect(ctx.staffLookupConstraints).toContainEqual({
+      linkedUserId: "user-admin",
+      storeId: "store-1",
+    });
+    expect(ctx.inserts).toContainEqual(
+      expect.objectContaining({
+        table: "operationalWorkItem",
+        value: expect.objectContaining({
+          createdByStaffProfileId: "staff-admin",
+          createdByUserId: "user-admin",
+          metadata: expect.objectContaining({
+            appointmentId: "appointment-1",
+            serviceCatalogId: "catalog-1",
+            startAt: 1_772_550_000_000,
+          }),
+          type: "service_case",
+        }),
+      }),
+    );
+    expect(ctx.inserts).toContainEqual(
+      expect.objectContaining({
+        table: "operationalEvent",
+        value: expect.objectContaining({
+          actorUserId: "user-admin",
+          eventType: "service_case_created",
+        }),
+      }),
+    );
+    expect(ctx.inserts).toContainEqual(
+      expect.objectContaining({
+        table: "operationalEvent",
+        value: expect.objectContaining({
+          actorStaffProfileId: "staff-admin",
+          actorUserId: "user-admin",
+          eventType: "service_appointment_converted_to_walk_in",
+        }),
+      }),
+    );
+    expect(JSON.stringify(ctx.inserts)).not.toContain("user-spoof");
+  });
+
+  it("attributes appointment cancellation events to the authenticated user", async () => {
+    const ctx = createAppointmentMutationCtx();
+
+    const result = await getHandler(cancelAppointment)(ctx, {
+      appointmentId: "appointment-1" as Id<"serviceAppointment">,
+      notes: "Customer cancelled.",
+    });
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        _id: "appointment-1",
+        status: "cancelled",
+      },
+    });
+    await expect(
+      ctx.db.get("operationalWorkItem", "work-appointment-1"),
+    ).resolves.toMatchObject({
+      status: "cancelled",
+    });
+    expect(ctx.inserts).toContainEqual(
+      expect.objectContaining({
+        table: "operationalEvent",
+        value: expect.objectContaining({
+          actorStaffProfileId: "staff-admin",
+          actorUserId: "user-admin",
+          eventType: "service_appointment_cancelled",
+          metadata: expect.objectContaining({
+            nextWorkItemStatus: "cancelled",
+            previousStatus: "scheduled",
+          }),
+        }),
+      }),
+    );
+  });
 });
+
+function createAppointmentMutationCtx() {
+  const now = 1_772_550_000_000;
+  vi.spyOn(Date, "now").mockReturnValue(now);
+  const inserts: Array<{ table: string; value: Record<string, unknown> }> = [];
+  const staffLookupConstraints: Array<Record<string, unknown>> = [];
+  const rows: Record<string, Map<string, Record<string, unknown>>> = {
+    customerProfile: new Map([
+      [
+        "customer-1",
+        {
+          _id: "customer-1",
+          storeId: "store-1",
+        },
+      ],
+    ]),
+    operationalWorkItem: new Map([
+      [
+        "work-appointment-1",
+        {
+          _id: "work-appointment-1",
+          approvalState: "not_required",
+          createdAt: now - 1,
+          metadata: {
+            appointmentId: "appointment-1",
+          },
+          organizationId: "org-1",
+          priority: "normal",
+          status: "open",
+          storeId: "store-1",
+          title: "Closure Repair appointment",
+          type: "service_appointment",
+        },
+      ],
+    ]),
+    serviceAppointment: new Map([
+      [
+        "appointment-1",
+        {
+          _id: "appointment-1",
+          assignedStaffProfileId: "staff-assigned",
+          customerProfileId: "customer-1",
+          durationMinutes: 60,
+          endAt: now + 60 * 60 * 1000,
+          notes: "Walk-in ready",
+          organizationId: "org-1",
+          serviceCatalogId: "catalog-1",
+          startAt: now,
+          status: "scheduled",
+          storeId: "store-1",
+        },
+      ],
+    ]),
+    serviceCase: new Map(),
+    serviceCatalog: new Map([
+      [
+        "catalog-1",
+        {
+          _id: "catalog-1",
+          basePrice: 4_500,
+          name: "Closure Repair",
+          serviceMode: "repair",
+          storeId: "store-1",
+        },
+      ],
+    ]),
+    staffProfile: new Map([
+      [
+        "staff-admin",
+        {
+          _id: "staff-admin",
+          linkedUserId: "user-admin",
+          storeId: "store-1",
+        },
+      ],
+    ]),
+    store: new Map([
+      [
+        "store-1",
+        {
+          _id: "store-1",
+          organizationId: "org-1",
+        },
+      ],
+    ]),
+  };
+  const get = vi.fn(async (tableName: string, id: string) => {
+    return rows[tableName]?.get(id) ?? null;
+  });
+  const patch = vi.fn(
+    async (tableName: string, id: string, patchValue: Record<string, unknown>) => {
+      const row = rows[tableName]?.get(id);
+      if (row) {
+        rows[tableName].set(id, { ...row, ...patchValue });
+      }
+    },
+  );
+  const insert = vi.fn(async (tableName: string, value: Record<string, unknown>) => {
+    const id = `${tableName}-1`;
+    inserts.push({ table: tableName, value });
+    rows[tableName] ??= new Map();
+    rows[tableName].set(id, { _id: id, ...value });
+    return id;
+  });
+  const query = vi.fn((tableName: string) => ({
+    withIndex: vi.fn((_indexName: string, applyIndex: Function) => {
+      const constraints: Record<string, unknown> = {};
+      const queryBuilder = {
+        eq(field: string, value: unknown) {
+          constraints[field] = value;
+          return queryBuilder;
+        },
+      };
+      applyIndex(queryBuilder);
+
+      if (tableName === "staffProfile") {
+        staffLookupConstraints.push({ ...constraints });
+      }
+
+      const matchingRows = () =>
+        Array.from(rows[tableName]?.values() ?? []).filter((row) =>
+          Object.entries(constraints).every(([field, value]) => row[field] === value),
+        );
+
+      return {
+        collect: vi.fn(async () => matchingRows()),
+        first: vi.fn(async () => matchingRows()[0] ?? null),
+        order: vi.fn(() => ({
+          first: vi.fn(async () => matchingRows()[0] ?? null),
+        })),
+        take: vi.fn(async (limit: number) => matchingRows().slice(0, limit)),
+        unique: vi.fn(async () => matchingRows()[0] ?? null),
+      };
+    }),
+  }));
+
+  return {
+    db: {
+      get,
+      insert,
+      patch,
+      query,
+    },
+    inserts,
+    rows,
+    staffLookupConstraints,
+  };
+}

--- a/packages/athena-webapp/convex/serviceOps/serviceCases.test.ts
+++ b/packages/athena-webapp/convex/serviceOps/serviceCases.test.ts
@@ -5,6 +5,7 @@ import {
   assertValidServiceCaseStatusTransition,
   buildServiceCase,
   buildServiceCaseLineItem,
+  mapServiceCaseStatusToWorkItemStatus,
 } from "./serviceCases";
 
 type IndexExpectation = {
@@ -88,6 +89,22 @@ describe("service ops schema foundations", () => {
         message: "Invalid service case status transition.",
       },
     });
+  });
+
+  it("maps terminal service-case statuses out of Open Work", () => {
+    expect(mapServiceCaseStatusToWorkItemStatus("intake")).toBe("open");
+    expect(mapServiceCaseStatusToWorkItemStatus("scheduled")).toBe("open");
+    expect(mapServiceCaseStatusToWorkItemStatus("in_progress")).toBe(
+      "in_progress",
+    );
+    expect(mapServiceCaseStatusToWorkItemStatus("awaiting_approval")).toBe(
+      "in_progress",
+    );
+    expect(mapServiceCaseStatusToWorkItemStatus("awaiting_pickup")).toBe(
+      "in_progress",
+    );
+    expect(mapServiceCaseStatusToWorkItemStatus("completed")).toBe("completed");
+    expect(mapServiceCaseStatusToWorkItemStatus("cancelled")).toBe("cancelled");
   });
 
   it("shapes service cases and line items with persistence-safe defaults", () => {

--- a/packages/athena-webapp/convex/serviceOps/serviceCases.ts
+++ b/packages/athena-webapp/convex/serviceOps/serviceCases.ts
@@ -74,7 +74,9 @@ const SERVICE_CASE_STATUS_TRANSITIONS: Record<
   cancelled: [],
 };
 
-function mapServiceCaseStatusToWorkItemStatus(status: ServiceCaseStatus) {
+export function mapServiceCaseStatusToWorkItemStatus(
+  status: ServiceCaseStatus,
+) {
   switch (status) {
     case "intake":
     case "scheduled":

--- a/packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts
+++ b/packages/athena-webapp/convex/stockOps/purchaseOrders.test.ts
@@ -19,6 +19,7 @@ import {
   advancePurchaseOrderToOrderedCommand,
   createPurchaseOrderCommand,
   createPurchaseOrderWithCtx,
+  mapPurchaseOrderStatusToWorkItemStatus,
   mapPurchaseOrderCommandError,
   updatePurchaseOrderStatusCommand,
   updatePurchaseOrderStatusWithCtx,
@@ -105,6 +106,18 @@ describe("stock ops purchase orders", () => {
     ).toThrow("Cannot change purchase order from ordered to received.");
   });
 
+  it("preserves purchase-order terminal semantics on linked work items", () => {
+    expect(mapPurchaseOrderStatusToWorkItemStatus("received")).toBe(
+      "completed",
+    );
+    expect(mapPurchaseOrderStatusToWorkItemStatus("cancelled")).toBe(
+      "cancelled",
+    );
+    expect(mapPurchaseOrderStatusToWorkItemStatus("partially_received")).toBe(
+      "in_progress",
+    );
+  });
+
   it("writes purchase-order workflow changes through the shared operations rails", () => {
     const source = getSource("./purchaseOrders.ts");
 
@@ -165,6 +178,80 @@ describe("stock ops purchase orders", () => {
       }),
     ).rejects.toThrow("Authentication required.");
     expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("syncs terminal purchase-order cancellation to the linked operations work item", async () => {
+    mockedAuthServer.getAuthUserId.mockResolvedValue("auth-user-1");
+
+    const purchaseOrder = {
+      _id: "purchase-order-1",
+      operationalWorkItemId: "work-item-1",
+      organizationId: "org-1",
+      poNumber: "PO-001",
+      status: "ordered",
+      storeId: "store-1",
+    };
+    const insert = vi.fn(async () => "operational-event-1");
+    const patch = vi.fn(async (_table: string, _id: string, updates: object) => {
+      Object.assign(purchaseOrder, updates);
+    });
+    const runMutation = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async (table: string, id: string) => {
+          if (table === "users" && id === "auth-user-1") {
+            return { _id: "auth-user-1", email: "admin@example.com" };
+          }
+          if (table === "store" && id === "store-1") {
+            return { _id: "store-1", organizationId: "org-1" };
+          }
+          if (table === "purchaseOrder" && id === "purchase-order-1") {
+            return purchaseOrder;
+          }
+          return null;
+        }),
+        insert,
+        patch,
+        query: vi.fn((table: string) => ({
+          filter: vi.fn(() => ({
+            first: vi.fn(async () => {
+              if (table === "athenaUser") {
+                return { _id: "athena-user-1", email: "admin@example.com" };
+              }
+              if (table === "organizationMember") {
+                return {
+                  _id: "member-1",
+                  organizationId: "org-1",
+                  role: "full_admin",
+                  userId: "athena-user-1",
+                };
+              }
+              return null;
+            }),
+          })),
+          withIndex: vi.fn(() => ({
+            collect: vi.fn(async () => []),
+            first: vi.fn(async () => null),
+            take: vi.fn(async () => []),
+          })),
+        })),
+      },
+      runMutation,
+    } as unknown as MutationCtx;
+
+    const result = await updatePurchaseOrderStatusWithCtx(ctx, {
+      nextStatus: "cancelled",
+      purchaseOrderId: "purchase-order-1" as Id<"purchaseOrder">,
+    });
+
+    expect(result).toMatchObject({
+      _id: "purchase-order-1",
+      status: "cancelled",
+    });
+    expect(runMutation).toHaveBeenCalledWith(expect.anything(), {
+      status: "cancelled",
+      workItemId: "work-item-1",
+    });
   });
 
   it("maps expected purchase-order creation failures to command-result user errors", () => {

--- a/packages/athena-webapp/convex/stockOps/purchaseOrders.ts
+++ b/packages/athena-webapp/convex/stockOps/purchaseOrders.ts
@@ -152,9 +152,13 @@ function buildPurchaseOrderNumber() {
   return `PO-${Date.now().toString(36).toUpperCase()}`;
 }
 
-function getOperationalWorkItemStatus(status: string) {
-  if (["received", "cancelled"].includes(status)) {
+export function mapPurchaseOrderStatusToWorkItemStatus(status: string) {
+  if (status === "received") {
     return "completed";
+  }
+
+  if (status === "cancelled") {
+    return "cancelled";
   }
 
   if (
@@ -523,7 +527,7 @@ export async function updatePurchaseOrderStatusWithCtx(
     await ctx.runMutation(
       internal.operations.operationalWorkItems.updateOperationalWorkItemStatus,
       {
-        status: getOperationalWorkItemStatus(args.nextStatus),
+        status: mapPurchaseOrderStatusToWorkItemStatus(args.nextStatus),
         workItemId: purchaseOrder.operationalWorkItemId,
       },
     );

--- a/packages/athena-webapp/convex/stockOps/receiving.test.ts
+++ b/packages/athena-webapp/convex/stockOps/receiving.test.ts
@@ -85,7 +85,9 @@ function createReceivingMutationCtx(args?: {
       ],
     ]),
     catalogSummary: new Map<string, Record<string, unknown>>(),
+    inventoryMovement: new Map<string, Record<string, unknown>>(),
     receivingBatch: new Map<string, Record<string, unknown>>(),
+    skuActivityEvent: new Map<string, Record<string, unknown>>(),
     store: new Map<string, Record<string, unknown>>([
       ["store-1", { _id: "store-1", organizationId: "org-1" }],
     ]),
@@ -94,12 +96,16 @@ function createReceivingMutationCtx(args?: {
     ]),
   };
   const insertCounters: Record<
-    "catalogSummary" | "receivingBatch" | "inventoryMovement",
+    | "catalogSummary"
+    | "receivingBatch"
+    | "inventoryMovement"
+    | "skuActivityEvent",
     number
   > = {
     catalogSummary: 0,
     inventoryMovement: 0,
     receivingBatch: 0,
+    skuActivityEvent: 0,
   };
 
   const ctx = {
@@ -108,11 +114,16 @@ function createReceivingMutationCtx(args?: {
         return tables[table].get(id) ?? null;
       },
       async insert(
-        table: "catalogSummary" | "inventoryMovement" | "receivingBatch",
+        table:
+          | "catalogSummary"
+          | "inventoryMovement"
+          | "receivingBatch"
+          | "skuActivityEvent",
         value: Record<string, unknown>
       ) {
         insertCounters[table] += 1;
         const id = `${table}-${insertCounters[table]}`;
+        tables[table].set(id, { _id: id, ...value });
         return id;
       },
       async patch(
@@ -190,6 +201,35 @@ function createReceivingMutationCtx(args?: {
                     }
                   }
                 },
+              };
+            },
+          };
+        }
+
+        if (table === "inventoryMovement") {
+          return {
+            withIndex(
+              _index: string,
+              applyIndex: (queryBuilder: {
+                eq: (field: string, value: unknown) => unknown;
+              }) => unknown
+            ) {
+              const filters: Array<[string, unknown]> = [];
+              const queryBuilder = {
+                eq(field: string, value: unknown) {
+                  filters.push([field, value]);
+                  return queryBuilder;
+                },
+              };
+
+              applyIndex(queryBuilder);
+
+              return {
+                collect: async () =>
+                  Array.from(tables.inventoryMovement.values()).filter(
+                    (record) =>
+                      filters.every(([field, value]) => record[field] === value)
+                  ),
               };
             },
           };
@@ -408,5 +448,55 @@ describe("stock ops receiving", () => {
         message: "You cannot receive more than ordered.",
       },
     });
+  });
+
+  it("keeps linked purchase-order work in progress until the order is fully received", async () => {
+    const partial = createReceivingMutationCtx();
+
+    await receivePurchaseOrderBatchCommandWithCtx(partial.ctx, {
+      lineItems: [
+        {
+          purchaseOrderLineItemId: "line-item-1" as Id<"purchaseOrderLineItem">,
+          receivedQuantity: 1,
+        },
+      ],
+      notes: undefined,
+      purchaseOrderId: "purchase-order-1" as Id<"purchaseOrder">,
+      receivedByUserId: undefined,
+      storeId: "store-1" as Id<"store">,
+      submissionKey: "receive-partial",
+    });
+
+    expect(partial.ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        status: "in_progress",
+        workItemId: "work-item-1",
+      }),
+    );
+
+    const complete = createReceivingMutationCtx();
+
+    await receivePurchaseOrderBatchCommandWithCtx(complete.ctx, {
+      lineItems: [
+        {
+          purchaseOrderLineItemId: "line-item-1" as Id<"purchaseOrderLineItem">,
+          receivedQuantity: 3,
+        },
+      ],
+      notes: undefined,
+      purchaseOrderId: "purchase-order-1" as Id<"purchaseOrder">,
+      receivedByUserId: undefined,
+      storeId: "store-1" as Id<"store">,
+      submissionKey: "receive-complete",
+    });
+
+    expect(complete.ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        status: "completed",
+        workItemId: "work-item-1",
+      }),
+    );
   });
 });

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 16 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, cycleCountDrafts.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 8 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCaseTracing.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 19 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 618 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 620 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 9 file(s); key children: README.md, SUMMARY.md, pos, prod.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -97,6 +97,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/operations/helpers/eventBuilders.test.ts`](../../convex/operations/helpers/eventBuilders.test.ts)
 - [`convex/operations/inventoryMovements.test.ts`](../../convex/operations/inventoryMovements.test.ts)
 - [`convex/operations/managerElevations.test.ts`](../../convex/operations/managerElevations.test.ts)
+- [`convex/operations/openWorkInventoryReviews.test.ts`](../../convex/operations/openWorkInventoryReviews.test.ts)
 - [`convex/operations/operationalEvents.test.ts`](../../convex/operations/operationalEvents.test.ts)
 - [`convex/operations/operationalWorkItems.test.ts`](../../convex/operations/operationalWorkItems.test.ts)
 - [`convex/operations/operationsQueryIndexes.test.ts`](../../convex/operations/operationsQueryIndexes.test.ts)

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -1561,6 +1561,161 @@ describe("DailyCloseViewContent", () => {
     });
   });
 
+  it("routes carry-forward item completion through the resolver action", async () => {
+    const user = userEvent.setup();
+    const onResolveCarryForward = vi.fn(async () =>
+      ok({ workItemId: "carry-1" }),
+    );
+    const snapshot: DailyCloseSnapshot = {
+      ...readySnapshot,
+      carryForwardItems: [
+        {
+          carryForwardResolution: {
+            businessDate: "2026-05-07",
+            dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+            sourceId: "customer-follow-up",
+            workItemId: "carry-1" as Id<"operationalWorkItem">,
+          },
+          description: "Call customer during opening.",
+          id: "carry-1",
+          statusLabel: "Carry forward",
+          subject: {
+            id: "carry-1",
+            label: "Customer follow-up",
+            type: "operational_work_item",
+          },
+          title: "Customer follow-up",
+        },
+      ],
+      status: "carry_forward",
+      summary: {
+        ...baseSummary,
+        carryForwardCount: 1,
+      },
+    };
+
+    renderContent(snapshot, { onResolveCarryForward });
+
+    await user.click(screen.getByRole("button", { name: /mark complete/i }));
+
+    await waitFor(() => {
+      expect(onResolveCarryForward).toHaveBeenCalledWith({
+        businessDate: "2026-05-07",
+        dailyCloseId: "daily-close-1",
+        outcome: "completed",
+        reason: "Carry-forward follow-up completed from EOD Review.",
+        sourceId: "customer-follow-up",
+        workItemId: "carry-1",
+      });
+    });
+  });
+
+  it("routes carry-forward item cancellation through the resolver action", async () => {
+    const user = userEvent.setup();
+    const onResolveCarryForward = vi.fn(async () =>
+      ok({ workItemId: "carry-1" }),
+    );
+    const snapshot: DailyCloseSnapshot = {
+      ...readySnapshot,
+      carryForwardItems: [
+        {
+          carryForwardResolution: {
+            businessDate: "2026-05-07",
+            dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+            sourceId: "customer-follow-up",
+            workItemId: "carry-1" as Id<"operationalWorkItem">,
+          },
+          description: "Call customer during opening.",
+          id: "carry-1",
+          statusLabel: "Carry forward",
+          subject: {
+            id: "carry-1",
+            label: "Customer follow-up",
+            type: "operational_work_item",
+          },
+          title: "Customer follow-up",
+        },
+      ],
+      status: "carry_forward",
+      summary: {
+        ...baseSummary,
+        carryForwardCount: 1,
+      },
+    };
+
+    renderContent(snapshot, { onResolveCarryForward });
+
+    await user.click(screen.getByRole("button", { name: /cancel follow-up/i }));
+
+    await waitFor(() => {
+      expect(onResolveCarryForward).toHaveBeenCalledWith({
+        businessDate: "2026-05-07",
+        dailyCloseId: "daily-close-1",
+        outcome: "cancelled",
+        reason: "Carry-forward follow-up cancelled from EOD Review.",
+        sourceId: "customer-follow-up",
+        workItemId: "carry-1",
+      });
+    });
+  });
+
+  it("shows cancellation loading on the cancel action without replacing mark complete", async () => {
+    const user = userEvent.setup();
+    let resolveAction!: (value: ReturnType<typeof ok>) => void;
+    const pendingAction = new Promise<ReturnType<typeof ok>>((resolve) => {
+      resolveAction = resolve;
+    });
+    const onResolveCarryForward = vi.fn(() => pendingAction);
+    const snapshot: DailyCloseSnapshot = {
+      ...readySnapshot,
+      carryForwardItems: [
+        {
+          carryForwardResolution: {
+            businessDate: "2026-05-07",
+            dailyCloseId: "daily-close-1" as Id<"dailyClose">,
+            sourceId: "customer-follow-up",
+            workItemId: "carry-1" as Id<"operationalWorkItem">,
+          },
+          description: "Call customer during opening.",
+          id: "carry-1",
+          statusLabel: "Carry forward",
+          subject: {
+            id: "carry-1",
+            label: "Customer follow-up",
+            type: "operational_work_item",
+          },
+          title: "Customer follow-up",
+        },
+      ],
+      status: "carry_forward",
+      summary: {
+        ...baseSummary,
+        carryForwardCount: 1,
+      },
+    };
+
+    renderContent(snapshot, { onResolveCarryForward });
+
+    await user.click(screen.getByRole("button", { name: /cancel follow-up/i }));
+
+    await waitFor(() => {
+      expect(onResolveCarryForward).toHaveBeenCalled();
+    });
+    expect(
+      screen.getByRole("button", { name: /mark complete/i }),
+    ).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: /cancel follow-up/i }),
+    ).not.toBeInTheDocument();
+
+    resolveAction(ok({ workItemId: "carry-1" }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /cancel follow-up/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("does not send redacted carry-forward placeholders as completion ids", async () => {
     const user = userEvent.setup();
     const onComplete = vi.fn(async () => ok({ closeId: "close-1" }));

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -88,6 +88,7 @@ type DailyCloseApi = {
   completeDailyClose?: unknown;
   getDailyCloseSnapshot?: unknown;
   reopenDailyClose?: unknown;
+  resolveDailyCloseCarryForward?: unknown;
 };
 
 const useExpectedDailyCloseQuery = useQuery as unknown as (
@@ -117,6 +118,8 @@ export type DailyCloseStatus =
   | "ready"
   | "completed";
 
+type CarryForwardResolutionOutcome = "completed" | "cancelled";
+
 export type DailyCloseItemLink = {
   href?: string;
   label?: string;
@@ -126,6 +129,12 @@ export type DailyCloseItemLink = {
 };
 
 export type DailyCloseItem = {
+  carryForwardResolution?: {
+    businessDate: string;
+    dailyCloseId: Id<"dailyClose"> | string;
+    sourceId: string;
+    workItemId: Id<"operationalWorkItem"> | string;
+  };
   category?: string;
   description?: string | null;
   id?: string;
@@ -260,6 +269,16 @@ type ReopenArgs = {
   reason: string;
 };
 
+type CarryForwardResolutionArgs = {
+  approvalProofId?: Id<"approvalProof">;
+  businessDate: string;
+  dailyCloseId: Id<"dailyClose"> | string;
+  outcome: "completed" | "cancelled";
+  reason: string;
+  sourceId: string;
+  workItemId: Id<"operationalWorkItem"> | string;
+};
+
 export type BucketStatus = "blocked" | "carry-forward" | "ready" | "review";
 
 const bucketTabValues: BucketStatus[] = [
@@ -295,6 +314,9 @@ type DailyCloseViewContentProps = {
   ) => Promise<NormalizedApprovalCommandResult<unknown>>;
   onReopen?: (
     args: ReopenArgs,
+  ) => Promise<NormalizedApprovalCommandResult<unknown>>;
+  onResolveCarryForward?: (
+    args: CarryForwardResolutionArgs,
   ) => Promise<NormalizedApprovalCommandResult<unknown>>;
   onOperatingDateChange?: (date: Date) => void;
   onAuthenticateForApproval?: (args: {
@@ -890,6 +912,21 @@ function getCarryForwardWorkItemIds(items: DailyCloseItem[]) {
     const workItemId = getCarryForwardWorkItemId(item);
     return workItemId ? [workItemId] : [];
   });
+}
+
+function getCarryForwardResolutionContext(item: DailyCloseItem) {
+  const resolution = item.carryForwardResolution;
+
+  if (
+    !resolution?.businessDate ||
+    !resolution.dailyCloseId ||
+    !resolution.sourceId ||
+    !resolution.workItemId
+  ) {
+    return null;
+  }
+
+  return resolution;
 }
 
 function getItemDescription(item: DailyCloseItem) {
@@ -2183,6 +2220,7 @@ function ItemLink({
 }
 
 function DailyCloseItemCard({
+  actionSlot,
   canViewFinancialDetails,
   currency,
   item,
@@ -2192,6 +2230,7 @@ function DailyCloseItemCard({
   storeUrlSlug,
   onSelectedChange,
 }: {
+  actionSlot?: ReactNode;
   canViewFinancialDetails: boolean;
   currency: string;
   item: DailyCloseItem;
@@ -2214,6 +2253,13 @@ function DailyCloseItemCard({
   );
   const collapsedMetadataEntries = getCollapsedMetadataEntries(metadataEntries);
   const hasSourceLink = Boolean(item.link);
+  const sourceAction = hasSourceLink ? (
+    <ItemLink
+      link={item.link}
+      orgUrlSlug={orgUrlSlug}
+      storeUrlSlug={storeUrlSlug}
+    />
+  ) : null;
   const badgeSlot = isVarianceApprovalItem(item) ? (
     <Badge className="border-warning/30 bg-warning/10 text-warning-foreground">
       Variance review
@@ -2223,12 +2269,11 @@ function DailyCloseItemCard({
   return (
     <OperationReviewItemCard
       actionSlot={
-        hasSourceLink ? (
-          <ItemLink
-            link={item.link}
-            orgUrlSlug={orgUrlSlug}
-            storeUrlSlug={storeUrlSlug}
-          />
+        actionSlot || sourceAction ? (
+          <div className="flex flex-wrap items-center gap-2">
+            {actionSlot}
+            {sourceAction}
+          </div>
         ) : null
       }
       collapsedMetadataEntries={collapsedMetadataEntries}
@@ -2254,6 +2299,47 @@ function DailyCloseItemCard({
   );
 }
 
+function CarryForwardResolutionActions({
+  isDisabled,
+  resolvingOutcome,
+  onResolve,
+}: {
+  isDisabled?: boolean;
+  resolvingOutcome?: CarryForwardResolutionOutcome | null;
+  onResolve: (outcome: CarryForwardResolutionOutcome) => void;
+}) {
+  const isResolving = Boolean(resolvingOutcome);
+
+  return (
+    <>
+      <LoadingButton
+        className="h-8 px-3 text-xs"
+        disabled={Boolean(isDisabled || isResolving)}
+        isLoading={resolvingOutcome === "completed"}
+        onClick={() => onResolve("completed")}
+        size="sm"
+        type="button"
+        variant="secondary"
+      >
+        <Check aria-hidden="true" className="h-3.5 w-3.5" />
+        Mark complete
+      </LoadingButton>
+      <LoadingButton
+        className="h-8 px-3 text-xs"
+        disabled={Boolean(isDisabled || isResolving)}
+        isLoading={resolvingOutcome === "cancelled"}
+        onClick={() => onResolve("cancelled")}
+        size="sm"
+        type="button"
+        variant="outline"
+      >
+        <Ban aria-hidden="true" className="h-3.5 w-3.5" />
+        Cancel follow-up
+      </LoadingButton>
+    </>
+  );
+}
+
 function BucketSection({
   ariaLabel,
   canViewFinancialDetails,
@@ -2269,7 +2355,10 @@ function BucketSection({
   storeUrlSlug,
   title,
   onPageChange,
+  onResolveCarryForward,
   onSelectedIdsChange,
+  resolvingCarryForwardOutcome,
+  resolvingCarryForwardKey,
 }: {
   ariaLabel: string;
   canViewFinancialDetails: boolean;
@@ -2278,12 +2367,18 @@ function BucketSection({
   emptyText: string;
   items: DailyCloseItem[];
   onPageChange: (page: number) => void;
+  onResolveCarryForward?: (
+    item: DailyCloseItem,
+    outcome: CarryForwardResolutionOutcome,
+  ) => void;
   onSelectedIdsChange?: (ids: string[]) => void;
   orgUrlSlug: string;
   page: number;
   selectedIds?: string[];
   showCountBadge?: boolean;
   status: "blocked" | "carry-forward" | "ready" | "review";
+  resolvingCarryForwardOutcome?: CarryForwardResolutionOutcome | null;
+  resolvingCarryForwardKey?: string | null;
   storeUrlSlug: string;
   title: string;
 }) {
@@ -2357,6 +2452,26 @@ function BucketSection({
 
             return (
               <DailyCloseItemCard
+                actionSlot={
+                  status === "carry-forward" &&
+                  onResolveCarryForward &&
+                  getCarryForwardResolutionContext(item) ? (
+                    <CarryForwardResolutionActions
+                      isDisabled={Boolean(
+                        resolvingCarryForwardKey &&
+                          resolvingCarryForwardKey !== getItemId(item),
+                      )}
+                      resolvingOutcome={
+                        resolvingCarryForwardKey === getItemId(item)
+                          ? resolvingCarryForwardOutcome
+                          : null
+                      }
+                      onResolve={(outcome) =>
+                        onResolveCarryForward(item, outcome)
+                      }
+                    />
+                  ) : null
+                }
                 canViewFinancialDetails={canViewFinancialDetails}
                 currency={currency}
                 item={item}
@@ -2404,19 +2519,28 @@ function BucketTabs({
   selectedIds,
   storeUrlSlug,
   onPageChange,
+  onResolveCarryForward,
   onValueChange,
   onSelectedIdsChange,
+  resolvingCarryForwardOutcome,
+  resolvingCarryForwardKey,
 }: {
   buckets: BucketConfig[];
   canViewFinancialDetails: boolean;
   currency: string;
   value: BucketStatus;
   onPageChange: (page: number) => void;
+  onResolveCarryForward?: (
+    item: DailyCloseItem,
+    outcome: CarryForwardResolutionOutcome,
+  ) => void;
   onValueChange: (value: BucketStatus) => void;
   onSelectedIdsChange: (ids: string[]) => void;
   orgUrlSlug: string;
   page: number;
   selectedIds: string[];
+  resolvingCarryForwardOutcome?: CarryForwardResolutionOutcome | null;
+  resolvingCarryForwardKey?: string | null;
   storeUrlSlug: string;
 }) {
   return (
@@ -2463,6 +2587,11 @@ function BucketTabs({
             emptyText={bucket.emptyText}
             items={bucket.items}
             onPageChange={onPageChange}
+            onResolveCarryForward={
+              bucket.value === "carry-forward"
+                ? onResolveCarryForward
+                : undefined
+            }
             onSelectedIdsChange={
               bucket.value === "carry-forward" ? onSelectedIdsChange : undefined
             }
@@ -2471,6 +2600,8 @@ function BucketTabs({
             selectedIds={
               bucket.value === "carry-forward" ? selectedIds : undefined
             }
+            resolvingCarryForwardKey={resolvingCarryForwardKey}
+            resolvingCarryForwardOutcome={resolvingCarryForwardOutcome}
             showCountBadge={false}
             status={bucket.status}
             storeUrlSlug={storeUrlSlug}
@@ -3242,6 +3373,7 @@ export function DailyCloseViewContent({
   onComplete,
   onOperatingDateChange,
   onReopen,
+  onResolveCarryForward,
   onAuthenticateForApproval,
   orgUrlSlug,
   snapshot,
@@ -3257,6 +3389,11 @@ export function DailyCloseViewContent({
   const [selectedCarryForwardIds, setSelectedCarryForwardIds] = useState<
     string[] | null
   >(null);
+  const [resolvingCarryForwardKey, setResolvingCarryForwardKey] = useState<
+    string | null
+  >(null);
+  const [resolvingCarryForwardOutcome, setResolvingCarryForwardOutcome] =
+    useState<CarryForwardResolutionOutcome | null>(null);
   const navigate = useNavigate();
   const search = useSearch({ strict: false }) as {
     o?: unknown;
@@ -3461,6 +3598,76 @@ export function DailyCloseViewContent({
     if (result.kind === "approval_required") return;
   };
 
+  const handleResolveCarryForward = async (
+    item: DailyCloseItem,
+    outcome: "completed" | "cancelled",
+  ) => {
+    if (!onResolveCarryForward || resolvingCarryForwardKey) return;
+
+    const resolution = getCarryForwardResolutionContext(item);
+
+    if (!resolution) {
+      setCommandMessage({
+        kind: "error",
+        message:
+          "Carry-forward follow-up context unavailable. Refresh before resolving.",
+      });
+      return;
+    }
+
+    setCommandMessage(null);
+    setResolvingCarryForwardKey(getItemId(item));
+    setResolvingCarryForwardOutcome(outcome);
+
+    const reason =
+      outcome === "completed"
+        ? "Carry-forward follow-up completed from EOD Review."
+        : "Carry-forward follow-up cancelled from EOD Review.";
+
+    try {
+      const result = await completionApprovalRunner.run({
+        execute: (approvalArgs: ApprovalRetryArgs) =>
+          onResolveCarryForward({
+            businessDate: resolution.businessDate,
+            dailyCloseId: resolution.dailyCloseId,
+            outcome,
+            reason,
+            sourceId: resolution.sourceId,
+            workItemId: resolution.workItemId,
+            ...(approvalArgs.approvalProofId
+              ? { approvalProofId: approvalArgs.approvalProofId }
+              : {}),
+          }),
+        onResult: (commandResult) => {
+          if (commandResult.kind === "approval_required") {
+            return;
+          }
+
+          if (commandResult.kind === "ok") {
+            setCommandMessage({
+              kind: "success",
+              message:
+                outcome === "completed"
+                  ? "Carry-forward follow-up completed."
+                  : "Carry-forward follow-up cancelled.",
+            });
+            return;
+          }
+
+          setCommandMessage({
+            kind: "error",
+            message: normalizeCommandMessage(commandResult),
+          });
+        },
+      });
+
+      if (result.kind === "approval_required") return;
+    } finally {
+      setResolvingCarryForwardKey(null);
+      setResolvingCarryForwardOutcome(null);
+    }
+  };
+
   const handleBucketValueChange = (value: BucketStatus) => {
     void navigate({
       search: ((current: Record<string, unknown>) => ({
@@ -3534,11 +3741,14 @@ export function DailyCloseViewContent({
               canViewFinancialDetails={hasFinancialDetailsAccess}
               currency={currency}
               onPageChange={handleBucketPageChange}
+              onResolveCarryForward={handleResolveCarryForward}
               onSelectedIdsChange={setSelectedCarryForwardIds}
               onValueChange={handleBucketValueChange}
               orgUrlSlug={orgUrlSlug}
               page={selectedBucketPage}
               selectedIds={selectedIds}
+              resolvingCarryForwardOutcome={resolvingCarryForwardOutcome}
+              resolvingCarryForwardKey={resolvingCarryForwardKey}
               storeUrlSlug={storeUrlSlug}
               value={selectedBucketValue}
             />
@@ -3798,12 +4008,14 @@ type DailyCloseConnectedViewProps = {
   completeDailyClose: unknown;
   getDailyCloseSnapshot: unknown;
   reopenDailyClose?: unknown;
+  resolveDailyCloseCarryForward?: unknown;
 };
 
 function DailyCloseConnectedView({
   completeDailyClose,
   getDailyCloseSnapshot,
   reopenDailyClose,
+  resolveDailyCloseCarryForward,
 }: DailyCloseConnectedViewProps) {
   const {
     activeStore,
@@ -3840,6 +4052,9 @@ function DailyCloseConnectedView({
     useExpectedDailyCloseMutation(completeDailyClose);
   const reopenDailyCloseMutation = useExpectedDailyCloseMutation(
     reopenDailyClose ?? completeDailyClose,
+  );
+  const resolveCarryForwardMutation = useExpectedDailyCloseMutation(
+    resolveDailyCloseCarryForward ?? completeDailyClose,
   );
   const authenticateForApproval = useMutation(
     api.operations.staffCredentials.authenticateStaffCredentialForApproval,
@@ -3905,6 +4120,34 @@ function DailyCloseConnectedView({
     }
   };
 
+  const handleResolveCarryForward = async (
+    args: CarryForwardResolutionArgs,
+  ) => {
+    if (!activeStore?._id || !resolveDailyCloseCarryForward) {
+      return {
+        kind: "user_error",
+        error: {
+          code: "validation_failed",
+          message: "Carry-forward resolution is not available yet.",
+        },
+      } as NormalizedCommandResult<unknown>;
+    }
+
+    return runCommand(
+      () =>
+        resolveCarryForwardMutation({
+          approvalProofId: args.approvalProofId,
+          businessDate: args.businessDate,
+          dailyCloseId: args.dailyCloseId,
+          outcome: args.outcome,
+          reason: args.reason,
+          sourceId: args.sourceId,
+          storeId: activeStore._id,
+          workItemId: args.workItemId,
+        }) as Promise<ApprovalCommandResult<unknown>>,
+    );
+  };
+
   const handleOperatingDateChange = (date: Date) => {
     const nextRange = getLocalOperatingDateRange(date);
 
@@ -3929,6 +4172,9 @@ function DailyCloseConnectedView({
       onComplete={handleComplete}
       onOperatingDateChange={handleOperatingDateChange}
       onReopen={reopenDailyClose ? handleReopen : undefined}
+      onResolveCarryForward={
+        resolveDailyCloseCarryForward ? handleResolveCarryForward : undefined
+      }
       onAuthenticateForApproval={(args) =>
         runCommand(
           () =>
@@ -3977,6 +4223,7 @@ export function DailyCloseView() {
       completeDailyClose={dailyCloseApi.completeDailyClose}
       getDailyCloseSnapshot={dailyCloseApi.getDailyCloseSnapshot}
       reopenDailyClose={dailyCloseApi.reopenDailyClose}
+      resolveDailyCloseCarryForward={dailyCloseApi.resolveDailyCloseCarryForward}
     />
   );
 }

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
@@ -5,6 +5,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import { getFunctionName } from "convex/server";
 import type { AnchorHTMLAttributes, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -230,6 +231,7 @@ const baseProps = {
     createdAt: number;
     customerName?: string | null;
     dueAt?: number | null;
+    metadata?: Record<string, unknown> | null;
     priority: string;
     status: string;
     title: string;
@@ -334,7 +336,7 @@ describe("OperationsQueueViewContent", () => {
             _id: "work-item-1" as Id<"operationalWorkItem">,
             approvalState: "pending",
             createdAt: Date.now() - 5 * 60 * 1000,
-            metadata: {
+            details: {
               lookupCode: "nahh",
               price: 80000,
               quantitySold: 1,
@@ -369,8 +371,8 @@ describe("OperationsQueueViewContent", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Work type")).toBeInTheDocument();
     expect(screen.getByText("2 work types")).toBeInTheDocument();
-    expect(screen.getByText("POS pending checkout")).toBeInTheDocument();
-    expect(screen.getByText("Service intake")).toBeInTheDocument();
+    expect(screen.getAllByText("POS pending checkout").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Service case").length).toBeGreaterThan(0);
     expect(screen.getAllByText("1 item")).toHaveLength(2);
     expect(
       screen.getByText("Review pending checkout item: Adore Dye"),
@@ -384,6 +386,71 @@ describe("OperationsQueueViewContent", () => {
     expect(screen.getByText("Follow Up Service Intake")).toBeInTheDocument();
     expect(screen.getByText("Owner")).toBeInTheDocument();
     expect(screen.getByText("Customer")).toBeInTheDocument();
+  });
+
+  it("shows when the open work queue is capped by the server", () => {
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        activeWorkflow="queue"
+        queueOverflow={{
+          approvalRequests: false,
+          workItems: {
+            inProgress: false,
+            open: true,
+          },
+        }}
+        workItems={[
+          {
+            _id: "work-item-1" as Id<"operationalWorkItem">,
+            approvalState: "not_required",
+            createdAt: Date.now() - 5 * 60 * 1000,
+            priority: "normal",
+            status: "open",
+            title: "Count stock",
+            type: "service_case",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("More open work is available")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Showing the first 1 open work items\. Resolve visible work/i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/change the sort order/i)).not.toBeInTheDocument();
+  });
+
+  it("shows when pending approvals are capped by the server", () => {
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        activeWorkflow="approvals"
+        approvalRequests={[
+          {
+            _id: "approval-1" as Id<"approvalRequest">,
+            requestType: "variance_review",
+            status: "pending",
+          },
+        ]}
+        queueOverflow={{
+          approvalRequests: true,
+          workItems: {
+            inProgress: false,
+            open: false,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("More approvals are available")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Showing the first 1 pending approvals\. Resolve visible approvals/i,
+      ),
+    ).toBeInTheDocument();
   });
 
   it("shows only the open work header while the queue is loading", () => {
@@ -601,7 +668,7 @@ describe("OperationsQueueViewContent", () => {
     );
 
     expect(screen.getByText("Closure Wig Wash And Style")).toBeInTheDocument();
-    expect(screen.getByText("Service Intake")).toBeInTheDocument();
+    expect(screen.getAllByText("Service intake").length).toBeGreaterThan(0);
     expect(screen.getByText("Intake Created")).toBeInTheDocument();
     expect(screen.getByText("Urgent")).toBeInTheDocument();
     expect(screen.getByText("Owner")).toBeInTheDocument();
@@ -657,9 +724,7 @@ describe("OperationsQueueViewContent", () => {
     expect(screen.getByText("Page 2 of 3")).toBeInTheDocument();
   });
 
-  it("sorts open work items by latest and oldest creation time", async () => {
-    const { default: userEvent } = await import("@testing-library/user-event");
-    const user = userEvent.setup();
+  it("preserves server-prioritized open work order", () => {
     const baseTime = Date.UTC(2026, 5, 28, 12, 0, 0);
     const workItems = Array.from({ length: 6 }, (_, index) => ({
       _id: `work-item-${index + 1}` as Id<"operationalWorkItem">,
@@ -679,25 +744,12 @@ describe("OperationsQueueViewContent", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: "Latest" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
-    expect(screen.getByText("Open Work Item 6")).toBeInTheDocument();
-    expect(screen.queryByText("Open Work Item 1")).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Oldest" }));
-
-    expect(screen.getByRole("button", { name: "Oldest" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
     expect(screen.getByText("Open Work Item 1")).toBeInTheDocument();
     expect(screen.queryByText("Open Work Item 6")).not.toBeInTheDocument();
     expect(screen.getByText("Page 1 of 2")).toBeInTheDocument();
   });
 
-  it("links pending checkout work items to stock adjustments with the provisional SKU selected", () => {
+  it("routes pending checkout work items to unresolved catalog review first", () => {
     render(
       <OperationsQueueViewContent
         {...baseProps}
@@ -709,9 +761,7 @@ describe("OperationsQueueViewContent", () => {
             _id: "work-item-1" as Id<"operationalWorkItem">,
             approvalState: "not_required",
             createdAt: Date.now() - 5 * 60 * 1000,
-            metadata: {
-              provisionalProductSkuId: "pending-sku-1",
-            },
+            details: {},
             priority: "normal",
             status: "open",
             title: "Review pending checkout item: BRUDDAH",
@@ -721,33 +771,28 @@ describe("OperationsQueueViewContent", () => {
       />,
     );
 
-    const titleHref = new URL(
-      screen
-        .getByRole("link", {
-          name: "Bruddah",
-        })
-        .getAttribute("href") ?? "",
-      "http://localhost",
-    );
     expect(
       screen.getByText((_content, element) =>
         element?.tagName.toLowerCase() === "p" &&
         element.textContent === "Review pending checkout item: Bruddah",
       ),
     ).toBeInTheDocument();
-    expect(titleHref.pathname).toBe(
-      "/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments",
-    );
-    expect(titleHref.searchParams.get("mode")).toBe("manual");
-    expect(titleHref.searchParams.get("sku")).toBe("pending-sku-1");
+    expect(screen.queryByRole("link", { name: "Bruddah" })).not.toBeInTheDocument();
 
     const actionHref = new URL(
       screen
-        .getByRole("link", { name: "Open stock adjustments" })
+        .getByRole("link", { name: "Review unresolved catalog" })
         .getAttribute("href") ?? "",
       "http://localhost",
     );
-    expect(actionHref.searchParams.get("sku")).toBe("pending-sku-1");
+    expect(actionHref.pathname).toBe(
+      "/$orgUrlSlug/store/$storeUrlSlug/products/unresolved",
+    );
+    expect(actionHref.searchParams.get("o")).toBeTruthy();
+    expect(
+      screen.queryByRole("link", { name: "Open stock adjustments" }),
+    ).not.toBeInTheDocument();
+    expect(actionHref.searchParams.get("sku")).toBeNull();
   });
 
   it("keeps pending checkout work item titles plain without provisional SKU metadata", () => {
@@ -784,9 +829,8 @@ describe("OperationsQueueViewContent", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("links synced sale inventory work items to manual stock adjustments", async () => {
-    const { default: userEvent } = await import("@testing-library/user-event");
-    const user = userEvent.setup();
+  it("renders type-specific open work owner and action contracts", () => {
+    const createdAt = Date.UTC(2026, 6, 1, 10, 0, 0);
 
     render(
       <OperationsQueueViewContent
@@ -796,15 +840,212 @@ describe("OperationsQueueViewContent", () => {
         storeUrlSlug="wigclub"
         workItems={[
           {
+            _id: "work-service-case" as Id<"operationalWorkItem">,
+            approvalState: "not_required",
+            assignedStaffName: "Akua Mensah",
+            createdAt,
+            customerName: "Efua Owusu",
+            dueAt: createdAt + 86_400_000,
+            priority: "normal",
+            status: "open",
+            title: "closure wig repair",
+            type: "service_case",
+          },
+          {
+            _id: "work-service-appointment" as Id<"operationalWorkItem">,
+            approvalState: "not_required",
+            assignedStaffName: "Ama Tetteh",
+            createdAt: createdAt + 1_000,
+            customerName: "Yaw Danso",
+            dueAt: createdAt + 3_600_000,
+            priority: "normal",
+            status: "open",
+            title: "install appointment",
+            type: "service_appointment",
+          },
+          {
+            _id: "work-purchase-order" as Id<"operationalWorkItem">,
+            approvalState: "not_required",
+            createdAt: createdAt + 2_000,
+            details: {
+              itemCount: 4,
+              purchaseOrderNumber: "PO-103",
+              vendorName: "Salon Supply Co.",
+            },
+            priority: "normal",
+            status: "in_progress",
+            title: "restock adhesives",
+            type: "purchase_order",
+          },
+          {
+            _id: "work-stock-review" as Id<"operationalWorkItem">,
+            approvalState: "pending",
+            createdAt: createdAt + 3_000,
+            details: {
+              reasonLabel: "Cycle count variance",
+            },
+            priority: "high",
+            status: "open",
+            title: "cycle count review",
+            type: "stock_adjustment_review",
+          },
+          {
+            _id: "work-carry-forward" as Id<"operationalWorkItem">,
+            approvalState: "not_required",
+            createdAt: createdAt + 4_000,
+            details: {
+              businessDate: "2026-07-01",
+              followUpReason: "Review drawer variance handoff",
+            },
+            priority: "normal",
+            status: "open",
+            title: "daily close carry forward",
+            type: "daily_close_carry_forward",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByText("Service case").length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: "Open service case" })).toHaveAttribute(
+      "href",
+      "/$orgUrlSlug/store/$storeUrlSlug/services/active-cases?o=%252F",
+    );
+    expect(screen.getAllByText("Service appointment").length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: "Open appointment" })).toHaveAttribute(
+      "href",
+      "/$orgUrlSlug/store/$storeUrlSlug/services/appointments?o=%252F",
+    );
+    expect(screen.getAllByText("Purchase order").length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: "Open purchase order" })).toHaveAttribute(
+      "href",
+      "/$orgUrlSlug/store/$storeUrlSlug/procurement?o=%252F",
+    );
+    expect(screen.getByText("PO-103")).toBeInTheDocument();
+    expect(screen.getByText("Salon Supply Co.")).toBeInTheDocument();
+    expect(screen.getByText("4 items")).toBeInTheDocument();
+    expect(screen.getAllByText("Stock adjustment approval").length).toBeGreaterThan(0);
+    expect(screen.getByText("Approval requests")).toBeInTheDocument();
+    expect(screen.getByText("Cycle count variance")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Review approval" })).toHaveAttribute(
+      "href",
+      "/$orgUrlSlug/store/$storeUrlSlug/operations/approvals?o=%252F",
+    );
+    expect(screen.getAllByText("Daily close follow-up").length).toBeGreaterThan(0);
+    expect(screen.getByText("July 1, 2026")).toBeInTheDocument();
+    const dailyCloseHref = new URL(
+      screen
+        .getByRole("link", { name: "Open Daily Close" })
+        .getAttribute("href") ?? "",
+      "http://localhost",
+    );
+    expect(dailyCloseHref.pathname).toBe(
+      "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
+    );
+    expect(dailyCloseHref.searchParams.get("o")).toBe("%2F");
+    expect(dailyCloseHref.searchParams.get("operatingDate")).toBe("2026-07-01");
+    expect(
+      screen.queryByRole("link", { name: "Open stock adjustments" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render service deposit review as a supported open work row", () => {
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        activeWorkflow="queue"
+        orgUrlSlug="wigclub"
+        storeUrlSlug="wigclub"
+        workItems={[
+          {
+            _id: "work-service-deposit" as Id<"operationalWorkItem">,
+            approvalState: "pending",
+            createdAt: Date.now() - 5 * 60 * 1000,
+            priority: "high",
+            status: "open",
+            title: "Service deposit review",
+            type: "service_deposit_review",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByText("Unsupported work type").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText("Service deposit review is not available in Open Work."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Not surfaced here")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /service deposit/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps raw metadata, proof, and internal payloads out of visible open work rows", () => {
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        activeWorkflow="queue"
+        orgUrlSlug="wigclub"
+        storeUrlSlug="wigclub"
+        workItems={[
+          {
+            _id: "work-item-raw-metadata" as Id<"operationalWorkItem">,
+            approvalState: "pending",
+            createdAt: Date.now() - 5 * 60 * 1000,
+            details: {
+              businessDate: "2026-07-01",
+            },
+            priority: "high",
+            status: "open",
+            title: "daily close carry forward",
+            type: "daily_close_carry_forward",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByText("Daily close follow-up").length).toBeGreaterThan(0);
+    expect(screen.queryByText("proof-visible-if-leaked")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("card-token-should-stay-server-side"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("raw-sync-json-should-not-render"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("manager-proof-should-not-render"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("store-other-should-not-render"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("links synced sale inventory work items to manual stock adjustments and resolution", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    const onResolveSyncedSaleInventoryReview = vi.fn();
+
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        activeWorkflow="queue"
+        orgUrlSlug="wigclub"
+        onResolveSyncedSaleInventoryReview={onResolveSyncedSaleInventoryReview}
+        storeUrlSlug="wigclub"
+        workItems={[
+          {
             _id: "work-item-1" as Id<"operationalWorkItem">,
             approvalState: "not_required",
             createdAt: Date.now() - 5 * 60 * 1000,
-            metadata: {
+            details: {
+              inventoryReviewLineCount: 1,
+              localRegisterSessionId: "local-register-session-1",
+              localTransactionId: "local-transaction-1",
               primaryProductSkuId: "product-sku-1" as Id<"productSku">,
               receiptNumber: "939540",
+              registerSessionId: "register-session-1" as Id<"registerSession">,
               sourceId: "transaction-1",
-              sourceType: "posTransaction",
-              trustedInventoryLines: [{ productSkuId: "product-sku-1" }],
+              terminalId: "terminal-1" as Id<"posTerminal">,
             },
             priority: "high",
             status: "open",
@@ -821,7 +1062,7 @@ describe("OperationsQueueViewContent", () => {
         element.textContent === "Review inventory for Adore Dye",
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText("Synced Sale Inventory Review")).toBeInTheDocument();
+    expect(screen.getAllByText("Synced sale inventory").length).toBeGreaterThan(0);
     const titleHref = new URL(
       screen
         .getByRole("link", { name: "Adore Dye" })
@@ -873,6 +1114,121 @@ describe("OperationsQueueViewContent", () => {
     );
     expect(stockAdjustmentsHref.searchParams.get("mode")).toBe("manual");
     expect(stockAdjustmentsHref.searchParams.get("sku")).toBe("product-sku-1");
+
+    await user.click(screen.getByRole("button", { name: "Mark reviewed" }));
+
+    expect(onResolveSyncedSaleInventoryReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _id: "work-item-1",
+        details: expect.objectContaining({
+          localRegisterSessionId: "local-register-session-1",
+          localTransactionId: "local-transaction-1",
+          receiptNumber: "939540",
+          registerSessionId: "register-session-1",
+          sourceId: "transaction-1",
+          terminalId: "terminal-1",
+        }),
+        type: "synced_sale_inventory_review",
+      }),
+    );
+  });
+
+  it("does not render synced sale resolution when resolver details are incomplete", () => {
+    const onResolveSyncedSaleInventoryReview = vi.fn();
+
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        activeWorkflow="queue"
+        orgUrlSlug="wigclub"
+        onResolveSyncedSaleInventoryReview={onResolveSyncedSaleInventoryReview}
+        storeUrlSlug="wigclub"
+        workItems={[
+          {
+            _id: "work-item-1" as Id<"operationalWorkItem">,
+            approvalState: "not_required",
+            createdAt: Date.now() - 5 * 60 * 1000,
+            details: {
+              inventoryReviewLineCount: 1,
+              primaryProductSkuId: "product-sku-1" as Id<"productSku">,
+              receiptNumber: "939540",
+              sourceId: "transaction-1",
+            },
+            priority: "high",
+            status: "open",
+            title: "Review inventory for ADORE DYE",
+            type: "synced_sale_inventory_review",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Mark reviewed" })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open stock adjustments" }),
+    ).toBeInTheDocument();
+  });
+
+  it("disables peer synced sale review buttons while one review is resolving", () => {
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        activeWorkflow="queue"
+        isResolvingSyncedSaleInventoryReviewId={
+          "work-item-active" as Id<"operationalWorkItem">
+        }
+        orgUrlSlug="wigclub"
+        onResolveSyncedSaleInventoryReview={vi.fn()}
+        storeUrlSlug="wigclub"
+        workItems={[
+          {
+            _id: "work-item-1" as Id<"operationalWorkItem">,
+            approvalState: "not_required",
+            createdAt: Date.now() - 5 * 60 * 1000,
+            details: {
+              inventoryReviewLineCount: 1,
+              localRegisterSessionId: "local-register-session-1",
+              localTransactionId: "local-transaction-1",
+              primaryProductSkuId: "product-sku-1" as Id<"productSku">,
+              receiptNumber: "939540",
+              registerSessionId: "register-session-1" as Id<"registerSession">,
+              sourceId: "transaction-1",
+              terminalId: "terminal-1" as Id<"posTerminal">,
+            },
+            priority: "high",
+            status: "open",
+            title: "Review inventory for ADORE DYE",
+            type: "synced_sale_inventory_review",
+          },
+          {
+            _id: "work-item-2" as Id<"operationalWorkItem">,
+            approvalState: "not_required",
+            createdAt: Date.now() - 4 * 60 * 1000,
+            details: {
+              inventoryReviewLineCount: 1,
+              localRegisterSessionId: "local-register-session-2",
+              localTransactionId: "local-transaction-2",
+              primaryProductSkuId: "product-sku-2" as Id<"productSku">,
+              receiptNumber: "939541",
+              registerSessionId: "register-session-1" as Id<"registerSession">,
+              sourceId: "transaction-2",
+              terminalId: "terminal-1" as Id<"posTerminal">,
+            },
+            priority: "normal",
+            status: "open",
+            title: "Review inventory for Lace tint",
+            type: "synced_sale_inventory_review",
+          },
+        ]}
+      />,
+    );
+
+    const reviewButtons = screen.getAllByRole("button", {
+      name: "Mark reviewed",
+    });
+    expect(reviewButtons).toHaveLength(2);
+    expect(reviewButtons[0]).toBeDisabled();
+    expect(reviewButtons[1]).toBeDisabled();
   });
 
   it("hydrates open work page and sort state from controlled search", () => {
@@ -893,22 +1249,17 @@ describe("OperationsQueueViewContent", () => {
         activeWorkflow="queue"
         openWorkSearch={{
           page: 2,
-          sort: "oldest",
         }}
         workItems={workItems}
       />,
     );
 
-    expect(screen.getByRole("button", { name: "Oldest" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
     expect(screen.getByText("Open Work Item 6")).toBeInTheDocument();
     expect(screen.queryByText("Open Work Item 1")).not.toBeInTheDocument();
     expect(screen.getByText("Page 2 of 2")).toBeInTheDocument();
   });
 
-  it("reports open work page and sort changes for route search state", async () => {
+  it("reports open work page changes for route search state", async () => {
     const { default: userEvent } = await import("@testing-library/user-event");
     const user = userEvent.setup();
     const onOpenWorkSearchChange = vi.fn();
@@ -934,13 +1285,6 @@ describe("OperationsQueueViewContent", () => {
     await user.click(screen.getByRole("button", { name: "Go to next page" }));
 
     expect(onOpenWorkSearchChange).toHaveBeenCalledWith({ page: 2 });
-
-    await user.click(screen.getByRole("button", { name: "Oldest" }));
-
-    expect(onOpenWorkSearchChange).toHaveBeenCalledWith({
-      page: undefined,
-      sort: "oldest",
-    });
   });
 
   it("does not link synced sale inventory work items without valid SKU metadata", () => {
@@ -955,8 +1299,7 @@ describe("OperationsQueueViewContent", () => {
             _id: "work-item-1" as Id<"operationalWorkItem">,
             approvalState: "not_required",
             createdAt: Date.now() - 5 * 60 * 1000,
-            metadata: {
-              primaryProductSkuId: 42,
+            details: {
               receiptNumber: "939540",
             },
             priority: "high",
@@ -985,7 +1328,7 @@ describe("OperationsQueueViewContent", () => {
             _id: "work-item-1" as Id<"operationalWorkItem">,
             approvalState: "not_required",
             createdAt: Date.now() - 5 * 60 * 1000,
-            metadata: {
+            details: {
               receiptNumber: "939540",
             },
             priority: "high",
@@ -1077,6 +1420,39 @@ describe("OperationsQueueViewContent", () => {
     expect(baseProps.onDecideApprovalRequest).toHaveBeenCalledWith({
       approvalRequestId: "approval-1",
       decision: "approved",
+    });
+  });
+
+  it("renders unsupported approval rows as retire-only actions", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        approvalRequests={[
+          {
+            _id: "approval-legacy" as Id<"approvalRequest">,
+            requestType: "service_deposit_review",
+            status: "pending",
+            workItemTitle: "Legacy deposit review",
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText(/legacy service deposit review cannot be approved/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /approve/i }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /retire review/i }));
+
+    expect(baseProps.onDecideApprovalRequest).toHaveBeenCalledWith({
+      approvalRequestId: "approval-legacy",
+      decision: "rejected",
     });
   });
 
@@ -1458,6 +1834,46 @@ describe("OperationsQueueViewContent", () => {
     ).toBeInTheDocument();
   });
 
+  it("passes register closeout context when deciding variance approvals", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    const onDecideApprovalRequest = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        approvalRequests={[
+          {
+            _id: "approval-variance-1" as Id<"approvalRequest">,
+            createdAt: 1_714_620_000_000,
+            registerSessionSummary: {
+              countedCash: 20000,
+              expectedCash: 40000,
+              registerNumber: "6",
+              registerSessionId: "register-6" as Id<"registerSession">,
+              status: "closing",
+              terminalName: "Safari QA",
+              variance: -20000,
+            },
+            requestType: "variance_review",
+            status: "pending",
+            workItemTitle: "Variance Review",
+          },
+        ]}
+        onDecideApprovalRequest={onDecideApprovalRequest}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /approve variance/i }));
+
+    expect(onDecideApprovalRequest).toHaveBeenCalledWith({
+      approvalRequestId: "approval-variance-1",
+      decision: "approved",
+      registerSessionId: "register-6",
+      requestType: "variance_review",
+    });
+  });
+
   it("renders synced register activity reviews in approvals", async () => {
     const { default: userEvent } = await import("@testing-library/user-event");
     const user = userEvent.setup();
@@ -1818,6 +2234,7 @@ describe("OperationsQueueViewContent", () => {
       .mockReturnValueOnce(vi.fn())
       .mockReturnValueOnce(vi.fn())
       .mockReturnValueOnce(vi.fn())
+      .mockReturnValueOnce(vi.fn())
       .mockReturnValueOnce(ensureCycleCountDraft)
       .mockReturnValueOnce(vi.fn())
       .mockReturnValueOnce(vi.fn())
@@ -1874,6 +2291,7 @@ describe("OperationsQueueViewContent", () => {
     mockedHooks.useQuery.mockReset();
     mockedHooks.useMutation.mockReturnValue(vi.fn());
     mockedHooks.useMutation
+      .mockReturnValueOnce(vi.fn())
       .mockReturnValueOnce(vi.fn())
       .mockReturnValueOnce(vi.fn())
       .mockReturnValueOnce(vi.fn())
@@ -2118,5 +2536,242 @@ describe("OperationsQueueViewContent", () => {
       ),
     );
     expect(mockedToast.error).not.toHaveBeenCalledWith("Please try again.");
+  });
+
+  it("resolves closeout variance approvals through the register closeout review mutation", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    const decideApprovalRequest = vi.fn().mockResolvedValue(ok({}));
+    const reviewRegisterSessionCloseout = vi.fn().mockResolvedValue(ok({}));
+    const authenticateStaffCredential = vi.fn().mockResolvedValue(
+      ok({
+        activeRoles: ["manager"],
+        staffProfile: {},
+        staffProfileId: "staff-manager-1",
+      }),
+    );
+    const authenticateStaffCredentialForApproval = vi.fn().mockResolvedValue(
+      ok({
+        approvalProofId: "proof-variance-1",
+        approvedByStaffProfileId: "staff-manager-1",
+        expiresAt: Date.now() + 60_000,
+      }),
+    );
+
+    mockedHooks.useMutation.mockReset();
+    mockedHooks.useMutation.mockImplementation((functionReference) => {
+      const functionName = getFunctionName(functionReference as never);
+
+      if (functionName === "operations/approvalRequests:decideApprovalRequest") {
+        return decideApprovalRequest;
+      }
+
+      if (
+        functionName ===
+        "operations/staffCredentials:authenticateStaffCredential"
+      ) {
+        return authenticateStaffCredential;
+      }
+
+      if (
+        functionName ===
+        "operations/staffCredentials:authenticateStaffCredentialForApproval"
+      ) {
+        return authenticateStaffCredentialForApproval;
+      }
+
+      if (
+        functionName ===
+        "cashControls/closeouts:reviewRegisterSessionCloseout"
+      ) {
+        return reviewRegisterSessionCloseout;
+      }
+
+      return vi.fn();
+    });
+    const queueSnapshot = {
+      approvalRequests: [
+        {
+          _id: "approval-variance-1",
+          registerSessionSummary: {
+            countedCash: 20000,
+            expectedCash: 40000,
+            registerNumber: "6",
+            registerSessionId: "register-6",
+            status: "closing",
+            terminalName: "Safari QA",
+            variance: -20000,
+          },
+          requestType: "variance_review",
+          status: "pending",
+          workItemTitle: "Variance Review",
+        },
+      ],
+      workItems: [],
+    };
+    let queryCallIndex = 0;
+    mockedHooks.useQuery.mockImplementation(() => {
+      queryCallIndex += 1;
+
+      return queryCallIndex % 2 === 1
+        ? queueSnapshot
+        : baseProps.inventoryItems;
+    });
+
+    render(<OperationsQueueView activeWorkflow="approvals" />);
+
+    await user.click(screen.getByRole("button", { name: /unlock approvals/i }));
+    await user.click(
+      within(
+        screen.getByRole("dialog", { name: /unlock approval decisions/i }),
+      ).getByRole("button", { name: /unlock approvals/i }),
+    );
+    await waitFor(() => expect(authenticateStaffCredential).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: /approve variance/i }));
+
+    await waitFor(() =>
+      expect(authenticateStaffCredentialForApproval).toHaveBeenCalledWith({
+        actionKey: "cash_controls.register_session.review_variance",
+        pinHash: "hashed:1234",
+        reason: "Resolve pending approval request.",
+        requiredRole: "manager",
+        storeId: "store-1",
+        subject: {
+          id: "register-6",
+          label: "6",
+          type: "register_session",
+        },
+        username: "manager",
+      }),
+    );
+    await waitFor(() =>
+      expect(reviewRegisterSessionCloseout).toHaveBeenCalledWith({
+        approvalProofId: "proof-variance-1",
+        decision: "approved",
+        registerSessionId: "register-6",
+        storeId: "store-1",
+      }),
+    );
+    expect(decideApprovalRequest).not.toHaveBeenCalled();
+  });
+
+  it("resolves synced register reviews with the minted approval proof", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    const decideApprovalRequest = vi.fn().mockResolvedValue(ok({}));
+    const resolveRegisterSessionSyncReview = vi.fn().mockResolvedValue(ok({}));
+    const authenticateStaffCredential = vi.fn().mockResolvedValue(
+      ok({
+        activeRoles: ["manager"],
+        staffProfile: {},
+        staffProfileId: "staff-manager-1",
+      }),
+    );
+    const authenticateStaffCredentialForApproval = vi.fn().mockResolvedValue(
+      ok({
+        approvalProofId: "proof-sync-1",
+        approvedByStaffProfileId: "staff-manager-1",
+        expiresAt: Date.now() + 60_000,
+      }),
+    );
+
+    mockedHooks.useMutation.mockReset();
+    mockedHooks.useMutation.mockImplementation((functionReference) => {
+      const functionName = getFunctionName(functionReference as never);
+
+      if (functionName === "operations/approvalRequests:decideApprovalRequest") {
+        return decideApprovalRequest;
+      }
+
+      if (
+        functionName === "cashControls/deposits:resolveRegisterSessionSyncReview"
+      ) {
+        return resolveRegisterSessionSyncReview;
+      }
+
+      if (
+        functionName ===
+        "operations/staffCredentials:authenticateStaffCredential"
+      ) {
+        return authenticateStaffCredential;
+      }
+
+      if (
+        functionName ===
+        "operations/staffCredentials:authenticateStaffCredentialForApproval"
+      ) {
+        return authenticateStaffCredentialForApproval;
+      }
+
+      return vi.fn();
+    });
+    const queueSnapshot = {
+      approvalRequests: [
+        {
+          _id: "register-sync-review:register-2",
+          registerSessionSummary: {
+            countedCash: null,
+            expectedCash: 50_000,
+            registerNumber: "2",
+            registerSessionId: "register-2",
+            status: "active",
+            terminalName: "Wigshop",
+            variance: null,
+          },
+          requestType: "register_sync_review",
+          status: "pending",
+          workItemTitle: "Synced register activity review",
+        },
+      ],
+      workItems: [],
+    };
+    let queryCallIndex = 0;
+    mockedHooks.useQuery.mockImplementation(() => {
+      queryCallIndex += 1;
+
+      return queryCallIndex % 2 === 1
+        ? queueSnapshot
+        : baseProps.inventoryItems;
+    });
+
+    render(<OperationsQueueView activeWorkflow="approvals" />);
+
+    await user.click(screen.getByRole("button", { name: /unlock approvals/i }));
+    await user.click(
+      within(
+        screen.getByRole("dialog", { name: /unlock approval decisions/i }),
+      ).getByRole("button", { name: /unlock approvals/i }),
+    );
+    await waitFor(() => expect(authenticateStaffCredential).toHaveBeenCalled());
+
+    await user.click(
+      screen.getByRole("button", { name: /approve synced sales/i }),
+    );
+
+    await waitFor(() =>
+      expect(authenticateStaffCredentialForApproval).toHaveBeenCalledWith({
+        actionKey: "cash_controls.register_session.resolve_sync_review",
+        pinHash: "hashed:1234",
+        reason: "Resolve pending approval request.",
+        requiredRole: "manager",
+        storeId: "store-1",
+        subject: {
+          id: "register-2",
+          label: "2",
+          type: "register_session",
+        },
+        username: "manager",
+      }),
+    );
+    await waitFor(() =>
+      expect(resolveRegisterSessionSyncReview).toHaveBeenCalledWith({
+        approvalProofId: "proof-sync-1",
+        decision: "approved",
+        registerSessionId: "register-2",
+        storeId: "store-1",
+      }),
+    );
+    expect(decideApprovalRequest).not.toHaveBeenCalled();
   });
 });

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
@@ -10,9 +10,11 @@ import { Link, useParams, useSearch } from "@tanstack/react-router";
 import { useMutation, usePaginatedQuery, useQuery } from "convex/react";
 import {
   ArrowUpRight,
+  CalendarClock,
   ClipboardCheck,
   Lock,
   LockOpen,
+  PackageCheck,
   ReceiptText,
   Scissors,
   ShoppingCart,
@@ -74,9 +76,15 @@ const operationsApi = api.operations;
 const stockOpsApi = api.stockOps;
 const ghsCurrencyFormatter = currencyFormatter("GHS");
 const APPROVAL_DECISION_ACTION_KEY = "operations.approval_request.decide";
+const REGISTER_SESSION_SYNC_REVIEW_APPROVAL_ACTION_KEY =
+  "cash_controls.register_session.resolve_sync_review";
+const REGISTER_VARIANCE_REVIEW_ACTION_KEY =
+  "cash_controls.register_session.review_variance";
 const APPROVAL_PAGE_UNLOCK_TTL_MS = 5 * 60 * 1000;
 const OPEN_WORK_ITEMS_PER_PAGE = 5;
 const UNCATEGORIZED_COUNT_SCOPE_KEY = "__uncategorized";
+const openWorkActionLinkClassName =
+  "inline-flex items-center gap-1.5 text-sm font-medium text-foreground underline-offset-4 transition-colors hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
 
 type ProductSkuSearchResponse = {
   results: Array<{
@@ -86,13 +94,37 @@ type ProductSkuSearchResponse = {
 
 type QueueWorkItem = {
   _id: Id<"operationalWorkItem">;
+  approvalRequestId?: Id<"approvalRequest">;
   approvalState: string;
   assignedStaffName?: string | null;
+  completedAt?: number | null;
   createdAt: number;
   customerName?: string | null;
+  details?: {
+    businessDate?: string | null;
+    displayNumber?: string | null;
+    followUpReason?: string | null;
+    inventoryReviewLineCount?: number | null;
+    itemCount?: number | null;
+    localRegisterSessionId?: string | null;
+    localTransactionId?: string | null;
+    lookupCode?: string | null;
+    price?: number | null;
+    primaryProductSkuId?: string | null;
+    purchaseOrderNumber?: string | null;
+    quantitySold?: number | null;
+    reasonLabel?: string | null;
+    receiptNumber?: string | null;
+    registerSessionId?: string | null;
+    sourceId?: string | null;
+    terminalId?: string | null;
+    totalQuantitySold?: number | null;
+    vendorName?: string | null;
+  } | null;
   dueAt?: number | null;
-  metadata?: Record<string, unknown> | null;
   priority: string;
+  sourceIdentity?: string;
+  startedAt?: number | null;
   status: string;
   title: string;
   type: string;
@@ -103,6 +135,14 @@ type QueueWorkItemMixEntry = {
   label: string;
   percent: number;
   type: string;
+};
+
+type QueueOverflow = {
+  approvalRequests: boolean;
+  workItems: {
+    inProgress: boolean;
+    open: boolean;
+  };
 };
 
 type QueueApprovalRequest = {
@@ -173,10 +213,8 @@ type QueueApprovalRequest = {
 };
 
 export type OperationsWorkflow = "stock" | "queue" | "approvals";
-export type OpenWorkSortOrder = "latest" | "oldest";
 export type OpenWorkSearchState = {
   page?: number;
-  sort?: OpenWorkSortOrder;
 };
 export type OpenWorkSearchPatch = Partial<OpenWorkSearchState>;
 
@@ -201,22 +239,6 @@ function formatApprovalsHeaderTitle(count: number) {
   if (count === 0) return "No pending approvals";
 
   return `${count.toLocaleString()} pending ${count === 1 ? "approval" : "approvals"}`;
-}
-
-function sortQueueWorkItems(
-  workItems: QueueWorkItem[],
-  sortOrder: OpenWorkSortOrder,
-) {
-  return [...workItems].sort((left, right) => {
-    const createdAtDelta =
-      sortOrder === "latest"
-        ? right.createdAt - left.createdAt
-        : left.createdAt - right.createdAt;
-
-    if (createdAtDelta !== 0) return createdAtDelta;
-
-    return left._id.localeCompare(right._id);
-  });
 }
 
 function formatQueueWorkItemValue(value: string) {
@@ -265,8 +287,32 @@ function getQueueWorkItemTypeLabel(type: string) {
     return "Synced sale inventory";
   }
 
-  if (type === "service_case" || type === "service_intake") {
+  if (type === "service_case") {
+    return "Service case";
+  }
+
+  if (type === "service_appointment") {
+    return "Service appointment";
+  }
+
+  if (type === "service_intake") {
     return "Service intake";
+  }
+
+  if (type === "purchase_order") {
+    return "Purchase order";
+  }
+
+  if (type === "stock_adjustment_review") {
+    return "Stock adjustment approval";
+  }
+
+  if (type === "daily_close_carry_forward") {
+    return "Daily close follow-up";
+  }
+
+  if (type === "service_deposit_review") {
+    return "Unsupported work type";
   }
 
   return formatQueueWorkItemValue(type);
@@ -307,6 +353,38 @@ function formatOpenWorkMixCount(count: number) {
   return `${count.toLocaleString()} ${count === 1 ? "item" : "items"}`;
 }
 
+function hasOpenWorkOverflow(overflow?: QueueOverflow | null) {
+  return Boolean(overflow?.workItems.open || overflow?.workItems.inProgress);
+}
+
+function CappedQueueNotice({
+  children,
+  title,
+}: {
+  children: ReactNode;
+  title: string;
+}) {
+  return (
+    <div
+      className="rounded-lg border border-warning/30 bg-warning/10 p-layout-sm text-sm leading-6 text-warning-foreground"
+      role="status"
+    >
+      <p className="font-medium text-foreground">{title}</p>
+      <p className="mt-1 text-muted-foreground">{children}</p>
+    </div>
+  );
+}
+
+function hasSyncedSaleInventoryResolverDetails(item: QueueWorkItem) {
+  return Boolean(
+    getQueueWorkItemStringDetail(item, "terminalId") &&
+      getQueueWorkItemStringDetail(item, "localRegisterSessionId") &&
+      getQueueWorkItemStringDetail(item, "localTransactionId") &&
+      getQueueWorkItemStringDetail(item, "registerSessionId") &&
+      getQueueWorkItemStringDetail(item, "sourceId"),
+  );
+}
+
 function getQueueWorkItemContextPresentation(type: string) {
   if (type === "pos_pending_checkout_item_review") {
     return {
@@ -327,12 +405,35 @@ function getQueueWorkItemContextPresentation(type: string) {
     };
   }
 
-  if (type === "service_case" || type === "service_intake") {
+  if (
+    type === "service_case" ||
+    type === "service_appointment" ||
+    type === "service_intake"
+  ) {
     return {
       cardClassName: "bg-surface-raised hover:border-border",
       Icon: Scissors,
       iconClassName: "border-success/25 bg-success/10 text-success",
       contextLabelClassName: "text-success",
+    };
+  }
+
+  if (type === "purchase_order") {
+    return {
+      cardClassName: "bg-surface-raised hover:border-border",
+      Icon: PackageCheck,
+      iconClassName:
+        "border-action-workflow-border bg-action-workflow-soft text-action-workflow",
+      contextLabelClassName: "text-action-workflow",
+    };
+  }
+
+  if (type === "daily_close_carry_forward") {
+    return {
+      cardClassName: "bg-surface-raised hover:border-border",
+      Icon: CalendarClock,
+      iconClassName: "border-warning-border bg-warning-soft text-warning",
+      contextLabelClassName: "text-warning",
     };
   }
 
@@ -365,60 +466,34 @@ function WorkItemContextIcon({
   );
 }
 
-function getQueueWorkItemStringMetadata(
+function getQueueWorkItemStringDetail(
   item: QueueWorkItem,
-  key: string,
+  key: keyof NonNullable<QueueWorkItem["details"]>,
 ): string | undefined {
-  const value = item.metadata?.[key];
+  const value = item.details?.[key];
   return typeof value === "string" && value.trim() ? value : undefined;
 }
 
-function getQueueWorkItemNumberMetadata(
+function getQueueWorkItemNumberDetail(
   item: QueueWorkItem,
-  key: string,
+  key: keyof NonNullable<QueueWorkItem["details"]>,
 ): number | undefined {
-  const value = item.metadata?.[key];
+  const value = item.details?.[key];
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
-function getQueueWorkItemArrayMetadataCount(
-  item: QueueWorkItem,
-  key: string,
-): number | undefined {
-  const value = item.metadata?.[key];
-  return Array.isArray(value) ? value.length : undefined;
-}
-
 function getQueueWorkItemInventoryReviewLineCount(item: QueueWorkItem) {
-  const skippedLineCount = getQueueWorkItemArrayMetadataCount(
+  return getQueueWorkItemNumberDetail(
     item,
-    "skippedMutationItems",
+    "inventoryReviewLineCount",
   );
-
-  if (skippedLineCount && skippedLineCount > 0) {
-    return skippedLineCount;
-  }
-
-  const trustedLineCount = getQueueWorkItemArrayMetadataCount(
-    item,
-    "trustedInventoryLines",
-  );
-
-  return trustedLineCount && trustedLineCount > 0 ? trustedLineCount : undefined;
 }
 
 function getQueueWorkItemStockAdjustmentSkuId(item: QueueWorkItem) {
   if (item.type === "synced_sale_inventory_review") {
-    return getQueueWorkItemStringMetadata(
+    return getQueueWorkItemStringDetail(
       item,
       "primaryProductSkuId",
-    ) as Id<"productSku"> | undefined;
-  }
-
-  if (item.type === "pos_pending_checkout_item_review") {
-    return getQueueWorkItemStringMetadata(
-      item,
-      "provisionalProductSkuId",
     ) as Id<"productSku"> | undefined;
   }
 
@@ -437,6 +512,14 @@ function formatOptionalLineCount(value: number | undefined) {
   return `${value.toLocaleString()} ${value === 1 ? "line" : "lines"}`;
 }
 
+function formatOptionalItemCount(value: number | undefined) {
+  if (typeof value !== "number") {
+    return "Not recorded";
+  }
+
+  return `${value.toLocaleString()} ${value === 1 ? "item" : "items"}`;
+}
+
 function formatOptionalMoney(value: number | undefined) {
   return typeof value === "number"
     ? formatStoredAmount(ghsCurrencyFormatter, value)
@@ -447,16 +530,24 @@ function formatReceiptNumber(value: string | undefined) {
   return value ? `#${value}` : "Unknown";
 }
 
+function formatBusinessDate(value: string | undefined) {
+  if (!value) return "Not recorded";
+
+  const date = new Date(`${value}T00:00:00`);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "long",
+  }).format(date);
+}
+
 function getQueueWorkItemTransactionId(item: QueueWorkItem) {
-  const sourceType = getQueueWorkItemStringMetadata(item, "sourceType");
-  const sourceId = getQueueWorkItemStringMetadata(item, "sourceId");
-  const transactionId = getQueueWorkItemStringMetadata(item, "transactionId");
+  const sourceId = getQueueWorkItemStringDetail(item, "sourceId");
 
-  if (transactionId) return transactionId as Id<"posTransaction">;
-
-  return sourceType === "posTransaction" && sourceId
-    ? (sourceId as Id<"posTransaction">)
-    : undefined;
+  return sourceId ? (sourceId as Id<"posTransaction">) : undefined;
 }
 
 function ReceiptReferenceLink({
@@ -479,7 +570,7 @@ function ReceiptReferenceLink({
   return (
     <Link
       aria-label={`Open transaction ${receiptLabel}`}
-      className="inline-flex items-center gap-1 text-foreground underline-offset-4 transition-colors hover:text-primary hover:underline"
+      className="inline-flex items-center gap-1 text-foreground underline-offset-4 transition-colors hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
       params={{
         orgUrlSlug,
         storeUrlSlug,
@@ -511,7 +602,7 @@ function StockAdjustmentReferenceLink({
 
   return (
     <Link
-      className="inline-flex items-center gap-1 text-foreground underline-offset-4 transition-colors hover:text-primary hover:underline"
+      className="inline-flex items-center gap-1 text-foreground underline-offset-4 transition-colors hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
       params={{
         orgUrlSlug,
         storeUrlSlug,
@@ -527,6 +618,155 @@ function StockAdjustmentReferenceLink({
       <ArrowUpRight aria-hidden="true" className="h-3 w-3" />
     </Link>
   );
+}
+
+function QueueWorkItemActionSlot({
+  isSyncedSaleInventoryReviewResolutionDisabled,
+  isResolvingSyncedSaleInventoryReview,
+  item,
+  onResolveSyncedSaleInventoryReview,
+  orgUrlSlug,
+  stockAdjustmentSkuId,
+  storeUrlSlug,
+}: {
+  isSyncedSaleInventoryReviewResolutionDisabled?: boolean;
+  isResolvingSyncedSaleInventoryReview?: boolean;
+  item: QueueWorkItem;
+  onResolveSyncedSaleInventoryReview?: (item: QueueWorkItem) => void;
+  orgUrlSlug?: string;
+  stockAdjustmentSkuId?: Id<"productSku">;
+  storeUrlSlug?: string;
+}) {
+  if (!orgUrlSlug || !storeUrlSlug) return null;
+
+  if (item.type === "pos_pending_checkout_item_review") {
+    return (
+      <Link
+        className={openWorkActionLinkClassName}
+        params={{ orgUrlSlug, storeUrlSlug }}
+        search={{ o: getOrigin() }}
+        to="/$orgUrlSlug/store/$storeUrlSlug/products/unresolved"
+      >
+        Review unresolved catalog
+        <ArrowUpRight aria-hidden="true" className="h-3.5 w-3.5" />
+      </Link>
+    );
+  }
+
+  if (item.type === "synced_sale_inventory_review") {
+    return (
+      <div className="flex flex-wrap items-center gap-3">
+        {stockAdjustmentSkuId ? (
+          <Link
+            className={openWorkActionLinkClassName}
+            params={{ orgUrlSlug, storeUrlSlug }}
+            search={{
+              mode: "manual",
+              o: getOrigin(),
+              sku: stockAdjustmentSkuId,
+            }}
+            to="/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments"
+          >
+            Open stock adjustments
+            <ArrowUpRight aria-hidden="true" className="h-3.5 w-3.5" />
+          </Link>
+        ) : null}
+        {onResolveSyncedSaleInventoryReview &&
+        hasSyncedSaleInventoryResolverDetails(item) ? (
+          <LoadingButton
+            className="h-8 px-3 text-xs"
+            disabled={Boolean(
+              isSyncedSaleInventoryReviewResolutionDisabled,
+            )}
+            isLoading={Boolean(isResolvingSyncedSaleInventoryReview)}
+            onClick={() => onResolveSyncedSaleInventoryReview(item)}
+            size="sm"
+            type="button"
+            variant="secondary"
+          >
+            Mark reviewed
+          </LoadingButton>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (item.type === "service_case" || item.type === "service_intake") {
+    return (
+      <Link
+        className={openWorkActionLinkClassName}
+        params={{ orgUrlSlug, storeUrlSlug }}
+        search={{ o: getOrigin() }}
+        to="/$orgUrlSlug/store/$storeUrlSlug/services/active-cases"
+      >
+        Open service case
+        <ArrowUpRight aria-hidden="true" className="h-3.5 w-3.5" />
+      </Link>
+    );
+  }
+
+  if (item.type === "service_appointment") {
+    return (
+      <Link
+        className={openWorkActionLinkClassName}
+        params={{ orgUrlSlug, storeUrlSlug }}
+        search={{ o: getOrigin() }}
+        to="/$orgUrlSlug/store/$storeUrlSlug/services/appointments"
+      >
+        Open appointment
+        <ArrowUpRight aria-hidden="true" className="h-3.5 w-3.5" />
+      </Link>
+    );
+  }
+
+  if (item.type === "purchase_order") {
+    return (
+      <Link
+        className={openWorkActionLinkClassName}
+        params={{ orgUrlSlug, storeUrlSlug }}
+        search={{ o: getOrigin() }}
+        to="/$orgUrlSlug/store/$storeUrlSlug/procurement"
+      >
+        Open purchase order
+        <ArrowUpRight aria-hidden="true" className="h-3.5 w-3.5" />
+      </Link>
+    );
+  }
+
+  if (item.type === "stock_adjustment_review") {
+    return (
+      <Link
+        className={openWorkActionLinkClassName}
+        params={{ orgUrlSlug, storeUrlSlug }}
+        search={{ o: getOrigin() }}
+        to="/$orgUrlSlug/store/$storeUrlSlug/operations/approvals"
+      >
+        Review approval
+        <ArrowUpRight aria-hidden="true" className="h-3.5 w-3.5" />
+      </Link>
+    );
+  }
+
+  if (item.type === "daily_close_carry_forward") {
+    const businessDate = getQueueWorkItemStringDetail(item, "businessDate");
+
+    return (
+      <Link
+        className={openWorkActionLinkClassName}
+        params={{ orgUrlSlug, storeUrlSlug }}
+        search={{
+          o: getOrigin(),
+          ...(businessDate ? { operatingDate: businessDate } : {}),
+        }}
+        to="/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close"
+      >
+        Open Daily Close
+        <ArrowUpRight aria-hidden="true" className="h-3.5 w-3.5" />
+      </Link>
+    );
+  }
+
+  return null;
 }
 
 function OpenWorkMixSummary({ workItems }: { workItems: QueueWorkItem[] }) {
@@ -579,18 +819,24 @@ function OpenWorkMixSummary({ workItems }: { workItems: QueueWorkItem[] }) {
 }
 
 function QueueWorkItemCard({
+  isSyncedSaleInventoryReviewResolutionDisabled,
+  isResolvingSyncedSaleInventoryReview,
   item,
+  onResolveSyncedSaleInventoryReview,
   orgUrlSlug,
   storeUrlSlug,
 }: {
+  isSyncedSaleInventoryReviewResolutionDisabled?: boolean;
+  isResolvingSyncedSaleInventoryReview?: boolean;
   item: QueueWorkItem;
+  onResolveSyncedSaleInventoryReview?: (item: QueueWorkItem) => void;
   orgUrlSlug?: string;
   storeUrlSlug?: string;
 }) {
   const stockAdjustmentSkuId = getQueueWorkItemStockAdjustmentSkuId(item);
-  const receiptNumber = getQueueWorkItemStringMetadata(item, "receiptNumber");
+  const receiptNumber = getQueueWorkItemStringDetail(item, "receiptNumber");
   const receiptTransactionId = getQueueWorkItemTransactionId(item);
-  const title = formatWorkItemTitle(item.title);
+  const fallbackTitle = formatWorkItemTitle(item.title);
   const pendingCheckoutTitleSubject =
     item.type === "pos_pending_checkout_item_review"
       ? getWorkItemTitleSubject(item.title, "Review pending checkout item: ")
@@ -600,22 +846,125 @@ function QueueWorkItemCard({
       ? getWorkItemTitleSubject(item.title, "Review inventory for ")
       : null;
   const contextPresentation = getQueueWorkItemContextPresentation(item.type);
-  const serviceCollapsedMetadataEntries: OperationReviewMetadataEntry[] = [
+  const serviceCollapsedMetadataEntries: OperationReviewMetadataEntry[] =
+    item.type === "service_appointment"
+      ? [
+          {
+            label: "Owner",
+            value: item.assignedStaffName ?? "Unassigned",
+          },
+          {
+            label: "Customer",
+            value: item.customerName ?? "No customer",
+          },
+          {
+            label: "Scheduled",
+            value: item.dueAt ? getRelativeTime(item.dueAt) : "Not scheduled",
+          },
+          {
+            label: "Created",
+            value: getRelativeTime(item.createdAt),
+          },
+        ]
+      : [
+          {
+            label: "Owner",
+            value: item.assignedStaffName ?? "Unassigned",
+          },
+          {
+            label: "Customer",
+            value: item.customerName ?? "No customer",
+          },
+          {
+            label: "Created",
+            value: getRelativeTime(item.createdAt),
+          },
+          {
+            label: "Due",
+            value: item.dueAt ? getRelativeTime(item.dueAt) : "Not scheduled",
+          },
+        ];
+  const purchaseOrderCollapsedMetadataEntries: OperationReviewMetadataEntry[] = [
     {
-      label: "Owner",
-      value: item.assignedStaffName ?? "Unassigned",
+      label: "Purchase order",
+      value:
+        getQueueWorkItemStringDetail(item, "purchaseOrderNumber") ??
+        getQueueWorkItemStringDetail(item, "displayNumber") ??
+        "Not recorded",
     },
     {
-      label: "Customer",
-      value: item.customerName ?? "No customer",
+      label: "Vendor",
+      value: getQueueWorkItemStringDetail(item, "vendorName") ?? "No vendor",
+    },
+    {
+      label: "Items",
+      value: formatOptionalItemCount(
+        getQueueWorkItemNumberDetail(item, "itemCount"),
+      ),
+    },
+    {
+      label: "Next action",
+      value: "Continue procurement",
+    },
+  ];
+  const stockAdjustmentReviewCollapsedMetadataEntries: OperationReviewMetadataEntry[] =
+    [
+      {
+        label: "Owner",
+        value: "Approval requests",
+      },
+      {
+        label: "Next action",
+        value:
+          item.approvalState === "pending"
+            ? "Review pending approval"
+            : "Check approval status",
+      },
+      {
+        label: "Reason",
+        value:
+          getQueueWorkItemStringDetail(item, "reasonLabel") ??
+          "Stock review",
+      },
+      {
+        label: "Created",
+        value: getRelativeTime(item.createdAt),
+      },
+    ];
+  const dailyCloseCollapsedMetadataEntries: OperationReviewMetadataEntry[] = [
+    {
+      label: "Business date",
+      value: formatBusinessDate(
+        getQueueWorkItemStringDetail(item, "businessDate"),
+      ),
+    },
+    {
+      label: "Owner",
+      value: "Daily Close",
+    },
+    {
+      label: "Follow-up",
+      value:
+        getQueueWorkItemStringDetail(item, "followUpReason") ??
+        "Review carry-forward work",
     },
     {
       label: "Created",
       value: getRelativeTime(item.createdAt),
     },
+  ];
+  const unsupportedCollapsedMetadataEntries: OperationReviewMetadataEntry[] = [
     {
-      label: "Due",
-      value: item.dueAt ? getRelativeTime(item.dueAt) : "Not scheduled",
+      label: "Owner",
+      value: "Not surfaced here",
+    },
+    {
+      label: "Next action",
+      value: "Wait for supported approval handling",
+    },
+    {
+      label: "Created",
+      value: getRelativeTime(item.createdAt),
     },
   ];
   const pendingCheckoutCollapsedMetadataEntries: OperationReviewMetadataEntry[] =
@@ -623,23 +972,23 @@ function QueueWorkItemCard({
       {
         label: "Item code",
         value:
-          getQueueWorkItemStringMetadata(item, "lookupCode") ?? "Not captured",
+          getQueueWorkItemStringDetail(item, "lookupCode") ?? "Not captured",
       },
       {
         label: "Quantity sold",
         value: formatOptionalQuantity(
-          getQueueWorkItemNumberMetadata(item, "quantitySold"),
+          getQueueWorkItemNumberDetail(item, "quantitySold"),
         ),
       },
       {
         label: "Total sold",
         value: formatOptionalQuantity(
-          getQueueWorkItemNumberMetadata(item, "totalQuantitySold"),
+          getQueueWorkItemNumberDetail(item, "totalQuantitySold"),
         ),
       },
       {
         label: "Price",
-        value: formatOptionalMoney(getQueueWorkItemNumberMetadata(item, "price")),
+        value: formatOptionalMoney(getQueueWorkItemNumberDetail(item, "price")),
       },
     ];
   const syncedSaleCollapsedMetadataEntries: OperationReviewMetadataEntry[] = [
@@ -668,7 +1017,15 @@ function QueueWorkItemCard({
       ? pendingCheckoutCollapsedMetadataEntries
       : item.type === "synced_sale_inventory_review"
         ? syncedSaleCollapsedMetadataEntries
-        : serviceCollapsedMetadataEntries;
+        : item.type === "purchase_order"
+          ? purchaseOrderCollapsedMetadataEntries
+          : item.type === "stock_adjustment_review"
+            ? stockAdjustmentReviewCollapsedMetadataEntries
+            : item.type === "daily_close_carry_forward"
+              ? dailyCloseCollapsedMetadataEntries
+              : item.type === "service_deposit_review"
+                ? unsupportedCollapsedMetadataEntries
+                : serviceCollapsedMetadataEntries;
   const expandedOnlyMetadataEntries: OperationReviewMetadataEntry[] =
     item.type === "synced_sale_inventory_review"
       ? [
@@ -696,28 +1053,31 @@ function QueueWorkItemCard({
       value: formatQueueWorkItemValue(item.approvalState),
     },
   ];
+  const title =
+    item.type === "service_deposit_review"
+      ? "Service deposit review is not available in Open Work."
+      : item.type === "daily_close_carry_forward"
+        ? "Daily close carry-forward follow-up"
+        : fallbackTitle;
 
   return (
     <OperationReviewItemCard
       actionSlot={
-        stockAdjustmentSkuId && orgUrlSlug && storeUrlSlug ? (
-          <Link
-            className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground underline-offset-4 transition-colors hover:text-primary hover:underline"
-            params={{
-              orgUrlSlug,
-              storeUrlSlug,
-            }}
-            search={{
-              mode: "manual",
-              o: getOrigin(),
-              sku: stockAdjustmentSkuId,
-            }}
-            to="/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments"
-          >
-            Open stock adjustments
-            <ArrowUpRight aria-hidden="true" className="h-3.5 w-3.5" />
-          </Link>
-        ) : null
+        <QueueWorkItemActionSlot
+          isSyncedSaleInventoryReviewResolutionDisabled={
+            isSyncedSaleInventoryReviewResolutionDisabled
+          }
+          isResolvingSyncedSaleInventoryReview={
+            isResolvingSyncedSaleInventoryReview
+          }
+          item={item}
+          onResolveSyncedSaleInventoryReview={
+            onResolveSyncedSaleInventoryReview
+          }
+          orgUrlSlug={orgUrlSlug}
+          stockAdjustmentSkuId={stockAdjustmentSkuId}
+          storeUrlSlug={storeUrlSlug}
+        />
       }
       badgeSlot={
         <>
@@ -743,7 +1103,7 @@ function QueueWorkItemCard({
           Icon={contextPresentation.Icon}
         />
       }
-      contextLabel={formatQueueWorkItemValue(item.type)}
+      contextLabel={getQueueWorkItemTypeLabel(item.type)}
       contextLabelClassName={contextPresentation.contextLabelClassName}
       description={null}
       itemId={item._id}
@@ -751,14 +1111,7 @@ function QueueWorkItemCard({
       title={
         pendingCheckoutTitleSubject ? (
           <>
-            Review pending checkout item:{" "}
-            <StockAdjustmentReferenceLink
-              orgUrlSlug={orgUrlSlug}
-              skuId={stockAdjustmentSkuId}
-              storeUrlSlug={storeUrlSlug}
-            >
-              {pendingCheckoutTitleSubject}
-            </StockAdjustmentReferenceLink>
+            Review pending checkout item: {pendingCheckoutTitleSubject}
           </>
         ) : syncedSaleTitleSubject ? (
           <>
@@ -802,10 +1155,7 @@ function getApprovalRequestCopy(requestType: string) {
     };
   }
 
-  if (
-    requestType === "pos_item_adjustment" ||
-    requestType === "pos_item_adjustment_review"
-  ) {
+  if (requestType === "pos_item_adjustment") {
     return {
       approveLabel: "Approve adjustment",
       approvedToast: "Item adjustment approved",
@@ -846,6 +1196,37 @@ function getApprovalRequestCopy(requestType: string) {
         "Manager approval voids the completed sale and records the payment, drawer, inventory, and audit reversal.",
       rejectedToast: "Completed sale void rejected",
       rejectLabel: "Reject void",
+    };
+  }
+
+  return null;
+}
+
+function getRetireOnlyApprovalRequestCopy(requestType: string) {
+  if (requestType === "service_deposit_review") {
+    return {
+      description:
+        "This legacy service deposit review cannot be approved from Open Work. Reject it to retire the pending approval and clear the linked review.",
+      rejectedToast: "Service deposit review retired",
+      rejectLabel: "Retire review",
+    };
+  }
+
+  if (requestType === "online_order_return_review") {
+    return {
+      description:
+        "Online return reviews need a dedicated resolver before approval can apply return changes. Reject it to retire the pending approval.",
+      rejectedToast: "Online return review retired",
+      rejectLabel: "Retire review",
+    };
+  }
+
+  if (requestType === "pos_item_adjustment_review") {
+    return {
+      description:
+        "This legacy item adjustment review cannot be approved from Open Work. Reject it to retire the pending approval.",
+      rejectedToast: "Item adjustment review retired",
+      rejectLabel: "Retire review",
     };
   }
 
@@ -1128,6 +1509,7 @@ type OperationsQueueViewContentProps = {
   isLoadingPermissions: boolean;
   isLoadingQueue: boolean;
   isLoadingStock?: boolean;
+  isResolvingSyncedSaleInventoryReviewId?: Id<"operationalWorkItem"> | null;
   isSubmittingStockBatch: boolean;
   onDecideApprovalRequest: (args: {
     approvalRequestId: string;
@@ -1139,6 +1521,7 @@ type OperationsQueueViewContentProps = {
   onLoadMoreInventoryItems?: () => void;
   onRequestApprovalDecisionUnlock?: () => void;
   onOpenWorkSearchChange?: (patch: OpenWorkSearchPatch) => void;
+  onResolveSyncedSaleInventoryReview?: (item: QueueWorkItem) => void;
   onDiscardCycleCountDraft?: () => Promise<NormalizedCommandResult<unknown>>;
   onRefreshCycleCountDraftLineBaseline?: (args: {
     productSkuId: Id<"productSku">;
@@ -1155,6 +1538,7 @@ type OperationsQueueViewContentProps = {
   }) => Promise<NormalizedCommandResult<unknown>>;
   onStockAdjustmentSearchChange?: (patch: StockAdjustmentSearchPatch) => void;
   orgUrlSlug?: string;
+  queueOverflow?: QueueOverflow | null;
   showBackButton?: boolean;
   storeId?: Id<"store">;
   storeUrlSlug?: string;
@@ -1181,6 +1565,7 @@ export function OperationsQueueViewContent({
   isLoadingPermissions,
   isLoadingQueue,
   isLoadingStock = isLoadingQueue,
+  isResolvingSyncedSaleInventoryReviewId,
   isSubmittingStockBatch,
   onDecideApprovalRequest,
   onDiscardCycleCountDraft,
@@ -1188,12 +1573,14 @@ export function OperationsQueueViewContent({
   onLoadMoreInventoryItems,
   onOpenWorkSearchChange,
   onRequestApprovalDecisionUnlock,
+  onResolveSyncedSaleInventoryReview,
   onRefreshCycleCountDraftLineBaseline,
   onSaveCycleCountDraftLine,
   onSubmitStockBatch,
   onSubmitCycleCountDraft,
   onStockAdjustmentSearchChange,
   orgUrlSlug,
+  queueOverflow,
   showBackButton = false,
   storeId,
   storeUrlSlug,
@@ -1202,24 +1589,17 @@ export function OperationsQueueViewContent({
   workItems,
 }: OperationsQueueViewContentProps) {
   const requestedOpenWorkPage = openWorkSearch?.page ?? 1;
-  const requestedOpenWorkSortOrder = openWorkSearch?.sort ?? "latest";
   const [openWorkPage, setOpenWorkPage] = useState(requestedOpenWorkPage);
-  const [openWorkSortOrder, setOpenWorkSortOrder] =
-    useState<OpenWorkSortOrder>(requestedOpenWorkSortOrder);
   const resolvedWorkflow =
     activeWorkflow ?? getDefaultWorkflow({ approvalRequests, workItems });
-  const sortedWorkItems = useMemo(
-    () => sortQueueWorkItems(workItems, openWorkSortOrder),
-    [openWorkSortOrder, workItems],
-  );
   const openWorkPageCount = Math.max(
     1,
-    Math.ceil(sortedWorkItems.length / OPEN_WORK_ITEMS_PER_PAGE),
+    Math.ceil(workItems.length / OPEN_WORK_ITEMS_PER_PAGE),
   );
   const clampedOpenWorkPage = Math.min(openWorkPage, openWorkPageCount);
   const openWorkPageStart =
     (clampedOpenWorkPage - 1) * OPEN_WORK_ITEMS_PER_PAGE;
-  const visibleWorkItems = sortedWorkItems.slice(
+  const visibleWorkItems = workItems.slice(
     openWorkPageStart,
     openWorkPageStart + OPEN_WORK_ITEMS_PER_PAGE,
   );
@@ -1257,14 +1637,12 @@ export function OperationsQueueViewContent({
 
   const shouldAnimateApprovalsHeader =
     isLoadingQueue || hasRenderedApprovalsLoadingHeaderRef.current;
+  const openWorkOverflow = hasOpenWorkOverflow(queueOverflow);
+  const approvalsOverflow = Boolean(queueOverflow?.approvalRequests);
 
   useEffect(() => {
     setOpenWorkPage(requestedOpenWorkPage);
   }, [requestedOpenWorkPage]);
-
-  useEffect(() => {
-    setOpenWorkSortOrder(requestedOpenWorkSortOrder);
-  }, [requestedOpenWorkSortOrder]);
 
   const handleOpenWorkPageChange = useCallback(
     (page: number) => {
@@ -1276,18 +1654,6 @@ export function OperationsQueueViewContent({
       });
     },
     [onOpenWorkSearchChange, openWorkPageCount],
-  );
-
-  const handleOpenWorkSortOrderChange = useCallback(
-    (sortOrder: OpenWorkSortOrder) => {
-      setOpenWorkSortOrder(sortOrder);
-      setOpenWorkPage(1);
-      onOpenWorkSearchChange?.({
-        page: undefined,
-        sort: sortOrder,
-      });
-    },
-    [onOpenWorkSearchChange],
   );
 
   useEffect(() => {
@@ -1379,6 +1745,13 @@ export function OperationsQueueViewContent({
             ) : (
               <PageWorkspaceGrid className="xl:grid-cols-[minmax(15rem,0.32fr)_minmax(0,1fr)]">
                 <PageWorkspaceRail className="gap-layout-md">
+                  {openWorkOverflow ? (
+                    <CappedQueueNotice title="More open work is available">
+                      Showing the first {workItems.length.toLocaleString()} open
+                      work items. Resolve visible work to continue through the
+                      remaining items.
+                    </CappedQueueNotice>
+                  ) : null}
                   <OpenWorkMixSummary workItems={workItems} />
                 </PageWorkspaceRail>
 
@@ -1387,7 +1760,7 @@ export function OperationsQueueViewContent({
                   className="space-y-0 rounded-lg border border-border bg-surface-raised shadow-surface"
                 >
                   <div className="border-b border-border px-layout-md py-layout-md">
-                    <div className="flex flex-col gap-layout-md sm:flex-row sm:items-end sm:justify-between">
+                    <div className="flex flex-col gap-layout-xs">
                       <div>
                         <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
                           Work queue
@@ -1396,42 +1769,6 @@ export function OperationsQueueViewContent({
                           Open items
                         </h2>
                       </div>
-
-                      <div
-                        aria-label="Sort open work"
-                        className="inline-flex w-fit rounded-md border border-border bg-background p-1"
-                        role="group"
-                      >
-                        {[
-                          ["latest", "Latest"],
-                          ["oldest", "Oldest"],
-                        ].map(([sortOrder, label]) => {
-                          const isSelected = openWorkSortOrder === sortOrder;
-
-                          return (
-                            <Button
-                              aria-pressed={isSelected}
-                              className={cn(
-                                "h-7 px-3 text-xs",
-                                isSelected
-                                  ? "bg-action-workflow-soft text-action-workflow hover:bg-action-workflow-soft/75"
-                                  : "text-muted-foreground hover:text-foreground",
-                              )}
-                              key={sortOrder}
-                              onClick={() =>
-                                handleOpenWorkSortOrderChange(
-                                  sortOrder as OpenWorkSortOrder,
-                                )
-                              }
-                              size="sm"
-                              type="button"
-                              variant="ghost"
-                            >
-                              {label}
-                            </Button>
-                          );
-                        })}
-                      </div>
                     </div>
                   </div>
 
@@ -1439,8 +1776,17 @@ export function OperationsQueueViewContent({
                     <div className="space-y-layout-2xl">
                       {visibleWorkItems.map((item) => (
                         <QueueWorkItemCard
+                          isSyncedSaleInventoryReviewResolutionDisabled={
+                            Boolean(isResolvingSyncedSaleInventoryReviewId)
+                          }
+                          isResolvingSyncedSaleInventoryReview={
+                            isResolvingSyncedSaleInventoryReviewId === item._id
+                          }
                           item={item}
                           key={item._id}
+                          onResolveSyncedSaleInventoryReview={
+                            onResolveSyncedSaleInventoryReview
+                          }
                           orgUrlSlug={orgUrlSlug}
                           storeUrlSlug={storeUrlSlug}
                         />
@@ -1484,6 +1830,14 @@ export function OperationsQueueViewContent({
             ) : (
               <PageWorkspaceGrid className="xl:grid-cols-[minmax(15rem,0.32fr)_minmax(0,1fr)]">
                 <PageWorkspaceRail className="gap-layout-md">
+                  {approvalsOverflow ? (
+                    <CappedQueueNotice title="More approvals are available">
+                      Showing the first{" "}
+                      {approvalRequests.length.toLocaleString()} pending
+                      approvals. Resolve visible approvals to continue through
+                      the remaining requests.
+                    </CappedQueueNotice>
+                  ) : null}
                   <OperationsSummaryMetric
                     helper="Pending approvals"
                     label="Waiting for review"
@@ -1563,6 +1917,10 @@ export function OperationsQueueViewContent({
                         const approvalCopy = getApprovalRequestCopy(
                           request.requestType,
                         );
+                        const retireOnlyApprovalCopy =
+                          getRetireOnlyApprovalRequestCopy(
+                            request.requestType,
+                          );
                         const requestLabel = request.workItemTitle
                           ? formatWorkItemTitle(request.workItemTitle)
                           : formatApprovalRequestType(request.requestType);
@@ -2432,7 +2790,9 @@ export function OperationsQueueViewContent({
                                           approvalRequestId: request._id,
                                           decision: "approved",
                                           ...(request.requestType ===
-                                          "register_sync_review"
+                                            "register_sync_review" ||
+                                          request.requestType ===
+                                            "variance_review"
                                             ? {
                                                 registerSessionId:
                                                   request.registerSessionSummary
@@ -2458,7 +2818,9 @@ export function OperationsQueueViewContent({
                                           approvalRequestId: request._id,
                                           decision: "rejected",
                                           ...(request.requestType ===
-                                          "register_sync_review"
+                                            "register_sync_review" ||
+                                          request.requestType ===
+                                            "variance_review"
                                             ? {
                                                 registerSessionId:
                                                   request.registerSessionSummary
@@ -2472,6 +2834,35 @@ export function OperationsQueueViewContent({
                                       variant="outline"
                                     >
                                       {approvalCopy.rejectLabel}
+                                    </Button>
+                                  </div>
+                                </div>
+                              </div>
+                            ) : null}
+
+                            {retireOnlyApprovalCopy ? (
+                              <div className="border-t border-border/70 bg-surface px-layout-md py-layout-md">
+                                <div className="flex flex-col gap-layout-md lg:flex-row lg:items-center lg:justify-between">
+                                  <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+                                    {retireOnlyApprovalCopy.description}
+                                  </p>
+                                  <div className="flex shrink-0 flex-wrap gap-2">
+                                    <Button
+                                      disabled={Boolean(
+                                        isDecidingApprovalRequestId ||
+                                          (approvalDecisionUnlockRequired &&
+                                            !approvalDecisionUnlocked),
+                                      )}
+                                      onClick={() =>
+                                        onDecideApprovalRequest({
+                                          approvalRequestId: request._id,
+                                          decision: "rejected",
+                                        })
+                                      }
+                                      size="sm"
+                                      variant="outline"
+                                    >
+                                      {retireOnlyApprovalCopy.rejectLabel}
                                     </Button>
                                   </div>
                                 </div>
@@ -2533,6 +2924,10 @@ export function OperationsQueueView({
   const [isSavingCycleCountDraft, setIsSavingCycleCountDraft] = useState(false);
   const [decisioningApprovalRequestId, setDecisioningApprovalRequestId] =
     useState<string | null>(null);
+  const [
+    resolvingSyncedSaleInventoryReviewId,
+    setResolvingSyncedSaleInventoryReviewId,
+  ] = useState<Id<"operationalWorkItem"> | null>(null);
   const [isApprovalUnlockOpen, setIsApprovalUnlockOpen] = useState(false);
   const [approvalDecisionUnlock, setApprovalDecisionUnlock] =
     useState<ApprovalDecisionUnlock | null>(null);
@@ -2543,6 +2938,7 @@ export function OperationsQueueView({
   ) as
     | {
         approvalRequests: QueueApprovalRequest[];
+        overflow?: QueueOverflow;
         workItems: QueueWorkItem[];
       }
     | undefined;
@@ -2672,6 +3068,9 @@ export function OperationsQueueView({
   const decideApprovalRequest = useMutation(
     operationsApi.approvalRequests.decideApprovalRequest,
   );
+  const resolveSyncedSaleInventoryReview = useMutation(
+    operationsApi.openWorkInventoryReviews.resolveSyncedSaleInventoryReview,
+  );
   const resolveRegisterSessionSyncReview = useMutation(
     api.cashControls.deposits.resolveRegisterSessionSyncReview,
   );
@@ -2695,6 +3094,9 @@ export function OperationsQueueView({
   );
   const submitCycleCountDraft = useMutation(
     stockOpsApi.cycleCountDrafts.submitActiveCycleCountDrafts,
+  );
+  const reviewRegisterSessionCloseout = useMutation(
+    api.cashControls.closeouts.reviewRegisterSessionCloseout,
   );
   const cycleCountDraft = useMemo<CycleCountDraftState | null>(() => {
     if (!activeCycleCountDraft?.draft) return null;
@@ -2883,21 +3285,49 @@ export function OperationsQueueView({
       return;
     }
 
+    if (
+      (args.requestType === "register_sync_review" ||
+        args.requestType === "variance_review") &&
+      !args.registerSessionId
+    ) {
+      presentCommandToast({
+        kind: "user_error",
+        error: {
+          code: "not_found",
+          message:
+            args.requestType === "variance_review"
+              ? "Register session was not available for this closeout review."
+              : "Register session was not available for this synced activity review.",
+        },
+      });
+      return;
+    }
+
     setDecisioningApprovalRequestId(args.approvalRequestId);
 
     try {
       const request = queue?.approvalRequests.find(
         (approvalRequest) => approvalRequest._id === args.approvalRequestId,
       );
-      const approvalProofResult = await runCommand(
-        () =>
-          authenticateStaffCredentialForApproval({
-            actionKey: APPROVAL_DECISION_ACTION_KEY,
-            pinHash: activeUnlock.pinHash,
-            reason: "Resolve pending approval request.",
-            requiredRole: "manager",
-            storeId: activeStore._id,
-            subject: {
+      const approvalActionKey =
+        args.requestType === "variance_review"
+          ? REGISTER_VARIANCE_REVIEW_ACTION_KEY
+          : args.requestType === "register_sync_review"
+            ? REGISTER_SESSION_SYNC_REVIEW_APPROVAL_ACTION_KEY
+            : APPROVAL_DECISION_ACTION_KEY;
+      const approvalSubject =
+        args.registerSessionId &&
+        (args.requestType === "register_sync_review" ||
+          args.requestType === "variance_review")
+          ? {
+              id: String(args.registerSessionId),
+              label:
+                request?.registerSessionSummary?.registerNumber ??
+                request?.workItemTitle ??
+                undefined,
+              type: "register_session",
+            }
+          : {
               id: String(args.approvalRequestId),
               label:
                 request?.workItemTitle ??
@@ -2905,7 +3335,16 @@ export function OperationsQueueView({
                   ? formatApprovalRequestType(request.requestType)
                   : undefined),
               type: "approval_request",
-            },
+            };
+      const approvalProofResult = await runCommand(
+        () =>
+          authenticateStaffCredentialForApproval({
+            actionKey: approvalActionKey,
+            pinHash: activeUnlock.pinHash,
+            reason: "Resolve pending approval request.",
+            requiredRole: "manager",
+            storeId: activeStore._id,
+            subject: approvalSubject,
             username: activeUnlock.username,
           }) as Promise<
             CommandResult<{
@@ -2926,27 +3365,25 @@ export function OperationsQueueView({
       let result: NormalizedApprovalCommandResult<unknown>;
 
       if (args.requestType === "register_sync_review") {
-        if (!args.registerSessionId) {
-          result = {
-            kind: "user_error",
-            error: {
-              code: "not_found",
-              message:
-                "Register session was not available for this synced activity review.",
-            },
-          };
-        } else {
-          const registerSessionId = args.registerSessionId;
-          result = await runCommand(() =>
-            resolveRegisterSessionSyncReview({
-              actorStaffProfileId:
-                approvalProofResult.data.approvedByStaffProfileId,
-              decision: args.decision,
-              registerSessionId,
-              storeId: activeStore._id,
-            }),
-          );
-        }
+        const registerSessionId = args.registerSessionId as Id<"registerSession">;
+        result = await runCommand(() =>
+          resolveRegisterSessionSyncReview({
+            approvalProofId: approvalProofResult.data.approvalProofId,
+            decision: args.decision,
+            registerSessionId,
+            storeId: activeStore._id,
+          }),
+        );
+      } else if (args.requestType === "variance_review") {
+        const registerSessionId = args.registerSessionId as Id<"registerSession">;
+        result = await runCommand(() =>
+          reviewRegisterSessionCloseout({
+            approvalProofId: approvalProofResult.data.approvalProofId,
+            decision: args.decision,
+            registerSessionId,
+            storeId: activeStore._id,
+          }),
+        );
       } else {
         result = await runCommand(() =>
           decideApprovalRequest({
@@ -2965,14 +3402,82 @@ export function OperationsQueueView({
       const approvalCopy = request
         ? getApprovalRequestCopy(request.requestType)
         : null;
+      const retireOnlyApprovalCopy = request
+        ? getRetireOnlyApprovalRequestCopy(request.requestType)
+        : null;
 
       toast.success(
         args.decision === "approved"
           ? (approvalCopy?.approvedToast ?? "Approval request approved")
-          : (approvalCopy?.rejectedToast ?? "Approval request rejected"),
+          : (approvalCopy?.rejectedToast ??
+            retireOnlyApprovalCopy?.rejectedToast ??
+            "Approval request rejected"),
       );
     } finally {
       setDecisioningApprovalRequestId(null);
+    }
+  };
+
+  const handleResolveSyncedSaleInventoryReview = async (item: QueueWorkItem) => {
+    if (resolvingSyncedSaleInventoryReviewId) return;
+
+    if (!activeStore?._id) {
+      presentCommandToast({
+        kind: "user_error",
+        error: {
+          code: "authentication_failed",
+          message: "Select a store before resolving inventory review work.",
+        },
+      });
+      return;
+    }
+
+    const localRegisterSessionId = getQueueWorkItemStringDetail(
+      item,
+      "localRegisterSessionId",
+    );
+    const localTransactionId = getQueueWorkItemStringDetail(
+      item,
+      "localTransactionId",
+    );
+    const receiptNumber = getQueueWorkItemStringDetail(item, "receiptNumber");
+    const registerSessionId = getQueueWorkItemStringDetail(
+      item,
+      "registerSessionId",
+    ) as Id<"registerSession"> | undefined;
+    const sourceId = getQueueWorkItemStringDetail(item, "sourceId") as
+      | Id<"posTransaction">
+      | undefined;
+    const terminalId = getQueueWorkItemStringDetail(item, "terminalId") as
+      | Id<"posTerminal">
+      | undefined;
+
+    setResolvingSyncedSaleInventoryReviewId(item._id);
+
+    try {
+      const result = await runCommand(() =>
+        resolveSyncedSaleInventoryReview({
+          localRegisterSessionId,
+          localTransactionId,
+          outcome: "completed",
+          reason: "Inventory review handled from Open Work.",
+          receiptNumber,
+          registerSessionId,
+          sourceId,
+          storeId: activeStore._id,
+          terminalId,
+          workItemId: item._id,
+        }),
+      );
+
+      if (result.kind !== "ok") {
+        presentCommandToast(result);
+        return;
+      }
+
+      toast.success("Inventory review marked complete");
+    } finally {
+      setResolvingSyncedSaleInventoryReviewId(null);
     }
   };
 
@@ -3047,6 +3552,9 @@ export function OperationsQueueView({
         isLoadingPermissions={false}
         isLoadingQueue={queue === undefined || isInventorySnapshotLoadingFirstPage}
         isLoadingStock={isInventorySnapshotLoadingFirstPage}
+        isResolvingSyncedSaleInventoryReviewId={
+          resolvingSyncedSaleInventoryReviewId
+        }
         onDiscardCycleCountDraft={handleDiscardCycleCountDraft}
         onDecideApprovalRequest={handleDecideApprovalRequest}
         onLoadMoreInventoryItems={() => inventorySnapshotPage.loadMore(100)}
@@ -3056,12 +3564,16 @@ export function OperationsQueueView({
           handleRefreshCycleCountDraftLineBaseline
         }
         onRequestApprovalDecisionUnlock={() => setIsApprovalUnlockOpen(true)}
+        onResolveSyncedSaleInventoryReview={
+          handleResolveSyncedSaleInventoryReview
+        }
         onSaveCycleCountDraftLine={handleSaveCycleCountDraftLine}
         isSubmittingStockBatch={isSubmittingStockBatch}
         onSubmitStockBatch={handleSubmitStockBatch}
         onSubmitCycleCountDraft={handleSubmitCycleCountDraft}
         onStockAdjustmentSearchChange={onStockAdjustmentSearchChange}
         orgUrlSlug={routeParams?.orgUrlSlug}
+        queueOverflow={queue?.overflow ?? null}
         showBackButton={typeof search.o === "string" && search.o.length > 0}
         storeId={activeStore._id}
         storeUrlSlug={routeParams?.storeUrlSlug}

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/open-work.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/open-work.tsx
@@ -7,7 +7,6 @@ import type { OpenWorkSearchPatch } from "~/src/components/operations/Operations
 const openWorkSearchSchema = z.object({
   o: z.string().optional(),
   page: z.coerce.number().int().positive().optional(),
-  sort: z.enum(["latest", "oldest"]).optional(),
 });
 
 export const Route = createFileRoute(
@@ -29,10 +28,6 @@ function OpenWorkRoute() {
 
         if (next.page === undefined) {
           delete next.page;
-        }
-
-        if (next.sort === undefined) {
-          delete next.sort;
         }
 
         return next;


### PR DESCRIPTION
## Summary
- add explicit Open Work resolution paths for approval requests, synced-sale inventory reviews, Daily Close carry-forward, register variance/sync reviews, service intake deposits, appointment conversions/cancellations, purchase orders, receiving, and catalog snapshot work
- fail closed on unsupported approval approvals while allowing reject/cancel retirement for terminal cleanup
- harden server-owned actor/proof boundaries for service intake, appointment actions, Daily Close carry-forward, register sync review, and synced sale inventory review metadata
- keep the existing Open Work workspace direction while adding row-specific operational actions and capped queue semantics

## Tracking
- V26-928
- V26-929
- V26-930
- V26-931
- V26-932
- V26-933
- V26-934

## Validation
- `bun run pr:athena`
- focused Vitest suite for cash controls, approval requests, daily close, operational work items, inventory reviews, service intake, appointments, POS sync projection, and Open Work/Daily Close UI
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bun run --filter '@athena/webapp' lint:frontend:changed`
- `bun run pre-commit:generated-artifacts`

## Notes
- `pr:athena` delivery-run passed after rebasing onto current origin/main. The scorecard is degraded only because the runtime trend artifact is absent; delivery-run, inferential review, and graphify pairing passed.
