### PR TITLE
Fix POS runtime status check-in storm

### DIFF
--- a/docs/solutions/performance/athena-pos-runtime-status-check-in-storm-2026-07-02.md
+++ b/docs/solutions/performance/athena-pos-runtime-status-check-in-storm-2026-07-02.md
@@ -1,0 +1,120 @@
+---
+title: Athena POS Runtime Status Check-In Storm
+date: 2026-07-02
+category: performance
+module: athena-webapp
+problem_type: performance_issue
+component: service_object
+symptoms:
+  - "Convex production logs showed repeated POS runtime check-ins from the local runtime"
+  - "reportTerminalRuntimeStatus calls clustered around the same terminal and produced optimistic concurrency retries"
+  - "Remote Assist and terminal recovery queries were repeatedly invalidated by redundant runtime-status writes"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - convex
+  - pos
+  - runtime-status
+  - remote-assist
+  - terminal-health
+---
+
+# Athena POS Runtime Status Check-In Storm
+
+## Problem
+
+The POS local runtime can have more than one browser-side publisher active for a
+terminal. When those publishers report the same terminal state independently,
+they can repeatedly call `reportTerminalRuntimeStatus`, patch the latest
+`posTerminalRuntimeStatus` row, and fan out Remote Assist and recovery-query
+invalidations.
+
+This is production-sensitive because the runtime status row is a shared latest
+state boundary. Multiple near-identical mutations against that row create both
+write load and optimistic concurrency retries.
+
+## Symptoms
+
+- `convex logs` showed repeated `pos/public/terminals:reportTerminalRuntimeStatus`
+  calls from POS terminals.
+- The same log window also showed repeated
+  `pos/public/terminals:getRuntimeRemoteAssistSession`,
+  `pos/public/terminals:listTerminalRecoveryCommands`,
+  `remoteAssist/public:getClientByRuntime`, and
+  `remoteAssist/public:getCurrentSessionByClient` reads.
+- Earlier samples had `occInfo` / `willRetry` on runtime-status writes.
+- After the first throttle, calls still clustered because alternating publishers
+  sometimes omitted staff identity or reported sync-only churn.
+
+## What Didn't Work
+
+- A hook-local in-flight guard is not enough. It only serializes a single hook
+  instance, so a second runtime host in the same browser can still publish for
+  the same terminal.
+- Server idempotency that compares every runtime field is too strict. Sync
+  counters, observed timestamps, and omitted staff identity can make the same
+  effective state look different.
+- Sampling logs before the terminals reload to the deployed build can make the
+  fix look ineffective because old-client traffic dominates the window.
+
+## Solution
+
+Use both client and server guardrails.
+
+On the client, keep a module-level per-terminal publish state in
+`usePosLocalSyncRuntime.ts`. The state coalesces duplicate publishers for the
+same `storeId` and `terminalId`, tracks one in-flight publish, and queues only
+the latest signature for replay.
+
+Keep the runtime publish material signature focused on operationally meaningful
+state. `runtimeStatusPublisher.ts` excludes volatile fields such as
+`reportedAt`, snapshot ages, observation timestamps, and sync-only status churn
+from the material comparison so routine local-sync bookkeeping waits for the
+normal heartbeat.
+
+On the server, make
+`convex/pos/infrastructure/repositories/terminalRepository.ts` return a write
+outcome from the latest-status upsert. Fast duplicate reports within the
+heartbeat window return `didWrite: false`; the public mutation strips that
+internal flag from the response and skips Remote Assist / recovery side effects
+for redundant reports.
+
+Also preserve same-status staff identity during server merges. If one runtime
+publisher reports `staffProfileId` and another same-status publisher omits it,
+the repository keeps the richer identity instead of flipping the latest row
+back and forth.
+
+## Why This Works
+
+The latest runtime status row should change when terminal posture changes, not
+when equivalent publishers report the same posture with different volatile
+metadata. Coalescing at the browser boundary reduces needless calls from the
+new build, and server-side idempotency protects production from older tabs,
+multiple publishers, or duplicate devices.
+
+Skipping side effects when `didWrite` is false avoids invalidating Remote Assist
+and recovery subscriptions for reports that did not change terminal state.
+
+## Prevention
+
+- Treat `posTerminalRuntimeStatus` as a latest-state aggregate. Do not patch it
+  for every diagnostic heartbeat if material state did not change.
+- Keep volatile fields out of publish signatures and server duplicate
+  comparison: timestamps, snapshot ages, sync trigger labels, and sync-only
+  status churn.
+- Preserve richer known identity when a duplicate same-status report omits
+  optional staff fields.
+- After production deploys, first verify active terminal `appVersion` /
+  `buildSha`, then sample `convex logs --deployment colorless-cardinal-870`.
+- Regression coverage should include duplicate publishers, fast duplicate
+  server writes, omitted app-update evidence, omitted staff identity, and the
+  heartbeat-boundary duplicate window.
+
+## Related
+
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeStatusPublisher.ts`
+- `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts`
+- `packages/athena-webapp/convex/pos/public/terminals.ts`
+- `docs/solutions/performance/athena-convex-read-amplification-2026-06-29.md`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8476 nodes · 10202 edges · 2085 communities detected
+- 8482 nodes · 10216 edges · 2085 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2179,36 +2179,36 @@ Cohesion: 0.06
 Nodes (24): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+16 more)
 
 ### Community 14 - "Community 14"
+Cohesion: 0.08
+Nodes (27): buildDisplaySafeConflictSummary(), buildTerminalSyncReviewSummary(), classifyTerminalSyncReviewConflict(), dedupeConflictsById(), emptyTerminalSyncReviewSummary(), getConflictBusinessKey(), getCurrentConflictKey(), getLatestRuntimeStatusForTerminal() (+19 more)
+
+### Community 15 - "Community 15"
 Cohesion: 0.09
 Nodes (28): buildRosterRecoveryPreview(), buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalOperationalStateForSummary(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), createTerminalCloudRepairQueryRepository(), formatRuntimeAppUpdateAssetSummary() (+20 more)
 
-### Community 15 - "Community 15"
+### Community 16 - "Community 16"
 Cohesion: 0.07
 Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
-### Community 16 - "Community 16"
+### Community 17 - "Community 17"
 Cohesion: 0.07
 Nodes (19): Boolean(), buildMissingDraftResult(), formatQueueWorkItemValue(), formatWorkItemTitle(), getQueueWorkItemInventoryReviewLineCount(), getQueueWorkItemNumberDetail(), getQueueWorkItemStockAdjustmentSkuId(), getQueueWorkItemStringDetail() (+11 more)
 
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
 Cohesion: 0.08
 Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.14
 Nodes (35): asRecord(), calculateLocalSaleExpectedCashDelta(), canUploadedRegisterOpenReplaceBlockedDrawer(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale() (+27 more)
 
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
 Cohesion: 0.11
 Nodes (33): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+25 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.13
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
-
-### Community 21 - "Community 21"
-Cohesion: 0.08
-Nodes (21): buildDisplaySafeConflictSummary(), buildTerminalSyncReviewSummary(), classifyTerminalSyncReviewConflict(), dedupeConflictsById(), emptyTerminalSyncReviewSummary(), getConflictBusinessKey(), getCurrentConflictKey(), getLatestRuntimeStatusForTerminal() (+13 more)
 
 ### Community 22 - "Community 22"
 Cohesion: 0.1
@@ -2707,56 +2707,56 @@ Cohesion: 0.29
 Nodes (8): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), resolveStoreOperatingRangeForDateWithCtx(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
 
 ### Community 146 - "Community 146"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 147 - "Community 147"
 Cohesion: 0.35
 Nodes (10): buildCtx(), buildMapping(), buildRegisterSession(), buildStaffProfile(), buildStore(), buildTerminal(), buildTransaction(), buildWorkItem() (+2 more)
 
-### Community 148 - "Community 148"
+### Community 147 - "Community 147"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 149 - "Community 149"
+### Community 148 - "Community 148"
 Cohesion: 0.2
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 150 - "Community 150"
+### Community 149 - "Community 149"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 151 - "Community 151"
+### Community 150 - "Community 150"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 152 - "Community 152"
+### Community 151 - "Community 151"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 153 - "Community 153"
+### Community 152 - "Community 152"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 154 - "Community 154"
+### Community 153 - "Community 153"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 155 - "Community 155"
+### Community 154 - "Community 154"
 Cohesion: 0.25
 Nodes (5): getRuntimeStatusPublishMaterialSignature(), getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusPublishMaterial(), normalizeRuntimeStatusSignature()
 
-### Community 156 - "Community 156"
+### Community 155 - "Community 155"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 157 - "Community 157"
+### Community 156 - "Community 156"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 158 - "Community 158"
+### Community 157 - "Community 157"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
+
+### Community 158 - "Community 158"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 159 - "Community 159"
 Cohesion: 0.18
@@ -2840,27 +2840,27 @@ Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger
 
 ### Community 179 - "Community 179"
 Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 180 - "Community 180"
 Cohesion: 0.39
-Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 181 - "Community 181"
+Cohesion: 0.39
+Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
+
+### Community 182 - "Community 182"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.31
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.22
 Nodes (0):
-
-### Community 184 - "Community 184"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 185 - "Community 185"
 Cohesion: 0.39

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8482 nodes · 10216 edges · 2085 communities detected
+- 8481 nodes · 10213 edges · 2085 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2179,12 +2179,12 @@ Cohesion: 0.06
 Nodes (24): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+16 more)
 
 ### Community 14 - "Community 14"
-Cohesion: 0.08
-Nodes (27): buildDisplaySafeConflictSummary(), buildTerminalSyncReviewSummary(), classifyTerminalSyncReviewConflict(), dedupeConflictsById(), emptyTerminalSyncReviewSummary(), getConflictBusinessKey(), getCurrentConflictKey(), getLatestRuntimeStatusForTerminal() (+19 more)
-
-### Community 15 - "Community 15"
 Cohesion: 0.09
 Nodes (28): buildRosterRecoveryPreview(), buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalOperationalStateForSummary(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), createTerminalCloudRepairQueryRepository(), formatRuntimeAppUpdateAssetSummary() (+20 more)
+
+### Community 15 - "Community 15"
+Cohesion: 0.08
+Nodes (26): buildDisplaySafeConflictSummary(), buildTerminalSyncReviewSummary(), classifyTerminalSyncReviewConflict(), dedupeConflictsById(), emptyTerminalSyncReviewSummary(), getConflictBusinessKey(), getCurrentConflictKey(), getLatestRuntimeStatusForTerminal() (+18 more)
 
 ### Community 16 - "Community 16"
 Cohesion: 0.07
@@ -2707,56 +2707,56 @@ Cohesion: 0.29
 Nodes (8): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), resolveStoreOperatingRangeForDateWithCtx(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
 
 ### Community 146 - "Community 146"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 147 - "Community 147"
 Cohesion: 0.35
 Nodes (10): buildCtx(), buildMapping(), buildRegisterSession(), buildStaffProfile(), buildStore(), buildTerminal(), buildTransaction(), buildWorkItem() (+2 more)
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.2
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.25
 Nodes (5): getRuntimeStatusPublishMaterialSignature(), getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusPublishMaterial(), normalizeRuntimeStatusSignature()
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
-
-### Community 158 - "Community 158"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 159 - "Community 159"
 Cohesion: 0.18
@@ -2840,27 +2840,27 @@ Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger
 
 ### Community 179 - "Community 179"
 Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 180 - "Community 180"
 Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
-
-### Community 181 - "Community 181"
-Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 182 - "Community 182"
+### Community 181 - "Community 181"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 183 - "Community 183"
+### Community 182 - "Community 182"
 Cohesion: 0.31
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 184 - "Community 184"
+### Community 183 - "Community 183"
 Cohesion: 0.22
 Nodes (0):
+
+### Community 184 - "Community 184"
+Cohesion: 0.39
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 185 - "Community 185"
 Cohesion: 0.39
@@ -2935,12 +2935,12 @@ Cohesion: 0.22
 Nodes (0):
 
 ### Community 203 - "Community 203"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 204 - "Community 204"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+
+### Community 204 - "Community 204"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 205 - "Community 205"
 Cohesion: 0.22
@@ -3391,8 +3391,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 317 - "Community 317"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 318 - "Community 318"
 Cohesion: 0.33
@@ -3407,76 +3407,76 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 321 - "Community 321"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 322 - "Community 322"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 323 - "Community 323"
+### Community 322 - "Community 322"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
+
+### Community 323 - "Community 323"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 324 - "Community 324"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 325 - "Community 325"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 326 - "Community 326"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 327 - "Community 327"
+### Community 326 - "Community 326"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 328 - "Community 328"
+### Community 327 - "Community 327"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 329 - "Community 329"
+### Community 328 - "Community 328"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 329 - "Community 329"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 330 - "Community 330"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 331 - "Community 331"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 332 - "Community 332"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 333 - "Community 333"
+### Community 332 - "Community 332"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 334 - "Community 334"
+### Community 333 - "Community 333"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 334 - "Community 334"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 335 - "Community 335"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 336 - "Community 336"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 337 - "Community 337"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 338 - "Community 338"
+### Community 337 - "Community 337"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 338 - "Community 338"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 339 - "Community 339"
 Cohesion: 0.53

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8481 nodes · 10213 edges · 2085 communities detected
+- 8483 nodes · 10217 edges · 2085 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2179,12 +2179,12 @@ Cohesion: 0.06
 Nodes (24): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+16 more)
 
 ### Community 14 - "Community 14"
-Cohesion: 0.09
-Nodes (28): buildRosterRecoveryPreview(), buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalOperationalStateForSummary(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), createTerminalCloudRepairQueryRepository(), formatRuntimeAppUpdateAssetSummary() (+20 more)
+Cohesion: 0.07
+Nodes (28): buildDisplaySafeConflictSummary(), buildTerminalSyncReviewSummary(), classifyTerminalSyncReviewConflict(), dedupeConflictsById(), emptyTerminalSyncReviewSummary(), getConflictBusinessKey(), getCurrentConflictKey(), getLatestRuntimeStatusForTerminal() (+20 more)
 
 ### Community 15 - "Community 15"
-Cohesion: 0.08
-Nodes (26): buildDisplaySafeConflictSummary(), buildTerminalSyncReviewSummary(), classifyTerminalSyncReviewConflict(), dedupeConflictsById(), emptyTerminalSyncReviewSummary(), getConflictBusinessKey(), getCurrentConflictKey(), getLatestRuntimeStatusForTerminal() (+18 more)
+Cohesion: 0.09
+Nodes (28): buildRosterRecoveryPreview(), buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalOperationalStateForSummary(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), createTerminalCloudRepairQueryRepository(), formatRuntimeAppUpdateAssetSummary() (+20 more)
 
 ### Community 16 - "Community 16"
 Cohesion: 0.07
@@ -2935,12 +2935,12 @@ Cohesion: 0.22
 Nodes (0):
 
 ### Community 203 - "Community 203"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
-
-### Community 204 - "Community 204"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 204 - "Community 204"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 205 - "Community 205"
 Cohesion: 0.22
@@ -3391,8 +3391,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 317 - "Community 317"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 318 - "Community 318"
 Cohesion: 0.33
@@ -3407,76 +3407,76 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 321 - "Community 321"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 322 - "Community 322"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 322 - "Community 322"
+### Community 323 - "Community 323"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
-
-### Community 323 - "Community 323"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 324 - "Community 324"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 325 - "Community 325"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 326 - "Community 326"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 327 - "Community 327"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 328 - "Community 328"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 326 - "Community 326"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 327 - "Community 327"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 328 - "Community 328"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
 ### Community 329 - "Community 329"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 330 - "Community 330"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 331 - "Community 331"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 332 - "Community 332"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 333 - "Community 333"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 334 - "Community 334"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 335 - "Community 335"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 336 - "Community 336"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 337 - "Community 337"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 337 - "Community 337"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 338 - "Community 338"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 339 - "Community 339"
 Cohesion: 0.53

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8474 nodes · 10200 edges · 2085 communities detected
+- 8476 nodes · 10202 edges · 2085 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2935,12 +2935,12 @@ Cohesion: 0.22
 Nodes (0):
 
 ### Community 203 - "Community 203"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
-
-### Community 204 - "Community 204"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 204 - "Community 204"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 205 - "Community 205"
 Cohesion: 0.22
@@ -3391,8 +3391,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 317 - "Community 317"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 318 - "Community 318"
 Cohesion: 0.33
@@ -3407,76 +3407,76 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 321 - "Community 321"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 322 - "Community 322"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 322 - "Community 322"
+### Community 323 - "Community 323"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
-
-### Community 323 - "Community 323"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 324 - "Community 324"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 325 - "Community 325"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 326 - "Community 326"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 327 - "Community 327"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 328 - "Community 328"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 326 - "Community 326"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 327 - "Community 327"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 328 - "Community 328"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
 ### Community 329 - "Community 329"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 330 - "Community 330"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 331 - "Community 331"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 332 - "Community 332"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 333 - "Community 333"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 334 - "Community 334"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 335 - "Community 335"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 336 - "Community 336"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 337 - "Community 337"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 337 - "Community 337"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 338 - "Community 338"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 339 - "Community 339"
 Cohesion: 0.53

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2158
-- Graph nodes: 8474
-- Graph edges: 10200
+- Graph nodes: 8476
+- Graph edges: 10202
 - Communities: 2085
 
 ## Graph Hotspots

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2158
-- Graph nodes: 8476
-- Graph edges: 10202
+- Graph nodes: 8482
+- Graph edges: 10216
 - Communities: 2085
 
 ## Graph Hotspots

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2158
-- Graph nodes: 8482
-- Graph edges: 10216
+- Graph nodes: 8481
+- Graph edges: 10213
 - Communities: 2085
 
 ## Graph Hotspots

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2158
-- Graph nodes: 8481
-- Graph edges: 10213
+- Graph nodes: 8483
+- Graph edges: 10217
 - Communities: 2085
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/pos/application/commands/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/terminals.ts
@@ -25,7 +25,7 @@ import {
   mapTerminalRecord,
   patchTerminalRecord,
   registerTerminalRecord,
-  upsertLatestRuntimeStatus,
+  upsertLatestRuntimeStatusWithOutcome,
 } from "../../infrastructure/repositories/terminalRepository";
 import { deleteTerminalRecord } from "../../infrastructure/repositories/terminalRepository";
 
@@ -453,6 +453,7 @@ export async function submitTerminalRuntimeStatus(
 ): Promise<
   CommandResult<{
     activeRegisterSessionDirective?: ActiveRegisterSessionDirective;
+    acceptedForSideEffects: boolean;
     drawerAuthorityDirective?: DrawerAuthorityDirective;
     terminalId: Id<"posTerminal">;
     reportedAt: number;
@@ -480,7 +481,7 @@ export async function submitTerminalRuntimeStatus(
     args.status.activeRegisterSession,
   );
   const drawerAuthority = cleanDrawerAuthority(args.status.drawerAuthority);
-  await upsertLatestRuntimeStatus(ctx, {
+  const runtimeStatusWrite = await upsertLatestRuntimeStatusWithOutcome(ctx, {
     storeId: args.storeId,
     terminalId: args.terminalId,
     reportedAt,
@@ -575,6 +576,7 @@ export async function submitTerminalRuntimeStatus(
       activeRegisterSessionDirective,
       drawerAuthorityDirective,
     }),
+    acceptedForSideEffects: runtimeStatusWrite.didWrite,
     terminalId: args.terminalId,
     reportedAt,
     receivedAt,

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -30,7 +30,7 @@ import {
   patchTerminalRecord,
   registerTerminalRecord,
   resolveTerminalRegisterSessionActionTarget,
-  upsertLatestRuntimeStatus,
+  upsertLatestRuntimeStatusWithOutcome,
 } from "../infrastructure/repositories/terminalRepository";
 import {
   createTerminalRecoveryCommandReadRepository,
@@ -87,7 +87,7 @@ vi.mock("../infrastructure/repositories/terminalRepository", () => ({
   patchTerminalRecord: vi.fn(),
   registerTerminalRecord: vi.fn(),
   resolveTerminalRegisterSessionActionTarget: vi.fn(),
-  upsertLatestRuntimeStatus: vi.fn(),
+  upsertLatestRuntimeStatusWithOutcome: vi.fn(),
   deleteTerminalRecord: vi.fn(),
 }));
 
@@ -400,9 +400,10 @@ describe("submitTerminalRuntimeStatus", () => {
 
   it("upserts one redacted latest runtime status record per terminal", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
-    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
-      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
-    );
+    vi.mocked(upsertLatestRuntimeStatusWithOutcome).mockResolvedValue({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    });
 
     const result = await submitTerminalRuntimeStatus(
       { db: null as never } as never,
@@ -443,9 +444,10 @@ describe("submitTerminalRuntimeStatus", () => {
         terminalId: "terminal-1",
         reportedAt: 100,
         receivedAt: 200,
+        acceptedForSideEffects: true,
       },
     });
-    expect(vi.mocked(upsertLatestRuntimeStatus)).toHaveBeenCalledWith(
+    expect(vi.mocked(upsertLatestRuntimeStatusWithOutcome)).toHaveBeenCalledWith(
       expect.anything(),
       expect.not.objectContaining({
         staffProofToken: expect.anything(),
@@ -455,7 +457,7 @@ describe("submitTerminalRuntimeStatus", () => {
         customerInfo: expect.anything(),
       }),
     );
-    expect(vi.mocked(upsertLatestRuntimeStatus)).toHaveBeenCalledWith(
+    expect(vi.mocked(upsertLatestRuntimeStatusWithOutcome)).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         storeId: "store-1",
@@ -488,9 +490,10 @@ describe("submitTerminalRuntimeStatus", () => {
 
   it("preserves closeout-rejected active register status in runtime status", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
-    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
-      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
-    );
+    vi.mocked(upsertLatestRuntimeStatusWithOutcome).mockResolvedValue({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    });
 
     await submitTerminalRuntimeStatus(
       { db: null as never } as never,
@@ -509,7 +512,7 @@ describe("submitTerminalRuntimeStatus", () => {
       },
     );
 
-    expect(vi.mocked(upsertLatestRuntimeStatus)).toHaveBeenCalledWith(
+    expect(vi.mocked(upsertLatestRuntimeStatusWithOutcome)).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         activeRegisterSession: expect.objectContaining({
@@ -522,9 +525,10 @@ describe("submitTerminalRuntimeStatus", () => {
 
   it("persists support-safe app-session recovery status in runtime status", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
-    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
-      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
-    );
+    vi.mocked(upsertLatestRuntimeStatusWithOutcome).mockResolvedValue({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    });
 
     await submitTerminalRuntimeStatus(
       { db: null as never } as never,
@@ -540,7 +544,7 @@ describe("submitTerminalRuntimeStatus", () => {
       },
     );
 
-    expect(vi.mocked(upsertLatestRuntimeStatus)).toHaveBeenCalledWith(
+    expect(vi.mocked(upsertLatestRuntimeStatusWithOutcome)).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         appSessionRecovery: {
@@ -552,9 +556,10 @@ describe("submitTerminalRuntimeStatus", () => {
 
   it("returns a cloud-closed drawer authority directive when the mapped cloud register is no longer usable", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
-    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
-      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
-    );
+    vi.mocked(upsertLatestRuntimeStatusWithOutcome).mockResolvedValue({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    });
     const db = {
       normalizeId: vi.fn(() => "cloud-register-1"),
       get: vi.fn(async () => ({
@@ -607,9 +612,10 @@ describe("submitTerminalRuntimeStatus", () => {
 
   it("returns an active register session directive when cloud has a usable drawer but runtime does not", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
-    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
-      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
-    );
+    vi.mocked(upsertLatestRuntimeStatusWithOutcome).mockResolvedValue({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    });
     const registerSessions = [
       {
         _creationTime: 300,
@@ -677,9 +683,10 @@ describe("submitTerminalRuntimeStatus", () => {
 
   it("returns an active register session directive when runtime is stuck on a closed cloud drawer", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
-    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
-      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
-    );
+    vi.mocked(upsertLatestRuntimeStatusWithOutcome).mockResolvedValue({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    });
     const registerSessions = [
       {
         _creationTime: 300,
@@ -767,9 +774,10 @@ describe("submitTerminalRuntimeStatus", () => {
 
   it("returns a cloud-closed drawer authority directive for closing local runtime evidence", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
-    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
-      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
-    );
+    vi.mocked(upsertLatestRuntimeStatusWithOutcome).mockResolvedValue({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    });
     const db = {
       normalizeId: vi.fn(() => "cloud-register-1"),
       get: vi.fn(async () => ({
@@ -818,9 +826,10 @@ describe("submitTerminalRuntimeStatus", () => {
 
   it("ignores malformed cloud register ids in runtime drawer authority evidence", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
-    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
-      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
-    );
+    vi.mocked(upsertLatestRuntimeStatusWithOutcome).mockResolvedValue({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    });
     const db = {
       normalizeId: vi.fn(() => null),
       get: vi.fn(),
@@ -860,9 +869,10 @@ describe("submitTerminalRuntimeStatus", () => {
 
   it("persists sanitized app-update runtime evidence", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
-    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
-      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
-    );
+    vi.mocked(upsertLatestRuntimeStatusWithOutcome).mockResolvedValue({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    });
 
     await submitTerminalRuntimeStatus(
       { db: null as never } as never,
@@ -893,7 +903,7 @@ describe("submitTerminalRuntimeStatus", () => {
       },
     );
 
-    expect(vi.mocked(upsertLatestRuntimeStatus)).toHaveBeenCalledWith(
+    expect(vi.mocked(upsertLatestRuntimeStatusWithOutcome)).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         appUpdate: {
@@ -919,9 +929,10 @@ describe("submitTerminalRuntimeStatus", () => {
 
   it("clears stale app-update evidence when older clients omit it", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
-    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
-      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
-    );
+    vi.mocked(upsertLatestRuntimeStatusWithOutcome).mockResolvedValue({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    });
 
     await submitTerminalRuntimeStatus(
       { db: null as never } as never,
@@ -932,7 +943,7 @@ describe("submitTerminalRuntimeStatus", () => {
       },
     );
 
-    expect(vi.mocked(upsertLatestRuntimeStatus)).toHaveBeenCalledWith(
+    expect(vi.mocked(upsertLatestRuntimeStatusWithOutcome)).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         appUpdate: undefined,
@@ -942,9 +953,10 @@ describe("submitTerminalRuntimeStatus", () => {
 
   it("clears stale app-session recovery status when runtime check-ins omit it", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
-    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
-      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
-    );
+    vi.mocked(upsertLatestRuntimeStatusWithOutcome).mockResolvedValue({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    });
 
     await submitTerminalRuntimeStatus(
       { db: null as never } as never,
@@ -955,7 +967,7 @@ describe("submitTerminalRuntimeStatus", () => {
       },
     );
 
-    expect(vi.mocked(upsertLatestRuntimeStatus)).toHaveBeenCalledWith(
+    expect(vi.mocked(upsertLatestRuntimeStatusWithOutcome)).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         appSessionRecovery: undefined,
@@ -965,9 +977,10 @@ describe("submitTerminalRuntimeStatus", () => {
 
   it("clears stale terminal diagnostics when runtime check-ins omit them", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
-    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
-      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
-    );
+    vi.mocked(upsertLatestRuntimeStatusWithOutcome).mockResolvedValue({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    });
 
     await submitTerminalRuntimeStatus(
       { db: null as never } as never,
@@ -978,7 +991,7 @@ describe("submitTerminalRuntimeStatus", () => {
       },
     );
 
-    expect(vi.mocked(upsertLatestRuntimeStatus)).toHaveBeenCalledWith(
+    expect(vi.mocked(upsertLatestRuntimeStatusWithOutcome)).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         drawerAuthority: undefined,
@@ -1008,7 +1021,9 @@ describe("submitTerminalRuntimeStatus", () => {
         message: "This terminal is not active for this store.",
       }),
     );
-    expect(vi.mocked(upsertLatestRuntimeStatus)).not.toHaveBeenCalled();
+    expect(
+      vi.mocked(upsertLatestRuntimeStatusWithOutcome),
+    ).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
@@ -212,8 +212,8 @@ describe("terminalRepository runtime status", () => {
     });
     const input = {
       ...buildRuntimeStatus(),
-      reportedAt: 30_000,
-      receivedAt: 30_000,
+      reportedAt: 31_000,
+      receivedAt: 31_000,
     };
 
     const result = await upsertLatestRuntimeStatusWithOutcome(
@@ -230,6 +230,28 @@ describe("terminalRepository runtime status", () => {
       "runtime-status-1",
       input,
     );
+  });
+
+  it("coalesces duplicate runtime status reports just before the heartbeat boundary", async () => {
+    const ctx = buildCtx({
+      posTerminalRuntimeStatus: [buildRuntimeStatus()],
+    });
+    const input = {
+      ...buildRuntimeStatus(),
+      reportedAt: 28_000,
+      receivedAt: 28_000,
+    };
+
+    const result = await upsertLatestRuntimeStatusWithOutcome(
+      ctx as never,
+      input,
+    );
+
+    expect(result).toEqual({
+      didWrite: false,
+      runtimeStatusId: "runtime-status-1",
+    });
+    expect(ctx.db.patch).not.toHaveBeenCalled();
   });
 
   it("ignores delayed older runtime status reports for the latest row", async () => {

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
@@ -134,6 +134,7 @@ describe("terminalRepository runtime status", () => {
       sync: {
         ...buildRuntimeStatus().sync,
         lastTrigger: "interval",
+        pendingEventCount: 3,
         status: "syncing" as const,
       },
     };

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
@@ -8,6 +8,7 @@ import {
   TERMINAL_SYNC_REVIEW_SUMMARY_CAP,
   TERMINAL_SYNC_REVIEW_TARGET_LOOKUP_CAP,
   upsertLatestRuntimeStatus,
+  upsertLatestRuntimeStatusWithOutcome,
 } from "./terminalRepository";
 
 describe("terminalRepository runtime status", () => {
@@ -27,6 +28,11 @@ describe("terminalRepository runtime status", () => {
     });
     const input = {
       ...buildRuntimeStatus(),
+      localStore: {
+        available: true,
+        schemaVersion: 2,
+        terminalSeedReady: true,
+      },
       reportedAt: 250,
       receivedAt: 260,
     };
@@ -95,7 +101,7 @@ describe("terminalRepository runtime status", () => {
       ...buildRuntimeStatus(),
       appUpdate: undefined,
       reportedAt: 250,
-      receivedAt: 260,
+      receivedAt: 30_260,
     };
 
     const result = await upsertLatestRuntimeStatus(ctx as never, input);
@@ -107,10 +113,67 @@ describe("terminalRepository runtime status", () => {
       expect.objectContaining({
         appUpdate,
         reportedAt: 250,
-        receivedAt: 260,
+        receivedAt: 30_260,
       }),
     );
     expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
+  it("coalesces fast duplicate runtime status reports without patching", async () => {
+    const ctx = buildCtx({
+      posTerminalRuntimeStatus: [buildRuntimeStatus()],
+    });
+    const input = {
+      ...buildRuntimeStatus(),
+      reportedAt: 250,
+      receivedAt: 260,
+      snapshots: {
+        catalogAgeMs: 1500,
+        serviceCatalogAgeMs: 1500,
+      },
+      sync: {
+        ...buildRuntimeStatus().sync,
+        lastTrigger: "interval",
+      },
+    };
+
+    const result = await upsertLatestRuntimeStatusWithOutcome(
+      ctx as never,
+      input,
+    );
+
+    expect(result).toEqual({
+      didWrite: false,
+      runtimeStatusId: "runtime-status-1",
+    });
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
+  it("refreshes duplicate runtime status after the server heartbeat window", async () => {
+    const ctx = buildCtx({
+      posTerminalRuntimeStatus: [buildRuntimeStatus()],
+    });
+    const input = {
+      ...buildRuntimeStatus(),
+      reportedAt: 30_000,
+      receivedAt: 30_000,
+    };
+
+    const result = await upsertLatestRuntimeStatusWithOutcome(
+      ctx as never,
+      input,
+    );
+
+    expect(result).toEqual({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1",
+    });
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "posTerminalRuntimeStatus",
+      "runtime-status-1",
+      input,
+    );
   });
 
   it("ignores delayed older runtime status reports for the latest row", async () => {

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
@@ -134,6 +134,7 @@ describe("terminalRepository runtime status", () => {
       sync: {
         ...buildRuntimeStatus().sync,
         lastTrigger: "interval",
+        status: "syncing" as const,
       },
     };
 

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
@@ -119,6 +119,60 @@ describe("terminalRepository runtime status", () => {
     expect(ctx.db.insert).not.toHaveBeenCalled();
   });
 
+  it("preserves same-status staff identity when another runtime publisher omits it", async () => {
+    const ctx = buildCtx({
+      posTerminalRuntimeStatus: [
+        buildRuntimeStatus({
+          receivedAt: 100,
+          saleAuthority: {
+            observedAt: 100,
+            staffProfileId: "staff-1" as Id<"staffProfile">,
+            status: "ready",
+          },
+          staffAuthority: {
+            staffProfileId: "staff-1" as Id<"staffProfile">,
+            status: "ready",
+          },
+        }),
+      ],
+    });
+    const input = {
+      ...buildRuntimeStatus(),
+      receivedAt: 30_000,
+      saleAuthority: {
+        observedAt: 30_000,
+        status: "ready" as const,
+      },
+      staffAuthority: {
+        status: "ready" as const,
+      },
+    };
+
+    const result = await upsertLatestRuntimeStatusWithOutcome(
+      ctx as never,
+      input,
+    );
+
+    expect(result).toEqual({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1",
+    });
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "posTerminalRuntimeStatus",
+      "runtime-status-1",
+      expect.objectContaining({
+        saleAuthority: expect.objectContaining({
+          staffProfileId: "staff-1",
+          status: "ready",
+        }),
+        staffAuthority: {
+          staffProfileId: "staff-1",
+          status: "ready",
+        },
+      }),
+    );
+  });
+
   it("coalesces fast duplicate runtime status reports without patching", async () => {
     const ctx = buildCtx({
       posTerminalRuntimeStatus: [buildRuntimeStatus()],

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
@@ -233,13 +233,57 @@ function mergeRuntimeStatusPatch(
   existing: Doc<"posTerminalRuntimeStatus">,
   input: Omit<Doc<"posTerminalRuntimeStatus">, "_id" | "_creationTime">,
 ) {
-  if (input.appUpdate !== undefined || existing.appUpdate === undefined) {
+  return {
+    ...input,
+    appUpdate:
+      input.appUpdate !== undefined || existing.appUpdate === undefined
+        ? input.appUpdate
+        : existing.appUpdate,
+    saleAuthority: mergeRuntimeSaleAuthority(
+      existing.saleAuthority,
+      input.saleAuthority,
+    ),
+    staffAuthority: mergeRuntimeStaffAuthority(
+      existing.staffAuthority,
+      input.staffAuthority,
+    ),
+  };
+}
+
+function mergeRuntimeStaffAuthority(
+  existing: Doc<"posTerminalRuntimeStatus">["staffAuthority"],
+  input: Doc<"posTerminalRuntimeStatus">["staffAuthority"],
+) {
+  if (
+    input.staffProfileId !== undefined ||
+    existing.staffProfileId === undefined ||
+    input.status !== existing.status
+  ) {
     return input;
   }
 
   return {
     ...input,
-    appUpdate: existing.appUpdate,
+    staffProfileId: existing.staffProfileId,
+  };
+}
+
+function mergeRuntimeSaleAuthority(
+  existing: Doc<"posTerminalRuntimeStatus">["saleAuthority"],
+  input: Doc<"posTerminalRuntimeStatus">["saleAuthority"],
+) {
+  if (
+    !input ||
+    input.staffProfileId !== undefined ||
+    existing?.staffProfileId === undefined ||
+    input.status !== existing.status
+  ) {
+    return input;
+  }
+
+  return {
+    ...input,
+    staffProfileId: existing.staffProfileId,
   };
 }
 

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
@@ -231,7 +231,7 @@ function stripRuntimeSyncVolatileFields(
     return undefined;
   }
 
-  const { lastTrigger: _lastTrigger, ...rest } = sync;
+  const { lastTrigger: _lastTrigger, status: _status, ...rest } = sync;
   return stripUndefined(rest);
 }
 

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
@@ -205,7 +205,6 @@ function runtimeStatusMaterialSignature(
     source: status.source,
     staffAuthority: status.staffAuthority,
     storeId: status.storeId,
-    sync: stripRuntimeSyncVolatileFields(status.sync),
     terminalId: status.terminalId,
     terminalIntegrity: stripObservedAt(status.terminalIntegrity),
   });
@@ -221,17 +220,6 @@ function stripObservedAt<T extends Record<string, unknown> | undefined>(
   }
 
   const { observedAt: _observedAt, ...rest } = value;
-  return stripUndefined(rest);
-}
-
-function stripRuntimeSyncVolatileFields(
-  sync: Doc<"posTerminalRuntimeStatus">["sync"] | undefined,
-) {
-  if (!sync) {
-    return undefined;
-  }
-
-  const { lastTrigger: _lastTrigger, status: _status, ...rest } = sync;
   return stripUndefined(rest);
 }
 

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
@@ -169,7 +169,7 @@ export async function upsertLatestRuntimeStatusWithOutcome(
   };
 }
 
-const RUNTIME_STATUS_FAST_DUPLICATE_WINDOW_MS = 25_000;
+const RUNTIME_STATUS_FAST_DUPLICATE_WINDOW_MS = 30_000;
 
 function isFastDuplicateRuntimeStatus(
   existing: Doc<"posTerminalRuntimeStatus">,

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
@@ -121,6 +121,17 @@ export async function upsertLatestRuntimeStatus(
   ctx: MutationCtx,
   input: Omit<Doc<"posTerminalRuntimeStatus">, "_id" | "_creationTime">,
 ) {
+  const result = await upsertLatestRuntimeStatusWithOutcome(ctx, input);
+  return result.runtimeStatusId;
+}
+
+export async function upsertLatestRuntimeStatusWithOutcome(
+  ctx: MutationCtx,
+  input: Omit<Doc<"posTerminalRuntimeStatus">, "_id" | "_creationTime">,
+): Promise<{
+  didWrite: boolean;
+  runtimeStatusId: Id<"posTerminalRuntimeStatus">;
+}> {
   const existing = await getLatestRuntimeStatusForTerminal(ctx, {
     storeId: input.storeId,
     terminalId: input.terminalId,
@@ -128,18 +139,106 @@ export async function upsertLatestRuntimeStatus(
 
   if (existing) {
     if (input.reportedAt < existing.reportedAt) {
-      return existing._id;
+      return {
+        didWrite: false,
+        runtimeStatusId: existing._id,
+      };
     }
 
-    await ctx.db.patch(
-      "posTerminalRuntimeStatus",
-      existing._id,
-      mergeRuntimeStatusPatch(existing, input),
-    );
-    return existing._id;
+    const patch = mergeRuntimeStatusPatch(existing, input);
+    if (isFastDuplicateRuntimeStatus(existing, patch)) {
+      return {
+        didWrite: false,
+        runtimeStatusId: existing._id,
+      };
+    }
+
+    await ctx.db.patch("posTerminalRuntimeStatus", existing._id, patch);
+    return {
+      didWrite: true,
+      runtimeStatusId: existing._id,
+    };
   }
 
-  return ctx.db.insert("posTerminalRuntimeStatus", omitUndefined(input));
+  return {
+    didWrite: true,
+    runtimeStatusId: await ctx.db.insert(
+      "posTerminalRuntimeStatus",
+      omitUndefined(input),
+    ),
+  };
+}
+
+const RUNTIME_STATUS_FAST_DUPLICATE_WINDOW_MS = 25_000;
+
+function isFastDuplicateRuntimeStatus(
+  existing: Doc<"posTerminalRuntimeStatus">,
+  patch: Omit<Doc<"posTerminalRuntimeStatus">, "_id" | "_creationTime">,
+) {
+  if (
+    patch.receivedAt - existing.receivedAt >=
+    RUNTIME_STATUS_FAST_DUPLICATE_WINDOW_MS
+  ) {
+    return false;
+  }
+
+  return (
+    runtimeStatusMaterialSignature(existing) ===
+    runtimeStatusMaterialSignature(patch)
+  );
+}
+
+function runtimeStatusMaterialSignature(
+  status: Partial<Doc<"posTerminalRuntimeStatus">>,
+) {
+  const material = stripUndefined({
+    activeRegisterSession: stripObservedAt(status.activeRegisterSession),
+    appSessionRecovery: status.appSessionRecovery,
+    appShell: stripObservedAt(status.appShell),
+    appUpdate: stripObservedAt(status.appUpdate),
+    appVersion: status.appVersion,
+    browserInfo: status.browserInfo,
+    buildSha: status.buildSha,
+    drawerAuthority: stripObservedAt(status.drawerAuthority),
+    localStore: status.localStore,
+    saleAuthority: stripObservedAt(status.saleAuthority),
+    source: status.source,
+    staffAuthority: status.staffAuthority,
+    storeId: status.storeId,
+    sync: stripRuntimeSyncVolatileFields(status.sync),
+    terminalId: status.terminalId,
+    terminalIntegrity: stripObservedAt(status.terminalIntegrity),
+  });
+
+  return JSON.stringify(material);
+}
+
+function stripObservedAt<T extends Record<string, unknown> | undefined>(
+  value: T,
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  const { observedAt: _observedAt, ...rest } = value;
+  return stripUndefined(rest);
+}
+
+function stripRuntimeSyncVolatileFields(
+  sync: Doc<"posTerminalRuntimeStatus">["sync"] | undefined,
+) {
+  if (!sync) {
+    return undefined;
+  }
+
+  const { lastTrigger: _lastTrigger, ...rest } = sync;
+  return stripUndefined(rest);
+}
+
+function stripUndefined<T extends Record<string, unknown>>(input: T) {
+  return Object.fromEntries(
+    Object.entries(input).filter((entry) => entry[1] !== undefined),
+  ) as T;
 }
 
 function mergeRuntimeStatusPatch(

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -838,6 +838,48 @@ describe("POS terminal public mutations", () => {
     );
   });
 
+  it("skips runtime side effects when the backend coalesces a fast duplicate check-in", async () => {
+    mocks.submitTerminalRuntimeStatusCommand.mockResolvedValue({
+      kind: "ok",
+      data: {
+        acceptedForSideEffects: false,
+        terminalId: "terminal-1",
+        reportedAt: 100,
+        receivedAt: 200,
+      },
+    });
+    const ctx = buildCtx({
+      terminal: {
+        _id: "terminal-1",
+        storeId: "store-1",
+        status: "active",
+        registeredByUserId: "athena-user-2",
+        syncSecretHash: SYNC_SECRET_HASH,
+        displayName: "Front register",
+      },
+    });
+
+    const result = await getHandler(submitTerminalRuntimeStatus)(ctx as never, {
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      syncSecretHash: "sync-secret-1",
+      status: buildRuntimeStatus(),
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: {
+        terminalId: "terminal-1",
+        reportedAt: 100,
+        receivedAt: 200,
+      },
+    });
+    expect(mocks.remoteAssistUpsertClient).not.toHaveBeenCalled();
+    expect(
+      mocks.verifyTerminalRecoveryCommandsFromRuntime,
+    ).not.toHaveBeenCalled();
+  });
+
   it("claims a connecting Remote Assist session after a successful runtime check-in", async () => {
     const session = buildRemoteAssistSession({ status: "connecting" });
     mocks.remoteAssistGetCurrentSessionForClient.mockResolvedValue(session);

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -7,7 +7,7 @@ import {
   requireAuthenticatedAthenaUserWithCtx,
   requireOrganizationMemberRoleWithCtx,
 } from "../../lib/athenaUserAuth";
-import { userError } from "../../../shared/commandResult";
+import { ok, userError } from "../../../shared/commandResult";
 import {
   deleteTerminal as deleteTerminalCommand,
   registerTerminal as registerTerminalCommand,
@@ -933,7 +933,13 @@ export const submitTerminalRuntimeStatus = mutation({
       terminalId: args.terminalId,
       status: safeStatus,
     });
-    if (result.kind === "ok") {
+    if (result.kind !== "ok") {
+      return result;
+    }
+
+    const { acceptedForSideEffects, ...runtimeStatusWriteResult } =
+      result.data;
+    if (acceptedForSideEffects !== false) {
       await runAcceptedRuntimeStatusSideEffects({
         ctx,
         receivedAt: result.data.receivedAt,
@@ -943,7 +949,7 @@ export const submitTerminalRuntimeStatus = mutation({
         terminalId: args.terminalId,
       });
     }
-    return result;
+    return ok(runtimeStatusWriteResult);
   },
 });
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeStatusPublisher.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeStatusPublisher.ts
@@ -158,11 +158,7 @@ function normalizeRuntimeStatusPublishMaterial(
     };
   }
   if (stableStatus.sync) {
-    stableStatus.sync = { ...stableStatus.sync };
-    delete (stableStatus.sync as Partial<PosTerminalRuntimeStatusPayload["sync"]>)
-      .lastTrigger;
-    delete (stableStatus.sync as Partial<PosTerminalRuntimeStatusPayload["sync"]>)
-      .status;
+    delete stableStatus.sync;
   }
 
   return stableStatus;

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -66,6 +66,7 @@ import {
   derivePosLocalRuntimeSyncStatus,
   getRuntimeStatusSignature,
   isPosLocalRuntimeDrainCandidate,
+  resetRuntimeStatusPublishStateForTests,
   usePosLocalSyncRuntimeStatus,
   writeReturnedLocalCloudMappings,
 } from "./usePosLocalSyncRuntime";
@@ -123,6 +124,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    resetRuntimeStatusPublishStateForTests();
     vi.useRealTimers();
   });
 
@@ -3955,6 +3957,64 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         }),
       ),
     );
+    expect(mocks.reportTerminalRuntimeStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces duplicate runtime check-in publishers for the same terminal", async () => {
+    const nextPublish = deferred<{
+      kind: "ok";
+      data: Record<string, never>;
+    }>();
+    mocks.reportTerminalRuntimeStatus.mockReturnValue(nextPublish.promise);
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+    };
+
+    const storeFactory = () => store as never;
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        mode: "status-only",
+        storeFactory,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        mode: "status-only",
+        storeFactory,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.reportTerminalRuntimeStatus).toHaveBeenCalledTimes(1),
+    );
+    await act(async () => {
+      nextPublish.resolve({
+        kind: "ok",
+        data: {},
+      });
+      await nextPublish.promise;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
     expect(mocks.reportTerminalRuntimeStatus).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -4394,6 +4394,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
           },
           sync: {
             ...runtimeStatus.sync,
+            pendingEventCount: 7,
             lastTrigger: "foreground-interval",
             status: "needs_review",
           },

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -1012,6 +1012,10 @@ export function usePosLocalSyncRuntimeStatus(input: {
     const checkInStoreId = storeId as string;
     const checkInTerminalId = runtimeStatusTerminalId as string;
     const checkInSyncSecretHash = runtimeStatusSyncSecretHash as string;
+    const publishState = getRuntimeStatusPublishState({
+      storeId: checkInStoreId,
+      terminalId: checkInTerminalId,
+    });
     const signature = getRuntimeStatusPublishSignature({
       observationToken: runtimeStatusObservationToken,
       runtimeStatus,
@@ -1023,17 +1027,22 @@ export function usePosLocalSyncRuntimeStatus(input: {
       storeId: checkInStoreId,
       terminalId: checkInTerminalId,
     });
-    if (runtimeStatusPublishInFlightRef.current) {
+    if (
+      runtimeStatusPublishInFlightRef.current ||
+      publishState.inFlight === true
+    ) {
       queuedRuntimeStatusSignatureRef.current = signature;
+      publishState.queuedSignature = signature;
       return;
     }
-    const forcePublish = forceNextRuntimeStatusPublishRef.current;
+    const forcePublish =
+      forceNextRuntimeStatusPublishRef.current || publishState.forceNextPublish;
     if (
       !forcePublish &&
       !shouldPublishRuntimeStatus({
-        lastMaterialSignature: lastRuntimeStatusMaterialSignatureRef.current,
-        lastPublishedAt: lastRuntimeStatusPublishedAtRef.current,
-        lastPublishSignature: lastRuntimeStatusSignatureRef.current,
+        lastMaterialSignature: publishState.lastMaterialSignature,
+        lastPublishedAt: publishState.lastPublishedAt,
+        lastPublishSignature: publishState.lastSignature,
         materialSignature,
         now: Date.now(),
         publishSignature: signature,
@@ -1042,12 +1051,17 @@ export function usePosLocalSyncRuntimeStatus(input: {
       return;
     }
     forceNextRuntimeStatusPublishRef.current = false;
+    publishState.forceNextPublish = false;
     lastRuntimeStatusSignatureRef.current = signature;
     lastRuntimeStatusMaterialSignatureRef.current = materialSignature;
+    publishState.lastSignature = signature;
+    publishState.lastMaterialSignature = materialSignature;
     runtimeStatusPublishInFlightRef.current = true;
+    publishState.inFlight = true;
 
     const attemptedAt = Date.now();
     lastRuntimeStatusPublishedAtRef.current = attemptedAt;
+    publishState.lastPublishedAt = attemptedAt;
     setDebug((current) =>
       withCheckInPublishDebug(current, {
         checkInPublishAttemptedAt: attemptedAt,
@@ -1198,6 +1212,8 @@ export function usePosLocalSyncRuntimeStatus(input: {
                   storeId: checkInStoreId,
                   terminalId: checkInTerminalId,
                 });
+              publishState.lastSignature =
+                lastRuntimeStatusSignatureRef.current;
               lastRuntimeStatusMaterialSignatureRef.current =
                 getRuntimeStatusPublishMaterialSignature({
                   runtimeStatus: buildPosTerminalRuntimeStatus({
@@ -1207,6 +1223,8 @@ export function usePosLocalSyncRuntimeStatus(input: {
                   storeId: checkInStoreId,
                   terminalId: checkInTerminalId,
                 });
+              publishState.lastMaterialSignature =
+                lastRuntimeStatusMaterialSignatureRef.current;
               setRuntimeReadiness((current) => ({
                 ...current,
                 terminalIntegrity,
@@ -1247,15 +1265,20 @@ export function usePosLocalSyncRuntimeStatus(input: {
       })
       .finally(() => {
         runtimeStatusPublishInFlightRef.current = false;
+        publishState.inFlight = false;
         const queuedSignature = queuedRuntimeStatusSignatureRef.current;
+        const queuedScopeSignature = publishState.queuedSignature;
         queuedRuntimeStatusSignatureRef.current = null;
+        publishState.queuedSignature = null;
+        const nextQueuedSignature = queuedSignature ?? queuedScopeSignature;
         if (
-          ((queuedSignature &&
-            queuedSignature !== lastRuntimeStatusSignatureRef.current) ||
+          ((nextQueuedSignature &&
+            nextQueuedSignature !== publishState.lastSignature) ||
             isStale) &&
           isRuntimeStatusPublisherMountedRef.current
         ) {
           forceNextRuntimeStatusPublishRef.current = true;
+          publishState.forceNextPublish = true;
           setRuntimeStatusObservationToken((current) => current + 1);
         }
       });
@@ -1590,6 +1613,41 @@ export function usePosLocalSyncRuntimeStatus(input: {
     runtimeStatus,
     staffProfileId,
   ]);
+}
+
+type RuntimeStatusPublishState = {
+  forceNextPublish: boolean;
+  inFlight: boolean;
+  lastMaterialSignature: string | null;
+  lastPublishedAt: number | null;
+  lastSignature: string | null;
+  queuedSignature: string | null;
+};
+
+const runtimeStatusPublishStates = new Map<string, RuntimeStatusPublishState>();
+
+export function resetRuntimeStatusPublishStateForTests() {
+  runtimeStatusPublishStates.clear();
+}
+
+function getRuntimeStatusPublishState(input: {
+  storeId: string;
+  terminalId: string;
+}) {
+  const key = `${input.storeId}:${input.terminalId}`;
+  const existing = runtimeStatusPublishStates.get(key);
+  if (existing) return existing;
+
+  const state: RuntimeStatusPublishState = {
+    forceNextPublish: false,
+    inFlight: false,
+    lastMaterialSignature: null,
+    lastPublishedAt: null,
+    lastSignature: null,
+    queuedSignature: null,
+  };
+  runtimeStatusPublishStates.set(key, state);
+  return state;
 }
 
 async function clearAcceptedTerminalIntegrityState(input: {


### PR DESCRIPTION
## Summary
- coalesce duplicate same-terminal POS runtime publishers in the browser runtime
- add Convex-side duplicate runtime status write coalescing and skip redundant side effects
- preserve same-status staff identity across alternating runtime check-ins and align the duplicate window with the heartbeat

## Production verification
- deployed Athena webapp `happy-bear-soars (20260702162411, e1066922ffb7)`
- deployed Convex hotfixes to `colorless-cardinal-870`
- confirmed active terminals report the latest build
- latest log samples show `occOrRetryCount: 0` for `reportTerminalRuntimeStatus`

## Validation
- `bun run test -- src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts convex/pos/infrastructure/repositories/terminalRepository.test.ts convex/pos/public/terminals.test.ts`
- `bun run --filter @athena/webapp typecheck`
- `bun run --filter @athena/webapp lint:frontend:changed`
- `bun run --filter @athena/webapp lint:convex:changed`
- `bun run graphify:rebuild`
- pre-push validation suite passed